### PR TITLE
[codex] add full-platform latest release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,135 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: build ${{ matrix.asset_name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - asset_name: bloom-linux-x86_64.tar.gz
+            os: ubuntu-latest
+            binary: bloom
+            archive: tar.gz
+          - asset_name: bloom-linux-aarch64.tar.gz
+            os: ubuntu-24.04-arm
+            binary: bloom
+            archive: tar.gz
+          - asset_name: bloom-macos-x86_64.tar.gz
+            os: macos-13
+            binary: bloom
+            archive: tar.gz
+          - asset_name: bloom-macos-aarch64.tar.gz
+            os: macos-latest
+            binary: bloom
+            archive: tar.gz
+          - asset_name: bloom-windows-x86_64.zip
+            os: windows-latest
+            binary: bloom.exe
+            archive: zip
+          - asset_name: bloom-windows-aarch64.zip
+            os: windows-11-arm
+            binary: bloom.exe
+            archive: zip
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Build full-feature binary
+        run: cargo build --release -p bloom --all-features --locked
+
+      - name: Stage package
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p package dist
+          cp "target/release/${{ matrix.binary }}" package/
+          cp README.md LICENSE package/
+
+      - name: Create tarball
+        if: matrix.archive == 'tar.gz'
+        shell: bash
+        run: tar -czf "dist/${{ matrix.asset_name }}" -C package .
+
+      - name: Create zip
+        if: matrix.archive == 'zip'
+        shell: pwsh
+        run: Compress-Archive -Path package/* -DestinationPath "dist/${{ matrix.asset_name }}"
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset_name }}
+          path: dist/${{ matrix.asset_name }}
+          if-no-files-found: error
+
+  publish:
+    name: publish latest release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Generate checksums
+        run: |
+          cd dist
+          sha256sum bloom-* > SHA256SUMS
+
+      - name: Move latest tag
+        run: |
+          git tag --force latest "$GITHUB_SHA"
+          git push --force origin refs/tags/latest
+
+      - name: Publish latest release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          notes_file="$(mktemp)"
+          cat > "$notes_file" <<EOF
+          Automated full-feature build for ${GITHUB_SHA}.
+
+          Stable download URLs use the \`latest\` tag, for example:
+
+          \`\`\`
+          https://github.com/${GITHUB_REPOSITORY}/releases/download/latest/bloom-linux-x86_64.tar.gz
+          \`\`\`
+          EOF
+
+          if gh release view latest >/dev/null 2>&1; then
+            gh release edit latest \
+              --target "$GITHUB_SHA" \
+              --title "Latest master build" \
+              --notes-file "$notes_file" \
+              --latest
+          else
+            gh release create latest \
+              --target "$GITHUB_SHA" \
+              --title "Latest master build" \
+              --notes-file "$notes_file" \
+              --latest
+          fi
+
+          gh release upload latest dist/* --clobber

--- a/README.md
+++ b/README.md
@@ -53,14 +53,17 @@ Two ways to drive the VFS:
   detect the socket and route through it, sharing daemon state (unlock
   cache, watches, defi sessions, etherscan cache). `bloom ipc call <method>`
   speaks the JSON-RPC directly.
-- **NFS mount** (optional) — build with `cargo build --features bloom-daemon/mount`
-  and call `Daemon::mount(path).await` to expose the VFS as a real
-  POSIX filesystem over the kernel NFS client.
+- **NFS mount** (optional) — build with `cargo build -p bloom --features mount`
+  or use a full-feature release binary, then run `bloom serve --mount [PATH]`
+  to expose the VFS as a real POSIX filesystem over the kernel NFS client.
+  With no path, the mount point defaults to `/bloom` on Linux and
+  `/Volumes/bloom` on macOS. The mount point must already exist and the
+  platform mount command may require elevated privileges.
 
 ## Filesystem layout
 
-The VFS is rooted at `/bloom/` (the default NFS mount path) with these
-top-level trees:
+The VFS is rooted at the selected mount path (for example `/bloom/` on
+Linux or `/Volumes/bloom/` on macOS) with these top-level trees:
 
 - `chains/<chain>/` — read-only chain views: head, blocks, addresses,
   ERC-20 balances, txs, receipts, gas, etherscan-backed history. The

--- a/crates/bloom-mount/src/server.rs
+++ b/crates/bloom-mount/src/server.rs
@@ -30,6 +30,21 @@ use crate::{MountConfig, MountError, MountHandle, build_mount_args};
 const MOUNT_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
 const UMOUNT_COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
 
+fn unmount_args(path: &Path) -> Vec<String> {
+    #[cfg(target_os = "linux")]
+    {
+        vec![
+            "-l".to_string(),
+            "-f".to_string(),
+            path.display().to_string(),
+        ]
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        vec!["-f".to_string(), path.display().to_string()]
+    }
+}
+
 fn run_command_with_timeout(
     cmd_name: &str,
     args: &[String],
@@ -102,10 +117,9 @@ impl Drop for NfsMountHandle {
         let already = *self.unmounted.lock();
         if !already {
             let mp = self.mount_path.clone();
+            let args = unmount_args(&mp);
             if let Err(e) = std::process::Command::new("umount")
-                .arg("-l")
-                .arg("-f")
-                .arg(&mp)
+                .args(&args)
                 .stdout(Stdio::null())
                 .stderr(Stdio::null())
                 .spawn()
@@ -135,7 +149,7 @@ impl MountHandle for NfsMountHandle {
         }
         let mp = self.mount_path.clone();
         let status = tokio::task::spawn_blocking(move || {
-            let args = vec!["-l".to_string(), "-f".to_string(), mp.display().to_string()];
+            let args = unmount_args(&mp);
             run_command_with_timeout("umount", &args, UMOUNT_COMMAND_TIMEOUT)
         })
         .await
@@ -438,6 +452,17 @@ mod tests {
             second.is_ok(),
             "second unmount should be a no-op, got {second:?}"
         );
+    }
+
+    #[test]
+    fn unmount_args_are_platform_compatible() {
+        let args = unmount_args(Path::new("/tmp/bloom"));
+        assert!(args.contains(&"-f".to_string()));
+        assert_eq!(args.last().map(String::as_str), Some("/tmp/bloom"));
+        #[cfg(target_os = "linux")]
+        assert!(args.contains(&"-l".to_string()));
+        #[cfg(not(target_os = "linux"))]
+        assert!(!args.contains(&"-l".to_string()));
     }
 
     /// Aborting the server task as part of `unmount` should cause the

--- a/crates/bloom-vfs/src/docs/README.md
+++ b/crates/bloom-vfs/src/docs/README.md
@@ -2,6 +2,21 @@
 
 This is the help file vendored into the daemon.
 
+## Running
+
+Use `bloom serve` for a long-running daemon with JSON-RPC IPC only. To expose
+the same VFS through the kernel NFS client, use a binary built with the `mount`
+feature and pass `--mount`:
+
+```sh
+bloom serve --mount              # /bloom on Linux, /Volumes/bloom on macOS
+bloom serve --mount /tmp/bloom   # explicit mount path
+```
+
+The mount point must already exist and the platform mount command may require
+elevated privileges. Without a mount, the same paths are available through
+`bloom vfs ls`, `bloom vfs cat`, and `bloom vfs write`.
+
 ## Top-level layout
 
 - `chains/<chain>/` — read-only chain views: head, blocks, tx, addresses,

--- a/crates/bloom-vfs/src/docs/agent-guidance.md
+++ b/crates/bloom-vfs/src/docs/agent-guidance.md
@@ -4,6 +4,11 @@ bloom exposes Ethereum workflows as a virtual filesystem. Prefer inspecting the
 tree with normal filesystem tools when it is mounted, or with `bloom vfs` when it
 is not mounted.
 
+To mount the tree, run a mount-enabled build as `bloom serve --mount`. With no
+path argument, the mount point is `/bloom` on Linux and `/Volumes/bloom` on
+macOS; pass `bloom serve --mount <path>` to choose another existing directory.
+Mounting uses the platform NFS client and may require elevated privileges.
+
 Useful commands:
 
 - `bloom vfs ls /` lists the VFS root.

--- a/crates/bloom-vfs/src/docs/examples.md
+++ b/crates/bloom-vfs/src/docs/examples.md
@@ -1,5 +1,15 @@
 # Examples
 
+These examples assume the VFS is mounted. Start a mount-enabled daemon first:
+
+```sh
+bloom serve --mount              # /bloom on Linux, /Volumes/bloom on macOS
+bloom serve --mount /tmp/bloom   # explicit mount path
+```
+
+If the tree is not mounted, use the equivalent `bloom vfs cat`, `bloom vfs ls`,
+and `bloom vfs write` commands against paths without the mount prefix.
+
 ## Local Anvil round-trip
 
 ```sh

--- a/crates/bloom/Cargo.toml
+++ b/crates/bloom/Cargo.toml
@@ -11,6 +11,8 @@ path = "src/main.rs"
 
 [features]
 default = []
+# Enable the embedded NFS mount adapter through the daemon crate.
+mount = ["bloom-daemon/mount", "dep:bloom-mount"]
 # Pass-through for the heimdall-rs decompile decoder. Build with
 # `cargo build --features bytecode-decompile` to enable.
 bytecode-decompile = ["bloom-daemon/bytecode-decompile"]
@@ -18,6 +20,7 @@ bytecode-decompile = ["bloom-daemon/bytecode-decompile"]
 [dependencies]
 bloom-proto.workspace = true
 bloom-daemon.workspace = true
+bloom-mount = { workspace = true, optional = true }
 bloom-keystore.workspace = true
 bloom-chain.workspace = true
 bloom-tx.workspace = true

--- a/crates/bloom/src/main.rs
+++ b/crates/bloom/src/main.rs
@@ -20,6 +20,13 @@ use clap::{Parser, Subcommand};
 use tracing::{debug, info, trace};
 use tracing_subscriber::EnvFilter;
 
+#[cfg(target_os = "linux")]
+const DEFAULT_MOUNT_PATH: &str = "/bloom";
+#[cfg(target_os = "macos")]
+const DEFAULT_MOUNT_PATH: &str = "/Volumes/bloom";
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+const DEFAULT_MOUNT_PATH: &str = "/bloom";
+
 #[derive(Parser, Debug)]
 #[command(
     name = "bloom",
@@ -45,10 +52,19 @@ enum Cmd {
     /// Wallet management.
     #[command(subcommand)]
     Wallet(WalletCmd),
-    /// Run the daemon as a long-lived process. The NFS mount adapter is
-    /// feature-gated and currently a stub; this exists so that the
-    /// invocation contract is stable.
-    Serve,
+    /// Run the daemon as a long-lived process.
+    Serve {
+        /// Mount the VFS for the lifetime of the daemon.
+        ///
+        /// With no PATH, defaults to /bloom on Linux and /Volumes/bloom on macOS.
+        #[arg(
+            long,
+            value_name = "PATH",
+            num_args = 0..=1,
+            default_missing_value = DEFAULT_MOUNT_PATH
+        )]
+        mount: Option<PathBuf>,
+    },
     /// Talk to a running `bloom serve` over its UDS JSON-RPC socket.
     #[command(subcommand)]
     Ipc(IpcCmd),
@@ -356,21 +372,25 @@ async fn run(cli: Cli) -> Result<()> {
             );
             Ok(())
         }
-        Cmd::Serve => {
+        Cmd::Serve { mount } => {
             let d = Daemon::from_home(home).context("build daemon")?;
             // Spawn the outbox expiry sweeper for the lifetime of the
             // serve command (fix #3). The handle is dropped (and the task
             // signalled to stop) right before the function returns.
             let sweeper = d.spawn_background_tasks();
+            let mount_handle = mount_bloom(&d, mount.as_deref()).await?;
             let chains: Vec<String> = d.chains.list_names();
             println!(
                 "bloom serve: home={} chains={:?}",
                 d.home.root().display(),
                 chains
             );
+            if let Some(mount_path) = mount.as_deref() {
+                println!("mount: {}", mount_path.display());
+            }
             let socket = default_socket_path(d.home.root());
             println!("ipc socket: {}", socket.display());
-            info!(home = %d.home.root().display(), chains = ?chains, socket = %socket.display(), "cli.serve.starting");
+            info!(home = %d.home.root().display(), chains = ?chains, socket = %socket.display(), mount = ?mount, "cli.serve.starting");
             let server = IpcServer::new(d.vfs.clone(), env!("CARGO_PKG_VERSION"), chains);
             let server2 = server.clone();
             // Trigger graceful shutdown on Ctrl-C.
@@ -379,12 +399,15 @@ async fn run(cli: Cli) -> Result<()> {
                 info!("cli.serve.ctrl_c_received");
                 server2.trigger_shutdown();
             });
-            server.serve(&socket).await.context("ipc serve")?;
+            let serve_result = server.serve(&socket).await.context("ipc serve");
             shutdown.abort();
             // Stop the outbox expiry sweeper (fix #3) and any other
             // daemon-owned workers (watch executor, etc., fix #6).
+            let unmount_result = unmount_bloom(mount_handle).await;
             sweeper.shutdown().await;
             d.shutdown().await;
+            serve_result?;
+            unmount_result?;
             info!("cli.serve.shutdown_complete");
             println!("shutting down");
             Ok(())
@@ -408,4 +431,47 @@ async fn run(cli: Cli) -> Result<()> {
             Ok(())
         }
     }
+}
+
+#[cfg(feature = "mount")]
+async fn mount_bloom(
+    daemon: &Daemon,
+    mount: Option<&std::path::Path>,
+) -> Result<Option<bloom_mount::NfsMountHandle>> {
+    match mount {
+        Some(path) => daemon
+            .mount(path)
+            .await
+            .map(Some)
+            .with_context(|| format!("mount bloom vfs at {}", path.display())),
+        None => Ok(None),
+    }
+}
+
+#[cfg(not(feature = "mount"))]
+async fn mount_bloom(daemon: &Daemon, mount: Option<&std::path::Path>) -> Result<Option<()>> {
+    let _ = daemon;
+    match mount {
+        Some(path) => anyhow::bail!(
+            "mount support is not enabled in this build; rebuild with --features mount (release binaries are built with --all-features): {}",
+            path.display()
+        ),
+        None => Ok(None),
+    }
+}
+
+#[cfg(feature = "mount")]
+async fn unmount_bloom(handle: Option<bloom_mount::NfsMountHandle>) -> Result<()> {
+    if let Some(handle) = handle {
+        bloom_mount::MountHandle::unmount(&handle)
+            .await
+            .context("unmount bloom vfs")?;
+    }
+    Ok(())
+}
+
+#[cfg(not(feature = "mount"))]
+async fn unmount_bloom(handle: Option<()>) -> Result<()> {
+    let _ = handle;
+    Ok(())
 }


### PR DESCRIPTION
## Summary

- Add a Release workflow that builds full-feature `bloom` binaries for Linux, macOS, and Windows on x86_64 and arm64 runners.
- Publish or update a stable `latest` GitHub release and force-move the `latest` tag to the current `master` commit so scripts can use URLs like `https://github.com/bloom-directory/bloom/releases/download/latest/bloom-linux-x86_64.tar.gz`.
- Expose the CLI `mount` feature on the `bloom` crate and add `bloom serve --mount [PATH]`, defaulting to `/bloom` on Linux and `/Volumes/bloom` on macOS when the flag has no path.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p bloom --locked`
- `cargo check -p bloom --all-features --locked`
- `cargo run -p bloom -- serve --help`

## Notes

The release workflow uses `cargo build --release -p bloom --all-features --locked` so the published binaries include the mount adapter and the bytecode decompile feature.