### PR TITLE
[codex] Add MIT license and update bloom mount path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ resolver = "2"
 version = "0.1.0"
 edition = "2024"
 rust-version = "1.85"
-license = "MIT OR Apache-2.0"
+license = "MIT"
 repository = "https://github.com/bloom-directory/bloom"
 
 [workspace.dependencies]

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -74,7 +74,7 @@ bloom ipc call lookup --params '{"path":"/status/version"}'
 # binary the docker tests use (or `Daemon::mount(path).await` from your own
 # binary). The kernel-mounted tree appears at the path you supply.
 cargo build --release -p bloom-mount --features mount --example mount_demo
-./target/release/examples/mount_demo /tmp/eth                  # mounts at /tmp/eth
+./target/release/examples/mount_demo /tmp/bloom                  # mounts at /tmp/bloom
 ```
 
 The IPC socket lives at `$BLOOM_HOME/run/bloom.sock` (mode 0600, created on
@@ -215,7 +215,7 @@ Coverage per mode:
 |------|---------------|----------|
 | `--workspace` | single container | The unit-test suite passes on Linux as well as macOS. CI-shape regression for OS-specific code. |
 | `--mount` (default) | single privileged container | NFS server + kernel mount: `ls`, `cat /status/version`, `cat /tools/keccak/abc`, `write /watch/new`. Regression-tests the WRITE-stability bug that returned EREMOTEIO. |
-| `--fork` | compose: anvil-fork sidecar + driver | End-to-end wallet flow over the mount: stage → confirm → broadcast → poll receipt → fee-bump replace; chain reads under `/eth/chains/base/{head,tx,gas,blocks}`. |
+| `--fork` | compose: anvil-fork sidecar + driver | End-to-end wallet flow over the mount: stage → confirm → broadcast → poll receipt → fee-bump replace; chain reads under `/bloom/chains/base/{head,tx,gas,blocks}`. |
 | `--enso` | compose: anvil-fork + driver | Full DeFi intent: post NL intent → confirm session → poll outbox → broadcast → assert aBaseUSDC > 0. Generous 5% slippage and 300s gas-estimation budget to absorb fork drift. |
 | `--enso-live` | single privileged container | Same flow against real Base mainnet, plus a balance-neutral unwind (redeem aBaseUSDC → ETH). Mounts `$BLOOM_LIVE_HOME` read-only and copies the keystore to a throwaway home. |
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -4,7 +4,7 @@
 filesystem. Reads are blockchain queries, writes are transaction
 intents, and `tail -f` is a live event stream. This document collects
 every notable surface as a runnable shell example, assuming the VFS is
-mounted at `/eth/` (the daemon's default NFS mount path).
+mounted at `/bloom/` (the daemon's default NFS mount path).
 
 Every command below is plain `cat`, `ls`, `echo > path`, or `tail -f`
 — there is no separate API. Where an example targets the real network,
@@ -43,9 +43,9 @@ bloom serve &
 
 # Optional: NFS mount so the rest of this doc runs verbatim.
 #   build with `cargo build --features bloom-daemon/mount` first.
-bloom mount /eth
+bloom mount /bloom
 
-# Without a mount, every `cat /eth/...` below maps 1:1 to:
+# Without a mount, every `cat /bloom/...` below maps 1:1 to:
 #   bloom vfs cat /...
 # and likewise for `ls`, `echo > path`, and `tail -f`.
 ```
@@ -78,10 +78,10 @@ The chain-read surface lives in `crates/bloom-vfs/src/handlers/{chains,chains_co
 ### Chain discovery
 
 ```sh
-ls /eth/chains/                                   # registered chains: ethereum, base, anvil, ...
-ls /eth/chains/ethereum/                          # chain_id, head/, blocks/, addresses/, tx/, gas/, contracts/
-cat /eth/chains/ethereum/chain_id                 # → 1
-cat /eth/chains/base/chain_id                     # → 8453
+ls /bloom/chains/                                   # registered chains: ethereum, base, anvil, ...
+ls /bloom/chains/ethereum/                          # chain_id, head/, blocks/, addresses/, tx/, gas/, contracts/
+cat /bloom/chains/ethereum/chain_id                 # → 1
+cat /bloom/chains/base/chain_id                     # → 8453
 ```
 
 ### Head
@@ -90,14 +90,14 @@ cat /eth/chains/base/chain_id                     # → 8453
 header lives inside `full.json`.
 
 ```sh
-ls /eth/chains/ethereum/head/                     # number, hash, timestamp, full.json
-cat /eth/chains/ethereum/head/number              # decimal block number
-cat /eth/chains/ethereum/head/hash                # 0x-prefixed block hash
-cat /eth/chains/ethereum/head/timestamp           # unix seconds
-cat /eth/chains/ethereum/head/full.json           # full block (header + tx hashes)
+ls /bloom/chains/ethereum/head/                     # number, hash, timestamp, full.json
+cat /bloom/chains/ethereum/head/number              # decimal block number
+cat /bloom/chains/ethereum/head/hash                # 0x-prefixed block hash
+cat /bloom/chains/ethereum/head/timestamp           # unix seconds
+cat /bloom/chains/ethereum/head/full.json           # full block (header + tx hashes)
 
 # parent_hash, gas_used, base_fee_per_gas, miner all live inside full.json:
-cat /eth/chains/ethereum/head/full.json | jq '.header.parentHash, .header.gasUsed, .header.baseFeePerGas, .header.miner'
+cat /bloom/chains/ethereum/head/full.json | jq '.header.parentHash, .header.gasUsed, .header.baseFeePerGas, .header.miner'
 ```
 
 ### Blocks
@@ -106,9 +106,9 @@ A specific block exposes only `full.json` (header + tx list). Per-tx
 detail is under `tx/<hash>/`.
 
 ```sh
-ls /eth/chains/ethereum/blocks/19000000/          # full.json
-cat /eth/chains/ethereum/blocks/19000000/full.json
-cat /eth/chains/ethereum/blocks/19000000/full.json | jq '.transactions | length'
+ls /bloom/chains/ethereum/blocks/19000000/          # full.json
+cat /bloom/chains/ethereum/blocks/19000000/full.json
+cat /bloom/chains/ethereum/blocks/19000000/full.json | jq '.transactions | length'
 # Note: there is no "latest" alias — use head/ or look up by number.
 ```
 
@@ -118,26 +118,26 @@ Single JSON leaf with the legacy gas price; EIP-1559 base fee lives
 in `head/full.json` (`baseFeePerGas`).
 
 ```sh
-cat /eth/chains/ethereum/gas/current.json         # {"gas_price_wei": <legacy gasPrice>}
-cat /eth/chains/ethereum/head/full.json | jq '.header.baseFeePerGas'
+cat /bloom/chains/ethereum/gas/current.json         # {"gas_price_wei": <legacy gasPrice>}
+cat /bloom/chains/ethereum/head/full.json | jq '.header.baseFeePerGas'
 ```
 
 ### Addresses (core, RPC-only)
 
 ```sh
 # vitalik.eth
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/balance       # wei (decimal)
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/balance.eth   # "1.234 ETH"
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nonce
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/code          # 0x for EOA
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/is_contract   # true / false
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/balance       # wei (decimal)
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/balance.eth   # "1.234 ETH"
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nonce
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/code          # 0x for EOA
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/is_contract   # true / false
 
 # A contract (USDC) — same leaves, code is non-empty:
-cat /eth/chains/ethereum/addresses/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/is_contract
-cat /eth/chains/ethereum/addresses/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/code | head -c 32
+cat /bloom/chains/ethereum/addresses/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/is_contract
+cat /bloom/chains/ethereum/addresses/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/code | head -c 32
 
 # ENS reverse (only when an ENS-capable chain is configured):
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/ens   # → vitalik.eth
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/ens   # → vitalik.eth
 ```
 
 ### ERC-20 holdings (per address)
@@ -147,14 +147,14 @@ Allowances are not exposed here — read them via the token contract's
 `allowance.read` method (below).
 
 ```sh
-ls /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/
+ls /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/
 # → balance, balance.raw, balance.formatted, symbol, decimals
 
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/balance.formatted   # "1234.56 USDC"
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/symbol            # → WETH
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/balance.formatted   # "1234.56 USDC"
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/symbol            # → WETH
 
 # Same shape on Base (USDC on Base):
-cat /eth/chains/base/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913/balance.formatted
+cat /bloom/chains/base/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913/balance.formatted
 ```
 
 ### Transactions and receipts
@@ -165,32 +165,32 @@ revert decoder uses trace internally — there is no separate `trace`
 leaf.
 
 ```sh
-ls /eth/chains/ethereum/tx/0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060/
+ls /bloom/chains/ethereum/tx/0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060/
 # → receipt.json, status, block_number, gas_used, logs.json, full.json, error.json
 
 # First-ever ETH transaction (block 46147, Aug 2015):
-cat /eth/chains/ethereum/tx/0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060/full.json
-cat /eth/chains/ethereum/tx/0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060/status
-cat /eth/chains/ethereum/tx/0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060/block_number   # 46147
-cat /eth/chains/ethereum/tx/0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060/receipt.json
-cat /eth/chains/ethereum/tx/0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060/logs.json
+cat /bloom/chains/ethereum/tx/0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060/full.json
+cat /bloom/chains/ethereum/tx/0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060/status
+cat /bloom/chains/ethereum/tx/0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060/block_number   # 46147
+cat /bloom/chains/ethereum/tx/0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060/receipt.json
+cat /bloom/chains/ethereum/tx/0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060/logs.json
 
 # error.json: only resolves on a reverted tx; tries the tiered revert decoder.
 # The DAO hack tx (June 2016) — substitute any reverted hash:
-cat /eth/chains/ethereum/tx/0x0ec3f2488a93839524add10ea229e773f6bc891b4eb4794c3337d4495263790b/error.json
+cat /bloom/chains/ethereum/tx/0x0ec3f2488a93839524add10ea229e773f6bc891b4eb4794c3337d4495263790b/error.json
 # Reading error.json on a successful tx returns NotFound ("did not revert").
 ```
 
 ### Contracts: source and ABI
 
 ```sh
-ls /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/
+ls /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/
 # With Etherscan: source, abi, methods/, events/, storage/, proxy/, nft/
 # Without Etherscan: storage/, proxy/, nft/
 
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/source   # requires backends.contract_metadata = "etherscan"
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/abi
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/abi | jq '.[] | select(.type=="function") | .name'
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/source   # requires backends.contract_metadata = "etherscan"
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/abi
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/abi | jq '.[] | select(.type=="function") | .name'
 ```
 
 ### Contracts: methods (`.read`, `.tx`, `.sig`)
@@ -202,38 +202,38 @@ then read the same path. Reading without writing first uses
 
 ```sh
 # Canonical signature + selector — no body needed:
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/decimals.sig
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/decimals.sig
 # decimals() returns (uint8)
 # selector: 0x313ce567
 
 # A no-arg read (USDC.decimals()):
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/decimals.read
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/decimals.read
 # → {"decoded":[6],"raw":"0x...0006","selector":"0x313ce567"}
 
 # Read with args — USDC.balanceOf(vitalik.eth):
 echo '{"args":["0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045"]}' \
-  > /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/balanceOf.read
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/balanceOf.read
+  > /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/balanceOf.read
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/balanceOf.read
 
 # Pin a historical block:
 echo '{"args":["0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045"],"block":"19000000"}' \
-  > /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/balanceOf.read
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/balanceOf.read
+  > /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/balanceOf.read
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/balanceOf.read
 
 # .tx — returns calldata only, no broadcast:
 echo '{"args":["0x70997970C51812dc3A010C7d01b50e0d17dc79C8","1000000"]}' \
-  > /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/transfer.tx
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/transfer.tx
+  > /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/transfer.tx
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/transfer.tx
 # → {"to":"0xA0b8...eB48","selector":"0xa9059cbb","calldata":"0x..."}
 
 # Disambiguate overloads via selector:
 echo '{"args":[...], "selector":"0xa9059cbb"}' \
-  > /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/transfer.read
+  > /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/transfer.read
 
 # Read allowance via the token's allowance() method:
 echo '{"args":["0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045","0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D"]}' \
-  > /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/allowance.read
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/allowance.read
+  > /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/allowance.read
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/allowance.read
 ```
 
 ### Contracts: events (`recent`, `query`, `live`)
@@ -246,51 +246,51 @@ cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/me
 # All three need backends.contract_metadata = "etherscan" (for the ABI).
 
 # Recent USDC Transfer events:
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/events/Transfer/recent
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/events/Transfer/recent
 
 # Custom block range via /query:
 echo '{"from_block":"19000000","to_block":"19000100"}' \
-  > /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/events/Transfer/query
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/events/Transfer/query
+  > /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/events/Transfer/query
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/events/Transfer/query
 
 # Filter by indexed param name (`where`) — Transfer(from, to, value):
 echo '{
   "from_block":"19000000",
   "to_block":"19010000",
   "where":{"from":"0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045"}
-}' > /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/events/Transfer/query
+}' > /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/events/Transfer/query
 
 # Filter by positional topics — topic0 is filled in from the event sig:
 # keccak256("Transfer(address,address,uint256)") = 0xddf252ad...3b3ef
 echo '{
   "from_block":"19000000",
   "topics":[null,"0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045"]
-}' > /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/events/Transfer/query
+}' > /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/events/Transfer/query
 
 # Live tail — each read emits logs since the last cursor and advances it:
-tail -f /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/events/Transfer/live
+tail -f /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/events/Transfer/live
 ```
 
 ### Contracts: storage and proxy
 
 ```sh
 # Direct eth_getStorageAt — slot is decimal or 0x-hex (RPC-only).
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/storage/0
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/storage/0x0
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/storage/0
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/storage/0x0
 
 # EIP-1967 proxy (USDC is a transparent proxy):
-ls /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/proxy/
+ls /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/proxy/
 # → implementation, admin, beacon
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/proxy/implementation
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/proxy/admin
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/proxy/implementation
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/proxy/admin
 
 # Non-proxy contract (WETH):
-cat /eth/chains/ethereum/contracts/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/proxy/implementation
+cat /bloom/chains/ethereum/contracts/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/proxy/implementation
 # → not a proxy
 
 # AAVE V3 Pool / Lido stETH (both proxies):
-cat /eth/chains/ethereum/contracts/0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2/proxy/implementation
-cat /eth/chains/ethereum/contracts/0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84/proxy/implementation
+cat /bloom/chains/ethereum/contracts/0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2/proxy/implementation
+cat /bloom/chains/ethereum/contracts/0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84/proxy/implementation
 ```
 
 ### Address history (Etherscan-backed)
@@ -300,19 +300,19 @@ the path layer in v1.
 
 ```sh
 # All four require backends.address_history = "etherscan":
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/txs            # native txs
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/internal_txs   # internal calls
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/erc20_txs      # ERC-20 transfers
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/erc721_txs     # ERC-721 transfers
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/txs            # native txs
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/internal_txs   # internal calls
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/erc20_txs      # ERC-20 transfers
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/erc721_txs     # ERC-721 transfers
 
 # ERC-1155 history is under nfts/, not at the address root:
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/erc1155_txs
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/erc1155_txs
 
 # Same on Base:
-cat /eth/chains/base/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/erc20_txs
+cat /bloom/chains/base/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/erc20_txs
 
 # Slice with jq:
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/erc20_txs \
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/erc20_txs \
   | jq '.[] | {hash, tokenSymbol, value, from, to}'
 ```
 
@@ -323,14 +323,14 @@ TOKEN=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48   # USDC
 HOLDER=0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045  # vitalik.eth
 SPENDER=0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D # Uniswap V2 Router
 
-cat /eth/chains/ethereum/contracts/$TOKEN/methods/symbol.read | jq '.decoded[0]'
-cat /eth/chains/ethereum/contracts/$TOKEN/methods/decimals.read | jq '.decoded[0]'
+cat /bloom/chains/ethereum/contracts/$TOKEN/methods/symbol.read | jq '.decoded[0]'
+cat /bloom/chains/ethereum/contracts/$TOKEN/methods/decimals.read | jq '.decoded[0]'
 
-echo '{"args":["'$HOLDER'"]}' > /eth/chains/ethereum/contracts/$TOKEN/methods/balanceOf.read
-cat /eth/chains/ethereum/contracts/$TOKEN/methods/balanceOf.read | jq '.decoded[0]'
+echo '{"args":["'$HOLDER'"]}' > /bloom/chains/ethereum/contracts/$TOKEN/methods/balanceOf.read
+cat /bloom/chains/ethereum/contracts/$TOKEN/methods/balanceOf.read | jq '.decoded[0]'
 
-echo '{"args":["'$HOLDER'","'$SPENDER'"]}' > /eth/chains/ethereum/contracts/$TOKEN/methods/allowance.read
-cat /eth/chains/ethereum/contracts/$TOKEN/methods/allowance.read | jq '.decoded[0]'
+echo '{"args":["'$HOLDER'","'$SPENDER'"]}' > /bloom/chains/ethereum/contracts/$TOKEN/methods/allowance.read
+cat /bloom/chains/ethereum/contracts/$TOKEN/methods/allowance.read | jq '.decoded[0]'
 ```
 
 ---
@@ -352,34 +352,34 @@ probe — useful for non-standard contracts.
 
 ```sh
 # BAYC: ERC-165 detection + name + symbol + supply (RPC-only).
-cat /eth/chains/ethereum/contracts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/nft/kind          # → erc721
-cat /eth/chains/ethereum/contracts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/nft/name          # → BoredApeYachtClub
-cat /eth/chains/ethereum/contracts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/nft/symbol        # → BAYC
-cat /eth/chains/ethereum/contracts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/nft/total_supply  # → 10000 (or "unknown")
+cat /bloom/chains/ethereum/contracts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/nft/kind          # → erc721
+cat /bloom/chains/ethereum/contracts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/nft/name          # → BoredApeYachtClub
+cat /bloom/chains/ethereum/contracts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/nft/symbol        # → BAYC
+cat /bloom/chains/ethereum/contracts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/nft/total_supply  # → 10000 (or "unknown")
 
 # ERC-1155 collection (OpenSea Shared Storefront):
-cat /eth/chains/ethereum/contracts/0x495f947276749Ce646f68AC8c248420045cb7b5e/nft/kind          # → erc1155
+cat /bloom/chains/ethereum/contracts/0x495f947276749Ce646f68AC8c248420045cb7b5e/nft/kind          # → erc1155
 
 # CryptoPunks: ERC-165 returns erc721, but transferFrom is non-standard.
 # `nft_transfer` will encode the standard ERC-721 selector that the contract
 # does NOT implement — use the dedicated CryptoPunks methods via a `call` intent.
-cat /eth/chains/ethereum/contracts/0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb/nft/kind
+cat /bloom/chains/ethereum/contracts/0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb/nft/kind
 ```
 
 ### Per-token collection lookups
 
 ```sh
 # CryptoPunks #5822 owner.
-cat /eth/chains/ethereum/contracts/0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb/nft/owner_of/5822
+cat /bloom/chains/ethereum/contracts/0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb/nft/owner_of/5822
 
 # Pudgy Penguins #6873 tokenURI.
-cat /eth/chains/ethereum/contracts/0xBd3531dA5CF5857e7CfAA92426877b022e612cf8/nft/token_uri/6873
+cat /bloom/chains/ethereum/contracts/0xBd3531dA5CF5857e7CfAA92426877b022e612cf8/nft/token_uri/6873
 
 # Nouns #1 owner.
-cat /eth/chains/ethereum/contracts/0x9C8fF314C9Bc7F6e59A9d9225Fb22946427eDC03/nft/owner_of/1
+cat /bloom/chains/ethereum/contracts/0x9C8fF314C9Bc7F6e59A9d9225Fb22946427eDC03/nft/owner_of/1
 
 # isApprovedForAll(owner, operator) — has vitalik.eth approved an operator on BAYC?
-cat /eth/chains/ethereum/contracts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/nft/is_approved_for_all/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/0x1E0049783F008A0085193E00003D00cd54003c71
+cat /bloom/chains/ethereum/contracts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/nft/is_approved_for_all/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/0x1E0049783F008A0085193E00003D00cd54003c71
 ```
 
 For ERC-1155, `owner_of` returns the literal `not applicable`
@@ -389,12 +389,12 @@ For ERC-1155, `owner_of` returns the literal `not applicable`
 
 ```sh
 # requires backends.address_history = "etherscan"
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/erc721_txs
-cat /eth/chains/ethereum/addresses/0xd387a6e4e84a6c86bd90c158c6028a58cc8ac459/nfts/erc1155_txs
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/erc721_txs
+cat /bloom/chains/ethereum/addresses/0xd387a6e4e84a6c86bd90c158c6028a58cc8ac459/nfts/erc1155_txs
 
 # Best-effort holdings: reduces in/out from the ERC-721 history.
 # Carries a "caveat" field; out-of-band transfers and reorgs will skew it.
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/owned.json
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/owned.json
 ```
 
 `owned.json` schema:
@@ -417,21 +417,21 @@ is the holder context — used for `balance` / `is_owner`.
 
 ```sh
 # BAYC #1, viewed from Vitalik's holder context.
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/1/owner
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/1/uri
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/1/owner
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/1/uri
 
 # external HTTP fetch
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/1/metadata.json
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/1/metadata.json
 
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/1/balance     # 0 or 1 for ERC-721
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/1/is_owner
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/1/approved
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/1/balance     # 0 or 1 for ERC-721
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/1/is_owner
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/1/approved
 
 # ERC-1155 — token id is parsed as decimal. The metadata URI's `{id}` is
 # substituted with the lowercase 64-char hex form (no 0x) per the spec.
-cat /eth/chains/ethereum/addresses/0xd387a6e4e84a6c86bd90c158c6028a58cc8ac459/nfts/0x495f947276749Ce646f68AC8c248420045cb7b5e/10/uri
-cat /eth/chains/ethereum/addresses/0xd387a6e4e84a6c86bd90c158c6028a58cc8ac459/nfts/0x495f947276749Ce646f68AC8c248420045cb7b5e/10/balance
-cat /eth/chains/ethereum/addresses/0xd387a6e4e84a6c86bd90c158c6028a58cc8ac459/nfts/0x495f947276749Ce646f68AC8c248420045cb7b5e/10/metadata.json
+cat /bloom/chains/ethereum/addresses/0xd387a6e4e84a6c86bd90c158c6028a58cc8ac459/nfts/0x495f947276749Ce646f68AC8c248420045cb7b5e/10/uri
+cat /bloom/chains/ethereum/addresses/0xd387a6e4e84a6c86bd90c158c6028a58cc8ac459/nfts/0x495f947276749Ce646f68AC8c248420045cb7b5e/10/balance
+cat /bloom/chains/ethereum/addresses/0xd387a6e4e84a6c86bd90c158c6028a58cc8ac459/nfts/0x495f947276749Ce646f68AC8c248420045cb7b5e/10/metadata.json
 ```
 
 ### NFT writes — outbox intents
@@ -449,7 +449,7 @@ echo '{
   "contract": "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
   "to":       "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
   "token_id": "1"
-}' > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+}' > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 
 # Legacy unsafe transfer (skips onERC721Received).
 echo '{
@@ -458,13 +458,13 @@ echo '{
   "to":       "vitalik.eth",
   "token_id": "1234",
   "safe":     false
-}' > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+}' > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 
 # Shell shorthand (no `#` prefix on the token id):
 echo 'nft transfer 0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D 1 to 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 on ethereum' \
