### PR TITLE
[codex] update macOS release runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,11 +28,11 @@ jobs:
             binary: bloom
             archive: tar.gz
           - asset_name: bloom-macos-x86_64.tar.gz
-            os: macos-13
+            os: macos-26-intel
             binary: bloom
             archive: tar.gz
           - asset_name: bloom-macos-aarch64.tar.gz
-            os: macos-latest
+            os: macos-26
             binary: bloom
             archive: tar.gz
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary

- Move macOS x86_64 release builds from `macos-13` to `macos-26-intel`.
- Move macOS arm64 release builds from `macos-latest` to `macos-26`.

## Validation

- `cargo build --release -p bloom --all-features --locked`