-  > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+  > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 echo 'nft transfer 0xBd3531dA5CF5857e7CfAA92426877b022e612cf8 6873 to vitalik.eth on ethereum' \
-  > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+  > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 ```
 
 #### `nft_transfer` — ERC-1155 (with amount and optional data)
@@ -478,7 +478,7 @@ echo '{
   "token_id": "10",
   "standard": "erc1155",
   "amount":   "3"
-}' > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+}' > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 
 # With optional `data` payload (forwarded to onERC1155Received):
 echo '{
@@ -489,11 +489,11 @@ echo '{
   "standard": "erc1155",
   "amount":   "1",
   "data":     "0xdeadbeef"
-}' > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+}' > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 
 # Shell shorthand: the `amount <n>` clause flips the standard hint to erc1155.
 echo 'nft transfer 0x495f947276749Ce646f68AC8c248420045cb7b5e 10 amount 3 to 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 on ethereum' \
-  > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+  > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 ```
 
 #### `nft_approve` — ERC-721 per-token (ERC-1155 rejected)
@@ -505,11 +505,11 @@ echo '{
   "contract": "0x8a90CAb2b38dba80c64b7734e58Ee1dB38B8992e",
   "operator": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
   "token_id": "1234"
-}' > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+}' > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 
 # Shell shorthand:
 echo 'nft approve 0x8a90CAb2b38dba80c64b7734e58Ee1dB38B8992e 1234 to 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 on ethereum' \
-  > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+  > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 
 # Revoke: pass the zero address as operator.
 echo '{
@@ -517,7 +517,7 @@ echo '{
   "contract": "0x8a90CAb2b38dba80c64b7734e58Ee1dB38B8992e",
   "operator": "0x0000000000000000000000000000000000000000",
   "token_id": "1234"
-}' > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+}' > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 
 # ERC-1155 rejection — per-token approve fails at staging:
 echo '{
@@ -525,9 +525,9 @@ echo '{
   "contract": "0x495f947276749Ce646f68AC8c248420045cb7b5e",
   "operator": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
   "token_id": "10"
-}' > /eth/wallets/alice/chains/ethereum/outbox/new.tx
-ls /eth/wallets/alice/chains/ethereum/outbox/failed/
-cat /eth/wallets/alice/chains/ethereum/outbox/failed/0001-*/error
+}' > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
+ls /bloom/wallets/alice/chains/ethereum/outbox/failed/
+cat /bloom/wallets/alice/chains/ethereum/outbox/failed/0001-*/error
 # => ERC-1155 has no per-token approval; use nft_approve_all
 ```
 
@@ -544,11 +544,11 @@ echo '{
   "contract": "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
   "operator": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
   "approved": true
-}' > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+}' > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 
 # Shell shorthand:
 echo 'nft set_approval_for_all 0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 true on ethereum' \
-  > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+  > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 
 # Revoke (no WARN):
 echo '{
@@ -556,18 +556,18 @@ echo '{
   "contract": "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
   "operator": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
   "approved": false
-}' > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+}' > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 ```
 
 #### Inspect, then confirm
 
 ```sh
-ls /eth/wallets/alice/chains/ethereum/outbox/pending/
+ls /bloom/wallets/alice/chains/ethereum/outbox/pending/
 # 0001-7f3c.../
 
-cat /eth/wallets/alice/chains/ethereum/outbox/pending/0001-*/plan.md
-echo y > /eth/wallets/alice/chains/ethereum/outbox/pending/0001-*/confirm
-ls /eth/wallets/alice/chains/ethereum/outbox/sent/
+cat /bloom/wallets/alice/chains/ethereum/outbox/pending/0001-*/plan.md
+echo y > /bloom/wallets/alice/chains/ethereum/outbox/pending/0001-*/confirm
+ls /bloom/wallets/alice/chains/ethereum/outbox/sent/
 ```
 
 ---
@@ -577,20 +577,20 @@ ls /eth/wallets/alice/chains/ethereum/outbox/sent/
 ### List, create, import, watch
 
 ```sh
-ls /eth/wallets/
+ls /bloom/wallets/
 
 # Shorthand: plain name = create a local wallet called 'alice'.
-echo alice > /eth/wallets/new
+echo alice > /bloom/wallets/new
 
 # Full TOML: create a fresh local wallet.
-cat <<'EOF' > /eth/wallets/new
+cat <<'EOF' > /bloom/wallets/new
 name = "alice"
 kind = "local"
 passphrase = "devonly"
 EOF
 
 # Import an existing private key (BLOOM_PASSPHRASE applies if 'passphrase' is omitted).
-cat <<'EOF' > /eth/wallets/new
+cat <<'EOF' > /bloom/wallets/new
 name = "imported"
 kind = "import"
 private_key = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
@@ -598,7 +598,7 @@ passphrase = "devonly"
 EOF
 
 # Watch-only (no private key, signing disabled).
-cat <<'EOF' > /eth/wallets/new
+cat <<'EOF' > /bloom/wallets/new
 name = "vitalik"
 kind = "watch"
 address = "0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045"
@@ -614,24 +614,24 @@ re-locks every invocation.
 ### Per-wallet leaves
 
 ```sh
-cat /eth/wallets/alice/address          # 0x... (EIP-55 checksum)
-cat /eth/wallets/alice/public_key       # 0x04... uncompressed secp256k1
-cat /eth/wallets/alice/kind             # local | watch
-cat /eth/wallets/alice/policy.toml      # current policy
+cat /bloom/wallets/alice/address          # 0x... (EIP-55 checksum)
+cat /bloom/wallets/alice/public_key       # 0x04... uncompressed secp256k1
+cat /bloom/wallets/alice/kind             # local | watch
+cat /bloom/wallets/alice/policy.toml      # current policy
 
 # Per-chain native balance + nonce.
-cat /eth/wallets/alice/chains/base/balance       # raw wei
-cat /eth/wallets/alice/chains/base/balance.eth   # human "0.123 ETH"
-cat /eth/wallets/alice/chains/base/balance.raw
-cat /eth/wallets/alice/chains/base/nonce
+cat /bloom/wallets/alice/chains/base/balance       # raw wei
+cat /bloom/wallets/alice/chains/base/balance.eth   # human "0.123 ETH"
+cat /bloom/wallets/alice/chains/base/balance.raw
+cat /bloom/wallets/alice/chains/base/nonce
 ```
 
 ERC-20 reads are not under `wallets/` — they live under the chain
 reader at `chains/<c>/addresses/<addr>/tokens/<token>/...`:
 
 ```sh
-ALICE=$(cat /eth/wallets/alice/address)
-cat /eth/chains/base/addresses/$ALICE/tokens/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913/balance.formatted
+ALICE=$(cat /bloom/wallets/alice/address)
+cat /bloom/chains/base/addresses/$ALICE/tokens/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913/balance.formatted
 ```
 
 ### Signing
@@ -641,16 +641,16 @@ All three sign endpoints write the resulting hex signature to a
 
 ```sh
 # EIP-191 personal_sign over a UTF-8 message.
-echo -n 'gm bloom' > /eth/wallets/alice/sign/message
+echo -n 'gm bloom' > /bloom/wallets/alice/sign/message
 cat ~/.bloom/keystore/alice/sign/message.sig
 
 # Raw 32-byte hash (must be 0x-hex, exactly 32 bytes).
 echo -n '0x1c8aff950685c2ed4bc3174f3472287b56d9517b9c948127319a09a7a36deac8' \
-  > /eth/wallets/alice/sign/hash
+  > /bloom/wallets/alice/sign/hash
 cat ~/.bloom/keystore/alice/sign/hash.sig
 
 # EIP-712 typed data — example: EIP-2612 permit for USDC on mainnet.
-cat <<'EOF' > /eth/wallets/alice/sign/typed_data
+cat <<'EOF' > /bloom/wallets/alice/sign/typed_data
 {
   "types": {
     "EIP712Domain": [
@@ -708,10 +708,10 @@ the kill-switch (`block_mainnet_broadcast` + per-chain
 ```sh
 # Native send, shell shorthand.
 echo 'send 0.01 eth to 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 on anvil' \
-  > /eth/wallets/alice/chains/anvil/outbox/new.tx
+  > /bloom/wallets/alice/chains/anvil/outbox/new.tx
 
 # Native send, JSON.
-cat <<'EOF' > /eth/wallets/alice/chains/anvil/outbox/new.tx
+cat <<'EOF' > /bloom/wallets/alice/chains/anvil/outbox/new.tx
 {
   "kind": "send",
   "to": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
@@ -722,7 +722,7 @@ EOF
 
 # ERC-20 transfer (token + value with a unit triggers ERC-20 encoding).
 # Below: send 10 USDC on Base to a test recipient.
-cat <<'EOF' > /eth/wallets/alice/chains/base/outbox/new.tx
+cat <<'EOF' > /bloom/wallets/alice/chains/base/outbox/new.tx
 {
   "kind": "send",
   "to": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
@@ -733,7 +733,7 @@ cat <<'EOF' > /eth/wallets/alice/chains/base/outbox/new.tx
 EOF
 
 # Generic call: WETH deposit() with 0.05 ETH attached on Base.
-cat <<'EOF' > /eth/wallets/alice/chains/base/outbox/new.tx
+cat <<'EOF' > /bloom/wallets/alice/chains/base/outbox/new.tx
 {
   "kind": "call",
   "contract": "0x4200000000000000000000000000000000000006",
@@ -753,10 +753,10 @@ surfaces as a write error — nothing lands in `pending/`.
 ### Review
 
 ```sh
-ls /eth/wallets/alice/chains/anvil/outbox/pending/
-ID=$(ls /eth/wallets/alice/chains/anvil/outbox/pending/ | head -n1)
+ls /bloom/wallets/alice/chains/anvil/outbox/pending/
+ID=$(ls /bloom/wallets/alice/chains/anvil/outbox/pending/ | head -n1)
 
-cat /eth/wallets/alice/chains/anvil/outbox/pending/$ID/plan.md
+cat /bloom/wallets/alice/chains/anvil/outbox/pending/$ID/plan.md
 ```
 
 `plan.md` is rendered from the `StagedTx`:
@@ -781,8 +781,8 @@ Write `y` to `confirm` to broadcast, `cancel` to discard, `override` to bypass s
 ```
 
 ```sh
-cat /eth/wallets/alice/chains/anvil/outbox/pending/$ID/intent.json
-cat /eth/wallets/alice/chains/anvil/outbox/pending/$ID/policy_check.json
+cat /bloom/wallets/alice/chains/anvil/outbox/pending/$ID/intent.json
+cat /bloom/wallets/alice/chains/anvil/outbox/pending/$ID/policy_check.json
 ```
 
 Note: there is no separate `tx.json` — the on-disk file is
@@ -795,21 +795,21 @@ appear in `ls` of any pending entry even before they exist on disk.
 Empty bodies are rejected.
 
 ```sh
-echo y > /eth/wallets/alice/chains/anvil/outbox/pending/$ID/confirm
+echo y > /bloom/wallets/alice/chains/anvil/outbox/pending/$ID/confirm
 
 # Override token to bypass soft-policy warnings (Warn only; Deny is never overridable):
-echo override > /eth/wallets/alice/chains/anvil/outbox/pending/$ID/confirm
+echo override > /bloom/wallets/alice/chains/anvil/outbox/pending/$ID/confirm
 ```
 
 After a successful broadcast the daemon moves the directory to
 `sent/<id>/` and writes a `tx_hash` file:
 
 ```sh
-ls /eth/wallets/alice/chains/anvil/outbox/sent/$ID/
+ls /bloom/wallets/alice/chains/anvil/outbox/sent/$ID/
 # intent.json  plan.md  policy_check.json  tx_hash
 
-HASH=$(cat /eth/wallets/alice/chains/anvil/outbox/sent/$ID/tx_hash)
-cat /eth/chains/anvil/tx/$HASH/receipt.json
+HASH=$(cat /bloom/wallets/alice/chains/anvil/outbox/sent/$ID/tx_hash)
+cat /bloom/chains/anvil/tx/$HASH/receipt.json
 ```
 
 The receipt is exposed under the chain reader, not the outbox.
@@ -820,12 +820,12 @@ The receipt is exposed under the chain reader, not the outbox.
 # Replace: bumped fees + substituted intent body. Same nonce, the
 # original record stays in place; engine writes replacement_intent.json
 # and replacement_tx_hash alongside.
-cat <<'EOF' > /eth/wallets/alice/chains/anvil/outbox/pending/$ID/replace
+cat <<'EOF' > /bloom/wallets/alice/chains/anvil/outbox/pending/$ID/replace
 send 0.02 eth to 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 on anvil
 EOF
 
 # Cancel: fires a self-send replacement at the same nonce with a >=10% bump.
-echo y > /eth/wallets/alice/chains/anvil/outbox/pending/$ID/cancel
+echo y > /bloom/wallets/alice/chains/anvil/outbox/pending/$ID/cancel
 ```
 
 ### Mainnet broadcast
@@ -848,10 +848,10 @@ Sessions are in-memory; lifetime is the daemon process.
 ### Create a session
 
 ```sh
-ls /eth/simulate/                    # new   last
+ls /bloom/simulate/                    # new   last
 
 # Native send simulation (no signing, no broadcast).
-cat <<'EOF' > /eth/simulate/new
+cat <<'EOF' > /bloom/simulate/new
 {
   "kind": "send",
   "from": "0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045",
@@ -861,8 +861,8 @@ cat <<'EOF' > /eth/simulate/new
 }
 EOF
 
-ID=$(cat /eth/simulate/last)         # sim-0001
-ls /eth/simulate/$ID/
+ID=$(cat /bloom/simulate/last)         # sim-0001
+ls /bloom/simulate/$ID/
 # intent.json  plan.md  simulation.json  state-override.json  trace.json
 ```
 
@@ -872,10 +872,10 @@ account); the underlying intent parser ignores it.
 ### Read results
 
 ```sh
-cat /eth/simulate/$ID/simulation.json   # SimResult: success, gas_used, return_data_hex
-cat /eth/simulate/$ID/plan.md           # short markdown summary
-cat /eth/simulate/$ID/trace.json        # debug_traceCall, or {"unsupported": "..."}
-cat /eth/simulate/$ID/intent.json
+cat /bloom/simulate/$ID/simulation.json   # SimResult: success, gas_used, return_data_hex
+cat /bloom/simulate/$ID/plan.md           # short markdown summary
+cat /bloom/simulate/$ID/trace.json        # debug_traceCall, or {"unsupported": "..."}
+cat /bloom/simulate/$ID/intent.json
 ```
 
 ### State overrides
@@ -887,7 +887,7 @@ synchronously against the original intent. The shape is the standard
 
 ```sh
 # Force USDC balance for vitalik.eth to 1,000,000 USDC (1e12 raw, slot 9 layout).
-cat <<'EOF' > /eth/simulate/$ID/state-override.json
+cat <<'EOF' > /bloom/simulate/$ID/state-override.json
 {
   "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": {
     "stateDiff": {
@@ -897,15 +897,15 @@ cat <<'EOF' > /eth/simulate/$ID/state-override.json
 }
 EOF
 
-cat /eth/simulate/$ID/simulation.json
+cat /bloom/simulate/$ID/simulation.json
 
 # Simpler override — zero a sender's native balance to test the revert path:
-cat <<'EOF' > /eth/simulate/$ID/state-override.json
+cat <<'EOF' > /bloom/simulate/$ID/state-override.json
 {
   "0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045": { "balance": "0x0" }
 }
 EOF
-cat /eth/simulate/$ID/simulation.json
+cat /bloom/simulate/$ID/simulation.json
 # {"success": false, "revert_reason": "insufficient funds ...", ...}
 ```
 
@@ -916,7 +916,7 @@ separate `eth_call/<to>/<calldata>` path. Stage a `call` intent with
 `state_override` inline:
 
 ```sh
-cat <<'EOF' > /eth/simulate/new
+cat <<'EOF' > /bloom/simulate/new
 {
   "kind": "call",
   "contract": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
@@ -932,8 +932,8 @@ cat <<'EOF' > /eth/simulate/new
   }
 }
 EOF
-ID=$(cat /eth/simulate/last)
-cat /eth/simulate/$ID/simulation.json    # return_data_hex carries the balance
+ID=$(cat /bloom/simulate/last)
+cat /bloom/simulate/$ID/simulation.json    # return_data_hex carries the balance
 ```
 
 NFT intents go through the wallet outbox stage path. Enso routes go
@@ -960,7 +960,7 @@ reorgs are dropped silently.
 
 ```sh
 # 1. Balance watch on vitalik.eth.
-cat <<'EOF' > /eth/watch/new
+cat <<'EOF' > /bloom/watch/new
 kind = "balance"
 wallet = "alice"
 address = "0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045"
@@ -970,14 +970,14 @@ note = "any balance change"
 EOF
 
 # 2. Block watch.
-cat <<'EOF' > /eth/watch/new
+cat <<'EOF' > /bloom/watch/new
 kind = "block"
 wallet = "alice"
 chain = "base"
 EOF
 
 # 3. Gas-price watch (fires when below 25 gwei).
-cat <<'EOF' > /eth/watch/new
+cat <<'EOF' > /bloom/watch/new
 kind = "gas_price"
 wallet = "alice"
 chain = "ethereum"
@@ -985,7 +985,7 @@ threshold_gwei = 25.0
 EOF
 
 # 4. Event watch — WETH Transfer on mainnet.
-cat <<'EOF' > /eth/watch/new
+cat <<'EOF' > /bloom/watch/new
 kind = "event"
 wallet = "alice"
 chain = "ethereum"
@@ -993,20 +993,20 @@ contract = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
 topic0 = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
 EOF
 
-ls /eth/watch/
+ls /bloom/watch/
 # new   w-0001   w-0002   w-0003   w-0004
 ```
 
 ### Tail and read
 
 ```sh
-tail -f /eth/watch/w-0001/live
-cat /eth/watch/w-0001/history.jsonl
-cat /eth/watch/w-0001/history.jsonl.1
-ls /eth/watch/w-0001/
+tail -f /bloom/watch/w-0001/live
+cat /bloom/watch/w-0001/history.jsonl
+cat /bloom/watch/w-0001/history.jsonl.1
+ls /bloom/watch/w-0001/
 # spec.toml   live   history.jsonl   history.jsonl.1   delete
 
-cat /eth/watch/w-0001/spec.toml
+cat /bloom/watch/w-0001/spec.toml
 # id = "w-0001"
 # wallet = "alice"
 # created_ms = "1731177900000"
@@ -1018,7 +1018,7 @@ cat /eth/watch/w-0001/spec.toml
 # threshold_wei = "0"
 # comparator = ">"
 
-echo y > /eth/watch/w-0001/delete
+echo y > /bloom/watch/w-0001/delete
 ```
 
 `spec.toml` is the only metadata leaf. Last-seen state is in-process
@@ -1066,18 +1066,18 @@ Session IDs look like `0001-12345` (seq + ms suffix).
 
 ```sh
 # 1) Open a session — default chain is `ethereum`.
-echo 'swap 100 usdc to eth' > /eth/defi/intents/alice/new
+echo 'swap 100 usdc to eth' > /bloom/defi/intents/alice/new
 
 # 2) See sessions.
-ls /eth/defi/intents/alice/
+ls /bloom/defi/intents/alice/
 # new
 # 0001-12345
 
 # 3) Inspect.
-ls /eth/defi/intents/alice/0001-12345/
+ls /bloom/defi/intents/alice/0001-12345/
 # intent.txt  route.json  plan.md  tx.json  simulation.json  confirm
 
-cat /eth/defi/intents/alice/0001-12345/plan.md
+cat /bloom/defi/intents/alice/0001-12345/plan.md
 # # DeFi intent
 #
 # Intent:    swap 100 usdc to eth
@@ -1094,20 +1094,20 @@ cat /eth/defi/intents/alice/0001-12345/plan.md
 
 # 4) Read the prepared RawIntent list. For ERC-20 -> ETH with insufficient
 #    allowance, this is [approve(token, spender, max), raw(swap)].
-cat /eth/defi/intents/alice/0001-12345/tx.json
+cat /bloom/defi/intents/alice/0001-12345/tx.json
 
 # 5) Optional dry-run via eth_call. Reverts get tiered-decoded.
-cat /eth/defi/intents/alice/0001-12345/simulation.json
+cat /bloom/defi/intents/alice/0001-12345/simulation.json
 
 # 6) First confirm: stage both intents into the wallet outbox.
-echo y > /eth/defi/intents/alice/0001-12345/confirm
+echo y > /bloom/defi/intents/alice/0001-12345/confirm
 
 # 7) Outbox now has two pending entries (approve, then swap).
-ls /eth/wallets/alice/chains/ethereum/outbox/pending/
+ls /bloom/wallets/alice/chains/ethereum/outbox/pending/
 
 # 8) Second confirm: the actual broadcast. Approve must mine first.
-echo y > /eth/wallets/alice/chains/ethereum/outbox/pending/<approve-id>/confirm
-echo y > /eth/wallets/alice/chains/ethereum/outbox/pending/<swap-id>/confirm
+echo y > /bloom/wallets/alice/chains/ethereum/outbox/pending/<approve-id>/confirm
+echo y > /bloom/wallets/alice/chains/ethereum/outbox/pending/<swap-id>/confirm
 ```
 
 ### JSON-explicit and slippage override
@@ -1118,15 +1118,15 @@ field itself stays in NL form — it's what the Enso parser consumes.
 
 ```sh
 echo '{"intent":"swap 100 usdc to eth","chain":"ethereum"}' \
-  > /eth/defi/intents/alice/new
+  > /bloom/defi/intents/alice/new
 
 # Override the 50-bps default slippage:
 echo '{"intent":"swap 100 usdc to eth","slippage_bps":100}' \
-  > /eth/defi/intents/alice/new
+  > /bloom/defi/intents/alice/new
 
 # To feed an explicit token address, embed the hex in the NL string:
 echo 'swap 100 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 to ETH' \
-  > /eth/defi/intents/alice/new
+  > /bloom/defi/intents/alice/new
 ```
 
 NL-only writes always use the 50-bps default; only the JSON form
@@ -1136,17 +1136,17 @@ carries `slippage_bps`.
 
 ```sh
 # ETH -> USDC on Ethereum (native in, no approve; tx.value carries ETH).
-echo 'swap 0.5 eth to usdc' > /eth/defi/intents/alice/new
+echo 'swap 0.5 eth to usdc' > /bloom/defi/intents/alice/new
 
 # USDC -> DAI on Base (different chain, auto-approve).
 # Base USDC: 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913
 # Base DAI:  0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb
 echo 'swap 100 usdc to 0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb on base' \
-  > /eth/defi/intents/alice/new
+  > /bloom/defi/intents/alice/new
 
 # ETH -> stETH on Lido (Lido stETH: 0xae7a...fE84).
 echo 'swap 1 eth to 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84' \
-  > /eth/defi/intents/alice/new
+  > /bloom/defi/intents/alice/new
 ```
 
 The handler resolves only `USDC` by symbol on Base today; everything
@@ -1165,32 +1165,32 @@ the input is JSON written to `in.json` and the result is read from
 
 ```sh
 # keccak — full hash.
-cat /eth/tools/keccak/hello%20world
+cat /bloom/tools/keccak/hello%20world
 # 0x47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad
 
 # Event topic via keccak:
-cat /eth/tools/keccak/Transfer(address,address,uint256)
+cat /bloom/tools/keccak/Transfer(address,address,uint256)
 # 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef
 
 # selector — 4-byte function selector.
-cat /eth/tools/selector/transfer(address,uint256)     # 0xa9059cbb
-cat /eth/tools/selector/approve(address,uint256)      # 0x095ea7b3
+cat /bloom/tools/selector/transfer(address,uint256)     # 0xa9059cbb
+cat /bloom/tools/selector/approve(address,uint256)      # 0x095ea7b3
 
 # EIP-55 checksum.
-cat /eth/tools/address/checksum/0xd8da6bf26964af9d7eed9e03e53415d37aa96045
+cat /bloom/tools/address/checksum/0xd8da6bf26964af9d7eed9e03e53415d37aa96045
 # 0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045
 
-cat /eth/tools/sha256/hello%20world
-cat /eth/tools/blake3/hello%20world
+cat /bloom/tools/sha256/hello%20world
+cat /bloom/tools/blake3/hello%20world
 
-cat /eth/tools/hex/encode/hello                       # 0x68656c6c6f
-cat /eth/tools/hex/decode/0x68656c6c6f                # hello
-cat /eth/tools/base64/encode/hello                    # aGVsbG8=
-cat /eth/tools/base64/decode/aGVsbG8=                 # hello
+cat /bloom/tools/hex/encode/hello                       # 0x68656c6c6f
+cat /bloom/tools/hex/decode/0x68656c6c6f                # hello
+cat /bloom/tools/base64/encode/hello                    # aGVsbG8=
+cat /bloom/tools/base64/decode/aGVsbG8=                 # hello
 
-cat /eth/tools/unit/parse/1.5/eth                     # 1500000000000000000
-cat /eth/tools/unit/parse/25/gwei                     # 25000000000
-cat /eth/tools/unit/format/1500000000000000000/18     # 1.5
+cat /bloom/tools/unit/parse/1.5/eth                     # 1500000000000000000
+cat /bloom/tools/unit/parse/25/gwei                     # 25000000000
+cat /bloom/tools/unit/format/1500000000000000000/18     # 1.5
 ```
 
 ### ABI / RLP / EIP-712 sessions
@@ -1198,23 +1198,23 @@ cat /eth/tools/unit/format/1500000000000000000/18     # 1.5
 ```sh
 # ABI encode.
 echo '{"sig":"transfer(address,uint256)","args":["0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045","1000000"]}' \
-  > /eth/tools/abi/encode/s1/in.json
-cat /eth/tools/abi/encode/s1/out.hex
+  > /bloom/tools/abi/encode/s1/in.json
+cat /bloom/tools/abi/encode/s1/out.hex
 # 0xa9059cbb000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa960450000000000000000000000000000000000000000000000000000000000000f4240
 
 # ABI decode.
 echo '{"types":["address","uint256"],"data":"0x000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa960450000000000000000000000000000000000000000000000000000000000000f4240"}' \
-  > /eth/tools/abi/decode/s1/in.json
-cat /eth/tools/abi/decode/s1/out.json
+  > /bloom/tools/abi/decode/s1/in.json
+cat /bloom/tools/abi/decode/s1/out.json
 
 # RLP.
-echo '{"value":["0x83","0xff",["0x01"]]}' > /eth/tools/rlp/encode/r1/in.json
-cat /eth/tools/rlp/encode/r1/out.hex                  # 0xc6818381ffc101
-echo '{"data":"0xc6818381ffc101"}' > /eth/tools/rlp/decode/r1/in.json
-cat /eth/tools/rlp/decode/r1/out.json
+echo '{"value":["0x83","0xff",["0x01"]]}' > /bloom/tools/rlp/encode/r1/in.json
+cat /bloom/tools/rlp/encode/r1/out.hex                  # 0xc6818381ffc101
+echo '{"data":"0xc6818381ffc101"}' > /bloom/tools/rlp/decode/r1/in.json
+cat /bloom/tools/rlp/decode/r1/out.json
 
 # EIP-712 hash.
-cat <<'JSON' > /eth/tools/eip712/hash/m1/in.json
+cat <<'JSON' > /bloom/tools/eip712/hash/m1/in.json
 {
   "domain": {},
   "types": {
@@ -1230,7 +1230,7 @@ cat <<'JSON' > /eth/tools/eip712/hash/m1/in.json
   }
 }
 JSON
-cat /eth/tools/eip712/hash/m1/out.hex
+cat /bloom/tools/eip712/hash/m1/out.hex
 ```
 
 `namehash` is not currently wired into the `tools/` handler —
@@ -1246,28 +1246,28 @@ lives at `chains/<chain>/addresses/<addr>/ens` (per spec §3.2).
 
 ```sh
 # Forward (resolve to address).
-cat /eth/ens/vitalik.eth/address
+cat /bloom/ens/vitalik.eth/address
 # 0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045
 # Unresolved names return the literal string `unresolved`.
 
 # Reverse — chain-rooted.
-cat /eth/chains/mainnet/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/ens
+cat /bloom/chains/mainnet/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/ens
 
 # Text records — any key; unset keys return `not set`.
-cat /eth/ens/vitalik.eth/text/url
-cat /eth/ens/vitalik.eth/text/com.twitter
-cat /eth/ens/brantly.eth/text/email
+cat /bloom/ens/vitalik.eth/text/url
+cat /bloom/ens/vitalik.eth/text/com.twitter
+cat /bloom/ens/brantly.eth/text/email
 
 # `avatar` is a shortcut for the avatar text record.
-cat /eth/ens/vitalik.eth/avatar
+cat /bloom/ens/vitalik.eth/avatar
 # (same as)
-cat /eth/ens/vitalik.eth/text/avatar
+cat /bloom/ens/vitalik.eth/text/avatar
 
 # EIP-1577 contenthash, returned as 0x-prefixed hex.
-cat /eth/ens/ens.eth/content_hash
+cat /bloom/ens/ens.eth/content_hash
 
 # List a name's surface.
-ls /eth/ens/vitalik.eth/
+ls /bloom/ens/vitalik.eth/
 # address  avatar  content_hash  text
 ```
 
@@ -1285,15 +1285,15 @@ Coin segment forms:
 
 ```sh
 # Spot — `.usd` returns the scalar; bare returns the JSON quote.
-cat /eth/prices/spot/eth.usd
-cat /eth/prices/spot/btc.usd
-cat /eth/prices/spot/usdc.usd
-cat /eth/prices/spot/eth
+cat /bloom/prices/spot/eth.usd
+cat /bloom/prices/spot/btc.usd
+cat /bloom/prices/spot/usdc.usd
+cat /bloom/prices/spot/eth
 # {"price": ..., "symbol": "ETH", "decimals": 18, "timestamp": ..., "confidence": ...}
 
 # 24h change — there is no `.usd` variant on this path.
-cat /eth/prices/change_24h/eth
-cat /eth/prices/change_24h/usdc
+cat /bloom/prices/change_24h/eth
+cat /bloom/prices/change_24h/usdc
 ```
 
 ---
@@ -1304,21 +1304,21 @@ A local petname directory persisted to `<home>/addressbook.toml`.
 Reads return the EIP-55 checksum address with a trailing newline.
 
 ```sh
-ls /eth/addressbook/
+ls /bloom/addressbook/
 # new  vitalik  weth  usdc
 
-cat /eth/addressbook/vitalik
+cat /bloom/addressbook/vitalik
 # 0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045
 
 # Set an alias — write the address directly, or post `alias=0x…` to `new`.
-echo "0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045" > /eth/addressbook/vitalik
-echo "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" > /eth/addressbook/weth
-echo "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" > /eth/addressbook/usdc
-echo "vitalik=0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045" > /eth/addressbook/new
+echo "0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045" > /bloom/addressbook/vitalik
+echo "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" > /bloom/addressbook/weth
+echo "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" > /bloom/addressbook/usdc
+echo "vitalik=0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045" > /bloom/addressbook/new
 
 # Remove — write `delete` (case-insensitive) or an empty body:
-echo "delete" > /eth/addressbook/vitalik
-: > /eth/addressbook/vitalik
+echo "delete" > /bloom/addressbook/vitalik
+: > /bloom/addressbook/vitalik
 ```
 
 ---
@@ -1333,24 +1333,24 @@ snapshot for every configured RPC URL.
 ### Daemon
 
 ```sh
-ls /eth/status/                                      # daemon.json, version, uptime, started_at, home, chains/, audit/, cache/, policies/, wallets/, outbox/, backends/
-cat /eth/status/version                              # daemon version, e.g. 0.0.0
-cat /eth/status/uptime                               # "Ns" under a minute, "HH:MM:SS" otherwise
-cat /eth/status/started_at                           # RFC3339 UTC
-cat /eth/status/home                                 # absolute home dir, e.g. /home/you/.bloom
-cat /eth/status/daemon.json                          # JSON: {version, started_unix_ms, started_at, uptime_secs, home, chains}
+ls /bloom/status/                                      # daemon.json, version, uptime, started_at, home, chains/, audit/, cache/, policies/, wallets/, outbox/, backends/
+cat /bloom/status/version                              # daemon version, e.g. 0.0.0
+cat /bloom/status/uptime                               # "Ns" under a minute, "HH:MM:SS" otherwise
+cat /bloom/status/started_at                           # RFC3339 UTC
+cat /bloom/status/home                                 # absolute home dir, e.g. /home/you/.bloom
+cat /bloom/status/daemon.json                          # JSON: {version, started_unix_ms, started_at, uptime_secs, home, chains}
 ```
 
 ### Chains
 
 ```sh
-ls /eth/status/chains/                               # registered chain names
-ls /eth/status/chains/ethereum/                      # chain_id, connected, block_number, rpc_url, endpoints/
-cat /eth/status/chains/ethereum/chain_id             # → 1
-cat /eth/status/chains/ethereum/connected            # "true" / "false" — RPC ping with 750 ms timeout, 2 s cached
-cat /eth/status/chains/ethereum/block_number         # latest block from the same probe
-cat /eth/status/chains/ethereum/rpc_url              # first configured RPC URL, redacted (api keys → ***)
-cat /eth/status/chains/base/chain_id                 # → 8453
+ls /bloom/status/chains/                               # registered chain names
+ls /bloom/status/chains/ethereum/                      # chain_id, connected, block_number, rpc_url, endpoints/
+cat /bloom/status/chains/ethereum/chain_id             # → 1
+cat /bloom/status/chains/ethereum/connected            # "true" / "false" — RPC ping with 750 ms timeout, 2 s cached
+cat /bloom/status/chains/ethereum/block_number         # latest block from the same probe
+cat /bloom/status/chains/ethereum/rpc_url              # first configured RPC URL, redacted (api keys → ***)
+cat /bloom/status/chains/base/chain_id                 # → 8453
 ```
 
 `connected` and `block_number` share a 2-second handler-level probe
@@ -1369,14 +1369,14 @@ direct `eth_blockNumber` per endpoint, bypassing the alloy
 `FallbackLayer`).
 
 ```sh
-ls /eth/status/chains/ethereum/endpoints/            # 0, 1, 2, ...
-ls /eth/status/chains/ethereum/endpoints/0/          # url, score, cooldown_until, latency_ms, success_rate, last_block
-cat /eth/status/chains/ethereum/endpoints/0/url
-cat /eth/status/chains/ethereum/endpoints/0/score            # composite score in [0,1] (3-decimal text)
-cat /eth/status/chains/ethereum/endpoints/0/latency_ms       # EWMA round-trip ms (alpha=0.3)
-cat /eth/status/chains/ethereum/endpoints/0/success_rate     # rolling success rate over last 10 probes
-cat /eth/status/chains/ethereum/endpoints/0/last_block       # last block seen via this endpoint
-cat /eth/status/chains/ethereum/endpoints/0/cooldown_until   # Unix-seconds deadline if parked, blank if healthy
+ls /bloom/status/chains/ethereum/endpoints/            # 0, 1, 2, ...
+ls /bloom/status/chains/ethereum/endpoints/0/          # url, score, cooldown_until, latency_ms, success_rate, last_block
+cat /bloom/status/chains/ethereum/endpoints/0/url
+cat /bloom/status/chains/ethereum/endpoints/0/score            # composite score in [0,1] (3-decimal text)
+cat /bloom/status/chains/ethereum/endpoints/0/latency_ms       # EWMA round-trip ms (alpha=0.3)
+cat /bloom/status/chains/ethereum/endpoints/0/success_rate     # rolling success rate over last 10 probes
+cat /bloom/status/chains/ethereum/endpoints/0/last_block       # last block seen via this endpoint
+cat /bloom/status/chains/ethereum/endpoints/0/cooldown_until   # Unix-seconds deadline if parked, blank if healthy
 ```
 
 Cooldown semantics:
@@ -1390,7 +1390,7 @@ Cooldown semantics:
 The WP-4 WebSocket fast path adds no VFS leaves; `supports_subscriptions`
 and `ws_provider` live entirely inside `RpcEngine`. WS reachability
 shows up indirectly via `watch.subscribe_blocks.ended_falling_back_to_poll`
-log lines and per-watch state under `/eth/watch/<id>/`.
+log lines and per-watch state under `/bloom/watch/<id>/`.
 
 ### Audit
 
@@ -1399,51 +1399,51 @@ The audit log file at `~/.bloom/audit.jsonl` is **out-of-band**
 tip and a recent-window:
 
 ```sh
-ls /eth/status/audit/                                # head, count, last
-cat /eth/status/audit/head                           # rolling digest (one line of hex)
-cat /eth/status/audit/count                          # total records appended
-cat /eth/status/audit/last                           # JSON array of the last 10 records
+ls /bloom/status/audit/                                # head, count, last
+cat /bloom/status/audit/head                           # rolling digest (one line of hex)
+cat /bloom/status/audit/count                          # total records appended
+cat /bloom/status/audit/last                           # JSON array of the last 10 records
 ```
 
 Verify the chain advanced after a write:
 
 ```sh
-before=$(cat /eth/status/audit/head)
-echo y > /eth/wallets/alice/chains/anvil/outbox/pending/0001-abc/confirm
-after=$(cat /eth/status/audit/head)
+before=$(cat /bloom/status/audit/head)
+echo y > /bloom/wallets/alice/chains/anvil/outbox/pending/0001-abc/confirm
+after=$(cat /bloom/status/audit/head)
 [ "$before" != "$after" ] && echo "audit chain advanced"
 ```
 
 ### Cache, wallets, outbox, policies
 
 ```sh
-ls /eth/status/cache/                                # etherscan_entries, prices_entries
-cat /eth/status/cache/etherscan_entries
-cat /eth/status/cache/prices_entries                 # currently always 0
+ls /bloom/status/cache/                                # etherscan_entries, prices_entries
+cat /bloom/status/cache/etherscan_entries
+cat /bloom/status/cache/prices_entries                 # currently always 0
 
-ls /eth/status/wallets/                              # count
-cat /eth/status/wallets/count
+ls /bloom/status/wallets/                              # count
+cat /bloom/status/wallets/count
 
-ls /eth/status/outbox/                               # pending_count
-cat /eth/status/outbox/pending_count
+ls /bloom/status/outbox/                               # pending_count
+cat /bloom/status/outbox/pending_count
 
-ls /eth/status/policies/                             # block_mainnet_broadcast
-cat /eth/status/policies/block_mainnet_broadcast     # "true" / "false"
+ls /bloom/status/policies/                             # block_mainnet_broadcast
+cat /bloom/status/policies/block_mainnet_broadcast     # "true" / "false"
 ```
 
 Per-wallet policy is **not** under `status/`; it lives at
-`/eth/wallets/<wallet>/policy.toml`.
+`/bloom/wallets/<wallet>/policy.toml`.
 
 ### Backends
 
 ```sh
-ls /eth/status/backends/                             # contract_metadata, address_history, event_logs, storage_reads, proxy_detection, summary.json
-cat /eth/status/backends/contract_metadata           # → "etherscan"
-cat /eth/status/backends/address_history             # → "etherscan"
-cat /eth/status/backends/event_logs                  # → "rpc"
-cat /eth/status/backends/storage_reads               # → "rpc"
-cat /eth/status/backends/proxy_detection             # → "rpc"
-cat /eth/status/backends/summary.json                # JSON map of all of the above
+ls /bloom/status/backends/                             # contract_metadata, address_history, event_logs, storage_reads, proxy_detection, summary.json
+cat /bloom/status/backends/contract_metadata           # → "etherscan"
+cat /bloom/status/backends/address_history             # → "etherscan"
+cat /bloom/status/backends/event_logs                  # → "rpc"
+cat /bloom/status/backends/storage_reads               # → "rpc"
+cat /bloom/status/backends/proxy_detection             # → "rpc"
+cat /bloom/status/backends/summary.json                # JSON map of all of the above
 ```
 
 `status/backends/*` is read-only. Switching a backend is done by
@@ -1454,15 +1454,15 @@ the daemon — the config file is not VFS-writable.
 
 ## 15. Docs (vendored)
 
-`/eth/docs/` is the daemon's vendored help. The bytes are
+`/bloom/docs/` is the daemon's vendored help. The bytes are
 `include_str!`'d at compile time from `crates/bloom-vfs/src/docs/`,
 so the content is stable for the daemon's lifetime — there is no
 on-disk copy to mutate.
 
 ```sh
-ls /eth/docs/                                        # README.md, examples.md
-cat /eth/docs/README.md
-cat /eth/docs/examples.md
+ls /bloom/docs/                                        # README.md, examples.md
+cat /bloom/docs/README.md
+cat /bloom/docs/examples.md
 ```
 
 These update with the binary; refresh them after a workspace update

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Bloom Directory contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -3,7 +3,7 @@
 A short Anvil-backed walkthrough of the `bloom` CLI. The CLI's `vfs`
 subcommands are the v1 substitute for the optional NFS mount: every
 `cat` / `ls` / `write` here is what an agent would otherwise do
-through the mounted `/eth/` tree.
+through the mounted `/bloom/` tree.
 
 ## Prerequisites
 
@@ -96,7 +96,7 @@ an NFS mount this would be:
 
 ```sh
 echo 'send 0.01 eth to 0xabc... on anvil' \
-  > /eth/wallets/alice/chains/anvil/outbox/new.tx
+  > /bloom/wallets/alice/chains/anvil/outbox/new.tx
 ```
 
 Without the mount, the equivalent is:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Two ways to drive the VFS:
 
 ## Filesystem layout
 
-The VFS is rooted at `/eth/` (the default NFS mount path) with these
+The VFS is rooted at `/bloom/` (the default NFS mount path) with these
 top-level trees:
 
 - `chains/<chain>/` — read-only chain views: head, blocks, addresses,
@@ -191,4 +191,4 @@ map and live-network verification log.
 
 ## License
 
-Licensed under either of MIT or Apache-2.0 at your option.
+Licensed under the MIT License. See [LICENSE](./LICENSE).

--- a/crates/bloom-proto/src/config.rs
+++ b/crates/bloom-proto/src/config.rs
@@ -155,7 +155,7 @@ pub struct EnsoConfig {
 }
 
 fn default_mount_path() -> String {
-    "/eth".to_string()
+    "/bloom".to_string()
 }
 fn default_nfs_listen() -> String {
     "127.0.0.1:12049".to_string()
@@ -302,7 +302,7 @@ mod tests {
     fn local_default_shape() {
         let cfg = Config::local_default();
         assert_eq!(cfg.default_chain, "anvil");
-        assert_eq!(cfg.mount_path, "/eth");
+        assert_eq!(cfg.mount_path, "/bloom");
         assert_eq!(cfg.nfs_listen_addr, "127.0.0.1:12049");
         assert!(cfg.block_mainnet_broadcast);
         assert!(cfg.etherscan.is_none());

--- a/crates/bloom-vfs/src/docs/README.md
+++ b/crates/bloom-vfs/src/docs/README.md
@@ -28,43 +28,43 @@ This is the help file vendored into the daemon.
 Reads are RPC / API queries. Examples:
 
 ```sh
-cat /eth/chains/anvil/head/number
-cat /eth/chains/ethereum/blocks/19000000/json
-cat /eth/wallets/alice/chains/anvil/balance.eth
-cat /eth/wallets/alice/chains/ethereum/history.json
-cat /eth/tools/keccak/hello
-cat /eth/tools/abi/decode/<sig>/<hex>
-cat /eth/ens/vitalik.eth/address
-cat /eth/ens/vitalik.eth/avatar
-cat /eth/ens/vitalik.eth/text/url
-cat /eth/prices/spot/eth.usd
-cat /eth/addressbook/alice
+cat /bloom/chains/anvil/head/number
+cat /bloom/chains/ethereum/blocks/19000000/json
+cat /bloom/wallets/alice/chains/anvil/balance.eth
+cat /bloom/wallets/alice/chains/ethereum/history.json
+cat /bloom/tools/keccak/hello
+cat /bloom/tools/abi/decode/<sig>/<hex>
+cat /bloom/ens/vitalik.eth/address
+cat /bloom/ens/vitalik.eth/avatar
+cat /bloom/ens/vitalik.eth/text/url
+cat /bloom/prices/spot/eth.usd
+cat /bloom/addressbook/alice
 ```
 
 NFT reads (auto-detects ERC-721 vs ERC-1155 via ERC-165):
 
 ```sh
 # Per-holder views (transfer history requires etherscan-backed history).
-cat /eth/chains/ethereum/addresses/0xd8da.../nfts/erc721_txs
-cat /eth/chains/ethereum/addresses/0xd8da.../nfts/erc1155_txs
-cat /eth/chains/ethereum/addresses/0xd8da.../nfts/owned.json   # best-effort
+cat /bloom/chains/ethereum/addresses/0xd8da.../nfts/erc721_txs
+cat /bloom/chains/ethereum/addresses/0xd8da.../nfts/erc1155_txs
+cat /bloom/chains/ethereum/addresses/0xd8da.../nfts/owned.json   # best-effort
 
 # Per-token reads (RPC-only):
-cat /eth/chains/ethereum/addresses/0xd8da.../nfts/<contract>/<id>/owner
-cat /eth/chains/ethereum/addresses/0xd8da.../nfts/<contract>/<id>/uri
-cat /eth/chains/ethereum/addresses/0xd8da.../nfts/<contract>/<id>/metadata.json
-cat /eth/chains/ethereum/addresses/0xd8da.../nfts/<contract>/<id>/balance
-cat /eth/chains/ethereum/addresses/0xd8da.../nfts/<contract>/<id>/is_owner
-cat /eth/chains/ethereum/addresses/0xd8da.../nfts/<contract>/<id>/approved
+cat /bloom/chains/ethereum/addresses/0xd8da.../nfts/<contract>/<id>/owner
+cat /bloom/chains/ethereum/addresses/0xd8da.../nfts/<contract>/<id>/uri
+cat /bloom/chains/ethereum/addresses/0xd8da.../nfts/<contract>/<id>/metadata.json
+cat /bloom/chains/ethereum/addresses/0xd8da.../nfts/<contract>/<id>/balance
+cat /bloom/chains/ethereum/addresses/0xd8da.../nfts/<contract>/<id>/is_owner
+cat /bloom/chains/ethereum/addresses/0xd8da.../nfts/<contract>/<id>/approved
 
 # Collection-level views:
-cat /eth/chains/ethereum/contracts/<contract>/nft/kind          # erc721 | erc1155 | unknown
-cat /eth/chains/ethereum/contracts/<contract>/nft/name
-cat /eth/chains/ethereum/contracts/<contract>/nft/symbol
-cat /eth/chains/ethereum/contracts/<contract>/nft/total_supply
-cat /eth/chains/ethereum/contracts/<contract>/nft/owner_of/<id>
-cat /eth/chains/ethereum/contracts/<contract>/nft/token_uri/<id>
-cat /eth/chains/ethereum/contracts/<contract>/nft/is_approved_for_all/<owner>/<operator>
+cat /bloom/chains/ethereum/contracts/<contract>/nft/kind          # erc721 | erc1155 | unknown
+cat /bloom/chains/ethereum/contracts/<contract>/nft/name
+cat /bloom/chains/ethereum/contracts/<contract>/nft/symbol
+cat /bloom/chains/ethereum/contracts/<contract>/nft/total_supply
+cat /bloom/chains/ethereum/contracts/<contract>/nft/owner_of/<id>
+cat /bloom/chains/ethereum/contracts/<contract>/nft/token_uri/<id>
+cat /bloom/chains/ethereum/contracts/<contract>/nft/is_approved_for_all/<owner>/<operator>
 ```
 
 ## Writing (stage-confirm)
@@ -73,17 +73,17 @@ Native send (canonical):
 
 ```sh
 echo 'send 0.01 eth to 0xabc... on anvil' \
-  > /eth/wallets/alice/chains/anvil/outbox/new.tx
-ls /eth/wallets/alice/chains/anvil/outbox/pending/
-cat /eth/wallets/alice/chains/anvil/outbox/pending/<id>/plan.md
-echo y > /eth/wallets/alice/chains/anvil/outbox/pending/<id>/confirm
+  > /bloom/wallets/alice/chains/anvil/outbox/new.tx
+ls /bloom/wallets/alice/chains/anvil/outbox/pending/
+cat /bloom/wallets/alice/chains/anvil/outbox/pending/<id>/plan.md
+echo y > /bloom/wallets/alice/chains/anvil/outbox/pending/<id>/confirm
 ```
 
 ERC-20 send (token symbol resolved via address book / token registry):
 
 ```sh
 echo 'send 100 USDC to alice on ethereum' \
-  > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+  > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 ```
 
 NFT writes — three intent kinds, ERC-721 + ERC-1155, ERC-165
@@ -92,15 +92,15 @@ auto-detected:
 ```sh
 # Transfer ERC-721 #1234 to Bob (encodes `safeTransferFrom`):
 echo 'nft transfer 0xb47e3...3bbb #1234 to 0x70997...79C8' \
-  > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+  > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 
 # Per-token approve (ERC-721 only — ERC-1155 is rejected):
 echo 'nft approve 0xb47e3...3bbb #1234 operator 0x111...111' \
-  > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+  > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 
 # Operator-wide approval — always policy-warned:
 echo 'nft set_approval_for_all 0xb47e3...3bbb operator 0x111...111 approved true' \
-  > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+  > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 ```
 
 JSON form supports `"standard": "erc721"|"erc1155"` to skip the
@@ -111,8 +111,8 @@ legacy `transferFrom` selector. ERC-1155 transfers accept an
 Replace / cancel pending tx:
 
 ```sh
-echo replace > /eth/wallets/alice/chains/ethereum/outbox/pending/<id>/replace
-echo cancel  > /eth/wallets/alice/chains/ethereum/outbox/pending/<id>/cancel
+echo replace > /bloom/wallets/alice/chains/ethereum/outbox/pending/<id>/replace
+echo cancel  > /bloom/wallets/alice/chains/ethereum/outbox/pending/<id>/cancel
 ```
 
 DeFi intent (Enso shortcuts) — natural language is the canonical input;
@@ -121,10 +121,10 @@ with an API key (`BLOOM_ENSO_KEY`):
 
 ```sh
 echo 'swap 0.1 eth to USDC on base' \
-  > /eth/defi/intents/alice/new
-ls /eth/defi/intents/alice/
-cat /eth/defi/intents/alice/<sess>/plan.md
-echo y > /eth/defi/intents/alice/<sess>/confirm
+  > /bloom/defi/intents/alice/new
+ls /bloom/defi/intents/alice/
+cat /bloom/defi/intents/alice/<sess>/plan.md
+echo y > /bloom/defi/intents/alice/<sess>/confirm
 ```
 
 ERC-20 token-in routes auto-prepend an `approve(spender, max)` ahead
@@ -134,29 +134,29 @@ Subscribe + read (TOML body, kinds: `block`, `balance`, `gas_price`,
 `event`):
 
 ```sh
-cat <<'EOF' > /eth/watch/new
+cat <<'EOF' > /bloom/watch/new
 kind = "block"
 chain = "anvil"
 EOF
-tail -f /eth/watch/<id>/live              # in-process running state
-cat    /eth/watch/<id>/history.jsonl     # rotated archive (1 MiB each)
+tail -f /bloom/watch/<id>/live              # in-process running state
+cat    /bloom/watch/<id>/history.jsonl     # rotated archive (1 MiB each)
 ```
 
 Sign arbitrary message / raw hash / EIP-712 typed data:
 
 ```sh
-echo 'hello world' > /eth/wallets/alice/sign/message
-cat /eth/wallets/alice/sign/message.sig
-cat eip712.json     > /eth/wallets/alice/sign/typed_data
-cat /eth/wallets/alice/sign/typed_data.sig
+echo 'hello world' > /bloom/wallets/alice/sign/message
+cat /bloom/wallets/alice/sign/message.sig
+cat eip712.json     > /bloom/wallets/alice/sign/typed_data
+cat /bloom/wallets/alice/sign/typed_data.sig
 ```
 
 Address book petnames:
 
 ```sh
 echo '0x000000000000000000000000000000000000beef' \
-  > /eth/addressbook/alice
-cat /eth/addressbook/alice
+  > /bloom/addressbook/alice
+cat /bloom/addressbook/alice
 ```
 
 Mainnet broadcasts are **disabled by default**. Configure via

--- a/crates/bloom-vfs/src/docs/examples.md
+++ b/crates/bloom-vfs/src/docs/examples.md
@@ -10,52 +10,52 @@ anvil --port 8545
 bloom wallet new alice --passphrase 'devonly'
 
 # 3. Inspect chain
-cat /eth/chains/anvil/head/number
-cat /eth/chains/anvil/chain_id
+cat /bloom/chains/anvil/head/number
+cat /bloom/chains/anvil/chain_id
 
 # 4. Stage a send
 echo '{"to":"0x70997970C51812dc3A010C7d01b50e0d17dc79C8","value":"0.1 eth","chain":"anvil"}' \
-  > /eth/wallets/alice/chains/anvil/outbox/new.tx
+  > /bloom/wallets/alice/chains/anvil/outbox/new.tx
 
 # 5. Inspect plan
-ls /eth/wallets/alice/chains/anvil/outbox/pending/
-cat /eth/wallets/alice/chains/anvil/outbox/pending/0001-*/plan.md
+ls /bloom/wallets/alice/chains/anvil/outbox/pending/
+cat /bloom/wallets/alice/chains/anvil/outbox/pending/0001-*/plan.md
 
 # 6. Confirm
-echo y > /eth/wallets/alice/chains/anvil/outbox/pending/0001-*/confirm
+echo y > /bloom/wallets/alice/chains/anvil/outbox/pending/0001-*/confirm
 
 # 7. Inspect receipt
-ls /eth/wallets/alice/chains/anvil/outbox/sent/
+ls /bloom/wallets/alice/chains/anvil/outbox/sent/
 ```
 
 ## Tools
 
 ```sh
-cat /eth/tools/keccak/abc                     # hex digest
-cat /eth/tools/address/checksum/0xabc...      # EIP-55 form
-cat /eth/tools/unit/parse/1.5/eth             # → 1500000000000000000
-cat /eth/tools/unit/format/1500000000000000000/18  # → 1.5
+cat /bloom/tools/keccak/abc                     # hex digest
+cat /bloom/tools/address/checksum/0xabc...      # EIP-55 form
+cat /bloom/tools/unit/parse/1.5/eth             # → 1500000000000000000
+cat /bloom/tools/unit/format/1500000000000000000/18  # → 1.5
 ```
 
 ## NFTs (ERC-721 / ERC-1155)
 
 ```sh
 # CryptoPunks #5822 — collection view (RPC-only, no etherscan needed):
-cat /eth/chains/ethereum/contracts/0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb/nft/kind
-cat /eth/chains/ethereum/contracts/0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb/nft/name
-cat /eth/chains/ethereum/contracts/0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb/nft/owner_of/5822
+cat /bloom/chains/ethereum/contracts/0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb/nft/kind
+cat /bloom/chains/ethereum/contracts/0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb/nft/name
+cat /bloom/chains/ethereum/contracts/0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb/nft/owner_of/5822
 
 # BoredApe #1 — per-holder view (history needs an etherscan API key):
-cat /eth/chains/ethereum/addresses/0xd8da6bf26964af9d7eed9e03e53415d37aa96045/nfts/erc721_txs
-cat /eth/chains/ethereum/addresses/0xd8da6bf26964af9d7eed9e03e53415d37aa96045/nfts/owned.json
+cat /bloom/chains/ethereum/addresses/0xd8da6bf26964af9d7eed9e03e53415d37aa96045/nfts/erc721_txs
+cat /bloom/chains/ethereum/addresses/0xd8da6bf26964af9d7eed9e03e53415d37aa96045/nfts/owned.json
 
 # Per-token detail (auto-detects ERC-1155 and substitutes the {id}
 # placeholder in the metadata URI):
-cat /eth/chains/ethereum/addresses/0x.../nfts/0x.../1/owner
-cat /eth/chains/ethereum/addresses/0x.../nfts/0x.../1/uri
-cat /eth/chains/ethereum/addresses/0x.../nfts/0x.../1/metadata.json
-cat /eth/chains/ethereum/addresses/0x.../nfts/0x.../1/is_owner       # true/false
-cat /eth/chains/ethereum/addresses/0x.../nfts/0x.../1/balance         # always 1 for ERC-721
+cat /bloom/chains/ethereum/addresses/0x.../nfts/0x.../1/owner
+cat /bloom/chains/ethereum/addresses/0x.../nfts/0x.../1/uri
+cat /bloom/chains/ethereum/addresses/0x.../nfts/0x.../1/metadata.json
+cat /bloom/chains/ethereum/addresses/0x.../nfts/0x.../1/is_owner       # true/false
+cat /bloom/chains/ethereum/addresses/0x.../nfts/0x.../1/balance         # always 1 for ERC-721
 ```
 
 `metadata.json` follows `data:`, `ipfs://`, and `http(s)://` URIs (1 MiB
@@ -78,16 +78,16 @@ echo '{
   "contract": "0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb",
   "to":       "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
   "token_id": "1234"
-}' > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+}' > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 
 # Same intent in shell form:
 echo 'nft transfer 0xb47e3...3bbb #1234 to 0x70997...79C8' \
-  > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+  > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 
 # 2. Per-token approve (ERC-721 only; ERC-1155 has no per-token approval
 #    and the engine rejects it with a clear error):
 echo 'nft approve 0xb47e3...3bbb #1234 operator 0x111...111' \
-  > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+  > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 
 # 3. setApprovalForAll — operator-wide. This always trips a policy WARN
 #    so the resulting plan.md flags the broad scope before you confirm.
@@ -96,7 +96,7 @@ echo '{
   "contract": "0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb",
   "operator": "0x1111111111111111111111111111111111111111",
   "approved": true
-}' > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+}' > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 
 # 4. ERC-1155 transfer with explicit amount:
 echo '{
@@ -106,13 +106,13 @@ echo '{
   "token_id": "0x...id...",
   "standard": "erc1155",
   "amount":   "3"
-}' > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+}' > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 ```
 
 Inspect the plan before confirming — it shows the decoded NFT action,
 the contract / counterparty, the token id, and any policy warnings:
 
 ```sh
-cat /eth/wallets/alice/chains/ethereum/outbox/pending/0001-*/plan.md
-echo y > /eth/wallets/alice/chains/ethereum/outbox/pending/0001-*/confirm
+cat /bloom/wallets/alice/chains/ethereum/outbox/pending/0001-*/plan.md
+echo y > /bloom/wallets/alice/chains/ethereum/outbox/pending/0001-*/confirm
 ```

--- a/crates/bloom-vfs/src/handlers/ens.rs
+++ b/crates/bloom-vfs/src/handlers/ens.rs
@@ -69,7 +69,7 @@ struct Cache {
     /// keyed by `(name, kind, sub)` where `sub` is the text key for text
     /// records, otherwise empty.
     entries: HashMap<(String, &'static str, String), CachedEntry>,
-    /// Names looked up in this process (so `ls /eth/ens/` shows
+    /// Names looked up in this process (so `ls /bloom/ens/` shows
     /// something useful). Persistent enumeration of the global ENS name
     /// space is impossible.
     seen_names: Vec<String>,
@@ -416,14 +416,14 @@ mod tests {
 
     // --- Shape B (directory) contract pins ----------------------------
     //
-    // EXAMPLES.md §11 documents `/eth/ens/<name>/` as a *directory*
+    // EXAMPLES.md §11 documents `/bloom/ens/<name>/` as a *directory*
     // containing `address`, `avatar`, `content_hash`, `text/`. These
     // tests pin that shape so a future refactor can't silently flip
     // `<name>` into a file (which would break `cat <name>/address`).
 
     #[tokio::test]
     async fn name_is_a_directory_not_a_file() {
-        // The user-reported "bug" was that `/eth/ens/vitalik.eth`
+        // The user-reported "bug" was that `/bloom/ens/vitalik.eth`
         // reads as a directory. That is the documented contract —
         // every example uses `<name>/<field>`. Pin it.
         let h = EnsHandler::new(None);
@@ -556,7 +556,7 @@ mod tests {
 
     #[tokio::test]
     async fn list_name_dir_matches_examples_md() {
-        // EXAMPLES.md §11: `ls /eth/ens/vitalik.eth/` →
+        // EXAMPLES.md §11: `ls /bloom/ens/vitalik.eth/` →
         //   address  avatar  content_hash  text
         let h = EnsHandler::new(None);
         let entries = h

--- a/crates/bloom-vfs/src/handlers/simulate.rs
+++ b/crates/bloom-vfs/src/handlers/simulate.rs
@@ -764,7 +764,7 @@ impl SimulateHandler {
         let segs = path.segments();
         match segs.len() {
             1 if segs[0] == "new" => {
-                Ok(b"# write a JSON simulate envelope to allocate a session\n# example:\n#   echo '{\"intent\":{\"chain\":\"anvil\",\"to\":\"0x...\",\"data\":\"0x...\"}}' > /eth/simulate/new\n# read the resulting session id from /eth/simulate/last\n".to_vec())
+                Ok(b"# write a JSON simulate envelope to allocate a session\n# example:\n#   echo '{\"intent\":{\"chain\":\"anvil\",\"to\":\"0x...\",\"data\":\"0x...\"}}' > /bloom/simulate/new\n# read the resulting session id from /bloom/simulate/last\n".to_vec())
             }
             1 if segs[0] == "last" => {
                 let g = self.sessions.read();

--- a/crates/bloom-vfs/src/handlers/watch.rs
+++ b/crates/bloom-vfs/src/handlers/watch.rs
@@ -153,7 +153,7 @@ impl WatchHandler {
     async fn read_inner(&self, path: &VfsPath) -> Result<Vec<u8>, HandlerError> {
         let segs = path.segments();
         if segs.len() == 1 && segs[0] == "new" {
-            return Ok(b"# write a TOML watch spec to subscribe\n# examples (one of the kinds):\n#   printf 'kind = \"head\"\\nchain = \"anvil\"\\n' > /eth/watch/new\n#   printf 'kind = \"addr\"\\nchain = \"anvil\"\\naddress = \"0x...\"\\n' > /eth/watch/new\n#   printf 'kind = \"log\"\\nchain = \"anvil\"\\naddress = \"0x...\"\\ntopics = []\\n' > /eth/watch/new\n# optional: id = \"...\", wallet = \"...\", note = \"...\"\n".to_vec());
+            return Ok(b"# write a TOML watch spec to subscribe\n# examples (one of the kinds):\n#   printf 'kind = \"head\"\\nchain = \"anvil\"\\n' > /bloom/watch/new\n#   printf 'kind = \"addr\"\\nchain = \"anvil\"\\naddress = \"0x...\"\\n' > /bloom/watch/new\n#   printf 'kind = \"log\"\\nchain = \"anvil\"\\naddress = \"0x...\"\\ntopics = []\\n' > /bloom/watch/new\n# optional: id = \"...\", wallet = \"...\", note = \"...\"\n".to_vec());
         }
         match segs.len() {
             2 => {

--- a/crates/bloom-vfs/src/path.rs
+++ b/crates/bloom-vfs/src/path.rs
@@ -8,7 +8,7 @@ use std::fmt;
 /// become VFS path segments. The kernel splits paths on `/` and hands us
 /// each component verbatim, so users embed bytes that the shell/kernel
 /// can't pass literally (notably space, `?`, `#`, etc.) using percent-
-/// escapes — `cat /eth/tools/keccak/hello%20world` should hash the
+/// escapes — `cat /bloom/tools/keccak/hello%20world` should hash the
 /// six-byte string `hello world`, not the literal ASCII `hello%20world`.
 ///
 /// Decoding rules:

--- a/crates/bloom/src/main.rs
+++ b/crates/bloom/src/main.rs
@@ -68,9 +68,9 @@ enum IpcCmd {
 
 #[derive(Subcommand, Debug)]
 enum VfsCmd {
-    /// `cat /eth/<path>` — read a file via the VFS.
+    /// `cat /bloom/<path>` — read a file via the VFS.
     Cat { path: String },
-    /// `ls /eth/<path>` — list a directory via the VFS.
+    /// `ls /bloom/<path>` — list a directory via the VFS.
     Ls { path: String },
     /// Write data to a writable VFS path. Reads from stdin if `--data` is omitted.
     Write {

--- a/docs/examples-domain/01-chains.md
+++ b/docs/examples-domain/01-chains.md
@@ -1,14 +1,14 @@
 # `chains/` — domain examples
 
-This doc walks the read-only chain surface as it exists in `crates/bloom-vfs/src/handlers/chains.rs` (plus `chains_contracts.rs` and `chains_history.rs`). Every example assumes the VFS is mounted at `/eth/` (the daemon's default NFS path), so a shell can drive it with plain `cat`, `ls`, `echo`, and `tail -f`. Chains used below are `ethereum` (mainnet) and `base` (Base mainnet); the registered set is whatever your `~/.bloom/config.toml` configures. Etherscan-backed paths (`source`, `abi`, `methods/*`, `events/*`, address `txs`/`internal_txs`/`erc20_txs`/`erc721_txs`) only mount when `[etherscan]` is configured and the relevant `[backends]` entry resolves to `"etherscan"`. RPC-only paths (`storage`, `proxy`, `nft/...`, head/blocks/balance/code/tx) work with no Etherscan key.
+This doc walks the read-only chain surface as it exists in `crates/bloom-vfs/src/handlers/chains.rs` (plus `chains_contracts.rs` and `chains_history.rs`). Every example assumes the VFS is mounted at `/bloom/` (the daemon's default NFS path), so a shell can drive it with plain `cat`, `ls`, `echo`, and `tail -f`. Chains used below are `ethereum` (mainnet) and `base` (Base mainnet); the registered set is whatever your `~/.bloom/config.toml` configures. Etherscan-backed paths (`source`, `abi`, `methods/*`, `events/*`, address `txs`/`internal_txs`/`erc20_txs`/`erc721_txs`) only mount when `[etherscan]` is configured and the relevant `[backends]` entry resolves to `"etherscan"`. RPC-only paths (`storage`, `proxy`, `nft/...`, head/blocks/balance/code/tx) work with no Etherscan key.
 
 ## Chain discovery
 
 ```sh
-ls /eth/chains/                                   # registered chain names (e.g. ethereum, base, anvil)
-ls /eth/chains/ethereum/                          # chain_id, head/, blocks/, addresses/, tx/, gas/, contracts/
-cat /eth/chains/ethereum/chain_id                 # → 1
-cat /eth/chains/base/chain_id                     # → 8453
+ls /bloom/chains/                                   # registered chain names (e.g. ethereum, base, anvil)
+ls /bloom/chains/ethereum/                          # chain_id, head/, blocks/, addresses/, tx/, gas/, contracts/
+cat /bloom/chains/ethereum/chain_id                 # → 1
+cat /bloom/chains/base/chain_id                     # → 8453
 ```
 
 ## Head
@@ -17,13 +17,13 @@ cat /eth/chains/base/chain_id                     # → 8453
 lives inside `full.json`.
 
 ```sh
-ls /eth/chains/ethereum/head/                     # number, hash, timestamp, full.json
-cat /eth/chains/ethereum/head/number              # decimal block number
-cat /eth/chains/ethereum/head/hash                 # 0x-prefixed block hash
-cat /eth/chains/ethereum/head/timestamp           # unix seconds
-cat /eth/chains/ethereum/head/full.json           # full block (header + tx hashes)
+ls /bloom/chains/ethereum/head/                     # number, hash, timestamp, full.json
+cat /bloom/chains/ethereum/head/number              # decimal block number
+cat /bloom/chains/ethereum/head/hash                 # 0x-prefixed block hash
+cat /bloom/chains/ethereum/head/timestamp           # unix seconds
+cat /bloom/chains/ethereum/head/full.json           # full block (header + tx hashes)
 # parent_hash, gas_used, base_fee_per_gas, miner, etc. are inside full.json:
-cat /eth/chains/ethereum/head/full.json | jq '.header.parentHash, .header.gasUsed, .header.baseFeePerGas, .header.miner'
+cat /bloom/chains/ethereum/head/full.json | jq '.header.parentHash, .header.gasUsed, .header.baseFeePerGas, .header.miner'
 ```
 
 ## Blocks
@@ -33,9 +33,9 @@ to slice into transactions / receipts when needed; per-tx detail is
 under `tx/<hash>/`.
 
 ```sh
-ls /eth/chains/ethereum/blocks/19000000/          # full.json
-cat /eth/chains/ethereum/blocks/19000000/full.json
-cat /eth/chains/ethereum/blocks/19000000/full.json | jq '.transactions | length'
+ls /bloom/chains/ethereum/blocks/19000000/          # full.json
+cat /bloom/chains/ethereum/blocks/19000000/full.json
+cat /bloom/chains/ethereum/blocks/19000000/full.json | jq '.transactions | length'
 # Note: there is no "latest" block alias — use head/full.json or look up by number.
 ```
 
@@ -45,9 +45,9 @@ Single JSON leaf with the legacy gas price; EIP-1559 base fee / priority
 fee live inside `head/full.json` (`baseFeePerGas`).
 
 ```sh
-ls /eth/chains/ethereum/gas/                      # current.json
-cat /eth/chains/ethereum/gas/current.json         # {"gas_price_wei": <legacy gasPrice>}
-cat /eth/chains/ethereum/head/full.json | jq '.header.baseFeePerGas'
+ls /bloom/chains/ethereum/gas/                      # current.json
+cat /bloom/chains/ethereum/gas/current.json         # {"gas_price_wei": <legacy gasPrice>}
+cat /bloom/chains/ethereum/head/full.json | jq '.header.baseFeePerGas'
 ```
 
 ## Addresses (core, RPC-only)
@@ -59,15 +59,15 @@ backend is wired (see further below).
 
 ```sh
 # vitalik.eth
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/balance       # wei (decimal)
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/balance.eth   # "1.234567 ETH"
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nonce
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/code          # 0x for EOA
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/is_contract   # true / false
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/balance       # wei (decimal)
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/balance.eth   # "1.234567 ETH"
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nonce
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/code          # 0x for EOA
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/is_contract   # true / false
 
 # A contract (USDC) — same leaves, code is non-empty:
-cat /eth/chains/ethereum/addresses/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/is_contract
-cat /eth/chains/ethereum/addresses/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/code | head -c 32
+cat /bloom/chains/ethereum/addresses/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/is_contract
+cat /bloom/chains/ethereum/addresses/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/code | head -c 32
 
 # storage_root is not a dedicated leaf — pull it from head/full.json or
 # a specific block, or read individual slots via contracts/<addr>/storage/<slot>.
@@ -76,7 +76,7 @@ cat /eth/chains/ethereum/addresses/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/co
 ENS reverse resolution (only when an ENS-capable chain is configured):
 
 ```sh
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/ens   # → vitalik.eth (or "unresolved")
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/ens   # → vitalik.eth (or "unresolved")
 ```
 
 ## Address ERC-20 holdings
@@ -86,20 +86,20 @@ allowance is **not** exposed at this address-scoped path; use
 `contracts/<token>/methods/allowance.read` to read allowances.
 
 ```sh
-ls /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/
+ls /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/
 # → balance, balance.raw, balance.formatted, symbol, decimals
 
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/balance.formatted   # "1234.56 USDC"
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/symbol            # → WETH
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0x6B175474E89094C44Da98b954EedeAC495271d0f/decimals          # → 18
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/balance.formatted   # "1234.56 USDC"
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/symbol            # → WETH
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0x6B175474E89094C44Da98b954EedeAC495271d0f/decimals          # → 18
 
 # Same shape on Base (USDC on Base):
-cat /eth/chains/base/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913/balance.formatted
+cat /bloom/chains/base/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913/balance.formatted
 
 # Allowance: read it via the token's allowance() method.
 echo '{"args":["0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045","0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D"]}' \
-  > /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/allowance.read
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/allowance.read
+  > /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/allowance.read
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/allowance.read
 # requires backends.contract_metadata = "etherscan"
 ```
 
@@ -110,20 +110,20 @@ listed below; `error.json` is exposed at this level and only resolves
 when the receipt's status is `reverted`.
 
 ```sh
-ls /eth/chains/ethereum/tx/0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060/
+ls /bloom/chains/ethereum/tx/0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060/
 # → receipt.json, status, block_number, gas_used, logs.json, full.json, error.json
 
 # First-ever ETH transaction (block 46147, Aug 2015):
-cat /eth/chains/ethereum/tx/0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060/full.json
-cat /eth/chains/ethereum/tx/0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060/status         # success / reverted
-cat /eth/chains/ethereum/tx/0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060/block_number   # 46147
-cat /eth/chains/ethereum/tx/0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060/gas_used
-cat /eth/chains/ethereum/tx/0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060/receipt.json
-cat /eth/chains/ethereum/tx/0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060/logs.json
+cat /bloom/chains/ethereum/tx/0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060/full.json
+cat /bloom/chains/ethereum/tx/0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060/status         # success / reverted
+cat /bloom/chains/ethereum/tx/0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060/block_number   # 46147
+cat /bloom/chains/ethereum/tx/0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060/gas_used
+cat /bloom/chains/ethereum/tx/0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060/receipt.json
+cat /bloom/chains/ethereum/tx/0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060/logs.json
 
 # error.json: only resolves on a reverted tx; tries the tiered revert decoder.
 # The DAO hack tx (June 2016, mainnet) — substitute any reverted hash you have:
-cat /eth/chains/ethereum/tx/0x0ec3f2488a93839524add10ea229e773f6bc891b4eb4794c3337d4495263790b/error.json
+cat /bloom/chains/ethereum/tx/0x0ec3f2488a93839524add10ea229e773f6bc891b4eb4794c3337d4495263790b/error.json
 # Reading error.json on a successful tx returns NotFound ("did not revert").
 # There is no `trace` leaf at this path — the revert decoder uses trace internally.
 ```
@@ -131,13 +131,13 @@ cat /eth/chains/ethereum/tx/0x0ec3f2488a93839524add10ea229e773f6bc891b4eb4794c33
 ## Contracts: source and ABI
 
 ```sh
-ls /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/
+ls /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/
 # With Etherscan: source, abi, methods/, events/, storage/, proxy/, nft/
 # Without Etherscan: storage/, proxy/, nft/
 
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/source   # requires backends.contract_metadata = "etherscan"
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/abi      # requires backends.contract_metadata = "etherscan"
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/abi | jq '.[] | select(.type=="function") | .name'
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/source   # requires backends.contract_metadata = "etherscan"
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/abi      # requires backends.contract_metadata = "etherscan"
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/abi | jq '.[] | select(.type=="function") | .name'
 ```
 
 ## Contracts: methods (`.read`, `.tx`, `.sig`)
@@ -150,41 +150,41 @@ keyed by path; reading without writing first uses the default
 
 ```sh
 # Canonical signature + selector — no body needed:
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/decimals.sig
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/decimals.sig
 # decimals() returns (uint8)
 # selector: 0x313ce567
 
 # requires backends.contract_metadata = "etherscan" (needs the verified ABI)
 
 # A no-arg read (USDC.decimals()):
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/decimals.read
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/decimals.read
 # → {"decoded":[6],"raw":"0x...0006","selector":"0x313ce567"}
 
 # Read with args — USDC.balanceOf(vitalik.eth):
 echo '{"args":["0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045"]}' \
-  > /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/balanceOf.read
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/balanceOf.read
+  > /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/balanceOf.read
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/balanceOf.read
 # → {"decoded":["<wei-as-string>"], "raw":"0x...", "selector":"0x70a08231"}
 
 # Pin a historical block:
 echo '{"args":["0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045"],"block":"19000000"}' \
-  > /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/balanceOf.read
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/balanceOf.read
+  > /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/balanceOf.read
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/balanceOf.read
 
 # Disambiguate overloads via selector:
 echo '{"args":[...], "selector":"0xa9059cbb"}' \
-  > /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/transfer.read
+  > /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/transfer.read
 
 # .tx — returns calldata only, no broadcast (pipe the JSON into the wallet outbox to send):
 echo '{"args":["0x70997970C51812dc3A010C7d01b50e0d17dc79C8","1000000"]}' \
-  > /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/transfer.tx
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/transfer.tx
+  > /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/transfer.tx
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/transfer.tx
 # → {"to":"0xA0b8...eB48","selector":"0xa9059cbb","calldata":"0x..."}
 
 # Simulate as a different sender:
 echo '{"args":[...], "from":"0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045"}' \
-  > /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/balanceOf.read
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/balanceOf.read
+  > /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/balanceOf.read
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/methods/balanceOf.read
 
 # Methods/ does not pre-list names — `ls methods/` is empty; cat by ABI name directly.
 ```
@@ -199,20 +199,20 @@ length). `query` is writable JSON: `{from_block?, to_block?, topics?, where?}`.
 # All three need backends.contract_metadata = "etherscan" (for the ABI).
 
 # Recent USDC Transfer events:
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/events/Transfer/recent
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/events/Transfer/recent
 
 # Custom block range via /query — write JSON, read same leaf:
 echo '{"from_block":"19000000","to_block":"19000100"}' \
-  > /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/events/Transfer/query
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/events/Transfer/query
+  > /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/events/Transfer/query
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/events/Transfer/query
 
 # Filter by indexed param name (`where`) — Transfer(from, to, value):
 echo '{
   "from_block":"19000000",
   "to_block":"19010000",
   "where":{"from":"0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045"}
-}' > /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/events/Transfer/query
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/events/Transfer/query
+}' > /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/events/Transfer/query
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/events/Transfer/query
 
 # Filter by positional topics — topic0 is filled in from the event sig
 # (keccak256("Transfer(address,address,uint256)") = 0xddf252ad...3b3ef);
@@ -222,12 +222,12 @@ cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/ev
 echo '{
   "from_block":"19000000",
   "topics":[null,"0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045"]
-}' > /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/events/Transfer/query
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/events/Transfer/query
+}' > /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/events/Transfer/query
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/events/Transfer/query
 
 # Live tail — each read emits logs since the last cursor and advances it.
 # Cursor is shared per (chain, addr, event) across clients (v1 trade-off).
-tail -f /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/events/Transfer/live
+tail -f /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/events/Transfer/live
 ```
 
 ## Contracts: storage
@@ -238,14 +238,14 @@ RPC-only, no Etherscan needed.
 
 ```sh
 # Slot 0 in decimal — for a typical ERC-20 this is `_balances` mapping root or owner depending on layout:
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/storage/0
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/storage/0
 # → 0x000...<32 bytes>
 
 # Same slot in 0x-hex:
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/storage/0x0
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/storage/0x0
 
 # An EIP-1967 implementation slot read directly via storage/ (the proxy/ subdir is a friendlier API):
-cat /eth/chains/ethereum/contracts/0x00000000219ab540356cBB839Cbe05303d7705Fa/storage/0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc
+cat /bloom/chains/ethereum/contracts/0x00000000219ab540356cBB839Cbe05303d7705Fa/storage/0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc
 ```
 
 ## Contracts: proxy
@@ -255,22 +255,22 @@ If the slot is empty the leaf returns the literal `not a proxy\n`.
 RPC-only.
 
 ```sh
-ls /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/proxy/
+ls /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/proxy/
 # → implementation, admin, beacon
 
 # USDC is a transparent proxy — implementation resolves; admin is the proxy admin:
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/proxy/implementation
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/proxy/admin
-cat /eth/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/proxy/beacon          # → "not a proxy" for non-beacon proxies
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/proxy/implementation
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/proxy/admin
+cat /bloom/chains/ethereum/contracts/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/proxy/beacon          # → "not a proxy" for non-beacon proxies
 
 # WETH is a non-proxy contract:
-cat /eth/chains/ethereum/contracts/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/proxy/implementation  # → not a proxy
+cat /bloom/chains/ethereum/contracts/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/proxy/implementation  # → not a proxy
 
 # AAVE V3 Pool (proxy):
-cat /eth/chains/ethereum/contracts/0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2/proxy/implementation
+cat /bloom/chains/ethereum/contracts/0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2/proxy/implementation
 
 # Lido stETH (proxy):
-cat /eth/chains/ethereum/contracts/0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84/proxy/implementation
+cat /bloom/chains/ethereum/contracts/0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84/proxy/implementation
 ```
 
 ## Address history (Etherscan-backed)
@@ -283,21 +283,21 @@ recent page).
 
 ```sh
 # All four require backends.address_history = "etherscan":
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/txs            # native txs
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/internal_txs   # internal calls
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/erc20_txs      # ERC-20 transfers
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/erc721_txs     # ERC-721 transfers
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/txs            # native txs
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/internal_txs   # internal calls
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/erc20_txs      # ERC-20 transfers
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/erc721_txs     # ERC-721 transfers
 
 # ERC-1155 transfers are not exposed at the address root in v1 — they live under nfts/:
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/erc1155_txs
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/erc721_txs
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/owned.json
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/erc1155_txs
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/erc721_txs
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/owned.json
 
 # Same on Base:
-cat /eth/chains/base/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/erc20_txs
+cat /bloom/chains/base/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/erc20_txs
 
 # Slice with jq:
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/erc20_txs \
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/erc20_txs \
   | jq '.[] | {hash, tokenSymbol, value, from, to}'
 ```
 
@@ -310,12 +310,12 @@ TOKEN=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48   # USDC
 HOLDER=0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045  # vitalik.eth
 SPENDER=0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D # Uniswap V2 Router
 
-cat /eth/chains/ethereum/contracts/$TOKEN/methods/symbol.read | jq '.decoded[0]'
-cat /eth/chains/ethereum/contracts/$TOKEN/methods/decimals.read | jq '.decoded[0]'
+cat /bloom/chains/ethereum/contracts/$TOKEN/methods/symbol.read | jq '.decoded[0]'
+cat /bloom/chains/ethereum/contracts/$TOKEN/methods/decimals.read | jq '.decoded[0]'
 
-echo '{"args":["'$HOLDER'"]}' > /eth/chains/ethereum/contracts/$TOKEN/methods/balanceOf.read
-cat /eth/chains/ethereum/contracts/$TOKEN/methods/balanceOf.read | jq '.decoded[0]'
+echo '{"args":["'$HOLDER'"]}' > /bloom/chains/ethereum/contracts/$TOKEN/methods/balanceOf.read
+cat /bloom/chains/ethereum/contracts/$TOKEN/methods/balanceOf.read | jq '.decoded[0]'
 
-echo '{"args":["'$HOLDER'","'$SPENDER'"]}' > /eth/chains/ethereum/contracts/$TOKEN/methods/allowance.read
-cat /eth/chains/ethereum/contracts/$TOKEN/methods/allowance.read | jq '.decoded[0]'
+echo '{"args":["'$HOLDER'","'$SPENDER'"]}' > /bloom/chains/ethereum/contracts/$TOKEN/methods/allowance.read
+cat /bloom/chains/ethereum/contracts/$TOKEN/methods/allowance.read | jq '.decoded[0]'
 ```

--- a/docs/examples-domain/02-nfts.md
+++ b/docs/examples-domain/02-nfts.md
@@ -1,6 +1,6 @@
 # NFT examples (ERC-721 / ERC-1155)
 
-These examples assume the bloom VFS is mounted at `/eth/`. The NFT
+These examples assume the bloom VFS is mounted at `/bloom/`. The NFT
 surface lives under two trees on every chain:
 
 - `chains/<chain>/contracts/<a>/nft/...` — collection-level views.
@@ -30,16 +30,16 @@ hits Etherscan or an external HTTP fetch is annotated inline.
 
 ```sh
 # BAYC: ERC-165 detection + name + symbol + supply (RPC-only).
-cat /eth/chains/ethereum/contracts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/nft/kind
+cat /bloom/chains/ethereum/contracts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/nft/kind
 # => erc721
 
-cat /eth/chains/ethereum/contracts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/nft/name
+cat /bloom/chains/ethereum/contracts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/nft/name
 # => BoredApeYachtClub
 
-cat /eth/chains/ethereum/contracts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/nft/symbol
+cat /bloom/chains/ethereum/contracts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/nft/symbol
 # => BAYC
 
-cat /eth/chains/ethereum/contracts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/nft/total_supply
+cat /bloom/chains/ethereum/contracts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/nft/total_supply
 # => 10000   (or "unknown" if the contract does not expose totalSupply)
 ```
 
@@ -50,14 +50,14 @@ the literal string `unknown` rather than erroring.
 ERC-1155 collection on the OpenSea Shared Storefront:
 
 ```sh
-cat /eth/chains/ethereum/contracts/0x495f947276749Ce646f68AC8c248420045cb7b5e/nft/kind
+cat /bloom/chains/ethereum/contracts/0x495f947276749Ce646f68AC8c248420045cb7b5e/nft/kind
 # => erc1155
 ```
 
 CryptoPunks — note the caveat:
 
 ```sh
-cat /eth/chains/ethereum/contracts/0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb/nft/kind
+cat /bloom/chains/ethereum/contracts/0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb/nft/kind
 # => erc721 (it does answer ERC-165, but its `transferFrom` is non-standard;
 #    `nft_transfer` will encode the standard ERC-721 selector which the
 #    contract does NOT implement. Use the dedicated CryptoPunks methods
@@ -71,14 +71,14 @@ leaf names are the token id in decimal:
 
 ```sh
 # CryptoPunks #5822 owner.
-cat /eth/chains/ethereum/contracts/0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb/nft/owner_of/5822
+cat /bloom/chains/ethereum/contracts/0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb/nft/owner_of/5822
 
 # Pudgy Penguins #6873 tokenURI (just the URI string, not the metadata).
-cat /eth/chains/ethereum/contracts/0xBd3531dA5CF5857e7CfAA92426877b022e612cf8/nft/token_uri/6873
+cat /bloom/chains/ethereum/contracts/0xBd3531dA5CF5857e7CfAA92426877b022e612cf8/nft/token_uri/6873
 
 # Nouns #1 owner — Nouns DAO holds the auctioneer pattern, the owner is
 # the winning bidder (or the treasury for unsold auctions).
-cat /eth/chains/ethereum/contracts/0x9C8fF314C9Bc7F6e59A9d9225Fb22946427eDC03/nft/owner_of/1
+cat /bloom/chains/ethereum/contracts/0x9C8fF314C9Bc7F6e59A9d9225Fb22946427eDC03/nft/owner_of/1
 ```
 
 For ERC-1155, `owner_of` returns the literal `not applicable` (1155
@@ -92,7 +92,7 @@ marketplace on a given collection:
 
 ```sh
 # Has vitalik.eth approved the OpenSea conduit (example operator) on BAYC?
-cat /eth/chains/ethereum/contracts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/nft/is_approved_for_all/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/0x1E0049783F008A0085193E00003D00cd54003c71
+cat /bloom/chains/ethereum/contracts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/nft/is_approved_for_all/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/0x1E0049783F008A0085193E00003D00cd54003c71
 # => true / false
 ```
 
@@ -105,17 +105,17 @@ These three top-level leaves rely on Etherscan (`backends.address_history`):
 ```sh
 # Vitalik's ERC-721 transfer history.
 # requires backends.address_history = "etherscan"
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/erc721_txs
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/erc721_txs
 
 # Pranksy's ERC-1155 transfer history.
 # requires backends.address_history = "etherscan"
-cat /eth/chains/ethereum/addresses/0xd387a6e4e84a6c86bd90c158c6028a58cc8ac459/nfts/erc1155_txs
+cat /bloom/chains/ethereum/addresses/0xd387a6e4e84a6c86bd90c158c6028a58cc8ac459/nfts/erc1155_txs
 
 # Best-effort holdings: reduces in/out from the ERC-721 history. Carries
 # a "caveat" field flagging that this is not authoritative — out-of-band
 # transfers, missed history, or reorgs will skew the result. Page-capped.
 # requires backends.address_history = "etherscan"
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/owned.json
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/owned.json
 ```
 
 Output schema for `owned.json`:
@@ -143,25 +143,25 @@ the URI over HTTP/IPFS. These are valid for any holder-context path
 
 ```sh
 # The actual on-chain owner.
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/1/owner
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/1/owner
 
 # Token URI (just the URI).
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/1/uri
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/1/uri
 
 # Pretty-printed metadata. Fetches the URI over HTTP / IPFS / data:.
 # Caps: 1 MiB body, 5s total timeout. ipfs:// is rewritten to
 # https://ipfs.io/ipfs/<cid>. data: URIs are decoded inline (base64
 # or URL-encoded JSON).
 # external HTTP fetch
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/1/metadata.json
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/1/metadata.json
 
 # `balance` is always 0 or 1 for ERC-721; `is_owner` is the boolean form.
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/1/balance
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/1/is_owner
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/1/balance
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/1/is_owner
 
 # Per-token approved operator (ERC-721 only). For ERC-1155 this leaf
 # returns the literal "not applicable".
-cat /eth/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/1/approved
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nfts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/1/approved
 ```
 
 ### ERC-1155 example: OpenSea Shared Storefront, large hex id
@@ -176,15 +176,15 @@ ERC-1155 metadata spec.
 ```sh
 # Token id 0x000000000000000000000000000000000000000000000000000000000000000a
 # is decimal 10. URI for token id 10 on OpenSea Shared Storefront:
-cat /eth/chains/ethereum/addresses/0xd387a6e4e84a6c86bd90c158c6028a58cc8ac459/nfts/0x495f947276749Ce646f68AC8c248420045cb7b5e/10/uri
+cat /bloom/chains/ethereum/addresses/0xd387a6e4e84a6c86bd90c158c6028a58cc8ac459/nfts/0x495f947276749Ce646f68AC8c248420045cb7b5e/10/uri
 
 # Pranksy's balance of that id.
-cat /eth/chains/ethereum/addresses/0xd387a6e4e84a6c86bd90c158c6028a58cc8ac459/nfts/0x495f947276749Ce646f68AC8c248420045cb7b5e/10/balance
+cat /bloom/chains/ethereum/addresses/0xd387a6e4e84a6c86bd90c158c6028a58cc8ac459/nfts/0x495f947276749Ce646f68AC8c248420045cb7b5e/10/balance
 
 # Metadata: if the contract's URI is "https://api.opensea.io/api/v1/metadata/0x495f.../{id}",
 # bloom fetches "https://api.opensea.io/api/v1/metadata/0x495f.../000...000000000a".
 # external HTTP fetch
-cat /eth/chains/ethereum/addresses/0xd387a6e4e84a6c86bd90c158c6028a58cc8ac459/nfts/0x495f947276749Ce646f68AC8c248420045cb7b5e/10/metadata.json
+cat /bloom/chains/ethereum/addresses/0xd387a6e4e84a6c86bd90c158c6028a58cc8ac459/nfts/0x495f947276749Ce646f68AC8c248420045cb7b5e/10/metadata.json
 ```
 
 ### Base mainnet — same shape
@@ -192,7 +192,7 @@ cat /eth/chains/ethereum/addresses/0xd387a6e4e84a6c86bd90c158c6028a58cc8ac459/nf
 ```sh
 # An ERC-721 collection on Base. Same per-token leaves apply; only the
 # chain segment changes.
-cat /eth/chains/base/contracts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/nft/kind
+cat /bloom/chains/base/contracts/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/nft/kind
 ```
 
 ---
@@ -224,7 +224,7 @@ echo '{
   "contract": "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
   "to":       "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
   "token_id": "1"
-}' > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+}' > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 ```
 
 Legacy unsafe transfer (skips `onERC721Received` callback):
@@ -236,7 +236,7 @@ echo '{
   "to":       "vitalik.eth",
   "token_id": "1234",
   "safe":     false
-}' > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+}' > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 ```
 
 ### `nft_transfer` — ERC-721, shell shorthand
@@ -247,11 +247,11 @@ The shell parser accepts `nft transfer <contract> <token_id> to <addr>
 ```sh
 # Same as the JSON BAYC #1 transfer above.
 echo 'nft transfer 0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D 1 to 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 on ethereum' \
-  > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+  > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 
 # Pudgy Penguins #6873 to vitalik.eth.
 echo 'nft transfer 0xBd3531dA5CF5857e7CfAA92426877b022e612cf8 6873 to vitalik.eth on ethereum' \
-  > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+  > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 ```
 
 ### `nft_transfer` — ERC-1155 with amount and optional data
@@ -270,7 +270,7 @@ echo '{
   "token_id": "10",
   "standard": "erc1155",
   "amount":   "3"
-}' > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+}' > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 
 # Same with optional `data` payload (forwarded to onERC1155Received).
 echo '{
@@ -281,7 +281,7 @@ echo '{
   "standard": "erc1155",
   "amount":   "1",
   "data":     "0xdeadbeef"
-}' > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+}' > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 ```
 
 Shell shorthand for ERC-1155 (the `amount <n>` clause flips the
@@ -289,7 +289,7 @@ standard hint to erc1155, so no JSON is needed):
 
 ```sh
 echo 'nft transfer 0x495f947276749Ce646f68AC8c248420045cb7b5e 10 amount 3 to 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 on ethereum' \
-  > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+  > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 ```
 
 ### `nft_approve` — ERC-721 per-token
@@ -309,11 +309,11 @@ echo '{
   "contract": "0x8a90CAb2b38dba80c64b7734e58Ee1dB38B8992e",
   "operator": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
   "token_id": "1234"
-}' > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+}' > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 
 # Equivalent shell shorthand:
 echo 'nft approve 0x8a90CAb2b38dba80c64b7734e58Ee1dB38B8992e 1234 to 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 on ethereum' \
-  > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+  > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 
 # Revoke: pass the zero address as operator.
 echo '{
@@ -321,7 +321,7 @@ echo '{
   "contract": "0x8a90CAb2b38dba80c64b7734e58Ee1dB38B8992e",
   "operator": "0x0000000000000000000000000000000000000000",
   "token_id": "1234"
-}' > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+}' > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 ```
 
 Rejection example — the OpenSea Shared Storefront is ERC-1155, so a
@@ -333,12 +333,12 @@ echo '{
   "contract": "0x495f947276749Ce646f68AC8c248420045cb7b5e",
   "operator": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
   "token_id": "10"
-}' > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+}' > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 
 # Inspect the failure: the failed/ slot will hold the rejected intent
 # with the engine error. Nothing lands in pending/.
-ls /eth/wallets/alice/chains/ethereum/outbox/failed/
-cat /eth/wallets/alice/chains/ethereum/outbox/failed/0001-*/error
+ls /bloom/wallets/alice/chains/ethereum/outbox/failed/
+cat /bloom/wallets/alice/chains/ethereum/outbox/failed/0001-*/error
 # => ERC-1155 has no per-token approval; use nft_approve_all
 ```
 
@@ -362,12 +362,12 @@ echo '{
   "contract": "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
   "operator": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
   "approved": true
-}' > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+}' > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 
 # Shell shorthand (note: verb is `set_approval_for_all`, with operator
 # before the boolean):
 echo 'nft set_approval_for_all 0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 true on ethereum' \
-  > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+  > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 
 # Revoke a previously-granted operator-wide approval (no WARN).
 echo '{
@@ -375,7 +375,7 @@ echo '{
   "contract": "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
   "operator": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
   "approved": false
-}' > /eth/wallets/alice/chains/ethereum/outbox/new.tx
+}' > /bloom/wallets/alice/chains/ethereum/outbox/new.tx
 ```
 
 ### Inspect the plan, then confirm
@@ -386,16 +386,16 @@ counterparty, token id, ERC-1155 amount when set, and any policy
 checks (including the `nft.approve_all` WARN):
 
 ```sh
-ls /eth/wallets/alice/chains/ethereum/outbox/pending/
+ls /bloom/wallets/alice/chains/ethereum/outbox/pending/
 # 0001-7f3c.../
 
-cat /eth/wallets/alice/chains/ethereum/outbox/pending/0001-*/plan.md
+cat /bloom/wallets/alice/chains/ethereum/outbox/pending/0001-*/plan.md
 
 # Confirm.
-echo y > /eth/wallets/alice/chains/ethereum/outbox/pending/0001-*/confirm
+echo y > /bloom/wallets/alice/chains/ethereum/outbox/pending/0001-*/confirm
 
 # Receipt lands under sent/.
-ls /eth/wallets/alice/chains/ethereum/outbox/sent/
+ls /bloom/wallets/alice/chains/ethereum/outbox/sent/
 ```
 
 If a policy WARN surfaced a write-override requirement, the daemon

--- a/docs/examples-domain/03-wallets-simulate-watch.md
+++ b/docs/examples-domain/03-wallets-simulate-watch.md
@@ -1,6 +1,6 @@
 # Wallets, Simulate, Watch
 
-Cheatsheet for the three write-heavy surfaces of the `/eth/` VFS.
+Cheatsheet for the three write-heavy surfaces of the `/bloom/` VFS.
 Every command below is a plain `cat`, `ls`, `echo > path`, or `tail -f`
 against the mounted filesystem. Mainnet broadcasts are gated by
 `block_mainnet_broadcast = true` in `config.toml` (the kill-switch);
@@ -12,7 +12,7 @@ runnable flows here use `anvil` or `base` so they are safe by default.
 ### List, create, import, watch
 
 ```sh
-ls /eth/wallets/
+ls /bloom/wallets/
 ```
 
 `new` is a writable file. The body can be plain text (a wallet name)
@@ -20,17 +20,17 @@ or a TOML spec.
 
 ```sh
 # Shorthand: plain name = create a local wallet called 'alice'.
-echo alice > /eth/wallets/new
+echo alice > /bloom/wallets/new
 
 # Full TOML form for a fresh local wallet.
-cat <<'EOF' > /eth/wallets/new
+cat <<'EOF' > /bloom/wallets/new
 name = "alice"
 kind = "local"
 passphrase = "devonly"
 EOF
 
 # Import an existing private key (BLOOM_PASSPHRASE applies if 'passphrase' is omitted).
-cat <<'EOF' > /eth/wallets/new
+cat <<'EOF' > /bloom/wallets/new
 name = "imported"
 kind = "import"
 private_key = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
@@ -38,7 +38,7 @@ passphrase = "devonly"
 EOF
 
 # Watch-only (no private key, signing is disabled).
-cat <<'EOF' > /eth/wallets/new
+cat <<'EOF' > /bloom/wallets/new
 name = "vitalik"
 kind = "watch"
 address = "0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045"
@@ -56,16 +56,16 @@ runnable examples assume.
 ### Per-wallet leaves
 
 ```sh
-cat /eth/wallets/alice/address          # 0x... (EIP-55 checksum)
-cat /eth/wallets/alice/public_key       # 0x04... uncompressed secp256k1
-cat /eth/wallets/alice/kind             # local | watch
-cat /eth/wallets/alice/policy.toml      # current policy
+cat /bloom/wallets/alice/address          # 0x... (EIP-55 checksum)
+cat /bloom/wallets/alice/public_key       # 0x04... uncompressed secp256k1
+cat /bloom/wallets/alice/kind             # local | watch
+cat /bloom/wallets/alice/policy.toml      # current policy
 
 # Per-chain native balance + nonce.
-cat /eth/wallets/alice/chains/base/balance       # raw wei
-cat /eth/wallets/alice/chains/base/balance.eth   # human "0.123 ETH"
-cat /eth/wallets/alice/chains/base/balance.raw   # same as balance
-cat /eth/wallets/alice/chains/base/nonce
+cat /bloom/wallets/alice/chains/base/balance       # raw wei
+cat /bloom/wallets/alice/chains/base/balance.eth   # human "0.123 ETH"
+cat /bloom/wallets/alice/chains/base/balance.raw   # same as balance
+cat /bloom/wallets/alice/chains/base/nonce
 ```
 
 `policy.toml` is read-only via this surface — edit `~/.bloom/keystore/<wallet>/policy.toml`
@@ -77,8 +77,8 @@ chain-rooted reader at
 For example, alice's USDC balance on Base:
 
 ```sh
-ALICE=$(cat /eth/wallets/alice/address)
-cat /eth/chains/base/addresses/$ALICE/tokens/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913/balance.formatted
+ALICE=$(cat /bloom/wallets/alice/address)
+cat /bloom/chains/base/addresses/$ALICE/tokens/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913/balance.formatted
 ```
 
 ### Signing
@@ -88,17 +88,17 @@ All three sign endpoints write the resulting hex signature to a
 
 ```sh
 # EIP-191 personal_sign over a UTF-8 message.
-echo -n 'gm bloom' > /eth/wallets/alice/sign/message
+echo -n 'gm bloom' > /bloom/wallets/alice/sign/message
 cat ~/.bloom/keystore/alice/sign/message.sig
 
 # Raw 32-byte hash (must be 0x-hex, exactly 32 bytes).
 echo -n '0x1c8aff950685c2ed4bc3174f3472287b56d9517b9c948127319a09a7a36deac8' \
-  > /eth/wallets/alice/sign/hash
+  > /bloom/wallets/alice/sign/hash
 cat ~/.bloom/keystore/alice/sign/hash.sig
 
 # EIP-712 typed data — body is the standard RPC JSON shape. Example:
 # an EIP-2612 permit for USDC on mainnet (chainId 1).
-cat <<'EOF' > /eth/wallets/alice/sign/typed_data
+cat <<'EOF' > /bloom/wallets/alice/sign/typed_data
 {
   "types": {
     "EIP712Domain": [
@@ -153,10 +153,10 @@ JSON, or TOML.
 ```sh
 # Native send, shell shorthand.
 echo 'send 0.01 eth to 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 on anvil' \
-  > /eth/wallets/alice/chains/anvil/outbox/new.tx
+  > /bloom/wallets/alice/chains/anvil/outbox/new.tx
 
 # Native send, JSON.
-cat <<'EOF' > /eth/wallets/alice/chains/anvil/outbox/new.tx
+cat <<'EOF' > /bloom/wallets/alice/chains/anvil/outbox/new.tx
 {
   "kind": "send",
   "to": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
@@ -168,7 +168,7 @@ EOF
 # ERC-20 transfer, JSON. Token + value with a unit triggers ERC-20 encoding.
 # The engine resolves the token, encodes transfer(address,uint256),
 # and renders the plan as a token transfer (TokenRef in plan.md).
-cat <<'EOF' > /eth/wallets/alice/chains/base/outbox/new.tx
+cat <<'EOF' > /bloom/wallets/alice/chains/base/outbox/new.tx
 {
   "kind": "send",
   "to": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
@@ -180,7 +180,7 @@ EOF
 
 # Generic call against an arbitrary contract via ABI signature + args.
 # Example: WETH deposit() with 0.05 ETH attached on Base.
-cat <<'EOF' > /eth/wallets/alice/chains/base/outbox/new.tx
+cat <<'EOF' > /bloom/wallets/alice/chains/base/outbox/new.tx
 {
   "kind": "call",
   "contract": "0x4200000000000000000000000000000000000006",
@@ -200,12 +200,12 @@ error — nothing lands in `pending/`.
 ### Review
 
 ```sh
-ls /eth/wallets/alice/chains/anvil/outbox/pending/
+ls /bloom/wallets/alice/chains/anvil/outbox/pending/
 # 0001-21699/
 
-ID=$(ls /eth/wallets/alice/chains/anvil/outbox/pending/ | head -n1)
+ID=$(ls /bloom/wallets/alice/chains/anvil/outbox/pending/ | head -n1)
 
-cat /eth/wallets/alice/chains/anvil/outbox/pending/$ID/plan.md
+cat /bloom/wallets/alice/chains/anvil/outbox/pending/$ID/plan.md
 ```
 
 `plan.md` is rendered from the `StagedTx` and looks like:
@@ -237,8 +237,8 @@ slot renders `transfer ERC-721 …` / `transfer ERC-1155 …`.
 ```sh
 # The full StagedTx JSON. (Note: the on-disk file is intent.json — there
 # is no separate tx.json; the staged record carries every field.)
-cat /eth/wallets/alice/chains/anvil/outbox/pending/$ID/intent.json
-cat /eth/wallets/alice/chains/anvil/outbox/pending/$ID/policy_check.json
+cat /bloom/wallets/alice/chains/anvil/outbox/pending/$ID/intent.json
+cat /bloom/wallets/alice/chains/anvil/outbox/pending/$ID/policy_check.json
 ```
 
 ### Confirm (broadcast)
@@ -249,11 +249,11 @@ The wallet must be unlocked. Empty bodies are rejected.
 
 ```sh
 # Plain confirm.
-echo y > /eth/wallets/alice/chains/anvil/outbox/pending/$ID/confirm
+echo y > /bloom/wallets/alice/chains/anvil/outbox/pending/$ID/confirm
 
 # Override token to bypass soft-policy warnings (Warn outcome only;
 # Deny is never overridable).
-echo override > /eth/wallets/alice/chains/anvil/outbox/pending/$ID/confirm
+echo override > /bloom/wallets/alice/chains/anvil/outbox/pending/$ID/confirm
 ```
 
 After a successful broadcast the daemon moves the directory to
@@ -261,15 +261,15 @@ After a successful broadcast the daemon moves the directory to
 artefacts:
 
 ```sh
-ls /eth/wallets/alice/chains/anvil/outbox/sent/$ID/
+ls /bloom/wallets/alice/chains/anvil/outbox/sent/$ID/
 # intent.json   plan.md   policy_check.json   tx_hash
 
-cat /eth/wallets/alice/chains/anvil/outbox/sent/$ID/tx_hash
+cat /bloom/wallets/alice/chains/anvil/outbox/sent/$ID/tx_hash
 # 0xabc...
 
 # The receipt itself is exposed under the chain reader, keyed by hash:
-HASH=$(cat /eth/wallets/alice/chains/anvil/outbox/sent/$ID/tx_hash)
-cat /eth/chains/anvil/tx/$HASH/receipt
+HASH=$(cat /bloom/wallets/alice/chains/anvil/outbox/sent/$ID/tx_hash)
+cat /bloom/chains/anvil/tx/$HASH/receipt
 ```
 
 Note: there is no `receipt.json` written by the outbox. The status of
@@ -286,13 +286,13 @@ non-empty body and require the wallet to be unlocked.
 # Replace: bumped fees plus a substituted intent body. Same nonce, the
 # original record stays in place; the engine writes replacement_intent.json
 # and replacement_tx_hash alongside.
-cat <<'EOF' > /eth/wallets/alice/chains/anvil/outbox/pending/$ID/replace
+cat <<'EOF' > /bloom/wallets/alice/chains/anvil/outbox/pending/$ID/replace
 send 0.02 eth to 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 on anvil
 EOF
 
 # Cancel: fires a self-send replacement at the same nonce with a >=10%
 # fee bump. Body is any non-empty token, conventionally 'y'.
-echo y > /eth/wallets/alice/chains/anvil/outbox/pending/$ID/cancel
+echo y > /bloom/wallets/alice/chains/anvil/outbox/pending/$ID/cancel
 ```
 
 ### Mainnet broadcast
@@ -310,11 +310,11 @@ Sessions are in-memory. Lifetime is the daemon process.
 ### Create a session
 
 ```sh
-ls /eth/simulate/
+ls /bloom/simulate/
 # new   last
 
 # Native send simulation (no signing, no broadcast).
-cat <<'EOF' > /eth/simulate/new
+cat <<'EOF' > /bloom/simulate/new
 {
   "kind": "send",
   "from": "0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045",
@@ -324,8 +324,8 @@ cat <<'EOF' > /eth/simulate/new
 }
 EOF
 
-ID=$(cat /eth/simulate/last)   # sim-0001
-ls /eth/simulate/$ID/
+ID=$(cat /bloom/simulate/last)   # sim-0001
+ls /bloom/simulate/$ID/
 # intent.json   plan.md   simulation.json   state-override.json   trace.json
 ```
 
@@ -336,10 +336,10 @@ ignores it.
 ### Read results
 
 ```sh
-cat /eth/simulate/$ID/simulation.json   # SimResult: success, gas_used, return_data_hex, ...
-cat /eth/simulate/$ID/plan.md           # short markdown summary
-cat /eth/simulate/$ID/trace.json        # debug_traceCall, or {"unsupported": "..."}
-cat /eth/simulate/$ID/intent.json
+cat /bloom/simulate/$ID/simulation.json   # SimResult: success, gas_used, return_data_hex, ...
+cat /bloom/simulate/$ID/plan.md           # short markdown summary
+cat /bloom/simulate/$ID/trace.json        # debug_traceCall, or {"unsupported": "..."}
+cat /bloom/simulate/$ID/intent.json
 ```
 
 ### State overrides
@@ -353,7 +353,7 @@ synchronously against the original intent. The shape is the standard
 # Force USDC balance for vitalik.eth to 1,000,000.000000 (1e12 raw).
 # USDC stores balances in slot 9; storage keys are the keccak256 of
 # (address || slot) padded.
-cat <<'EOF' > /eth/simulate/$ID/state-override.json
+cat <<'EOF' > /bloom/simulate/$ID/state-override.json
 {
   "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": {
     "stateDiff": {
@@ -364,19 +364,19 @@ cat <<'EOF' > /eth/simulate/$ID/state-override.json
 EOF
 
 # Re-read the result.
-cat /eth/simulate/$ID/simulation.json
+cat /bloom/simulate/$ID/simulation.json
 ```
 
 A simpler override — zero out a sender's native balance to test that
 your transfer reverts with insufficient funds — is the canonical demo:
 
 ```sh
-cat <<'EOF' > /eth/simulate/$ID/state-override.json
+cat <<'EOF' > /bloom/simulate/$ID/state-override.json
 {
   "0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045": { "balance": "0x0" }
 }
 EOF
-cat /eth/simulate/$ID/simulation.json
+cat /bloom/simulate/$ID/simulation.json
 # {"success": false, "revert_reason": "insufficient funds ...", ...}
 ```
 
@@ -387,7 +387,7 @@ no separate `eth_call/<to>/<calldata>` path. Stage a `call` intent with
 the calldata you want, attach overrides, and read `simulation.json`:
 
 ```sh
-cat <<'EOF' > /eth/simulate/new
+cat <<'EOF' > /bloom/simulate/new
 {
   "kind": "call",
   "contract": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
@@ -403,8 +403,8 @@ cat <<'EOF' > /eth/simulate/new
   }
 }
 EOF
-ID=$(cat /eth/simulate/last)
-cat /eth/simulate/$ID/simulation.json   # return_data_hex carries the balance
+ID=$(cat /bloom/simulate/last)
+cat /bloom/simulate/$ID/simulation.json   # return_data_hex carries the balance
 ```
 
 NFT intents are not simulated through `/simulate` — they go through
@@ -431,11 +431,11 @@ a consumer's point of view the live / history files look identical.
 ### Subscribe (one example per kind)
 
 ```sh
-ls /eth/watch/
+ls /bloom/watch/
 # new
 
 # 1. Balance watch on vitalik.eth.
-cat <<'EOF' > /eth/watch/new
+cat <<'EOF' > /bloom/watch/new
 kind = "balance"
 wallet = "alice"
 address = "0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045"
@@ -445,14 +445,14 @@ note = "any balance change"
 EOF
 
 # 2. Block watch.
-cat <<'EOF' > /eth/watch/new
+cat <<'EOF' > /bloom/watch/new
 kind = "block"
 wallet = "alice"
 chain = "base"
 EOF
 
 # 3. Gas-price watch (fires when below 25 gwei).
-cat <<'EOF' > /eth/watch/new
+cat <<'EOF' > /bloom/watch/new
 kind = "gas_price"
 wallet = "alice"
 chain = "ethereum"
@@ -461,7 +461,7 @@ EOF
 
 # 4. Event watch — WETH Transfer on mainnet.
 # topic0 = keccak256("Transfer(address,address,uint256)")
-cat <<'EOF' > /eth/watch/new
+cat <<'EOF' > /bloom/watch/new
 kind = "event"
 wallet = "alice"
 chain = "ethereum"
@@ -473,7 +473,7 @@ EOF
 Listing then shows the allocated ids:
 
 ```sh
-ls /eth/watch/
+ls /bloom/watch/
 # new   w-0001   w-0002   w-0003   w-0004
 ```
 
@@ -481,14 +481,14 @@ ls /eth/watch/
 
 ```sh
 # Stream live JSONL as records are appended.
-tail -f /eth/watch/w-0001/live
+tail -f /bloom/watch/w-0001/live
 
 # Most-recent rotated archive (when live overflowed 1 MiB).
-cat /eth/watch/w-0001/history.jsonl
+cat /bloom/watch/w-0001/history.jsonl
 
 # Older archives are numbered.
-cat /eth/watch/w-0001/history.jsonl.1
-ls /eth/watch/w-0001/
+cat /bloom/watch/w-0001/history.jsonl.1
+ls /bloom/watch/w-0001/
 # spec.toml   live   history.jsonl   history.jsonl.1   delete
 ```
 
@@ -498,7 +498,7 @@ The spec is round-trippable as TOML at `spec.toml`. The id, wallet,
 created-time millis, kind, and optional note all live on the spec:
 
 ```sh
-cat /eth/watch/w-0001/spec.toml
+cat /bloom/watch/w-0001/spec.toml
 # id = "w-0001"
 # wallet = "alice"
 # created_ms = "1731177900000"
@@ -520,7 +520,7 @@ each `live` / `history` record.
 ### Delete
 
 ```sh
-echo y > /eth/watch/w-0001/delete
+echo y > /bloom/watch/w-0001/delete
 ```
 
 Removes the spec from the registry and the per-watch directory.

--- a/docs/examples-domain/04-tools-ens-prices-addressbook.md
+++ b/docs/examples-domain/04-tools-ens-prices-addressbook.md
@@ -1,6 +1,6 @@
 # Tools, ENS, Prices, Addressbook
 
-VFS is mounted at `/eth/`. All paths below are relative to that mount.
+VFS is mounted at `/bloom/`. All paths below are relative to that mount.
 
 ## Tools
 
@@ -12,7 +12,7 @@ Sessions auto-expire after 5 minutes of idle.
 ### keccak
 
 ```sh
-cat /eth/tools/keccak/hello%20world
+cat /bloom/tools/keccak/hello%20world
 # 0x47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad
 ```
 
@@ -24,17 +24,17 @@ back with `/` (so `keccak/a/b` hashes the literal string `a/b`).
 4-byte function selector (the first 4 bytes of `keccak(sig)`).
 
 ```sh
-cat /eth/tools/selector/transfer(address,uint256)
+cat /bloom/tools/selector/transfer(address,uint256)
 # 0xa9059cbb
 
-cat /eth/tools/selector/approve(address,uint256)
+cat /bloom/tools/selector/approve(address,uint256)
 # 0x095ea7b3
 ```
 
 Note the full event-topic form is just `keccak`:
 
 ```sh
-cat /eth/tools/keccak/Transfer(address,address,uint256)
+cat /bloom/tools/keccak/Transfer(address,address,uint256)
 # 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef
 ```
 
@@ -43,28 +43,28 @@ cat /eth/tools/keccak/Transfer(address,address,uint256)
 EIP-55 checksum a lowercase or any-case address.
 
 ```sh
-cat /eth/tools/address/checksum/0xd8da6bf26964af9d7eed9e03e53415d37aa96045
+cat /bloom/tools/address/checksum/0xd8da6bf26964af9d7eed9e03e53415d37aa96045
 # 0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045
 ```
 
 ### sha256, blake3
 
 ```sh
-cat /eth/tools/sha256/hello%20world
-cat /eth/tools/blake3/hello%20world
+cat /bloom/tools/sha256/hello%20world
+cat /bloom/tools/blake3/hello%20world
 ```
 
 ### hex / base64
 
 ```sh
-cat /eth/tools/hex/encode/hello
+cat /bloom/tools/hex/encode/hello
 # 0x68656c6c6f
-cat /eth/tools/hex/decode/0x68656c6c6f
+cat /bloom/tools/hex/decode/0x68656c6c6f
 # hello
 
-cat /eth/tools/base64/encode/hello
+cat /bloom/tools/base64/encode/hello
 # aGVsbG8=
-cat /eth/tools/base64/decode/aGVsbG8=
+cat /bloom/tools/base64/decode/aGVsbG8=
 # hello
 ```
 
@@ -76,13 +76,13 @@ cat /eth/tools/base64/decode/aGVsbG8=
 takes a u256 and a decimals count and produces a human-readable scalar.
 
 ```sh
-cat /eth/tools/unit/parse/1.5/eth
+cat /bloom/tools/unit/parse/1.5/eth
 # 1500000000000000000
 
-cat /eth/tools/unit/parse/25/gwei
+cat /bloom/tools/unit/parse/25/gwei
 # 25000000000
 
-cat /eth/tools/unit/format/1500000000000000000/18
+cat /bloom/tools/unit/format/1500000000000000000/18
 # 1.5
 ```
 
@@ -92,29 +92,29 @@ Write the input JSON to `in.json` under any session id, then read the result.
 
 ```sh
 echo '{"sig":"transfer(address,uint256)","args":["0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045","1000000"]}' \
-  > /eth/tools/abi/encode/s1/in.json
-cat /eth/tools/abi/encode/s1/out.hex
+  > /bloom/tools/abi/encode/s1/in.json
+cat /bloom/tools/abi/encode/s1/out.hex
 # 0xa9059cbb000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa960450000000000000000000000000000000000000000000000000000000000000f4240
 ```
 
 ```sh
 echo '{"types":["address","uint256"],"data":"0x000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa960450000000000000000000000000000000000000000000000000000000000000f4240"}' \
-  > /eth/tools/abi/decode/s1/in.json
-cat /eth/tools/abi/decode/s1/out.json
+  > /bloom/tools/abi/decode/s1/in.json
+cat /bloom/tools/abi/decode/s1/out.json
 ```
 
-`ls /eth/tools/abi/encode/` lists live session ids; `ls /eth/tools/abi/encode/s1/`
+`ls /bloom/tools/abi/encode/` lists live session ids; `ls /bloom/tools/abi/encode/s1/`
 shows `in.json` and `out.hex`.
 
 ### rlp (encode / decode) — session
 
 ```sh
-echo '{"value":["0x83","0xff",["0x01"]]}' > /eth/tools/rlp/encode/r1/in.json
-cat /eth/tools/rlp/encode/r1/out.hex
+echo '{"value":["0x83","0xff",["0x01"]]}' > /bloom/tools/rlp/encode/r1/in.json
+cat /bloom/tools/rlp/encode/r1/out.hex
 # 0xc6818381ffc101
 
-echo '{"data":"0xc6818381ffc101"}' > /eth/tools/rlp/decode/r1/in.json
-cat /eth/tools/rlp/decode/r1/out.json
+echo '{"data":"0xc6818381ffc101"}' > /bloom/tools/rlp/decode/r1/in.json
+cat /bloom/tools/rlp/decode/r1/out.json
 ```
 
 ### eip712/hash — session
@@ -139,8 +139,8 @@ cat > /tmp/mail.json <<'JSON'
   }
 }
 JSON
-cp /tmp/mail.json /eth/tools/eip712/hash/m1/in.json
-cat /eth/tools/eip712/hash/m1/out.hex
+cp /tmp/mail.json /bloom/tools/eip712/hash/m1/in.json
+cat /bloom/tools/eip712/hash/m1/out.hex
 # 0x25c3d40a39e639a4d0b6e4d2ace5e1281e039c88494d97d8d08f99a6ea75d775
 ```
 
@@ -148,13 +148,13 @@ cat /eth/tools/eip712/hash/m1/out.hex
 
 The `ens/` surface is forward-only and read-only. Reverse resolution is not
 mounted here — it lives at `chains/<chain>/addresses/<addr>/ens` (per spec
-§3.2). Listing `/eth/ens/` returns names looked up in this session only;
+§3.2). Listing `/bloom/ens/` returns names looked up in this session only;
 agents can `cat` any `*.eth` name without listing it first.
 
 ### Forward (resolve to address)
 
 ```sh
-cat /eth/ens/vitalik.eth/address
+cat /bloom/ens/vitalik.eth/address
 # 0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045
 ```
 
@@ -165,7 +165,7 @@ Unresolved names return the literal string `unresolved`.
 Routed through the chain handler:
 
 ```sh
-cat /eth/chains/mainnet/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/ens
+cat /bloom/chains/mainnet/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/ens
 ```
 
 ### Text records
@@ -173,17 +173,17 @@ cat /eth/chains/mainnet/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/ens
 Any text key is accepted; unset keys return `not set`.
 
 ```sh
-cat /eth/ens/vitalik.eth/text/url
-cat /eth/ens/vitalik.eth/text/com.twitter
-cat /eth/ens/brantly.eth/text/email
+cat /bloom/ens/vitalik.eth/text/url
+cat /bloom/ens/vitalik.eth/text/com.twitter
+cat /bloom/ens/brantly.eth/text/email
 ```
 
 `avatar` is exposed both as a top-level file (a shortcut for the `avatar` text
 record) and via the `text/` directory:
 
 ```sh
-cat /eth/ens/vitalik.eth/avatar
-# (same as) cat /eth/ens/vitalik.eth/text/avatar
+cat /bloom/ens/vitalik.eth/avatar
+# (same as) cat /bloom/ens/vitalik.eth/text/avatar
 ```
 
 ### Contenthash
@@ -191,13 +191,13 @@ cat /eth/ens/vitalik.eth/avatar
 EIP-1577 contenthash, returned as `0x`-prefixed hex (no codec decoding).
 
 ```sh
-cat /eth/ens/ens.eth/content_hash
+cat /bloom/ens/ens.eth/content_hash
 ```
 
 ### Listing a name's surface
 
 ```sh
-ls /eth/ens/vitalik.eth/
+ls /bloom/ens/vitalik.eth/
 # address  avatar  content_hash  text
 ```
 
@@ -223,11 +223,11 @@ Coin segment forms:
 scalar price as text.
 
 ```sh
-cat /eth/prices/spot/eth.usd
-cat /eth/prices/spot/btc.usd
-cat /eth/prices/spot/usdc.usd
+cat /bloom/prices/spot/eth.usd
+cat /bloom/prices/spot/btc.usd
+cat /bloom/prices/spot/usdc.usd
 
-cat /eth/prices/spot/eth
+cat /bloom/prices/spot/eth
 # {"price": ..., "symbol": "ETH", "decimals": 18, "timestamp": ..., "confidence": ...}
 ```
 
@@ -237,8 +237,8 @@ cat /eth/prices/spot/eth
 variant on this path.
 
 ```sh
-cat /eth/prices/change_24h/eth
-cat /eth/prices/change_24h/usdc
+cat /bloom/prices/change_24h/eth
+cat /bloom/prices/change_24h/usdc
 ```
 
 ## Addressbook
@@ -249,10 +249,10 @@ the EIP-55 checksum address with a trailing newline. Writes register or delete.
 ### List & read
 
 ```sh
-ls /eth/addressbook/
+ls /bloom/addressbook/
 # new  vitalik  weth  usdc
 
-cat /eth/addressbook/vitalik
+cat /bloom/addressbook/vitalik
 # 0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045
 ```
 
@@ -265,12 +265,12 @@ Either write the address directly to the alias file, or post `alias=0x…` to
 `new`:
 
 ```sh
-echo "0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045" > /eth/addressbook/vitalik
-echo "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" > /eth/addressbook/weth
-echo "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" > /eth/addressbook/usdc
+echo "0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045" > /bloom/addressbook/vitalik
+echo "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" > /bloom/addressbook/weth
+echo "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" > /bloom/addressbook/usdc
 
 # Alternative form via the `new` endpoint:
-echo "vitalik=0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045" > /eth/addressbook/new
+echo "vitalik=0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045" > /bloom/addressbook/new
 ```
 
 The address is checksum-normalised on write.
@@ -280,7 +280,7 @@ The address is checksum-normalised on write.
 Write `delete` (case-insensitive) or an empty body to the alias file:
 
 ```sh
-echo "delete" > /eth/addressbook/vitalik
+echo "delete" > /bloom/addressbook/vitalik
 # or
-: > /eth/addressbook/vitalik
+: > /bloom/addressbook/vitalik
 ```

--- a/docs/examples-domain/05-defi.md
+++ b/docs/examples-domain/05-defi.md
@@ -2,7 +2,7 @@
 
 The `defi/intents/<wallet>/` surface is an "intent compiler" that turns a natural-language or JSON DeFi request into one or more concrete `RawIntent`s using the Enso Shortcuts API, and then forwards them — on confirm — into the same wallet outbox the rest of bloom uses. The full lifecycle is: write an intent under `defi/intents/<wallet>/new` to open a session; review the routed plan, full Enso response, prepared `RawIntent`s, and an `eth_call` simulation under `defi/intents/<wallet>/<id>/`; write to that session's `confirm` to stage the resulting tx (or `[approve, swap]` pair) into `wallets/<wallet>/chains/<chain>/outbox/pending/<tx-id>/`; then write to the outbox's own `confirm` to actually broadcast. There are always two confirms — one to commit the route into the outbox, one to actually broadcast each pending tx — and the second confirm is where ordering, gas, and policy checks live. Sessions are in-memory only and evaporate on daemon restart; the outbox entry is the durable artefact.
 
-All paths below are rooted at `/eth/`. Mainnet broadcast is gated by `block_mainnet_broadcast=false` and per-chain `allow_broadcast=true` in daemon config; the `ethereum` examples below are written as if those are off (demonstration; broadcast disabled by default), and the `base` examples assume per-chain broadcast was opted in.
+All paths below are rooted at `/bloom/`. Mainnet broadcast is gated by `block_mainnet_broadcast=false` and per-chain `allow_broadcast=true` in daemon config; the `ethereum` examples below are written as if those are off (demonstration; broadcast disabled by default), and the `base` examples assume per-chain broadcast was opted in.
 
 ## Session layout
 
@@ -28,24 +28,24 @@ This walks the whole pipeline end to end. USDC is an ERC-20, so the auto-approve
 
 ```
 # 1) Open a session by writing an NL intent. Default chain is `ethereum`.
-echo 'swap 100 usdc to eth' > /eth/defi/intents/alice/new
+echo 'swap 100 usdc to eth' > /bloom/defi/intents/alice/new
 
 # 2) See which sessions exist for this wallet (plus the writable `new` file).
-ls /eth/defi/intents/alice/
+ls /bloom/defi/intents/alice/
 # -> new
 #    0001-12345
 
 # 3) Inspect what's inside the session.
-ls /eth/defi/intents/alice/0001-12345/
+ls /bloom/defi/intents/alice/0001-12345/
 # -> intent.txt  route.json  plan.md  tx.json  simulation.json  confirm
 
 # 4) Read the original intent verbatim.
-cat /eth/defi/intents/alice/0001-12345/intent.txt
+cat /bloom/defi/intents/alice/0001-12345/intent.txt
 # swap 100 usdc to eth
 
 # 5) Read the human plan. Because USDC is ERC-20 and current allowance to the
 #    Enso router is below 100e6, the plan announces an auto-approve step.
-cat /eth/defi/intents/alice/0001-12345/plan.md
+cat /bloom/defi/intents/alice/0001-12345/plan.md
 # # DeFi intent
 #
 # Intent:    swap 100 usdc to eth
@@ -68,7 +68,7 @@ cat /eth/defi/intents/alice/0001-12345/plan.md
 # wallet's outbox; review there before broadcasting.
 
 # 6) Read the full Enso response (calldata, value, route description, gas).
-cat /eth/defi/intents/alice/0001-12345/route.json
+cat /bloom/defi/intents/alice/0001-12345/route.json
 # {
 #   "tx": {
 #     "to":   "0x<EnsoRouter>",
@@ -84,7 +84,7 @@ cat /eth/defi/intents/alice/0001-12345/route.json
 
 # 7) Read the ordered RawIntent list that will be staged. For ERC-20 -> ETH
 #    with insufficient allowance this is `[approve(token,spender,max), raw]`.
-cat /eth/defi/intents/alice/0001-12345/tx.json
+cat /bloom/defi/intents/alice/0001-12345/tx.json
 # [
 #   {
 #     "body": {
@@ -114,32 +114,32 @@ cat /eth/defi/intents/alice/0001-12345/tx.json
 
 # 8) Optional: dry-run via eth_call. Reverts get tiered-decoded into a
 #    structured `decoded_error`. Reads recompute on each cat.
-cat /eth/defi/intents/alice/0001-12345/simulation.json
+cat /bloom/defi/intents/alice/0001-12345/simulation.json
 # { "success": true, "return_data": "0x...", "gas_estimate": "210000" }
 
 # 9) First confirm: stage both intents into the wallet outbox.
-echo y > /eth/defi/intents/alice/0001-12345/confirm
+echo y > /bloom/defi/intents/alice/0001-12345/confirm
 
 # 10) The outbox now has two pending entries (approve, then swap). The
 #     daemon writes intent.json + plan.md + policy_check.json per id and
 #     advertises confirm/replace/cancel as writable control files.
-ls /eth/wallets/alice/chains/ethereum/outbox/pending/
+ls /bloom/wallets/alice/chains/ethereum/outbox/pending/
 # -> 0001-...   (approve)
 #    0002-...   (swap)
 
-ls /eth/wallets/alice/chains/ethereum/outbox/pending/0001-.../
+ls /bloom/wallets/alice/chains/ethereum/outbox/pending/0001-.../
 # -> intent.json  plan.md  policy_check.json  confirm  replace  cancel
 
-cat /eth/wallets/alice/chains/ethereum/outbox/pending/0001-.../plan.md
+cat /bloom/wallets/alice/chains/ethereum/outbox/pending/0001-.../plan.md
 # (per-tx plan: signed payload preview, gas, policy notes)
 
 # 11) Second confirm — the actual broadcast. The approve must broadcast and
 #     mine before the swap; review both, then confirm in order.
-echo y > /eth/wallets/alice/chains/ethereum/outbox/pending/0001-.../confirm
-echo y > /eth/wallets/alice/chains/ethereum/outbox/pending/0002-.../confirm
+echo y > /bloom/wallets/alice/chains/ethereum/outbox/pending/0001-.../confirm
+echo y > /bloom/wallets/alice/chains/ethereum/outbox/pending/0002-.../confirm
 
 # 12) After broadcast, entries migrate to outbox/sent/.
-ls /eth/wallets/alice/chains/ethereum/outbox/sent/
+ls /bloom/wallets/alice/chains/ethereum/outbox/sent/
 ```
 
 Note: this is the `ethereum` flow, gated as "demonstration; broadcast disabled by default" until both `block_mainnet_broadcast=false` (daemon-wide) and `allow_broadcast=true` (per-chain) are set in config. The first nine steps work locally regardless; only step 11 actually hits the network.
@@ -150,14 +150,14 @@ The handler accepts either a single-line NL string or a JSON body with `intent`,
 
 ```
 echo '{"intent":"swap 100 usdc to eth","chain":"ethereum"}' \
-  > /eth/defi/intents/alice/new
+  > /bloom/defi/intents/alice/new
 ```
 
 The handler is happy with `kind: "enso"` for symmetry with the wallet outbox parser (`{"kind":"enso","intent":"..."}`), but `kind` is optional. There is no addresses-only JSON form on the `defi/intents` surface — to feed an explicit token address, embed it in the NL string and the parser will treat it as a hex token (and consult `erc20_decimals()` for human-unit amounts):
 
 ```
 echo 'swap 100 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 to ETH' \
-  > /eth/defi/intents/alice/new
+  > /bloom/defi/intents/alice/new
 ```
 
 ## Overriding slippage
@@ -166,9 +166,9 @@ The default is 50 bps (0.5%). Override with the JSON form:
 
 ```
 echo '{"intent":"swap 100 usdc to eth","slippage_bps":100}' \
-  > /eth/defi/intents/alice/new
+  > /bloom/defi/intents/alice/new
 
-cat /eth/defi/intents/alice/0002-.../plan.md | grep Slippage
+cat /bloom/defi/intents/alice/0002-.../plan.md | grep Slippage
 # Slippage:  100 bps
 ```
 
@@ -185,21 +185,21 @@ an `approve(EnsoRouter, max)` is auto-prepended.
 
 ```
 # NL form
-echo 'swap 100 usdc to eth' > /eth/defi/intents/alice/new
+echo 'swap 100 usdc to eth' > /bloom/defi/intents/alice/new
 
 # JSON-explicit equivalent (slippage default 50 bps)
 echo '{"intent":"swap 100 usdc to eth","chain":"ethereum"}' \
-  > /eth/defi/intents/alice/new
+  > /bloom/defi/intents/alice/new
 
-cat /eth/defi/intents/alice/<id>/tx.json
+cat /bloom/defi/intents/alice/<id>/tx.json
 # [ { "body": { "Approve": { "token": "0xA0b86991...", "spender": "0x<EnsoRouter>",
 #                            "amount": "max" } }, "chain": "ethereum", ... },
 #   { "body": { "Raw":     { "to":    "0x<EnsoRouter>", "value": "0",
 #                            "data":  "0x..." } },                       ... } ]
 
-echo y > /eth/defi/intents/alice/<id>/confirm
-echo y > /eth/wallets/alice/chains/ethereum/outbox/pending/<approve-id>/confirm
-echo y > /eth/wallets/alice/chains/ethereum/outbox/pending/<swap-id>/confirm
+echo y > /bloom/defi/intents/alice/<id>/confirm
+echo y > /bloom/wallets/alice/chains/ethereum/outbox/pending/<approve-id>/confirm
+echo y > /bloom/wallets/alice/chains/ethereum/outbox/pending/<swap-id>/confirm
 ```
 
 (demonstration; broadcast disabled by default)
@@ -211,19 +211,19 @@ check entirely and produces a single `[swap]` intent. `tx.value` carries the
 ETH amount.
 
 ```
-echo 'swap 0.5 eth to usdc' > /eth/defi/intents/alice/new
+echo 'swap 0.5 eth to usdc' > /bloom/defi/intents/alice/new
 
 # JSON-explicit equivalent
 echo '{"intent":"swap 0.5 eth to usdc","chain":"ethereum"}' \
-  > /eth/defi/intents/alice/new
+  > /bloom/defi/intents/alice/new
 
-cat /eth/defi/intents/alice/<id>/tx.json
+cat /bloom/defi/intents/alice/<id>/tx.json
 # [ { "body": { "Raw": { "to":    "0x<EnsoRouter>",
 #                        "value": "500000000000000000",
 #                        "data":  "0x..." } }, "chain": "ethereum", ... } ]
 
-echo y > /eth/defi/intents/alice/<id>/confirm
-echo y > /eth/wallets/alice/chains/ethereum/outbox/pending/<swap-id>/confirm
+echo y > /bloom/defi/intents/alice/<id>/confirm
+echo y > /bloom/wallets/alice/chains/ethereum/outbox/pending/<swap-id>/confirm
 ```
 
 (demonstration; broadcast disabled by default)
@@ -240,24 +240,24 @@ field.
 ```
 # NL form, chain via 'on base'
 echo 'swap 100 usdc to 0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb on base' \
-  > /eth/defi/intents/alice/new
+  > /bloom/defi/intents/alice/new
 
 # JSON-explicit equivalent
 echo '{"intent":"swap 100 usdc to 0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb","chain":"base"}' \
-  > /eth/defi/intents/alice/new
+  > /bloom/defi/intents/alice/new
 
-cat /eth/defi/intents/alice/<id>/plan.md
+cat /bloom/defi/intents/alice/<id>/plan.md
 # Chain:     base (id 8453)
 # Token in:  0x833589fcd6edb6e08f4c7c32d4f71b54bda02913  amount=100000000 (raw)
 # Token out: 0x50c5725949a6f0c72e6c4a641f24049a917db0cb  amountOut=...
 
 # Auto-approve fires because USDC is ERC-20.
-cat /eth/defi/intents/alice/<id>/tx.json
+cat /bloom/defi/intents/alice/<id>/tx.json
 # [ approve(USDC -> EnsoRouter, max), raw(swap) ]
 
-echo y > /eth/defi/intents/alice/<id>/confirm
-echo y > /eth/wallets/alice/chains/base/outbox/pending/<approve-id>/confirm
-echo y > /eth/wallets/alice/chains/base/outbox/pending/<swap-id>/confirm
+echo y > /bloom/defi/intents/alice/<id>/confirm
+echo y > /bloom/wallets/alice/chains/base/outbox/pending/<approve-id>/confirm
+echo y > /bloom/wallets/alice/chains/base/outbox/pending/<swap-id>/confirm
 ```
 
 This is the chain to use for end-to-end exercise: per-chain `allow_broadcast=true`
@@ -272,11 +272,11 @@ target since the symbol table doesn't include `STETH`:
 
 ```
 echo 'swap 1 eth to 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84' \
-  > /eth/defi/intents/alice/new
+  > /bloom/defi/intents/alice/new
 
 # JSON-explicit equivalent
 echo '{"intent":"swap 1 eth to 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84","chain":"ethereum"}' \
-  > /eth/defi/intents/alice/new
+  > /bloom/defi/intents/alice/new
 ```
 
 Whether Enso routes this as a Lido `submit()` or a market buy depends on

--- a/docs/examples-domain/06-status-docs-endpoints.md
+++ b/docs/examples-domain/06-status-docs-endpoints.md
@@ -1,18 +1,18 @@
 # `status/`, `docs/`, and per-endpoint health — domain examples
 
-The `status/` tree is the daemon's introspection layer: uptime and version, per-chain RPC reachability, the audit-log digest, cache and outbox counts, the active backend mapping, and a per-endpoint health snapshot for every configured RPC URL. The `docs/` tree is the daemon's vendored help (the same markdown checked into `crates/bloom-vfs/src/docs/`). The per-endpoint leaves under `status/chains/<chain>/endpoints/<idx>/` are the RPC-robustness fleet view added in WP-3 (commit `9f5eab6`): one directory per configured endpoint, populated by a 15 s active probe loop with EWMA latency, success-rate sampling, and a cooldown state machine. All examples below assume the VFS is mounted at `/eth/`.
+The `status/` tree is the daemon's introspection layer: uptime and version, per-chain RPC reachability, the audit-log digest, cache and outbox counts, the active backend mapping, and a per-endpoint health snapshot for every configured RPC URL. The `docs/` tree is the daemon's vendored help (the same markdown checked into `crates/bloom-vfs/src/docs/`). The per-endpoint leaves under `status/chains/<chain>/endpoints/<idx>/` are the RPC-robustness fleet view added in WP-3 (commit `9f5eab6`): one directory per configured endpoint, populated by a 15 s active probe loop with EWMA latency, success-rate sampling, and a cooldown state machine. All examples below assume the VFS is mounted at `/bloom/`.
 
-A point of caution on naming: leaves are exactly what the source advertises. There is no `status/chains/<chain>.json`, no `status/chains/summary.json`, no `outbox/list.json`, no `wallets/list.json`, no `cache/count`, and no `audit/tail.jsonl`. Per-wallet policy lives at `/eth/wallets/<wallet>/policy.toml` (handled by the wallets handler, not status); the only policy leaf under `status/` is the global `block_mainnet_broadcast` flag. Use the listings below as the authoritative shape.
+A point of caution on naming: leaves are exactly what the source advertises. There is no `status/chains/<chain>.json`, no `status/chains/summary.json`, no `outbox/list.json`, no `wallets/list.json`, no `cache/count`, and no `audit/tail.jsonl`. Per-wallet policy lives at `/bloom/wallets/<wallet>/policy.toml` (handled by the wallets handler, not status); the only policy leaf under `status/` is the global `block_mainnet_broadcast` flag. Use the listings below as the authoritative shape.
 
 ## Daemon
 
 ```sh
-ls /eth/status/                                      # daemon.json, version, uptime, started_at, home, chains/, audit/, cache/, policies/, wallets/, outbox/, backends/
-cat /eth/status/version                              # daemon version (text, e.g. 0.0.0)
-cat /eth/status/uptime                               # "Ns" under a minute, "HH:MM:SS" otherwise (text)
-cat /eth/status/started_at                           # RFC3339 UTC, e.g. 2026-05-10T08:30:00Z (text)
-cat /eth/status/home                                 # absolute home dir, e.g. /home/you/.bloom (text)
-cat /eth/status/daemon.json                          # JSON: { version, started_unix_ms, started_at, uptime_secs, home, chains: [..] }
+ls /bloom/status/                                      # daemon.json, version, uptime, started_at, home, chains/, audit/, cache/, policies/, wallets/, outbox/, backends/
+cat /bloom/status/version                              # daemon version (text, e.g. 0.0.0)
+cat /bloom/status/uptime                               # "Ns" under a minute, "HH:MM:SS" otherwise (text)
+cat /bloom/status/started_at                           # RFC3339 UTC, e.g. 2026-05-10T08:30:00Z (text)
+cat /bloom/status/home                                 # absolute home dir, e.g. /home/you/.bloom (text)
+cat /bloom/status/daemon.json                          # JSON: { version, started_unix_ms, started_at, uptime_secs, home, chains: [..] }
 ```
 
 `daemon.json` is the one-shot summary; the individual text leaves exist for shell-friendly reads (`cat status/uptime` is more ergonomic than piping `daemon.json` through `jq`).
@@ -22,14 +22,14 @@ cat /eth/status/daemon.json                          # JSON: { version, started_
 The chain registry lists registered chain names; each name is a directory with five leaves and an `endpoints/` subdir. There is no per-chain JSON aggregate at this layer — read the individual leaves.
 
 ```sh
-ls /eth/status/chains/                               # registered chain names (one dir per chain)
-ls /eth/status/chains/ethereum/                      # chain_id, connected, block_number, rpc_url, endpoints/
-cat /eth/status/chains/ethereum/chain_id             # decimal chain id, e.g. 1
-cat /eth/status/chains/ethereum/connected            # "true" / "false" — RPC ping with 750 ms timeout, 2 s cached
-cat /eth/status/chains/ethereum/block_number         # latest block from the same probe; errors if unreachable
-cat /eth/status/chains/ethereum/rpc_url              # first configured RPC URL, redacted (api keys → ***)
-cat /eth/status/chains/base/chain_id                 # → 8453
-cat /eth/status/chains/base/connected                # → true
+ls /bloom/status/chains/                               # registered chain names (one dir per chain)
+ls /bloom/status/chains/ethereum/                      # chain_id, connected, block_number, rpc_url, endpoints/
+cat /bloom/status/chains/ethereum/chain_id             # decimal chain id, e.g. 1
+cat /bloom/status/chains/ethereum/connected            # "true" / "false" — RPC ping with 750 ms timeout, 2 s cached
+cat /bloom/status/chains/ethereum/block_number         # latest block from the same probe; errors if unreachable
+cat /bloom/status/chains/ethereum/rpc_url              # first configured RPC URL, redacted (api keys → ***)
+cat /bloom/status/chains/base/chain_id                 # → 8453
+cat /bloom/status/chains/base/connected                # → true
 ```
 
 The `connected` / `block_number` leaves share a 2-second handler-level probe cache and an additional 5-second router cache, so polling them in a tight loop is safe. URL redaction strips long opaque trailing path segments (≥20 alnum chars, e.g. Alchemy/Infura keys) and obvious query params (`apikey`, `api_key`, `key`, `token`, `access_token`).
@@ -39,15 +39,15 @@ The `connected` / `block_number` leaves share a 2-second handler-level probe cac
 Every configured RPC endpoint gets an indexed directory under `status/chains/<chain>/endpoints/<idx>/`. Indices are zero-based and stable for the daemon's lifetime — they map directly to the `endpoints` array in the chain's `ChainSpec`. The leaves are populated by the active probe loop in `crates/bloom-rpc/src/transport.rs`, which issues a direct `eth_blockNumber` against each HTTP endpoint every 15 s with a 2 s timeout, bypassing the alloy `FallbackLayer` so probes measure individual endpoints.
 
 ```sh
-ls /eth/status/chains/ethereum/endpoints/            # 0, 1, 2, ... — one dir per configured endpoint
-ls /eth/status/chains/ethereum/endpoints/0/          # url, score, cooldown_until, latency_ms, success_rate, last_block
-cat /eth/status/chains/ethereum/endpoints/0/url      # the endpoint URL, redacted (text)
-cat /eth/status/chains/ethereum/endpoints/0/score    # composite score in [0,1] (3-decimal text), 70% success + 30% latency
-cat /eth/status/chains/ethereum/endpoints/0/latency_ms       # EWMA round-trip latency in ms (alpha=0.3)
-cat /eth/status/chains/ethereum/endpoints/0/success_rate     # rolling success rate over the last 10 probes (3-decimal text)
-cat /eth/status/chains/ethereum/endpoints/0/last_block       # last block observed via this endpoint (decimal, blank if none yet)
-cat /eth/status/chains/ethereum/endpoints/0/cooldown_until   # Unix-seconds wall-clock deadline if parked, blank if healthy
-cat /eth/status/chains/ethereum/endpoints/1/score    # peek at the second endpoint in the failover pool
+ls /bloom/status/chains/ethereum/endpoints/            # 0, 1, 2, ... — one dir per configured endpoint
+ls /bloom/status/chains/ethereum/endpoints/0/          # url, score, cooldown_until, latency_ms, success_rate, last_block
+cat /bloom/status/chains/ethereum/endpoints/0/url      # the endpoint URL, redacted (text)
+cat /bloom/status/chains/ethereum/endpoints/0/score    # composite score in [0,1] (3-decimal text), 70% success + 30% latency
+cat /bloom/status/chains/ethereum/endpoints/0/latency_ms       # EWMA round-trip latency in ms (alpha=0.3)
+cat /bloom/status/chains/ethereum/endpoints/0/success_rate     # rolling success rate over the last 10 probes (3-decimal text)
+cat /bloom/status/chains/ethereum/endpoints/0/last_block       # last block observed via this endpoint (decimal, blank if none yet)
+cat /bloom/status/chains/ethereum/endpoints/0/cooldown_until   # Unix-seconds wall-clock deadline if parked, blank if healthy
+cat /bloom/status/chains/ethereum/endpoints/1/score    # peek at the second endpoint in the failover pool
 ```
 
 Cooldown semantics (from `crates/bloom-rpc/src/health.rs`):
@@ -61,17 +61,17 @@ Important scope note: cooldowns are observability-only today. Alloy's `FallbackL
 
 ### WebSocket fast path (WP-4)
 
-The WP-4 commit (`c369dc0`) added per-chain WS-backed `subscribe_*` providers used by the watch executor. It did **not** add new VFS leaves — `supports_subscriptions` and the lazy `ws_provider` live entirely inside `RpcEngine`. WS reachability today shows up indirectly: the watch executor logs `watch.subscribe_blocks.ended_falling_back_to_poll` / `watch.subscribe_logs.ended_falling_back_to_poll` and the HTTP poll loop continues. The closest VFS-visible signal is per-watch state under `/eth/watch/<id>/`, not under `status/`.
+The WP-4 commit (`c369dc0`) added per-chain WS-backed `subscribe_*` providers used by the watch executor. It did **not** add new VFS leaves — `supports_subscriptions` and the lazy `ws_provider` live entirely inside `RpcEngine`. WS reachability today shows up indirectly: the watch executor logs `watch.subscribe_blocks.ended_falling_back_to_poll` / `watch.subscribe_logs.ended_falling_back_to_poll` and the HTTP poll loop continues. The closest VFS-visible signal is per-watch state under `/bloom/watch/<id>/`, not under `status/`.
 
 ## Audit
 
 The audit log is a hash-chained JSONL file written for every state-mutating operation (sign, broadcast, outbox confirm, etc). The log file itself lives at `~/.bloom/audit.jsonl` and is **out-of-band** — it is not exposed through the VFS. What `status/audit/` exposes is the chain's tip and metadata:
 
 ```sh
-ls /eth/status/audit/                                # head, count, last
-cat /eth/status/audit/head                           # hex of the most recent record's digest (rolling head, one line)
-cat /eth/status/audit/count                          # total records appended (decimal)
-cat /eth/status/audit/last                           # JSON array of the last 10 records (pretty-printed)
+ls /bloom/status/audit/                                # head, count, last
+cat /bloom/status/audit/head                           # hex of the most recent record's digest (rolling head, one line)
+cat /bloom/status/audit/count                          # total records appended (decimal)
+cat /bloom/status/audit/last                           # JSON array of the last 10 records (pretty-printed)
 ```
 
 `status/audit/last` is the right surface for tailing recent events from inside the VFS — not `audit/tail.jsonl` (no such leaf exists). For the full append-only stream, read `~/.bloom/audit.jsonl` directly with normal Unix tools.
@@ -81,9 +81,9 @@ cat /eth/status/audit/last                           # JSON array of the last 10
 The `head` leaf is a digest that depends on every prior record. After any write that should produce an audit entry (e.g. confirming an outbox tx), capture the head before and after and confirm it changed:
 
 ```sh
-before=$(cat /eth/status/audit/head)
-echo y > /eth/wallets/alice/chains/anvil/outbox/pending/0001-abc/confirm
-after=$(cat /eth/status/audit/head)
+before=$(cat /bloom/status/audit/head)
+echo y > /bloom/wallets/alice/chains/anvil/outbox/pending/0001-abc/confirm
+after=$(cat /bloom/status/audit/head)
 [ "$before" != "$after" ] && echo "audit chain advanced"
 ```
 
@@ -91,49 +91,49 @@ To verify the chain is fully intact (no tampering of intermediate records), reco
 
 ## Cache, wallets, outbox, policies
 
-Counts only — no list surfaces here. (For the wallet list, use `/eth/wallets/`. For pending outbox detail, use `/eth/wallets/<wallet>/chains/<chain>/outbox/pending/`.)
+Counts only — no list surfaces here. (For the wallet list, use `/bloom/wallets/`. For pending outbox detail, use `/bloom/wallets/<wallet>/chains/<chain>/outbox/pending/`.)
 
 ```sh
-ls /eth/status/cache/                                # etherscan_entries, prices_entries
-cat /eth/status/cache/etherscan_entries              # files in the on-disk etherscan cache (decimal)
-cat /eth/status/cache/prices_entries                 # currently always 0 — no public accessor on PricesClient yet
+ls /bloom/status/cache/                                # etherscan_entries, prices_entries
+cat /bloom/status/cache/etherscan_entries              # files in the on-disk etherscan cache (decimal)
+cat /bloom/status/cache/prices_entries                 # currently always 0 — no public accessor on PricesClient yet
 
-ls /eth/status/wallets/                              # count
-cat /eth/status/wallets/count                        # number of registered wallets
+ls /bloom/status/wallets/                              # count
+cat /bloom/status/wallets/count                        # number of registered wallets
 
-ls /eth/status/outbox/                               # pending_count
-cat /eth/status/outbox/pending_count                 # total pending tx ids across all wallets and chains
+ls /bloom/status/outbox/                               # pending_count
+cat /bloom/status/outbox/pending_count                 # total pending tx ids across all wallets and chains
 
-ls /eth/status/policies/                             # block_mainnet_broadcast
-cat /eth/status/policies/block_mainnet_broadcast     # "true" / "false" — global mainnet broadcast lock
+ls /bloom/status/policies/                             # block_mainnet_broadcast
+cat /bloom/status/policies/block_mainnet_broadcast     # "true" / "false" — global mainnet broadcast lock
 ```
 
-Per-wallet policy is **not** under `status/`; it lives at `/eth/wallets/<wallet>/policy.toml` (read+write, handled by the wallets handler).
+Per-wallet policy is **not** under `status/`; it lives at `/bloom/wallets/<wallet>/policy.toml` (read+write, handled by the wallets handler).
 
 ## Backends
 
 `status/backends/` declares which backend implementation is wired to each feature. Each leaf is one of `etherscan`, `rpc`, or `indexer`. The five features are fixed by the daemon's surface contract.
 
 ```sh
-ls /eth/status/backends/                             # contract_metadata, address_history, event_logs, storage_reads, proxy_detection, summary.json
-cat /eth/status/backends/contract_metadata           # → "etherscan" (default; verified source/ABI lookups)
-cat /eth/status/backends/address_history             # → "etherscan" (default; paginated tx history)
-cat /eth/status/backends/event_logs                  # → "rpc"        (default; eth_getLogs)
-cat /eth/status/backends/storage_reads               # → "rpc"        (eth_getStorageAt; rpc-only)
-cat /eth/status/backends/proxy_detection             # → "rpc"        (EIP-1967 / EIP-1822 slot reads)
-cat /eth/status/backends/summary.json                # JSON map of all of the above
+ls /bloom/status/backends/                             # contract_metadata, address_history, event_logs, storage_reads, proxy_detection, summary.json
+cat /bloom/status/backends/contract_metadata           # → "etherscan" (default; verified source/ABI lookups)
+cat /bloom/status/backends/address_history             # → "etherscan" (default; paginated tx history)
+cat /bloom/status/backends/event_logs                  # → "rpc"        (default; eth_getLogs)
+cat /bloom/status/backends/storage_reads               # → "rpc"        (eth_getStorageAt; rpc-only)
+cat /bloom/status/backends/proxy_detection             # → "rpc"        (EIP-1967 / EIP-1822 slot reads)
+cat /bloom/status/backends/summary.json                # JSON map of all of the above
 ```
 
 Switching the backend for a feature is done by editing `~/.bloom/config.toml` under `[backends]` and restarting the daemon. That config file is **out-of-band** and not VFS-writable — `status/backends/*` is read-only in the handler (the `Entry::file` helper sets mode `0o444` and there is no `write` impl). The `status/backends/*` surface reflects the live config snapshot, not a writable dial.
 
 ## Docs
 
-`/eth/docs/` is the daemon's vendored help. The bytes are `include_str!`'d at compile time from `crates/bloom-vfs/src/docs/README.md` and `examples.md`, so the content is stable for the daemon's lifetime — there is no on-disk copy to mutate. Both files are mode `0o444`.
+`/bloom/docs/` is the daemon's vendored help. The bytes are `include_str!`'d at compile time from `crates/bloom-vfs/src/docs/README.md` and `examples.md`, so the content is stable for the daemon's lifetime — there is no on-disk copy to mutate. Both files are mode `0o444`.
 
 ```sh
-ls /eth/docs/                                        # README.md, examples.md
-cat /eth/docs/README.md                              # top-level layout, reading/writing patterns, NFT cheatsheet
-cat /eth/docs/examples.md                            # end-to-end demos: anvil round-trip, tools, NFTs
+ls /bloom/docs/                                        # README.md, examples.md
+cat /bloom/docs/README.md                              # top-level layout, reading/writing patterns, NFT cheatsheet
+cat /bloom/docs/examples.md                            # end-to-end demos: anvil round-trip, tools, NFTs
 ```
 
 If you want to refresh what the daemon ships with after a workspace update, just `cat` these — they update with the binary.

--- a/docs/specs/2026-05-08-bloom-design.md
+++ b/docs/specs/2026-05-08-bloom-design.md
@@ -42,7 +42,7 @@ The agent never imports a Web3 SDK. It writes files.
 ### In scope (target v1)
 
 - A single Rust daemon (`bloom` / `bloom`) exposing a virtual
-  filesystem at a configurable mount path (default `/eth`).
+  filesystem at a configurable mount path (default `/bloom`).
 - Mount via NFSv4.1 + `embednfs` on Linux and macOS 26+ (same
   approach as bloom; NFS is friendlier than FUSE for cross-platform,
   user-mode, and macOS-without-system-extension reasons).
@@ -91,7 +91,7 @@ The agent never imports a Web3 SDK. It writes files.
                  ┌──────────────────────────────────────┐
    kernel NFS    │  embednfs (FileSystem trait impl)    │
    client at     │              = mount                 │
-   /eth          └────────────────┬─────────────────────┘
+   /bloom        └────────────────┬─────────────────────┘
                                   │
                                   ▼
         ┌──────────────────────────────────────────────────┐
@@ -152,7 +152,7 @@ This is the heart of the spec. The path layout is the API.
 ### 3.1 Top-level layout
 
 ```
-/eth/
+/bloom/
 ├── chains/                # read-only chain views
 │   ├── ethereum/          # mainnet
 │   ├── optimism/
@@ -755,9 +755,9 @@ writing `cancel` issues a self-send replacement tx.
 The agent should be able to do:
 
 ```sh
-tail -f /eth/wallets/alice/chains/ethereum/inbox
-tail -f /eth/chains/ethereum/contracts/0xUNI/events/Swap/live
-tail -f /eth/watch/whale-alerts/live
+tail -f /bloom/wallets/alice/chains/ethereum/inbox
+tail -f /bloom/chains/ethereum/contracts/0xUNI/events/Swap/live
+tail -f /bloom/watch/whale-alerts/live
 ```
 
 Implementation:
@@ -782,9 +782,9 @@ bridge rotation cleanly.
 
 ```
 bloom init                          # config + first wallet, prompt passphrase
-bloom up                            # start daemon, mount /eth
+bloom up                            # start daemon, mount /bloom
 bloom down                          # graceful stop, unmount
-bloom status                        # mirror of /eth/status/daemon.json
+bloom status                        # mirror of /bloom/status/daemon.json
 bloom wallet new <name>             # generate or import
 bloom wallet import <name> <key|file|mnemonic>
 bloom wallet list
@@ -795,12 +795,12 @@ bloom send <wallet> <amount> <to>   # convenience over outbox
 bloom watch <spec>                  # convenience over watch/new
 bloom chain add <name> --rpc <url> --etherscan <url>  # custom chain
 bloom doctor                        # prints diagnostics, RPC health
-bloom tail <path>                   # follows a /eth path
+bloom tail <path>                   # follows a /bloom path
 bloom whois <addr>                  # resolves ENS / contract name
 ```
 
 The CLI is a thin wrapper over the FS; everything `bloom` does is also
-doable by writing files into `/eth`.
+doable by writing files into `/bloom`.
 
 ---
 
@@ -1053,8 +1053,8 @@ These are ideas worth surfacing in iteration. None are committed.
 14. **Notification subsystem.** `watch/<name>/notify.toml` says where
     to ping (webhook, mac OS notification, email, ntfy.sh) when an
     event matches. Agents already have file events; humans need pings.
-15. **Schema-versioned paths.** Top-level `/eth/v1/...` so the layout
-    can evolve without breaking scripts; `/eth/latest -> v1`.
+15. **Schema-versioned paths.** Top-level `/bloom/v1/...` so the layout
+    can evolve without breaking scripts; `/bloom/latest -> v1`.
 16. **A Petname directory.** Per bloom's later vision: stable, signed
     human names for contracts and addresses. Useful in plan.md.
 17. **A WASM "petal" runner.** Agents could drop a small WASM module

--- a/tests/docker/lib.sh
+++ b/tests/docker/lib.sh
@@ -19,10 +19,10 @@ require_env() {
 }
 
 # ---------- shared mount layout ----------
-# The chain tests (enso, fork) mount at /eth so user-facing paths read
-# `/eth/wallets/...`. The basic mount test overrides MNT/SENTINEL before
+# The chain tests (enso, fork) mount at /bloom so user-facing paths read
+# `/bloom/wallets/...`. The basic mount test overrides MNT/SENTINEL before
 # sourcing this file. PIDFILE/LOGFILE are stable across all of them.
-: "${MNT:=/eth}"
+: "${MNT:=/bloom}"
 : "${SENTINEL:=/.bloom-mounted}"
 : "${PIDFILE:=/tmp/mount_demo.pid}"
 : "${LOGFILE:=/tmp/mount_demo.log}"

--- a/tests/docker/run.sh
+++ b/tests/docker/run.sh
@@ -16,7 +16,7 @@
 #                   shared docker-compose stack (anvil-fork sidecar +
 #                   bloom-test-enso driver, selected via the `enso`
 #                   profile). Drives the Enso -> Aave intent flow end
-#                   to end through the NFS mount at /eth/. Requires
+#                   to end through the NFS mount at /bloom/. Requires
 #                   BLOOM_ENSO_KEY in the environment.
 #   --enso-live   — same Enso -> Aave flow but against Base mainnet,
 #                   broadcasting from the live keystore at $BLOOM_LIVE_HOME

--- a/tests/docker/test.sh
+++ b/tests/docker/test.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 LOG_PREFIX=mount-test
 
-# This test mounts at /mnt/bloom (not the chain tests' /eth) so the
+# This test mounts at /mnt/bloom (not the chain tests' /bloom) so the
 # sentinel sits at /mnt/.bloom-mounted. Override before sourcing.
 MNT=/mnt/bloom
 SENTINEL=/mnt/.bloom-mounted
@@ -66,7 +66,7 @@ echo "::endgroup::"
 # client routinely upgrades small writes to DATA_SYNC/FILE_SYNC, and
 # the embednfs server enforces `actual_stability >= requested`. The
 # adapter used to hard-code UNSTABLE in its WRITE reply, so a single
-# `printf '%s' BODY > /eth/<writable>` failed with EREMOTEIO (the
+# `printf '%s' BODY > /bloom/<writable>` failed with EREMOTEIO (the
 # kernel-side surface of NFS4ERR_SERVERFAULT) — even though the
 # handler had already accepted the body. The fix lives in
 # `crates/bloom-mount/src/adapter.rs::write` (honour the requested

--- a/tests/docker/test_enso_aave.sh
+++ b/tests/docker/test_enso_aave.sh
@@ -5,12 +5,12 @@
 # or by tests/docker/run.sh --enso-live (live mainnet mode).
 #
 # What this proves
-#   The agent-facing surface (NFS mount at /eth/) end-to-ends a real
+#   The agent-facing surface (NFS mount at /bloom/) end-to-ends a real
 #   DeFi intent: ETH -> aBaseUSDC via Enso shortcut -> Aave V3 supply.
 #   Every step except the wallet unlock (in-process by design) is
-#   driven through plain filesystem ops on /eth/ — no `bloom vfs write`
+#   driven through plain filesystem ops on /bloom/ — no `bloom vfs write`
 #   short-circuits, no `bloom ipc call`. If this test passes, an agent
-#   with shell access to /eth/ can place real DeFi trades.
+#   with shell access to /bloom/ can place real DeFi trades.
 #
 # Modes (selected by BLOOM_TEST_MODE; default "fork")
 #   fork  — broadcasts land on an anvil --fork-url=Base sidecar.
@@ -150,7 +150,7 @@ fi
 # of the route.
 INTENT_BODY=$(printf '{"intent":"swap %s ETH to %s on base","chain":"%s","slippage_bps":500}' \
     "$SWAP_AMOUNT_ETH" "$AUSDC" "$CHAIN")
-log "POST intent (via /eth write): $INTENT_BODY"
+log "POST intent (via /bloom write): $INTENT_BODY"
 
 # Snapshot the pending set so we can diff it after confirmation and
 # learn the staged id. This used to be impossible — `BloomFs::getattr`

--- a/tests/docker/test_fork_mount.sh
+++ b/tests/docker/test_fork_mount.sh
@@ -3,13 +3,13 @@
 #
 # Sibling of test_enso_aave.sh, but limited to the wallet/outbox +
 # chain read surface. No Enso, no DeFi route. The point is to prove
-# that an agent with shell access to /eth/ can:
+# that an agent with shell access to /bloom/ can:
 #
-#   1. Stage a plain native-ETH transfer via /eth/wallets/<w>/chains/<c>/outbox/new.tx
-#   2. Broadcast it via /eth/wallets/<w>/chains/<c>/outbox/pending/<id>/confirm
+#   1. Stage a plain native-ETH transfer via /bloom/wallets/<w>/chains/<c>/outbox/new.tx
+#   2. Broadcast it via /bloom/wallets/<w>/chains/<c>/outbox/pending/<id>/confirm
 #   3. Stage a SECOND tx and replace it (same nonce, bumped fees + fresh
-#      calldata) via /eth/wallets/<w>/chains/<c>/outbox/pending/<id>/replace
-#   4. Read tx receipt + chain head + gas via /eth/chains/<c>/...
+#      calldata) via /bloom/wallets/<w>/chains/<c>/outbox/pending/<id>/replace
+#   4. Read tx receipt + chain head + gas via /bloom/chains/<c>/...
 #
 # All writes go through the kernel NFS mount; nothing uses `bloom ipc
 # call` shortcuts. If this passes, the fork-mode mount surface is


### PR DESCRIPTION
## Summary

- Add a root MIT `LICENSE` file and update workspace package metadata to `MIT`.
- Change the default mount path from `/eth` to `/bloom` in config defaults and tests.
- Update README, quickstart, examples, vendored VFS docs, design docs, CLI help, and docker mount tests to use `/bloom` for mounted filesystem paths.

## Validation

- `cargo fmt --check`
- `cargo test -p bloom-proto` (71 passed)
- `cargo test -p bloom-vfs` (226 passed)
- `git diff --check`
- Searched for stale mount-path references such as `/eth/wallets`, `/eth/chains`, `MNT=/eth`, and `bloom mount /eth`.