### PR TITLE
Passkeys + Small fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1641,6 +1641,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1801,6 +1840,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backoff"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1837,6 +1924,17 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "base64urlsafedata"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b08e33815c87d8cadcddb1e74ac307368a3751fbe40c961538afa21a1899f21c"
+dependencies = [
+ "base64 0.21.7",
+ "pastey",
+ "serde",
+]
 
 [[package]]
 name = "bimap"
@@ -1990,6 +2088,7 @@ dependencies = [
  "bloom-tx",
  "bloom-vfs",
  "clap",
+ "clap_complete",
  "dirs 5.0.1",
  "hex",
  "predicates",
@@ -2252,6 +2351,8 @@ dependencies = [
  "alloy 2.0.5",
  "anyhow",
  "argon2",
+ "axum",
+ "base64 0.22.1",
  "blake3",
  "bloom-chain-types",
  "bloom-proto",
@@ -2259,14 +2360,18 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "ml-dsa",
+ "open",
  "parking_lot 0.12.5",
  "rand 0.8.6",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
+ "tokio",
  "toml 0.8.23",
  "tracing",
+ "url",
+ "webauthn-rs",
  "zeroize",
 ]
 
@@ -3020,6 +3125,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3640,6 +3754,20 @@ checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
  "const-oid 0.10.2",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -4534,6 +4662,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5199,6 +5338,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5512,6 +5670,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "maybe-owned"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5772,6 +5936,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5788,6 +5961,17 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "open"
+version = "5.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
 
 [[package]]
 name = "openssl"
@@ -5930,6 +6114,18 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -6753,6 +6949,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7085,6 +7290,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_cbor_2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aec2709de9078e077090abd848e967abab63c9fb3fdb5d4799ad359d8d482c"
+dependencies = [
+ "half",
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7115,6 +7330,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -8216,6 +8442,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8758,6 +8996,74 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webauthn-attestation-ca"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6475c0bbd1a3f04afaa3e98880408c5be61680c5e6bd3c6f8c250990d5d3e18e"
+dependencies = [
+ "base64urlsafedata",
+ "openssl",
+ "openssl-sys",
+ "serde",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "webauthn-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c548915e0e92ee946bbf2aecf01ea21bef53d974b0793cc6732ba81a03fc422"
+dependencies = [
+ "base64urlsafedata",
+ "serde",
+ "tracing",
+ "url",
+ "uuid",
+ "webauthn-rs-core",
+]
+
+[[package]]
+name = "webauthn-rs-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "296d2d501feb715d80b8e186fb88bab1073bca17f460303a1013d17b673bea6a"
+dependencies = [
+ "base64 0.21.7",
+ "base64urlsafedata",
+ "der-parser",
+ "hex",
+ "nom",
+ "openssl",
+ "openssl-sys",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "serde",
+ "serde_cbor_2",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tracing",
+ "url",
+ "uuid",
+ "webauthn-attestation-ca",
+ "webauthn-rs-proto",
+ "x509-parser",
+]
+
+[[package]]
+name = "webauthn-rs-proto"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c37393beac9c1ed1ca6dbb30b1e01783fb316ab3a45d90ecd48c99052dd7ef1e"
+dependencies = [
+ "base64 0.21.7",
+ "base64urlsafedata",
+ "serde",
+ "serde_json",
+ "url",
 ]
 
 [[package]]
@@ -9400,6 +9706,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ serde_json = "1"
 serde_with = "3"
 toml = "0.8"
 clap = { version = "4", features = ["derive", "env"] }
+clap_complete = "4"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 async-trait = "0.1"
@@ -93,6 +94,14 @@ wasmtime = { version = "26", default-features = false, features = ["async", "cra
 wasmtime-wasi = "26"
 wat = "1"
 wasmparser = "0.218"
+# danger-allow-state-serialisation: webauthn-rs requires this feature to allow
+# the PasskeyRegistration / PasskeyAuthentication state structs to be serialised
+# across await points. Our ceremony server holds state in Arc<Mutex<>> for the
+# duration of a single short-lived HTTP server, so this is safe — we never
+# persist the state to disk or send it across a network boundary.
+webauthn-rs = { version = "0.5.5", features = ["danger-allow-state-serialisation"] }
+open = "5"
+axum = { version = "0.8", default-features = false, features = ["http1", "tokio", "json"] }
 
 # Ethereum stack
 alloy = { version = "2", features = ["full", "signer-local", "rpc-types", "providers", "provider-http", "consensus", "network", "rlp", "json-abi", "k256", "eips", "essentials", "contract", "transport-throttle", "json-rpc"] }

--- a/crates/bloom-daemon/src/ipc.rs
+++ b/crates/bloom-daemon/src/ipc.rs
@@ -49,6 +49,15 @@ pub fn default_socket_path(home_root: &Path) -> PathBuf {
     home_root.join("run").join("bloom.sock")
 }
 
+/// RAII guard that removes the socket file on drop, covering normal exit
+/// and panics during [`IpcServer::serve`].
+struct SocketGuard(PathBuf);
+impl Drop for SocketGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct Request {
     #[serde(default)]
@@ -153,6 +162,7 @@ impl IpcServer {
             let _ = std::fs::remove_file(socket_path);
         }
         let listener = UnixListener::bind(socket_path)?;
+        let _guard = SocketGuard(socket_path.to_owned());
         // Best-effort restrict permissions to user.
         #[cfg(unix)]
         {
@@ -192,7 +202,6 @@ impl IpcServer {
         }
 
         info!(socket = %socket_path.display(), "ipc.shutdown");
-        let _ = std::fs::remove_file(socket_path);
         Ok(())
     }
 
@@ -222,7 +231,12 @@ impl IpcServer {
             };
             let mut out = serde_json::to_vec(&resp).unwrap_or_else(|e| {
                 debug!(error = %e, "ipc.response_serialise_failed");
-                b"{}".to_vec()
+                // We cannot echo the request id here (serialisation of the
+                // proper Response already failed, so we may not have a
+                // well-formed id either). `null` is the safe default per
+                // JSON-RPC 2.0 §5 when the id cannot be determined.
+                br#"{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"internal error"}}"#
+                    .to_vec()
             });
             out.push(b'\n');
             wr.write_all(&out).await?;

--- a/crates/bloom-it/tests/erc20_e2e.rs
+++ b/crates/bloom-it/tests/erc20_e2e.rs
@@ -135,6 +135,7 @@ async fn erc20_stage_fails_when_decimals_unreadable() -> Result<()> {
         chain: Some("anvil".to_string()),
         gas: Default::default(),
         nonce: None,
+        gas_limit_hint: None,
     };
 
     let res = engine
@@ -179,6 +180,7 @@ async fn replace_keeps_nonce_and_bumps_fees() -> Result<()> {
         chain: Some("anvil".to_string()),
         gas: Default::default(),
         nonce: None,
+        gas_limit_hint: None,
     };
 
     let staged = engine

--- a/crates/bloom-keystore/Cargo.toml
+++ b/crates/bloom-keystore/Cargo.toml
@@ -14,6 +14,7 @@ thiserror.workspace = true
 anyhow.workspace = true
 hex.workspace = true
 blake3.workspace = true
+base64.workspace = true
 argon2.workspace = true
 chacha20poly1305.workspace = true
 zeroize.workspace = true
@@ -24,6 +25,12 @@ tracing.workspace = true
 toml.workspace = true
 ml-dsa.workspace = true
 ed25519-dalek.workspace = true
+
+tokio.workspace = true
+webauthn-rs.workspace = true
+open.workspace = true
+axum.workspace = true
+url.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/bloom-keystore/src/lib.rs
+++ b/crates/bloom-keystore/src/lib.rs
@@ -6,22 +6,29 @@
 //! ~/.bloom/keystore/<wallet>/
 //! ├── address           # 0x-prefixed checksum
 //! ├── pubkey            # uncompressed secp256k1, hex
-//! ├── kind              # "local" | "watch"
-//! ├── encrypted.key     # CBOR blob with kdf+cipher params + ciphertext
+//! ├── kind              # "local" | "watch" | "passkey"
+//! ├── encrypted.key     # JSON blob with cipher params + ciphertext
+//! ├── prf.salt          # (passkey only) 64 hex chars, public — input to PRF
+//! ├── passkey.json      # (passkey only) serialised webauthn_rs::Passkey
 //! └── policy.toml
 //! ```
 //!
 //! ## Crypto
 //!
-//! - KDF: argon2id, parameters chosen for ~250ms on a modern laptop.
+//! - KDF: argon2id, parameters chosen for ~250ms on a modern laptop (Local).
 //! - Cipher: chacha20-poly1305 with a per-key random nonce.
 //! - Plaintext: 32-byte secp256k1 private key, zeroized on drop.
+//! - Passkey wallets use WebAuthn PRF: `wrap_key = blake3::derive_key(
+//!   "bloom passkey wrap key", prf_output)` where `prf_output` is a
+//!   32-byte value derived from the authenticator's internal secret and
+//!   `prf.salt`. PRF output is never stored on disk.
 //!
 //! Private keys never leave the daemon process. Only the public address +
 //! pubkey are exposed via the FS.
 
 #![forbid(unsafe_code)]
 
+pub(crate) mod passkey;
 pub mod xdsa;
 #[cfg(test)]
 mod xdsa_tests;
@@ -39,9 +46,11 @@ use parking_lot::RwLock;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use zeroize::Zeroize;
+use zeroize::{Zeroize, Zeroizing};
 
 use bloom_proto::{Policy, checksum_address};
+
+// ── errors ────────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Error)]
 pub enum KeystoreError {
@@ -69,6 +78,10 @@ pub enum KeystoreError {
     Signer(String),
     #[error("policy parse error: {0}")]
     Policy(String),
+    #[error("passkey ceremony failed: {0}")]
+    PasskeyCeremony(String),
+    #[error("passkey credential invalid: {0}")]
+    PasskeyCredential(String),
 }
 
 /// Signing algorithm for a wallet.
@@ -350,11 +363,18 @@ pub fn load_xdsa_wallet(
     })
 }
 
+// ── wallet kind ───────────────────────────────────────────────────────────────
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum WalletKind {
     Local,
     Watch,
+    /// secp256k1 key encrypted under a PRF-derived wrap key; a WebAuthn
+    /// ceremony (with PRF extension) is required before the daemon will
+    /// decrypt the key.
+    #[serde(rename = "passkey")]
+    PasskeyGated,
 }
 
 impl std::fmt::Display for WalletKind {
@@ -362,9 +382,12 @@ impl std::fmt::Display for WalletKind {
         match self {
             WalletKind::Local => f.write_str("local"),
             WalletKind::Watch => f.write_str("watch"),
+            WalletKind::PasskeyGated => f.write_str("passkey"),
         }
     }
 }
+
+// ── public types ──────────────────────────────────────────────────────────────
 
 /// Public-side wallet metadata.
 #[derive(Debug, Clone)]
@@ -374,25 +397,38 @@ pub struct WalletInfo {
     pub pubkey_hex: String,
     pub kind: WalletKind,
     pub policy: Policy,
+    /// Raw hex private key, present exactly once: immediately after a new
+    /// passkey wallet is created. `None` for all other operations.
+    /// The caller must display this and treat it like a seed phrase.
+    /// Uses `Zeroizing` so the heap copy is cleared when WalletInfo is dropped.
+    pub recovery_key: Option<Zeroizing<String>>,
 }
 
+// ── on-disk formats ───────────────────────────────────────────────────────────
+
+/// v=1 encrypted key: argon2id KDF + chacha20poly1305. Used by Local wallets.
 #[derive(Debug, Serialize, Deserialize)]
 struct EncryptedFile {
-    /// Format version.
     v: u8,
-    /// Hex-encoded 32-byte salt for argon2.
     salt_hex: String,
-    /// Hex-encoded 12-byte nonce for chacha20-poly1305.
     nonce_hex: String,
-    /// Argon2id `m_cost` (KiB).
     m_cost: u32,
-    /// Argon2id `t_cost` (iterations).
     t_cost: u32,
-    /// Argon2id `p_cost` (parallelism).
     p_cost: u32,
-    /// Hex ciphertext (key bytes encrypted under derived key).
     ciphertext_hex: String,
 }
+
+/// PRF-based encrypted key: wrap_key derived from authenticator PRF output.
+/// `wrap_key = blake3::derive_key("bloom passkey wrap key", prf_output)`.
+/// PRF output is never stored on disk — it is derived at each ceremony.
+#[derive(Debug, Serialize, Deserialize)]
+struct PasskeyEncrypted {
+    v: u8,
+    nonce_hex: String,
+    ciphertext_hex: String,
+}
+
+// ── constants ─────────────────────────────────────────────────────────────────
 
 const KEYSTORE_VERSION: u8 = 1;
 const ARGON2_M_COST: u32 = 64 * 1024;
@@ -400,6 +436,8 @@ const ARGON2_T_COST: u32 = 3;
 const ARGON2_P_COST: u32 = 1;
 const KEYSTORE_AAD: &[u8] = b"bloom-keystore-v1";
 const LEGACY_BETH_KEYSTORE_AAD: &[u8] = b"beth-keystore-v1";
+
+// ── keystore ──────────────────────────────────────────────────────────────────
 
 #[derive(Clone)]
 pub struct Keystore {
@@ -446,6 +484,8 @@ impl Keystore {
         }
         Ok(())
     }
+
+    // ── list / info ───────────────────────────────────────────────────────────
 
     pub fn list(&self) -> Result<Vec<WalletInfo>, KeystoreError> {
         let mut out = Vec::new();
@@ -503,25 +543,51 @@ impl Keystore {
         let kind: WalletKind = match read_trim(&kind_path)?.as_str() {
             "local" => WalletKind::Local,
             "watch" => WalletKind::Watch,
+            "passkey" => WalletKind::PasskeyGated,
             other => return Err(KeystoreError::Malformed(format!("kind: {other}"))),
         };
-        let policy = if policy_path.exists() {
-            let s = fs::read_to_string(&policy_path).map_err(|source| KeystoreError::Io {
+
+        // Read policy content as string so we can verify the sig before parsing.
+        let policy_content = if policy_path.exists() {
+            fs::read_to_string(&policy_path).map_err(|source| KeystoreError::Io {
                 path: policy_path.clone(),
                 source,
-            })?;
-            toml::from_str::<Policy>(&s).map_err(|e| KeystoreError::Policy(e.to_string()))?
+            })?
         } else {
-            Policy::default()
+            String::new()
         };
+
+        // Phase 2: verify policy.toml.sig for PasskeyGated wallets.
+        if kind == WalletKind::PasskeyGated && !policy_content.is_empty() {
+            let sig_path = dir.join("policy.toml.sig");
+            if sig_path.exists() {
+                passkey::verify_policy_sig(name, &policy_content, &address, &sig_path)?;
+            } else {
+                tracing::warn!(
+                    wallet = name,
+                    "passkey wallet has unsigned policy.toml (run sign-policy to sign it)"
+                );
+            }
+        }
+
+        let policy = if policy_content.is_empty() {
+            Policy::default()
+        } else {
+            toml::from_str::<Policy>(&policy_content)
+                .map_err(|e| KeystoreError::Policy(e.to_string()))?
+        };
+
         Ok(WalletInfo {
             name: name.into(),
             address,
             pubkey_hex,
             kind,
             policy,
+            recovery_key: None,
         })
     }
+
+    // ── create / import ───────────────────────────────────────────────────────
 
     pub fn create_local(&self, name: &str, passphrase: &str) -> Result<WalletInfo, KeystoreError> {
         let signer = PrivateKeySigner::random();
@@ -560,58 +626,32 @@ impl Keystore {
             pubkey_hex: String::new(),
             kind: WalletKind::Watch,
             policy: Policy::default(),
+            recovery_key: None,
         })
     }
 
-    fn import_local(
+    /// Create a new PasskeyGated wallet. Opens the browser for a WebAuthn
+    /// registration ceremony; blocks until completion or the 120 s timeout.
+    pub async fn create_passkey(&self, name: &str) -> Result<WalletInfo, KeystoreError> {
+        let signer = PrivateKeySigner::random();
+        self.import_passkey_inner(name, &signer).await
+    }
+
+    /// Import an existing hex private key as a PasskeyGated wallet.
+    /// Opens the browser for a WebAuthn registration ceremony.
+    pub async fn import_passkey(
         &self,
         name: &str,
-        signer: &PrivateKeySigner,
-        passphrase: &str,
+        private_key_hex: &str,
     ) -> Result<WalletInfo, KeystoreError> {
-        Self::validate_name(name)?;
-        let dir = self.wallet_path(name);
-        if dir.exists() {
-            return Err(KeystoreError::AlreadyExists(name.into()));
-        }
-        fs::create_dir_all(&dir).map_err(|source| KeystoreError::Io {
-            path: dir.clone(),
-            source,
-        })?;
-
-        let key_bytes = signer.to_bytes();
-        let encrypted = encrypt_key(key_bytes.as_slice(), passphrase)?;
-        let blob =
-            serde_json::to_vec(&encrypted).map_err(|e| KeystoreError::Malformed(e.to_string()))?;
-        write_atomic(&dir.join("encrypted.key"), &blob)?;
-
-        let address = signer.address();
-        let pub_hex = hex::encode(
-            signer
-                .credential()
-                .verifying_key()
-                .to_encoded_point(false)
-                .as_bytes(),
-        );
-        write_atomic(&dir.join("address"), checksum_address(&address).as_bytes())?;
-        write_atomic(&dir.join("pubkey"), pub_hex.as_bytes())?;
-        write_atomic(&dir.join("kind"), b"local")?;
-        let default_policy = Policy::default();
-        write_atomic(
-            &dir.join("policy.toml"),
-            toml::to_string_pretty(&default_policy)
-                .map_err(|e| KeystoreError::Policy(e.to_string()))?
-                .as_bytes(),
-        )?;
-
-        Ok(WalletInfo {
-            name: name.into(),
-            address,
-            pubkey_hex: pub_hex,
-            kind: WalletKind::Local,
-            policy: default_policy,
-        })
+        let bytes = decode_priv_hex(private_key_hex)
+            .map_err(|e| KeystoreError::Malformed(format!("private key: {e}")))?;
+        let signer = PrivateKeySigner::from_bytes(&bytes.into())
+            .map_err(|e| KeystoreError::Signer(e.to_string()))?;
+        self.import_passkey_inner(name, &signer).await
     }
+
+    // ── unlock ────────────────────────────────────────────────────────────────
 
     pub fn unlock(&self, name: &str, passphrase: &str) -> Result<(), KeystoreError> {
         Self::validate_name(name)?;
@@ -620,8 +660,13 @@ impl Keystore {
             tracing::debug!(wallet = name, "keystore.unlock_not_found");
             return Err(KeystoreError::NotFound(name.into()));
         }
-        let kind: WalletKind = match read_trim(&dir.join("kind"))?.as_str() {
-            "local" => WalletKind::Local,
+        match read_trim(&dir.join("kind"))?.as_str() {
+            "local" => {}
+            "passkey" => {
+                return Err(KeystoreError::Locked(format!(
+                    "{name}: passkey wallet — use unlock_passkey instead"
+                )));
+            }
             "watch" => {
                 tracing::debug!(wallet = name, "keystore.unlock_watch_only");
                 return Err(KeystoreError::Locked(name.into()));
@@ -634,40 +679,23 @@ impl Keystore {
                 );
                 return Err(KeystoreError::Malformed(format!("kind: {other}")));
             }
-        };
-        let _ = kind;
+        }
         let blob = fs::read(dir.join("encrypted.key")).map_err(|source| {
-            tracing::debug!(
-                wallet = name,
-                error = %source,
-                "keystore.unlock_read_failed"
-            );
+            tracing::debug!(wallet = name, error = %source, "keystore.unlock_read_failed");
             KeystoreError::Io {
                 path: dir.join("encrypted.key"),
                 source,
             }
         })?;
         let enc: EncryptedFile = serde_json::from_slice(&blob).map_err(|e| {
-            tracing::debug!(
-                wallet = name,
-                error = %e,
-                "keystore.unlock_blob_malformed"
-            );
+            tracing::debug!(wallet = name, error = %e, "keystore.unlock_blob_malformed");
             KeystoreError::Malformed(e.to_string())
         })?;
         let key_bytes = decrypt_key(&enc, passphrase).inspect_err(|e| {
-            tracing::debug!(
-                wallet = name,
-                error = %e,
-                "keystore.unlock_decrypt_failed"
-            );
+            tracing::debug!(wallet = name, error = %e, "keystore.unlock_decrypt_failed");
         })?;
         let signer = PrivateKeySigner::from_bytes(&key_bytes.into()).map_err(|e| {
-            tracing::debug!(
-                wallet = name,
-                error = %e,
-                "keystore.unlock_signer_failed"
-            );
+            tracing::debug!(wallet = name, error = %e, "keystore.unlock_signer_failed");
             KeystoreError::Signer(e.to_string())
         })?;
         self.inner
@@ -677,6 +705,40 @@ impl Keystore {
         tracing::debug!(wallet = name, "keystore.unlocked");
         Ok(())
     }
+
+    /// Write new policy content for `name` and, for PasskeyGated wallets,
+    /// immediately re-sign it. Returns `Locked` without touching disk if the
+    /// wallet is a passkey wallet that has not been unlocked yet.
+    pub fn write_policy(&self, name: &str, toml_bytes: &[u8]) -> Result<(), KeystoreError> {
+        Self::validate_name(name)?;
+        let dir = self.wallet_path(name);
+        if !dir.exists() {
+            return Err(KeystoreError::NotFound(name.into()));
+        }
+        let content = std::str::from_utf8(toml_bytes)
+            .map_err(|e| KeystoreError::Policy(format!("policy must be UTF-8: {e}")))?;
+        // Validate TOML is parseable before touching disk.
+        toml::from_str::<Policy>(content)
+            .map_err(|e| KeystoreError::Policy(format!("invalid policy TOML: {e}")))?;
+
+        let kind_str = read_trim(&dir.join("kind"))?;
+
+        // For passkey wallets check the signer is available BEFORE writing
+        // anything, so disk stays consistent if the wallet is locked.
+        if kind_str == "passkey" {
+            let _ = self.signer(name)?;
+        }
+
+        write_atomic(&dir.join("policy.toml"), toml_bytes)?;
+
+        if kind_str == "passkey" {
+            self.sign_policy(name)?;
+        }
+        tracing::debug!(wallet = name, "keystore.policy_written");
+        Ok(())
+    }
+
+    // ── lock / signer / delete ────────────────────────────────────────────────
 
     pub fn lock(&self, name: &str) {
         self.inner.unlocked.write().remove(name);
@@ -711,7 +773,63 @@ impl Keystore {
         tracing::debug!(wallet = name, "keystore.deleted");
         Ok(())
     }
+
+    // ── local wallet internals ────────────────────────────────────────────────
+
+    fn import_local(
+        &self,
+        name: &str,
+        signer: &PrivateKeySigner,
+        passphrase: &str,
+    ) -> Result<WalletInfo, KeystoreError> {
+        Self::validate_name(name)?;
+        let dir = self.wallet_path(name);
+        if dir.exists() {
+            return Err(KeystoreError::AlreadyExists(name.into()));
+        }
+        fs::create_dir_all(&dir).map_err(|source| KeystoreError::Io {
+            path: dir.clone(),
+            source,
+        })?;
+
+        let mut key_bytes = signer.to_bytes();
+        let encrypted = encrypt_key(key_bytes.as_slice(), passphrase)?;
+        key_bytes.zeroize();
+        let blob =
+            serde_json::to_vec(&encrypted).map_err(|e| KeystoreError::Malformed(e.to_string()))?;
+        write_atomic(&dir.join("encrypted.key"), &blob)?;
+
+        let address = signer.address();
+        let pub_hex = hex::encode(
+            signer
+                .credential()
+                .verifying_key()
+                .to_encoded_point(false)
+                .as_bytes(),
+        );
+        write_atomic(&dir.join("address"), checksum_address(&address).as_bytes())?;
+        write_atomic(&dir.join("pubkey"), pub_hex.as_bytes())?;
+        write_atomic(&dir.join("kind"), b"local")?;
+        let default_policy = Policy::default();
+        write_atomic(
+            &dir.join("policy.toml"),
+            toml::to_string_pretty(&default_policy)
+                .map_err(|e| KeystoreError::Policy(e.to_string()))?
+                .as_bytes(),
+        )?;
+
+        Ok(WalletInfo {
+            name: name.into(),
+            address,
+            pubkey_hex: pub_hex,
+            kind: WalletKind::Local,
+            policy: default_policy,
+            recovery_key: None,
+        })
+    }
 }
+
+// ── helpers ───────────────────────────────────────────────────────────────────
 
 fn read_trim(path: &Path) -> Result<String, KeystoreError> {
     let s = fs::read_to_string(path).map_err(|source| KeystoreError::Io {
@@ -749,6 +867,8 @@ fn decode_priv_hex(s: &str) -> Result<[u8; 32], String> {
     out.copy_from_slice(&v);
     Ok(out)
 }
+
+// ── v=1 crypto (Local wallets, argon2id + chacha20poly1305) ──────────────────
 
 fn derive_key(
     passphrase: &str,
@@ -821,9 +941,9 @@ fn decrypt_key(enc: &EncryptedFile, passphrase: &str) -> Result<[u8; 32], Keysto
     let cipher = ChaCha20Poly1305::new(Key::from_slice(&key));
     let nonce = Nonce::from_slice(&nonce_b);
     let pt = decrypt_with_aad(&cipher, nonce, &ct, KEYSTORE_AAD).or_else(|_| {
-        // Pre-rename live keystores were written by `beth` and used the
-        // legacy AAD string. Keep reads backward-compatible; newly written
-        // keys continue to use the Bloom AAD above.
+        // Pre-rename live keystores were written by `beth` with the legacy AAD.
+        // Keep reads backward-compatible; suggest re-encrypting.
+        tracing::warn!("decrypting with legacy beth AAD — re-create wallet to upgrade");
         decrypt_with_aad(&cipher, nonce, &ct, LEGACY_BETH_KEYSTORE_AAD)
     })?;
     key.zeroize();
@@ -854,6 +974,8 @@ fn decrypt_with_aad(
         )
         .map_err(|e| KeystoreError::Aead(e.to_string()))
 }
+
+// ── tests ──────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
@@ -916,7 +1038,6 @@ mod tests {
             .unwrap();
         key.zeroize();
         enc.ciphertext_hex = hex::encode(ciphertext);
-
         assert_eq!(decrypt_key(&enc, "legacy-pass").unwrap(), plaintext);
     }
 
@@ -952,6 +1073,371 @@ mod tests {
                 assert!(!s.contains(pk));
             }
         }
+    }
+
+    #[test]
+    fn prf_key_encryption_round_trip() {
+        let plaintext = [42u8; 32];
+        let mut prf_output = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut prf_output);
+        let enc = passkey::encrypt_passkey_key(&plaintext, &prf_output).unwrap();
+        let decrypted = passkey::decrypt_passkey_key(&enc, &prf_output).unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn prf_key_wrong_prf_rejected() {
+        let plaintext = [42u8; 32];
+        let mut prf_output = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut prf_output);
+        let enc = passkey::encrypt_passkey_key(&plaintext, &prf_output).unwrap();
+        let mut bad_prf = prf_output;
+        bad_prf[0] ^= 0xff;
+        assert!(passkey::decrypt_passkey_key(&enc, &bad_prf).is_err());
+    }
+
+    // ── policy-sig tests ──────────────────────────────────────────────────────
+
+    /// Helper: create a local wallet, unlock it (signer in memory), then
+    /// overwrite `kind` to "passkey" so sign_policy accepts it.  This lets
+    /// us test the sign/verify cycle without a real WebAuthn ceremony.
+    ///
+    /// NOTE: this wallet uses V1 crypto (argon2id), not PRF-based passkey
+    /// crypto. It only tests the secp256k1 sign/verify path, NOT the passkey
+    /// ceremony gating.  Use `passkey_kind_round_trip` for tests that
+    /// exercise the real PasskeyGated directory layout.
+    fn make_unlocked_passkey_wallet(ks: &Keystore, root: &Path, name: &str) {
+        ks.create_local(name, "p").unwrap();
+        ks.unlock(name, "p").unwrap();
+        // Overwrite kind so sign_policy accepts this wallet.
+        let kind_path = root.join(name).join("kind");
+        fs::write(&kind_path, b"passkey").unwrap();
+    }
+
+    /// sign_policy + verify_policy_sig: happy path round-trip.
+    #[test]
+    fn policy_signing_round_trip() {
+        let (dir, ks) = temp_store();
+        make_unlocked_passkey_wallet(&ks, dir.path(), "alice");
+
+        ks.sign_policy("alice").unwrap();
+
+        let wallet_dir = dir.path().join("alice");
+        let policy_content = fs::read_to_string(wallet_dir.join("policy.toml")).unwrap();
+        // Re-read address from disk (info() warns on missing sig, which is fine here
+        // since we haven't signed via the keystore flow yet, but we just wrote the sig).
+        let addr_str = read_trim(&wallet_dir.join("address")).unwrap();
+        let address = addr_str.parse::<Address>().unwrap();
+        let sig_path = wallet_dir.join("policy.toml.sig");
+        // Must exist
+        assert!(sig_path.exists(), "policy.toml.sig was not written");
+        // Must verify cleanly against the correct address
+        passkey::verify_policy_sig("alice", &policy_content, &address, &sig_path).unwrap();
+    }
+
+    /// Tampering with policy content is detected at verification time.
+    #[test]
+    fn policy_sig_tamper_detected() {
+        let (dir, ks) = temp_store();
+        make_unlocked_passkey_wallet(&ks, dir.path(), "alice");
+        ks.sign_policy("alice").unwrap();
+
+        let wallet_dir = dir.path().join("alice");
+        let addr_str = read_trim(&wallet_dir.join("address")).unwrap();
+        let address = addr_str.parse::<Address>().unwrap();
+        let sig_path = wallet_dir.join("policy.toml.sig");
+        let tampered = "# tampered content\n[caps]\nallow_all = true\n";
+        let err = passkey::verify_policy_sig("alice", tampered, &address, &sig_path).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("modified") || msg.contains("hash"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    /// A signature from a different wallet address is rejected.
+    #[test]
+    fn policy_sig_wrong_address_rejected() {
+        let (dir, ks) = temp_store();
+        make_unlocked_passkey_wallet(&ks, dir.path(), "alice");
+        ks.sign_policy("alice").unwrap();
+
+        let wallet_dir = dir.path().join("alice");
+        let policy_content = fs::read_to_string(wallet_dir.join("policy.toml")).unwrap();
+        let sig_path = wallet_dir.join("policy.toml.sig");
+        let wrong_address: Address = "0x000000000000000000000000000000000000dEaD"
+            .parse()
+            .unwrap();
+        let err = passkey::verify_policy_sig("alice", &policy_content, &wrong_address, &sig_path)
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("does not match") || msg.contains("address"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    /// A malformed sig file (missing required JSON fields) is rejected.
+    #[test]
+    fn policy_sig_missing_fields_rejected() {
+        let (dir, ks) = temp_store();
+        ks.create_local("alice", "p").unwrap();
+        let info = ks.info("alice").unwrap();
+        let wallet_dir = dir.path().join("alice");
+        let sig_path = wallet_dir.join("policy.toml.sig");
+        // Write a JSON object missing both required fields.
+        fs::write(&sig_path, r#"{"something_else": "value"}"#).unwrap();
+        let policy_content = fs::read_to_string(wallet_dir.join("policy.toml")).unwrap();
+        let err = passkey::verify_policy_sig("alice", &policy_content, &info.address, &sig_path)
+            .unwrap_err();
+        assert!(
+            matches!(err, KeystoreError::Policy(_)),
+            "expected Policy error, got: {err}"
+        );
+    }
+
+    // ── passkey wallet directory tests ────────────────────────────────────────
+
+    /// Shared test helper: create a skeleton passkey wallet directory
+    /// (address + pubkey + kind). Returns the directory path and parsed Address.
+    fn setup_passkey_dir(root: &Path, name: &str) -> (PathBuf, Address) {
+        let wallet_dir = root.join(name);
+        fs::create_dir_all(&wallet_dir).unwrap();
+        let addr: Address = "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"
+            .parse()
+            .unwrap();
+        write_atomic(
+            &wallet_dir.join("address"),
+            bloom_proto::checksum_address(&addr).as_bytes(),
+        )
+        .unwrap();
+        write_atomic(&wallet_dir.join("pubkey"), b"").unwrap();
+        write_atomic(&wallet_dir.join("kind"), b"passkey").unwrap();
+        (wallet_dir, addr)
+    }
+
+    /// info() correctly reads a manually constructed passkey wallet directory
+    /// and returns PasskeyGated kind without requiring a real ceremony.
+    /// A missing policy.toml.sig should warn (not error).
+    /// Passkey wallet info() should error when policy.toml.sig is tampered.
+    #[test]
+    fn passkey_info_rejects_tampered_policy_sig() {
+        let (dir, ks) = temp_store();
+        let (wallet_dir, _addr) = setup_passkey_dir(dir.path(), "tamper-gate");
+        let policy_toml = toml::to_string_pretty(&bloom_proto::Policy::default()).unwrap();
+        write_atomic(&wallet_dir.join("policy.toml"), policy_toml.as_bytes()).unwrap();
+
+        // Create a separate wallet, unlock it, and overwrite kind so
+        // sign_policy produces a valid signature from a *different* key.
+        make_unlocked_passkey_wallet(&ks, dir.path(), "signer-wallet");
+        ks.sign_policy("signer-wallet").unwrap();
+        let other_sig =
+            std::fs::read_to_string(dir.path().join("signer-wallet").join("policy.toml.sig"))
+                .unwrap();
+        std::fs::write(wallet_dir.join("policy.toml.sig"), other_sig).unwrap();
+
+        let err = ks.info("tamper-gate").unwrap_err();
+        assert!(
+            matches!(err, KeystoreError::Policy(_)),
+            "expected Policy error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn passkey_kind_round_trip() {
+        let (dir, ks) = temp_store();
+        let (wallet_dir, addr) = setup_passkey_dir(dir.path(), "passkey-test");
+        let policy = bloom_proto::Policy::default();
+        write_atomic(
+            &wallet_dir.join("policy.toml"),
+            toml::to_string_pretty(&policy).unwrap().as_bytes(),
+        )
+        .unwrap();
+        // No passkey.json, no prf.salt, no policy.toml.sig — just kind="passkey".
+        let info = ks.info("passkey-test").unwrap();
+        assert_eq!(info.kind, WalletKind::PasskeyGated);
+        assert_eq!(info.address, addr);
+    }
+
+    /// Calling unlock() (not unlock_passkey) on a passkey wallet returns a
+    /// helpful error directing the user to use unlock_passkey instead.
+    #[test]
+    fn unlock_on_passkey_wallet_returns_helpful_error() {
+        let (dir, ks) = temp_store();
+        setup_passkey_dir(dir.path(), "passkey-test");
+        let err = ks.unlock("passkey-test", "anything").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("unlock_passkey") || msg.contains("passkey"),
+            "expected helpful error, got: {msg}"
+        );
+        assert!(
+            matches!(err, KeystoreError::Locked(_)),
+            "expected Locked, got: {err}"
+        );
+    }
+
+    /// unlock_passkey() called on a passkey wallet that is missing
+    /// passkey.json must return an Io error before opening the browser.
+    #[tokio::test]
+    async fn unlock_passkey_missing_passkey_json() {
+        let (dir, ks) = temp_store();
+        setup_passkey_dir(dir.path(), "no-passkey");
+        // No passkey.json — should fail before attempting any PRF ceremony.
+        let err = ks.unlock_passkey("no-passkey").await.unwrap_err();
+        assert!(
+            matches!(err, KeystoreError::Io { .. }),
+            "expected Io error, got: {err}"
+        );
+        assert!(
+            err.to_string().contains("passkey.json"),
+            "error should mention passkey.json: {err}"
+        );
+    }
+
+    /// unlock_passkey() with a malformed passkey.json must return a
+    /// PasskeyCredential error before opening the browser.
+    #[tokio::test]
+    async fn unlock_passkey_malformed_passkey_json() {
+        let (dir, ks) = temp_store();
+        let (wallet_dir, _) = setup_passkey_dir(dir.path(), "bad-passkey");
+        write_atomic(&wallet_dir.join("passkey.json"), b"not valid json").unwrap();
+        let err = ks.unlock_passkey("bad-passkey").await.unwrap_err();
+        assert!(
+            matches!(err, KeystoreError::PasskeyCredential(_)),
+            "expected PasskeyCredential error, got: {err}"
+        );
+    }
+
+    /// sign_policy on a Watch wallet returns a clear error (not Locked).
+    #[test]
+    fn sign_policy_kind_guard() {
+        let (_dir, ks) = temp_store();
+        let addr: Address = "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"
+            .parse()
+            .unwrap();
+        ks.add_watch("watcher", addr).unwrap();
+        let err = ks.sign_policy("watcher").unwrap_err();
+        // Must not be Locked — must clearly indicate kind mismatch.
+        assert!(
+            matches!(err, KeystoreError::PasskeyCredential(_)),
+            "expected PasskeyCredential error, got: {err}"
+        );
+        assert!(
+            err.to_string().contains("passkey"),
+            "error should mention passkey: {err}"
+        );
+    }
+
+    /// sign_policy on a properly constructed PasskeyGated wallet that has
+    /// never been unlocked must return Locked — the signer isn't cached.
+    #[test]
+    fn sign_policy_rejects_never_unlocked_passkey_wallet() {
+        let (dir, ks) = temp_store();
+        let (wallet_dir, _) = setup_passkey_dir(dir.path(), "cold-passkey");
+        let policy = bloom_proto::Policy::default();
+        write_atomic(
+            &wallet_dir.join("policy.toml"),
+            toml::to_string_pretty(&policy).unwrap().as_bytes(),
+        )
+        .unwrap();
+
+        let err = ks.sign_policy("cold-passkey").unwrap_err();
+        assert!(
+            matches!(err, KeystoreError::Locked(_)),
+            "expected Locked error (never unlocked), got: {err}"
+        );
+    }
+
+    // ── write_policy tests ────────────────────────────────────────────────────
+
+    /// write_policy on a Local wallet: writes content, no .sig file created.
+    #[test]
+    fn write_policy_local_happy_path() {
+        let (_dir, ks) = temp_store();
+        ks.create_local("local-w", "p").unwrap();
+        let new_policy = "[caps]\nmax_value_eth = 1.0\n";
+        ks.write_policy("local-w", new_policy.as_bytes()).unwrap();
+        let info = ks.info("local-w").unwrap();
+        assert_eq!(info.policy.caps.max_value_eth, Some(1.0));
+    }
+
+    /// write_policy on an unlocked passkey wallet: writes content and re-signs.
+    #[test]
+    fn write_policy_passkey_unlocked_resigns() {
+        let (dir, ks) = temp_store();
+        make_unlocked_passkey_wallet(&ks, dir.path(), "pk-w");
+        // Initial sign so .sig exists.
+        ks.sign_policy("pk-w").unwrap();
+        // Write new policy — should re-sign automatically.
+        let new_policy = "[caps]\nmax_value_eth = 2.0\n";
+        ks.write_policy("pk-w", new_policy.as_bytes()).unwrap();
+        // info() must not error (sig must match new content).
+        let info = ks.info("pk-w").unwrap();
+        assert_eq!(info.policy.caps.max_value_eth, Some(2.0));
+    }
+
+    /// write_policy on a locked passkey wallet returns Locked without touching disk.
+    #[test]
+    fn write_policy_passkey_locked_returns_locked_before_write() {
+        let (dir, ks) = temp_store();
+        let (wallet_dir, _) = setup_passkey_dir(dir.path(), "locked-pk");
+        let orig = "[caps]\nmax_value_eth = 0.5\n";
+        write_atomic(&wallet_dir.join("policy.toml"), orig.as_bytes()).unwrap();
+
+        let new_policy = "[caps]\nmax_value_eth = 99.0\n";
+        let err = ks
+            .write_policy("locked-pk", new_policy.as_bytes())
+            .unwrap_err();
+        assert!(
+            matches!(err, KeystoreError::Locked(_)),
+            "expected Locked, got: {err}"
+        );
+        // Disk must be unchanged.
+        let on_disk = fs::read_to_string(wallet_dir.join("policy.toml")).unwrap();
+        assert_eq!(on_disk, orig, "policy.toml must not have been modified");
+    }
+
+    /// write_policy rejects invalid TOML before touching disk.
+    #[test]
+    fn write_policy_invalid_toml_rejected() {
+        let (_dir, ks) = temp_store();
+        ks.create_local("local-bad", "p").unwrap();
+        let err = ks
+            .write_policy("local-bad", b"not valid toml }{")
+            .unwrap_err();
+        assert!(
+            matches!(err, KeystoreError::Policy(_)),
+            "expected Policy error, got: {err}"
+        );
+    }
+
+    /// Passkey wallet write path: private key never appears in any on-disk
+    /// file (the encrypted.key blob must not contain the plaintext hex).
+    #[test]
+    fn prf_encrypted_key_does_not_contain_private_key() {
+        let needle_hex = "4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318";
+        let needle_bytes = hex::decode(needle_hex).expect("valid hex");
+
+        // Encrypt a known private key with a random PRF output.
+        let mut prf_output = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut prf_output);
+        let mut key_bytes = [0u8; 32];
+        key_bytes.copy_from_slice(&needle_bytes);
+        let enc = passkey::encrypt_passkey_key(&key_bytes, &prf_output).unwrap();
+
+        // The ciphertext (encrypted.key blob) must not contain the plaintext.
+        let blob = serde_json::to_string(&enc).unwrap();
+        assert!(
+            !blob.contains(needle_hex),
+            "plaintext hex appears in encrypted blob"
+        );
+        // The prf_output itself must not equal the private key.
+        assert_ne!(
+            &prf_output[..],
+            &key_bytes[..],
+            "prf_output must be independent of private key"
+        );
     }
 
     fn walkdir(p: &Path) -> Vec<PathBuf> {

--- a/crates/bloom-keystore/src/passkey.rs
+++ b/crates/bloom-keystore/src/passkey.rs
@@ -1,0 +1,1409 @@
+//! WebAuthn passkey ceremony helper for bloom.
+//!
+//! Spins up a short-lived local HTTP server on a fixed port, opens the system
+//! browser, and awaits the completion of a WebAuthn registration or
+//! authentication ceremony. The browser POSTs the credential JSON back to the
+//! local server, which forwards it to `webauthn-rs` for verification.
+//!
+//! ## PRF-based key derivation
+//! The passkey uses the WebAuthn PRF extension (pseudo-random function) to
+//! derive a wrap key from the authenticator's internal secret. During each
+//! ceremony, the browser extracts a 32-byte PRF output from the authenticator
+//! and POSTs it to the local ceremony server. The Rust keystore then derives
+//! `wrap_key = blake3::derive_key("bloom passkey wrap key", prf_output)` and
+//! uses it to encrypt/decrypt the secp256k1 private key.
+//!
+//! `prf_salt` (32 random bytes, stored in `prf.salt`) is the input fed to the
+//! authenticator's PRF. It is not secret. PRF output is never stored on disk.
+//! Without the physical authenticator you cannot reproduce the PRF output and
+//! therefore cannot decrypt the private key.
+//!
+//! ## RP identity
+//! The Relying Party ID is `"localhost"`. For a local CLI daemon the
+//! phishing-protection property of RP IDs is not relevant (no remote RP to
+//! impersonate), and `localhost` keeps credentials portable across machines
+//! and satisfies the WebAuthn origin-domain check.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::response::Html;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use base64::Engine as _;
+use parking_lot::Mutex;
+use rand::RngCore;
+use url::Url;
+use webauthn_rs::prelude::*;
+
+// ── constants ────────────────────────────────────────────────────────────────
+
+/// Fixed local port for the ceremony HTTP server. Chosen to avoid common
+/// service ports. Fails with a clear error if already in use.
+pub(crate) const CEREMONY_PORT: u16 = 18734;
+
+/// Timeout for the authentication ceremony. The WebAuthn prompt fires
+/// automatically on page load, so 120 s is ample.
+const AUTH_TIMEOUT_SECS: u64 = 120;
+
+/// Timeout for the registration ceremony. The user must read the policy
+/// form and optionally edit fields before clicking — allow 5 minutes.
+const REG_TIMEOUT_SECS: u64 = 300;
+
+/// Port for the recovery-key display page (must differ from CEREMONY_PORT
+/// so it can run immediately after the ceremony without a bind conflict).
+const RECOVERY_PORT: u16 = 18735;
+
+/// Timeout for the recovery-key display page.
+const RECOVERY_TIMEOUT_SECS: u64 = 300;
+
+/// WebAuthn Relying Party ID for all bloom passkey credentials.
+pub(crate) const RP_ID: &str = "localhost";
+
+/// Error text shown when the authenticator does not support the PRF extension.
+/// Referenced from both the Rust ceremony path and (via const) from lib.rs.
+pub(crate) const PRF_NOT_SUPPORTED_MSG: &str = "PRF output not received from authenticator. \
+     Bloom requires the WebAuthn PRF extension for passkey wallets. \
+     Supported authenticators: Touch ID (macOS/iOS), YubiKey 5+, \
+     Windows Hello (Chrome 147+), security keys with hmac-secret.";
+
+// ── browser launcher ──────────────────────────────────────────────────────────
+
+/// Open the ceremony URL in the default browser.
+///
+/// Normal (non-incognito) mode is used so the OS credential store persists
+/// the passkey across sessions. If a browser extension interferes with the
+/// WebAuthn API, the in-page error message advises the user to open the URL
+/// manually in an incognito/private window — but we do not force that by
+/// default because incognito windows on Linux do NOT persist passkeys to the
+/// OS keychain, which is exactly the failure mode we are avoiding.
+///
+/// Returns an error if no browser could be launched.
+fn launch_browser(url: &str) -> Result<(), String> {
+    let browsers: &[&str] = &[
+        "google-chrome",
+        "google-chrome-stable",
+        "chromium",
+        "chrome",
+        "firefox", // last: Firefox on Linux has no built-in passkey manager
+                   // and does not support WebAuthn PRF — the ceremony page
+                   // will show the unsupported-authenticator error message.
+    ];
+    for name in browsers {
+        if std::process::Command::new(name)
+            .arg(url)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .is_ok()
+        {
+            return Ok(());
+        }
+    }
+    // macOS: try Chrome / Chromium via `open -a` (no --incognito).
+    #[cfg(target_os = "macos")]
+    {
+        for app in &["Google Chrome", "Chromium"] {
+            if std::process::Command::new("open")
+                .args(["-a", app, url])
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn()
+                .is_ok()
+            {
+                return Ok(());
+            }
+        }
+    }
+    // Fall back to the system default browser.
+    open::that(url)
+        .map_err(|e| format!("could not open browser: {e} (install Chrome, Chromium, or Firefox)"))
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/// Inject PRF extension into a WebAuthn challenge JSON value.
+/// Merges into existing extensions rather than replacing them.
+fn inject_prf_into_challenge_json(
+    mut v: serde_json::Value,
+    prf_salt: &[u8; 32],
+) -> serde_json::Value {
+    let prf_salt_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(prf_salt);
+    if let Some(pk) = v["publicKey"].as_object_mut() {
+        let exts = pk
+            .entry("extensions".to_string())
+            .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+        if let Some(obj) = exts.as_object_mut() {
+            obj.insert(
+                "prf".to_string(),
+                serde_json::json!({ "eval": { "first": prf_salt_b64 } }),
+            );
+        }
+    }
+    v
+}
+
+/// Bind a local TCP listener on `127.0.0.1:{port}`. `ctx` is used in error
+/// messages to identify which server failed (e.g. "passkey ceremony").
+fn bind_local(port: u16, ctx: &str) -> Result<tokio::net::TcpListener, String> {
+    let sock = tokio::net::TcpSocket::new_v4().map_err(|e| format!("create {ctx} socket: {e}"))?;
+    sock.set_reuseaddr(true)
+        .map_err(|e| format!("SO_REUSEADDR: {e}"))?;
+    sock.bind(format!("127.0.0.1:{port}").parse().expect("valid addr"))
+        .map_err(|e| format!("cannot bind port {port} for {ctx}: {e}"))?;
+    sock.listen(128).map_err(|e| format!("listen: {e}"))
+}
+
+// ── builder ──────────────────────────────────────────────────────────────────
+
+fn build_webauthn() -> Result<Webauthn, String> {
+    let origin =
+        Url::parse(&format!("http://localhost:{CEREMONY_PORT}")).map_err(|e| e.to_string())?;
+    WebauthnBuilder::new(RP_ID, &origin)
+        .map_err(|e| format!("WebauthnBuilder: {e}"))?
+        .rp_name("bloom")
+        .build()
+        .map_err(|e| format!("Webauthn build: {e}"))
+}
+
+// ── registration ─────────────────────────────────────────────────────────────
+
+/// Run a WebAuthn registration ceremony for `wallet_name` with PRF key
+/// derivation. Opens `http://localhost:CEREMONY_PORT` in the default browser
+/// and blocks until the ceremony completes or the timeout elapses.
+///
+/// `prf_salt` is a 32-byte value generated by the caller and stored in
+/// `prf.salt` (public, not secret). It is embedded in the challenge so the
+/// authenticator's PRF function produces a deterministic output for this
+/// wallet. The returned PRF output is the raw 32-byte value from the
+/// authenticator — never store it; use it to derive `wrap_key` via BLAKE3.
+///
+/// `policy_toml` is the wallet's initial policy content. It is served at
+/// `/policy` so the registration page can display spend limits before the
+/// user completes the ceremony.
+pub(crate) async fn register_ceremony(
+    wallet_name: &str,
+    policy_toml: &str,
+    prf_salt: &[u8; 32],
+) -> Result<(Passkey, String, [u8; 32]), String> {
+    let webauthn = build_webauthn()?;
+
+    // Derive a stable UUID from the wallet name so re-registrations on the
+    // same machine map to the same resident-key slot.  We do this with
+    // blake3 (already in the dependency tree) rather than requiring the
+    // uuid crate's `v5` feature.
+    let hash = blake3::hash(wallet_name.as_bytes());
+    let mut uuid_bytes = [0u8; 16];
+    uuid_bytes.copy_from_slice(&hash.as_bytes()[..16]);
+    uuid_bytes[6] = (uuid_bytes[6] & 0x0f) | 0x50; // version = 5
+    uuid_bytes[8] = (uuid_bytes[8] & 0x3f) | 0x80; // variant = RFC 4122
+    let user_id = Uuid::from_bytes(uuid_bytes);
+    let (ccr, reg_state) = webauthn
+        .start_passkey_registration(user_id, wallet_name, wallet_name, None)
+        .map_err(|e| format!("start_passkey_registration: {e}"))?;
+
+    let mut challenge_json = serde_json::to_string(&ccr).map_err(|e| e.to_string())?;
+
+    // Patch the challenge JSON to (a) require resident keys and (b) inject
+    // the PRF extension. webauthn-rs 0.5.5 has no non-attested resident-key
+    // API and no PRF API. Drop this patch block when those are added upstream.
+    {
+        let mut v: serde_json::Value =
+            serde_json::from_str(&challenge_json).map_err(|e| e.to_string())?;
+        if let Some(sel) = v["publicKey"]["authenticatorSelection"].as_object_mut() {
+            sel.insert("requireResidentKey".into(), serde_json::Value::Bool(true));
+            sel.insert(
+                "residentKey".into(),
+                serde_json::Value::String("required".into()),
+            );
+        } else {
+            tracing::warn!(
+                "challenge JSON missing authenticatorSelection — QR code cross-device flow may not be offered"
+            );
+        }
+        let v = inject_prf_into_challenge_json(v, prf_salt);
+        challenge_json = serde_json::to_string(&v).map_err(|e| e.to_string())?;
+    }
+
+    let (tx, rx) = tokio::sync::oneshot::channel::<RegisterPublicKeyCredential>();
+    let challenge_b64 = extract_challenge_b64(&challenge_json);
+    let state = RegState {
+        challenge_json,
+        challenge_b64,
+        wallet_name: wallet_name.to_string(),
+        token: gen_token(),
+        prf_output: Arc::new(Mutex::new(None)),
+        fallback_challenge: Arc::new(Mutex::new(None)),
+        policy_toml: Arc::new(Mutex::new(policy_toml.to_string())),
+        tx: Arc::new(Mutex::new(Some(tx))),
+        shutdown: Arc::new(tokio::sync::Notify::new()),
+    };
+
+    let listener = bind_local(CEREMONY_PORT, "passkey ceremony")?;
+    let app = build_reg_app(state.clone());
+    let shutdown = state.shutdown.clone();
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app)
+            .with_graceful_shutdown(async move { shutdown.notified().await })
+            .await;
+    });
+
+    let url = format!("http://localhost:{CEREMONY_PORT}/?t={}", state.token);
+    eprintln!(
+        "[bloom] Opening browser for passkey registration — \
+         complete the ceremony at {url}"
+    );
+    if let Err(e) = launch_browser(&url) {
+        state.shutdown.notify_one();
+        let _ = server.await;
+        return Err(e);
+    }
+
+    let rpkc =
+        match tokio::time::timeout(std::time::Duration::from_secs(REG_TIMEOUT_SECS), rx).await {
+            Ok(Ok(cred)) => cred,
+            Ok(Err(_)) => {
+                state.shutdown.notify_one();
+                let _ = server.await;
+                return Err("ceremony cancelled (browser closed without completing)".into());
+            }
+            Err(_) => {
+                state.shutdown.notify_one();
+                let _ = server.await;
+                return Err(format!("ceremony timed out after {REG_TIMEOUT_SECS}s"));
+            }
+        };
+
+    state.shutdown.notify_one();
+    let _ = server.await;
+
+    let passkey = webauthn
+        .finish_passkey_registration(&rpkc, &reg_state)
+        .map_err(|e| format!("finish_passkey_registration: {e}"))?;
+    let final_policy = state.policy_toml.lock().clone();
+
+    // PRF output must have arrived before /register was POSTed (JS awaits
+    // /prf-output before calling fetch('/register')).
+    let prf_output = state
+        .prf_output
+        .lock()
+        .take()
+        .ok_or_else(|| PRF_NOT_SUPPORTED_MSG.to_string())?;
+
+    Ok((passkey, final_policy, prf_output))
+}
+
+// ── authentication ────────────────────────────────────────────────────────────
+
+/// Run a WebAuthn authentication ceremony against a stored `credential`.
+/// Opens the browser and blocks until completion or timeout.
+///
+/// If `prf_salt` is `Some`, the PRF extension is injected into the auth
+/// challenge so the authenticator produces PRF output. The browser POSTs
+/// it to `/prf-output`; the returned tuple includes `Some(prf_output)`.
+///
+/// If `prf_salt` is `None` (legacy/non-PRF path), no PRF extension is
+/// injected and the second element of the return tuple is `None`.
+///
+/// Returns `(AuthenticationResult, Option<prf_output>)`. The caller must
+/// update the credential counter if `auth_result.needs_update()`.
+pub(crate) async fn auth_ceremony(
+    credential: &Passkey,
+    prf_salt: Option<&[u8; 32]>,
+) -> Result<(AuthenticationResult, Option<[u8; 32]>), String> {
+    let webauthn = build_webauthn()?;
+
+    let (rcr, auth_state) = webauthn
+        .start_passkey_authentication(std::slice::from_ref(credential))
+        .map_err(|e| format!("start_passkey_authentication: {e}"))?;
+
+    let mut challenge_json = serde_json::to_string(&rcr).map_err(|e| e.to_string())?;
+
+    // Inject PRF extension if a salt is provided.
+    if let Some(salt) = prf_salt {
+        let v: serde_json::Value =
+            serde_json::from_str(&challenge_json).map_err(|e| e.to_string())?;
+        let v = inject_prf_into_challenge_json(v, salt);
+        challenge_json = serde_json::to_string(&v).map_err(|e| e.to_string())?;
+    }
+
+    let (tx, rx) = tokio::sync::oneshot::channel::<PublicKeyCredential>();
+    let challenge_b64 = extract_challenge_b64(&challenge_json);
+    let state = AuthState {
+        challenge_json,
+        challenge_b64,
+        token: gen_token(),
+        prf_output: Arc::new(Mutex::new(None)),
+        fallback_challenge: Arc::new(Mutex::new(None)),
+        tx: Arc::new(Mutex::new(Some(tx))),
+        shutdown: Arc::new(tokio::sync::Notify::new()),
+    };
+
+    let listener = bind_local(CEREMONY_PORT, "passkey ceremony")?;
+    let app = build_auth_app(state.clone());
+    let shutdown = state.shutdown.clone();
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app)
+            .with_graceful_shutdown(async move { shutdown.notified().await })
+            .await;
+    });
+
+    let url = format!("http://localhost:{CEREMONY_PORT}/?t={}", state.token);
+    eprintln!(
+        "[bloom] Opening browser for passkey authentication — \
+         complete the ceremony at {url}"
+    );
+    if let Err(e) = launch_browser(&url) {
+        state.shutdown.notify_one();
+        let _ = server.await;
+        return Err(e);
+    }
+
+    let pkc =
+        match tokio::time::timeout(std::time::Duration::from_secs(AUTH_TIMEOUT_SECS), rx).await {
+            Ok(Ok(cred)) => cred,
+            Ok(Err(_)) => {
+                state.shutdown.notify_one();
+                let _ = server.await;
+                return Err("ceremony cancelled (browser closed without completing)".into());
+            }
+            Err(_) => {
+                state.shutdown.notify_one();
+                let _ = server.await;
+                return Err(format!("ceremony timed out after {AUTH_TIMEOUT_SECS}s"));
+            }
+        };
+
+    state.shutdown.notify_one();
+    let _ = server.await;
+
+    let auth_result = webauthn
+        .finish_passkey_authentication(&pkc, &auth_state)
+        .map_err(|e| format!("finish_passkey_authentication: {e}"))?;
+
+    let prf_output = state.prf_output.lock().take();
+    Ok((auth_result, prf_output))
+}
+
+// ── axum apps ─────────────────────────────────────────────────────────────────
+
+/// Body sent to POST /prf-output. The bundled clientDataJSON lets the server
+/// check the PRF output was produced for the challenge it issued, which stops a
+/// cross-tab *browser* script from racing in a forged output. It does NOT by
+/// itself stop a local non-browser process (which can spoof `Origin` and read
+/// the challenge from GET /challenge) — that is what the per-server capability
+/// token enforced by `require_token` is for.
+#[derive(serde::Deserialize)]
+struct PrfOutputBody {
+    prf_output_b64: String,
+    client_data_json_b64: String,
+}
+
+/// Extract the base64url-encoded challenge from a serialised WebAuthn
+/// challenge JSON object (shape: `{"publicKey":{"challenge":"<b64url>",…}}`).
+fn extract_challenge_b64(challenge_json: &str) -> String {
+    serde_json::from_str::<serde_json::Value>(challenge_json)
+        .ok()
+        .and_then(|v| {
+            v.get("publicKey")?
+                .get("challenge")?
+                .as_str()
+                .map(str::to_string)
+        })
+        .unwrap_or_default()
+}
+
+fn parse_prf_output_body(
+    body: &PrfOutputBody,
+    main_challenge: &str,
+    fallback: &Mutex<Option<String>>,
+) -> Result<[u8; 32], axum::http::StatusCode> {
+    use base64::Engine as _;
+    let Ok(bytes) =
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(body.prf_output_b64.trim())
+    else {
+        return Err(axum::http::StatusCode::UNPROCESSABLE_ENTITY);
+    };
+    if bytes.len() != 32 {
+        return Err(axum::http::StatusCode::UNPROCESSABLE_ENTITY);
+    }
+    if !prf_challenge_ok(&body.client_data_json_b64, main_challenge, fallback) {
+        return Err(axum::http::StatusCode::FORBIDDEN);
+    }
+    let mut arr = [0u8; 32];
+    arr.copy_from_slice(&bytes);
+    Ok(arr)
+}
+
+fn issue_fallback_challenge(fallback_challenge: &Mutex<Option<String>>) -> Json<serde_json::Value> {
+    let mut challenge = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut challenge);
+    let b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(challenge);
+    *fallback_challenge.lock() = Some(b64.clone());
+    Json(serde_json::json!({ "challenge": b64 }))
+}
+
+/// Verify that the `clientDataJSON` supplied by the browser contains a
+/// `challenge` field matching either the main ceremony challenge or the
+/// stored fallback challenge (used on the secondary `credentials.get()` path).
+fn prf_challenge_ok(
+    client_data_json_b64: &str,
+    main_challenge: &str,
+    fallback: &Mutex<Option<String>>,
+) -> bool {
+    use base64::Engine as _;
+    let Ok(bytes) =
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(client_data_json_b64.trim())
+    else {
+        return false;
+    };
+    let Ok(cdj) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+        return false;
+    };
+    let Some(got) = cdj.get("challenge").and_then(|v| v.as_str()) else {
+        return false;
+    };
+    got == main_challenge || fallback.lock().as_deref() == Some(got)
+}
+
+#[derive(Clone)]
+struct RegState {
+    challenge_json: String,
+    /// Base64url of the challenge bytes sent to the browser (extracted from
+    /// `challenge_json` at construction time for fast comparison).
+    challenge_b64: String,
+    wallet_name: String,
+    /// Per-server capability token embedded in the launched URL; required on
+    /// state-changing requests by `require_token`.
+    token: String,
+    /// Filled by POST /prf-output once the browser extracts PRF output from
+    /// the authenticator.
+    prf_output: Arc<Mutex<Option<[u8; 32]>>>,
+    /// Set by GET /auth-challenge when the browser needs a second ceremony
+    /// to extract PRF output (the `prf.enabled=true` fallback path).
+    fallback_challenge: Arc<Mutex<Option<String>>>,
+    /// Shared mutable policy TOML — updated when the user edits fields in the
+    /// browser before completing the ceremony.
+    policy_toml: Arc<Mutex<String>>,
+    tx: Arc<Mutex<Option<tokio::sync::oneshot::Sender<RegisterPublicKeyCredential>>>>,
+    shutdown: Arc<tokio::sync::Notify>,
+}
+
+/// Returns `true` if the request is allowed through the origin check.
+/// POST requests must carry `Origin: http://localhost:<port>`; all other
+/// methods are unconditionally allowed (no Origin header on same-origin GETs).
+fn origin_ok(req: &axum::extract::Request, port: u16) -> bool {
+    if req.method() != axum::http::Method::POST {
+        return true;
+    }
+    let expected = format!("http://localhost:{port}");
+    req.headers()
+        .get(axum::http::header::ORIGIN)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|o| o.eq_ignore_ascii_case(&expected))
+}
+
+/// Axum middleware that rejects POST requests whose `Origin` header is not
+/// exactly `http://localhost:<CEREMONY_PORT>`. This prevents a cross-site
+/// script running in another browser tab from racing to inject a fake PRF
+/// output before the legitimate ceremony page does.
+async fn require_localhost_origin(
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    use axum::response::IntoResponse as _;
+    if !origin_ok(&req, CEREMONY_PORT) {
+        return axum::http::StatusCode::FORBIDDEN.into_response();
+    }
+    next.run(req).await
+}
+
+/// Same as `require_localhost_origin` but for the recovery-key page, which
+/// runs on `RECOVERY_PORT` (18735), not `CEREMONY_PORT` (18734).
+async fn require_recovery_origin(
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    use axum::response::IntoResponse as _;
+    if !origin_ok(&req, RECOVERY_PORT) {
+        return axum::http::StatusCode::FORBIDDEN.into_response();
+    }
+    next.run(req).await
+}
+
+/// Generate an unguessable 256-bit capability token (base64url, no pad). It is
+/// embedded in the URL bloom opens and required on every state-changing request
+/// (and the recovery `/data` read), binding the loopback server to the browser
+/// page bloom launched.
+fn gen_token() -> String {
+    let mut t = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut t);
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(t)
+}
+
+/// Capability-token gate. POSTs (and the recovery-page `GET /data`) must carry
+/// an `x-bloom-token` header equal to the per-server token embedded in the URL
+/// bloom opened. The `Origin` header is trivially spoofable by a local
+/// non-browser process and the challenge is readable via `GET /challenge`, so
+/// the origin check alone does not stop a local process from POSTing a forged
+/// PRF output or scraping the recovery key. The token — never sent to the
+/// network, only present in the URL bloom launched — closes that gap.
+async fn require_token(
+    axum::extract::State(token): axum::extract::State<String>,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    use axum::response::IntoResponse as _;
+    let sensitive = req.method() == axum::http::Method::POST
+        || (req.method() == axum::http::Method::GET && req.uri().path() == "/data");
+    if sensitive {
+        let ok = req
+            .headers()
+            .get("x-bloom-token")
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|t| t == token);
+        if !ok {
+            return axum::http::StatusCode::FORBIDDEN.into_response();
+        }
+    }
+    next.run(req).await
+}
+
+fn build_reg_app(state: RegState) -> Router {
+    let token = state.token.clone();
+    Router::new()
+        .route("/", get(reg_index))
+        .route("/challenge", get(reg_challenge))
+        .route("/name", get(reg_name))
+        .route("/policy", get(reg_policy))
+        .route("/policy/update", post(reg_policy_update))
+        .route("/prf-output", post(reg_prf_output))
+        .route("/auth-challenge", get(reg_auth_challenge))
+        .route("/register", post(reg_post))
+        .layer(axum::middleware::from_fn(require_localhost_origin))
+        .layer(axum::middleware::from_fn_with_state(token, require_token))
+        .with_state(state)
+}
+
+async fn reg_index() -> Html<&'static str> {
+    Html(REGISTER_HTML)
+}
+
+async fn reg_challenge(
+    State(state): State<RegState>,
+) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
+    serde_json::from_str(&state.challenge_json)
+        .map(Json)
+        .map_err(|_| axum::http::StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+async fn reg_name(State(state): State<RegState>) -> impl axum::response::IntoResponse {
+    (
+        [(
+            axum::http::header::CONTENT_TYPE,
+            "text/plain; charset=utf-8",
+        )],
+        state.wallet_name.clone(),
+    )
+}
+
+async fn reg_policy(State(state): State<RegState>) -> impl axum::response::IntoResponse {
+    let toml = state.policy_toml.lock().clone();
+    (
+        [(
+            axum::http::header::CONTENT_TYPE,
+            "text/plain; charset=utf-8",
+        )],
+        toml,
+    )
+}
+
+async fn reg_policy_update(State(state): State<RegState>, body: String) -> axum::http::StatusCode {
+    // Validate before accepting — must parse as a valid Policy (not just valid TOML).
+    if toml::from_str::<bloom_proto::Policy>(&body).is_err() {
+        return axum::http::StatusCode::UNPROCESSABLE_ENTITY;
+    }
+    *state.policy_toml.lock() = body;
+    axum::http::StatusCode::OK
+}
+
+async fn reg_prf_output(
+    State(state): State<RegState>,
+    Json(body): Json<PrfOutputBody>,
+) -> axum::http::StatusCode {
+    match parse_prf_output_body(&body, &state.challenge_b64, &state.fallback_challenge) {
+        Ok(arr) => {
+            // Reject a second PRF output rather than letting a late/racing POST
+            // overwrite the first — the value is consumed only at /register.
+            let mut g = state.prf_output.lock();
+            if g.is_some() {
+                return axum::http::StatusCode::CONFLICT;
+            }
+            *g = Some(arr);
+            axum::http::StatusCode::OK
+        }
+        Err(status) => status,
+    }
+}
+
+/// Issue a random challenge for the fallback PRF extraction flow (registration).
+async fn reg_auth_challenge(State(state): State<RegState>) -> Json<serde_json::Value> {
+    issue_fallback_challenge(&state.fallback_challenge)
+}
+
+/// Issue a random challenge for the fallback PRF extraction flow (authentication).
+async fn auth_auth_challenge(State(state): State<AuthState>) -> Json<serde_json::Value> {
+    issue_fallback_challenge(&state.fallback_challenge)
+}
+
+async fn reg_post(
+    State(state): State<RegState>,
+    Json(cred): Json<RegisterPublicKeyCredential>,
+) -> axum::http::StatusCode {
+    let sent = state
+        .tx
+        .lock()
+        .take()
+        .is_some_and(|tx| tx.send(cred).is_ok());
+    state.shutdown.notify_one();
+    if sent {
+        axum::http::StatusCode::OK
+    } else {
+        // Receiver was already dropped (ceremony timed out) — the credential is
+        // discarded; tell the browser so it does not show a false success.
+        axum::http::StatusCode::INTERNAL_SERVER_ERROR
+    }
+}
+
+// ──
+
+#[derive(Clone)]
+struct AuthState {
+    challenge_json: String,
+    /// Base64url of the challenge bytes sent to the browser.
+    challenge_b64: String,
+    /// Per-server capability token embedded in the launched URL; required on
+    /// state-changing requests by `require_token`.
+    token: String,
+    /// Filled by POST /prf-output.
+    prf_output: Arc<Mutex<Option<[u8; 32]>>>,
+    /// Set by GET /auth-challenge on the fallback PRF extraction path.
+    fallback_challenge: Arc<Mutex<Option<String>>>,
+    tx: Arc<Mutex<Option<tokio::sync::oneshot::Sender<PublicKeyCredential>>>>,
+    shutdown: Arc<tokio::sync::Notify>,
+}
+
+fn build_auth_app(state: AuthState) -> Router {
+    let token = state.token.clone();
+    Router::new()
+        .route("/", get(auth_index))
+        .route("/challenge", get(auth_challenge))
+        .route("/auth-challenge", get(auth_auth_challenge))
+        .route("/prf-output", post(auth_prf_output))
+        .route("/auth", post(auth_post))
+        .layer(axum::middleware::from_fn(require_localhost_origin))
+        .layer(axum::middleware::from_fn_with_state(token, require_token))
+        .with_state(state)
+}
+
+async fn auth_index() -> Html<&'static str> {
+    Html(AUTH_HTML)
+}
+
+async fn auth_challenge(
+    State(state): State<AuthState>,
+) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
+    serde_json::from_str(&state.challenge_json)
+        .map(Json)
+        .map_err(|_| axum::http::StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+async fn auth_prf_output(
+    State(state): State<AuthState>,
+    Json(body): Json<PrfOutputBody>,
+) -> axum::http::StatusCode {
+    match parse_prf_output_body(&body, &state.challenge_b64, &state.fallback_challenge) {
+        Ok(arr) => {
+            // Reject a second PRF output rather than letting a late/racing POST
+            // overwrite the first — the value is consumed only at /auth.
+            let mut g = state.prf_output.lock();
+            if g.is_some() {
+                return axum::http::StatusCode::CONFLICT;
+            }
+            *g = Some(arr);
+            axum::http::StatusCode::OK
+        }
+        Err(status) => status,
+    }
+}
+
+async fn auth_post(
+    State(state): State<AuthState>,
+    Json(cred): Json<PublicKeyCredential>,
+) -> axum::http::StatusCode {
+    let sent = state
+        .tx
+        .lock()
+        .take()
+        .is_some_and(|tx| tx.send(cred).is_ok());
+    state.shutdown.notify_one();
+    if sent {
+        axum::http::StatusCode::OK
+    } else {
+        axum::http::StatusCode::INTERNAL_SERVER_ERROR
+    }
+}
+
+// ── HTML pages ────────────────────────────────────────────────────────────────
+
+const REGISTER_HTML: &str = include_str!("passkey_register.html");
+
+const AUTH_HTML: &str = include_str!("passkey_auth.html");
+
+// ── recovery key display ──────────────────────────────────────────────────────
+
+/// Open a browser page that shows the recovery key for a newly created or
+/// rebound passkey wallet. Blocks until the user confirms they have stored
+/// it (POST /done) or the timeout elapses. The caller must already have
+/// printed the key to stderr as a fallback — this is the visual display.
+pub(crate) async fn display_recovery_key(
+    wallet_name: &str,
+    recovery_key_hex: &str,
+) -> Result<(), String> {
+    let state = RecoveryState {
+        wallet_name: wallet_name.to_string(),
+        recovery_key_hex: recovery_key_hex.to_string(),
+        token: gen_token(),
+        done: Arc::new(tokio::sync::Notify::new()),
+        shutdown: Arc::new(tokio::sync::Notify::new()),
+    };
+
+    let app = build_recovery_app(state.clone());
+    let listener = bind_local(RECOVERY_PORT, "recovery key page")?;
+    let shutdown = state.shutdown.clone();
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app)
+            .with_graceful_shutdown(async move { shutdown.notified().await })
+            .await;
+    });
+
+    let url = format!("http://localhost:{RECOVERY_PORT}/?t={}", state.token);
+    eprintln!("[bloom] Recovery key page: {url}");
+    if let Err(e) = launch_browser(&url) {
+        state.shutdown.notify_one();
+        let _ = server.await;
+        return Err(e);
+    }
+
+    let timed_out = tokio::time::timeout(
+        std::time::Duration::from_secs(RECOVERY_TIMEOUT_SECS),
+        state.done.notified(),
+    )
+    .await
+    .is_err();
+
+    state.shutdown.notify_one();
+    let _ = server.await;
+
+    if timed_out {
+        eprintln!("[bloom] Recovery key page timed out after {RECOVERY_TIMEOUT_SECS}s");
+        Err(format!(
+            "recovery key page timed out after {RECOVERY_TIMEOUT_SECS}s"
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct RecoveryState {
+    wallet_name: String,
+    recovery_key_hex: String,
+    /// Per-server capability token embedded in the launched URL; required on
+    /// `GET /data` and `POST /done` by `require_token`.
+    token: String,
+    done: Arc<tokio::sync::Notify>,
+    shutdown: Arc<tokio::sync::Notify>,
+}
+
+fn build_recovery_app(state: RecoveryState) -> Router {
+    let token = state.token.clone();
+    Router::new()
+        .route("/", get(recovery_index))
+        .route("/data", get(recovery_data))
+        .route("/done", post(recovery_done))
+        .layer(axum::middleware::from_fn(require_recovery_origin))
+        .layer(axum::middleware::from_fn_with_state(token, require_token))
+        .with_state(state)
+}
+
+async fn recovery_index() -> Html<&'static str> {
+    Html(RECOVERY_HTML)
+}
+
+async fn recovery_data(State(state): State<RecoveryState>) -> Json<serde_json::Value> {
+    Json(serde_json::json!({
+        "wallet": state.wallet_name,
+        "recovery_key": format!("0x{}", state.recovery_key_hex),
+        "recovery_command": format!(
+            "bloom wallet import {} 0x{}",
+            state.wallet_name, state.recovery_key_hex
+        ),
+    }))
+}
+
+async fn recovery_done(State(state): State<RecoveryState>) -> axum::http::StatusCode {
+    state.done.notify_one();
+    axum::http::StatusCode::OK
+}
+
+const RECOVERY_HTML: &str = include_str!("passkey_recovery.html");
+
+// ── keystore integration ──────────────────────────────────────────────────────
+//
+// Passkey-specific Keystore methods and crypto helpers live here, alongside the
+// ceremony code they depend on.  General keystore logic (local wallets, argon2,
+// list/info) remains in lib.rs.
+
+use alloy::primitives::{Address, B256};
+use alloy::signers::SignerSync as _;
+use alloy::signers::local::PrivateKeySigner;
+use bloom_proto::{Policy, checksum_address};
+use chacha20poly1305::aead::{Aead, KeyInit, Payload};
+use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
+use zeroize::{Zeroize, Zeroizing};
+
+use super::{KeystoreError, PasskeyEncrypted, WalletInfo, WalletKind, read_trim, write_atomic};
+
+// ── passkey crypto constants ──────────────────────────────────────────────────
+
+const PASSKEY_ENCRYPTED_VERSION: u8 = 1;
+const PASSKEY_AAD: &[u8] = b"bloom-keystore-passkey";
+
+// ── passkey crypto helpers ────────────────────────────────────────────────────
+
+/// Show the recovery key in a browser page; if that fails, return it so
+/// `main.rs` can display a terminal prompt instead. Either way the key is
+/// shown exactly once and never written to disk.
+async fn recovery_key_field(name: &str, signer: &PrivateKeySigner) -> Option<Zeroizing<String>> {
+    let hex_key = Zeroizing::new(hex::encode(signer.to_bytes()));
+    if display_recovery_key(name, &hex_key).await.is_ok() {
+        None
+    } else {
+        Some(hex_key)
+    }
+}
+
+/// Encrypt a 32-byte private key using a wrap key derived from `prf_output`.
+/// `wrap_key = blake3::derive_key("bloom passkey wrap key", prf_output)`.
+pub(super) fn encrypt_passkey_key(
+    plaintext: &[u8; 32],
+    prf_output: &[u8; 32],
+) -> Result<PasskeyEncrypted, KeystoreError> {
+    let wrap_key = Zeroizing::new(blake3::derive_key("bloom passkey wrap key", prf_output));
+    let mut nonce_bytes = [0u8; 12];
+    rand::thread_rng().fill_bytes(&mut nonce_bytes);
+    let cipher = ChaCha20Poly1305::new(Key::from_slice(&*wrap_key));
+    let nonce = Nonce::from_slice(&nonce_bytes);
+    let ciphertext = cipher
+        .encrypt(
+            nonce,
+            Payload {
+                msg: plaintext,
+                aad: PASSKEY_AAD,
+            },
+        )
+        .map_err(|e| KeystoreError::Aead(e.to_string()))?;
+    Ok(PasskeyEncrypted {
+        v: PASSKEY_ENCRYPTED_VERSION,
+        nonce_hex: hex::encode(nonce_bytes),
+        ciphertext_hex: hex::encode(&ciphertext),
+    })
+}
+
+/// Decrypt a `PasskeyEncrypted` blob using a wrap key derived from `prf_output`.
+pub(super) fn decrypt_passkey_key(
+    enc: &PasskeyEncrypted,
+    prf_output: &[u8; 32],
+) -> Result<[u8; 32], KeystoreError> {
+    if enc.v != PASSKEY_ENCRYPTED_VERSION {
+        return Err(KeystoreError::Malformed(format!(
+            "unsupported passkey encrypted version {}; expected {}",
+            enc.v, PASSKEY_ENCRYPTED_VERSION
+        )));
+    }
+    let wrap_key = Zeroizing::new(blake3::derive_key("bloom passkey wrap key", prf_output));
+    let nonce_b =
+        hex::decode(&enc.nonce_hex).map_err(|e| KeystoreError::Malformed(format!("nonce: {e}")))?;
+    if nonce_b.len() != 12 {
+        return Err(KeystoreError::Malformed("nonce length".into()));
+    }
+    let ct = hex::decode(&enc.ciphertext_hex)
+        .map_err(|e| KeystoreError::Malformed(format!("ciphertext: {e}")))?;
+    let cipher = ChaCha20Poly1305::new(Key::from_slice(&*wrap_key));
+    let nonce = Nonce::from_slice(&nonce_b);
+    let pt = cipher
+        .decrypt(
+            nonce,
+            Payload {
+                msg: &ct,
+                aad: PASSKEY_AAD,
+            },
+        )
+        .map_err(|e| KeystoreError::Aead(e.to_string()))?;
+    if pt.len() != 32 {
+        return Err(KeystoreError::Malformed(format!(
+            "plaintext len {} != 32",
+            pt.len()
+        )));
+    }
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&pt);
+    Ok(out)
+}
+
+/// Verify `policy.toml.sig` for a PasskeyGated wallet. Returns an error if
+/// the hash doesn't match the current content or the recovered signer address
+/// doesn't match the wallet address.
+pub(super) fn verify_policy_sig(
+    wallet_name: &str,
+    content: &str,
+    address: &Address,
+    sig_path: &std::path::Path,
+) -> Result<(), KeystoreError> {
+    let sig_json_str = std::fs::read_to_string(sig_path).map_err(|source| KeystoreError::Io {
+        path: sig_path.to_path_buf(),
+        source,
+    })?;
+    let sig_data: serde_json::Value = serde_json::from_str(&sig_json_str)
+        .map_err(|e| KeystoreError::Policy(format!("policy.toml.sig parse: {e}")))?;
+    let blake3_hex = sig_data["blake3_hex"]
+        .as_str()
+        .ok_or_else(|| KeystoreError::Policy("policy.toml.sig: missing blake3_hex".into()))?;
+    let sig_hex = sig_data["sig_hex"]
+        .as_str()
+        .ok_or_else(|| KeystoreError::Policy("policy.toml.sig: missing sig_hex".into()))?;
+
+    // Hash includes the wallet name to prevent a sig from one wallet being
+    // transplanted to another wallet with the same address.
+    let computed_hash = {
+        let input = format!("{wallet_name}:{content}");
+        blake3::hash(input.as_bytes())
+    };
+    let computed = hex::encode(computed_hash.as_bytes());
+    if computed != blake3_hex {
+        return Err(KeystoreError::Policy(
+            "policy.toml has been modified since it was signed — run sign-policy to re-sign".into(),
+        ));
+    }
+
+    let sig = sig_hex
+        .parse::<alloy::primitives::Signature>()
+        .map_err(|e| KeystoreError::Policy(format!("policy.toml.sig: bad signature: {e}")))?;
+    let hash_b256 = B256::from_slice(computed_hash.as_bytes());
+    let recovered = sig
+        .recover_address_from_prehash(&hash_b256)
+        .map_err(|e| KeystoreError::Policy(format!("policy.toml.sig: recovery failed: {e}")))?;
+    if &recovered != address {
+        return Err(KeystoreError::Policy(
+            "policy.toml.sig: signature does not match wallet address".into(),
+        ));
+    }
+    Ok(())
+}
+
+// ── shared helpers ────────────────────────────────────────────────────────────
+
+/// Compute the BLAKE3 name-scoped policy hash, sign it with `signer`, and
+/// atomically write `policy.toml.sig` into `dir`.
+///
+/// The name is included in the hash to prevent a signature from one wallet
+/// being transplanted to another wallet with the same address.
+fn write_policy_sig(
+    dir: &std::path::Path,
+    name: &str,
+    policy_toml: &str,
+    signer: &PrivateKeySigner,
+) -> Result<(), KeystoreError> {
+    let policy_hash = blake3::hash(format!("{name}:{policy_toml}").as_bytes());
+    let hash_b256 = B256::from_slice(policy_hash.as_bytes());
+    let sig = signer
+        .sign_hash_sync(&hash_b256)
+        .map_err(|e| KeystoreError::Signer(format!("sign_policy: {e}")))?;
+    let sig_json = serde_json::json!({
+        "blake3_hex": hex::encode(policy_hash.as_bytes()),
+        "sig_hex": sig.to_string(),
+    });
+    write_atomic(
+        &dir.join("policy.toml.sig"),
+        sig_json.to_string().as_bytes(),
+    )
+}
+
+// ── impl Keystore — passkey operations ───────────────────────────────────────
+
+impl super::Keystore {
+    /// Inner: write wallet files and run the registration ceremony.
+    /// Called by `create_passkey` and `import_passkey`.
+    pub(super) async fn import_passkey_inner(
+        &self,
+        name: &str,
+        signer: &PrivateKeySigner,
+    ) -> Result<WalletInfo, KeystoreError> {
+        Self::validate_name(name)?;
+        let dir = self.wallet_path(name);
+        if dir.exists() {
+            return Err(KeystoreError::AlreadyExists(name.into()));
+        }
+
+        // Generate the default policy string before the ceremony so the
+        // browser page can display it for the user to review.
+        let default_policy = Policy::default();
+        let policy_toml_str = toml::to_string_pretty(&default_policy)
+            .map_err(|e| KeystoreError::Policy(e.to_string()))?;
+
+        // Generate a random PRF salt. This is stored on disk (not secret);
+        // it is the input fed to the authenticator's PRF function so the
+        // same authenticator always produces the same wrap key for this wallet.
+        let mut prf_salt = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut prf_salt);
+
+        // Browser WebAuthn registration ceremony — injects the PRF salt into
+        // the challenge. User reviews and edits the policy in the form before
+        // completing. Returns (credential, final_policy_toml, prf_output).
+        let (credential, final_policy_toml, mut prf_output) =
+            register_ceremony(name, &policy_toml_str, &prf_salt)
+                .await
+                .map_err(KeystoreError::PasskeyCeremony)?;
+
+        // Write all wallet files to a temp directory first, then atomically
+        // rename it into place. This prevents leaving a partial wallet on disk
+        // if any write fails mid-way (e.g. disk full). The guard removes the
+        // temp dir on any early return.
+        let tmp_dir = self.inner.root.join(format!(".bloom-tmp-{name}"));
+        let _ = std::fs::remove_dir_all(&tmp_dir); // clean up any stale temp dir
+        std::fs::create_dir_all(&tmp_dir).map_err(|source| KeystoreError::Io {
+            path: tmp_dir.clone(),
+            source,
+        })?;
+        struct TmpGuard(std::path::PathBuf);
+        impl Drop for TmpGuard {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_dir_all(&self.0);
+            }
+        }
+        let guard = TmpGuard(tmp_dir.clone());
+
+        // Encrypt the secp256k1 private key with the PRF-derived wrap key.
+        // Zeroize unconditionally before propagating any error so that
+        // prf_output and key_bytes are never left un-zeroed on the error path
+        // ([u8;32] does not auto-zeroize on drop).
+        let mut key_bytes = signer.to_bytes();
+        let enc_result = encrypt_passkey_key(key_bytes.as_ref(), &prf_output);
+        prf_output.zeroize();
+        key_bytes.zeroize();
+        let enc = enc_result?;
+        let enc_blob =
+            serde_json::to_vec(&enc).map_err(|e| KeystoreError::Malformed(e.to_string()))?;
+        write_atomic(&tmp_dir.join("encrypted.key"), &enc_blob)?;
+
+        // Write prf.salt (public, not secret — used to reproduce prf_output
+        // on future ceremonies with the same authenticator).
+        write_atomic(&tmp_dir.join("prf.salt"), hex::encode(prf_salt).as_bytes())?;
+
+        // Serialise the WebAuthn credential.
+        let passkey_json = serde_json::to_string(&credential)
+            .map_err(|e| KeystoreError::Malformed(format!("passkey serialise: {e}")))?;
+        write_atomic(&tmp_dir.join("passkey.json"), passkey_json.as_bytes())?;
+
+        // Write address, pubkey, kind.
+        let address = signer.address();
+        let pub_hex = hex::encode(
+            signer
+                .credential()
+                .verifying_key()
+                .to_encoded_point(false)
+                .as_bytes(),
+        );
+        write_atomic(
+            &tmp_dir.join("address"),
+            checksum_address(&address).as_bytes(),
+        )?;
+        write_atomic(&tmp_dir.join("pubkey"), pub_hex.as_bytes())?;
+        write_atomic(&tmp_dir.join("kind"), b"passkey")?;
+
+        // Write the final policy — may differ from the pre-generated default
+        // if the user edited fields in the browser before completing the ceremony.
+        write_atomic(&tmp_dir.join("policy.toml"), final_policy_toml.as_bytes())?;
+
+        // Sign the policy immediately — signer is in scope and policy is freshly
+        // written. This eliminates the "unsigned policy" warning on first info().
+        write_policy_sig(&tmp_dir, name, &final_policy_toml, signer)?;
+
+        // All writes succeeded — atomically rename temp dir to final location.
+        std::fs::rename(&tmp_dir, &dir).map_err(|source| KeystoreError::Io {
+            path: dir.clone(),
+            source,
+        })?;
+        // Disarm the cleanup guard — directory is now committed.
+        std::mem::forget(guard);
+
+        // Parse the on-disk policy that was written above. This may differ from
+        // `default_policy` if the user edited fields in the browser during the
+        // ceremony — return what is actually on disk, not the pre-ceremony default.
+        let final_policy = toml::from_str::<Policy>(&final_policy_toml)
+            .map_err(|e| KeystoreError::Policy(format!("final policy parse: {e}")))?;
+
+        // Show the recovery key in a browser page; fall back to returning it
+        // for terminal display if the browser cannot be launched.
+        let recovery_key = recovery_key_field(name, signer).await;
+
+        // Cache the signer so the wallet is ready to use immediately after creation.
+        self.inner
+            .unlocked
+            .write()
+            .insert(name.to_string(), Arc::new(signer.clone()));
+
+        tracing::debug!(wallet = name, "keystore.passkey_created");
+        Ok(WalletInfo {
+            name: name.into(),
+            address,
+            pubkey_hex: pub_hex,
+            kind: WalletKind::PasskeyGated,
+            policy: final_policy,
+            recovery_key,
+        })
+    }
+
+    /// Unlock a passkey wallet via a browser WebAuthn authentication ceremony.
+    /// The ceremony uses the PRF extension to derive the wrap key from the
+    /// authenticator's internal secret, then decrypts and caches the signer.
+    pub async fn unlock_passkey(&self, name: &str) -> Result<(), KeystoreError> {
+        Self::validate_name(name)?;
+        // Fast path: already unlocked — skip the browser ceremony.
+        if self.is_unlocked(name) {
+            return Ok(());
+        }
+        let dir = self.wallet_path(name);
+        if !dir.exists() {
+            return Err(KeystoreError::NotFound(name.into()));
+        }
+
+        // Load stored passkey credential.
+        let passkey_json = std::fs::read_to_string(dir.join("passkey.json")).map_err(|source| {
+            KeystoreError::Io {
+                path: dir.join("passkey.json"),
+                source,
+            }
+        })?;
+        let mut credential: Passkey = serde_json::from_str(&passkey_json)
+            .map_err(|e| KeystoreError::PasskeyCredential(e.to_string()))?;
+
+        // Read prf.salt — public, not secret. Passed to the authenticator so
+        // it produces the deterministic PRF output for this wallet.
+        let prf_salt_hex = read_trim(&dir.join("prf.salt"))?;
+        let prf_salt_bytes = hex::decode(&prf_salt_hex)
+            .map_err(|e| KeystoreError::Malformed(format!("prf.salt: {e}")))?;
+        let prf_salt: [u8; 32] = prf_salt_bytes
+            .try_into()
+            .map_err(|_| KeystoreError::Malformed("prf.salt length != 32".into()))?;
+
+        // Authentication ceremony — injects the PRF salt into the challenge.
+        // Returns (auth_result, Some(prf_output)).
+        let (auth_result, prf_output_opt) = auth_ceremony(&credential, Some(&prf_salt))
+            .await
+            .map_err(KeystoreError::PasskeyCeremony)?;
+
+        // Persist updated counter if the authenticator incremented it. This
+        // happens before the decrypt below; if decryption later fails the
+        // monotonic counter is harmlessly bumped (no security impact — it only
+        // ever moves forward) while the unlock still returns an error.
+        if auth_result.needs_update() {
+            credential.update_credential(&auth_result);
+            let updated_json = serde_json::to_string(&credential)
+                .map_err(|e| KeystoreError::Malformed(format!("passkey re-serialise: {e}")))?;
+            write_atomic(&dir.join("passkey.json"), updated_json.as_bytes())?;
+        }
+
+        let mut prf_output = prf_output_opt
+            .ok_or_else(|| KeystoreError::PasskeyCeremony(PRF_NOT_SUPPORTED_MSG.into()))?;
+
+        let enc_blob =
+            std::fs::read(dir.join("encrypted.key")).map_err(|source| KeystoreError::Io {
+                path: dir.join("encrypted.key"),
+                source,
+            })?;
+        let enc: PasskeyEncrypted = serde_json::from_slice(&enc_blob)
+            .map_err(|e| KeystoreError::Malformed(format!("encrypted.key parse: {e}")))?;
+
+        // Decrypt with PRF-derived wrap key, then zeroize PRF output.
+        let result = decrypt_passkey_key(&enc, &prf_output);
+        prf_output.zeroize();
+        let mut key_bytes = result?;
+
+        let signer = PrivateKeySigner::from_bytes(&key_bytes.into())
+            .map_err(|e| KeystoreError::Signer(e.to_string()))?;
+        key_bytes.zeroize();
+        self.inner
+            .unlocked
+            .write()
+            .insert(name.to_string(), Arc::new(signer));
+        tracing::debug!(wallet = name, "keystore.passkey_unlocked");
+        Ok(())
+    }
+
+    /// Re-bind a PRF-based passkey wallet to a new passkey credential.
+    ///
+    /// Use this to add a second authenticator (device rotation, YubiKey
+    /// replacement, etc.) without moving funds.
+    ///
+    /// Flow:
+    /// 1. Unlock with the existing credential to prove ownership.
+    /// 2. Run a fresh WebAuthn registration ceremony (new credential + new PRF
+    ///    salt → new PRF output).
+    /// 3. Re-encrypt the private key under the new PRF-derived wrap key.
+    /// 4. Atomically replace `encrypted.key`, `prf.salt`, `passkey.json`,
+    ///    `policy.toml`, and `policy.toml.sig` on disk.
+    /// 5. Re-cache the signer under the same wallet name.
+    ///
+    /// A recovery key (raw hex private key) is printed once after the rebind.
+    /// Store it like a seed phrase: `bloom wallet import <name> 0x<key>`.
+    pub async fn rebind_passkey(&self, name: &str) -> Result<WalletInfo, KeystoreError> {
+        Self::validate_name(name)?;
+        let dir = self.wallet_path(name);
+        if !dir.exists() {
+            return Err(KeystoreError::NotFound(name.into()));
+        }
+
+        // Only valid for PRF-based passkey wallets.
+        let kind_str = read_trim(&dir.join("kind"))?;
+        if kind_str != "passkey" {
+            return Err(KeystoreError::PasskeyCredential(format!(
+                "rebind_passkey only applies to passkey wallets ('{name}' is '{kind_str}')"
+            )));
+        }
+        if dir.join("wrap.key").exists() {
+            return Err(KeystoreError::PasskeyCredential(format!(
+                "'{name}' has a legacy wrap.key on disk; this wallet predates PRF support and \
+                 cannot be rebound. Import the private key into a new passkey wallet instead."
+            )));
+        }
+
+        // Step 1: Unlock with existing credential (proves ownership).
+        self.unlock_passkey(name).await?;
+
+        // Step 2: Extract the private key bytes from the in-memory signer.
+        let signer = self
+            .inner
+            .unlocked
+            .read()
+            .get(name)
+            .cloned()
+            .ok_or_else(|| KeystoreError::Locked(name.into()))?;
+        let mut key_arr = [0u8; 32];
+        key_arr.copy_from_slice(&signer.credential().to_bytes());
+        let mut key_bytes = Zeroizing::new(key_arr);
+
+        // Step 3: Read the existing policy so the browser form can pre-populate it.
+        let policy_toml = std::fs::read_to_string(dir.join("policy.toml")).map_err(|source| {
+            KeystoreError::Io {
+                path: dir.join("policy.toml"),
+                source,
+            }
+        })?;
+
+        // Step 4: Generate a fresh PRF salt and run a new registration ceremony.
+        let mut prf_salt = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut prf_salt);
+
+        let (credential, final_policy_toml, mut prf_output) =
+            register_ceremony(name, &policy_toml, &prf_salt)
+                .await
+                .map_err(KeystoreError::PasskeyCeremony)?;
+
+        // Step 5: Re-encrypt under the new PRF-derived wrap key.
+        // Zeroize unconditionally before propagating any error — [u8;32]
+        // does not auto-zeroize on drop.
+        let enc_result = encrypt_passkey_key(&key_bytes, &prf_output);
+        key_bytes.zeroize();
+        prf_output.zeroize();
+        let enc_new = enc_result?;
+        let enc_blob_new =
+            serde_json::to_vec(&enc_new).map_err(|e| KeystoreError::Malformed(e.to_string()))?;
+
+        // Step 6: Atomic writes — order matters for crash safety.
+        //
+        // `encrypted.key` is written LAST so it acts as the commit point.
+        // Any crash before the final write leaves the old encrypted.key on
+        // disk, which still matches the old prf.salt and passkey.json, so
+        // the original authenticator can still unlock the wallet.
+        //
+        // Write order:
+        //   1. policy.toml / policy.toml.sig  — non-critical; crash here is harmless
+        //   2. passkey.json                   — new credential info
+        //   3. prf.salt                       — new PRF salt
+        //   4. encrypted.key                  — FINAL COMMIT: activates new authentication
+        write_atomic(&dir.join("policy.toml"), final_policy_toml.as_bytes())?;
+        write_policy_sig(&dir, name, &final_policy_toml, &signer)?;
+
+        let passkey_json = serde_json::to_string(&credential)
+            .map_err(|e| KeystoreError::Malformed(format!("passkey serialise: {e}")))?;
+        write_atomic(&dir.join("passkey.json"), passkey_json.as_bytes())?;
+        write_atomic(&dir.join("prf.salt"), hex::encode(prf_salt).as_bytes())?;
+        write_atomic(&dir.join("encrypted.key"), &enc_blob_new)?;
+
+        // Step 7: Show recovery key in browser; fall back to terminal if needed.
+        let recovery_key = recovery_key_field(name, &signer).await;
+
+        // Re-insert (same signer; new credential is now on disk).
+        self.inner.unlocked.write().insert(name.to_string(), signer);
+        tracing::info!(wallet = name, "keystore.passkey_rebound");
+
+        let addr_str = read_trim(&dir.join("address"))?;
+        let address = addr_str
+            .parse::<Address>()
+            .map_err(|e| KeystoreError::Malformed(format!("address: {e}")))?;
+        let pubkey_hex = read_trim(&dir.join("pubkey"))?;
+        let policy = toml::from_str::<Policy>(&final_policy_toml)
+            .map_err(|e| KeystoreError::Policy(e.to_string()))?;
+        Ok(WalletInfo {
+            name: name.into(),
+            address,
+            pubkey_hex,
+            kind: WalletKind::PasskeyGated,
+            policy,
+            recovery_key,
+        })
+    }
+
+    /// Sign the current `policy.toml` for a PasskeyGated wallet using the
+    /// wallet's secp256k1 key. The wallet must already be unlocked via
+    /// `unlock_passkey`. Writes `policy.toml.sig` alongside `policy.toml`.
+    pub fn sign_policy(&self, name: &str) -> Result<(), KeystoreError> {
+        Self::validate_name(name)?;
+        let dir = self.wallet_path(name);
+        if !dir.exists() {
+            return Err(KeystoreError::NotFound(name.into()));
+        }
+
+        // Only PasskeyGated wallets use signed policies.
+        let kind_str = read_trim(&dir.join("kind"))?;
+        if kind_str != "passkey" {
+            return Err(KeystoreError::PasskeyCredential(format!(
+                "sign_policy requires a passkey wallet (wallet '{name}' is '{kind_str}')"
+            )));
+        }
+
+        let policy_path = dir.join("policy.toml");
+        let content =
+            std::fs::read_to_string(&policy_path).map_err(|source| KeystoreError::Io {
+                path: policy_path.clone(),
+                source,
+            })?;
+
+        let signer = self.signer(name)?; // must be unlocked
+        write_policy_sig(&dir, name, &content, &signer)?;
+        tracing::debug!(wallet = name, "keystore.policy_signed");
+        Ok(())
+    }
+}

--- a/crates/bloom-keystore/src/passkey_auth.html
+++ b/crates/bloom-keystore/src/passkey_auth.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>bloom — Authenticate</title>
+  <style>
+    body{font-family:monospace;max-width:560px;margin:80px auto;padding:0 20px}
+    h1{font-size:1.1em;margin-bottom:0.3em}
+    p{color:#555;margin-top:0;font-size:0.9em}
+    #status{margin-top:1.2em;padding:1em;background:#f4f4f4;border-radius:4px;line-height:1.5}
+    .ok{background:#d4edda;color:#155724}
+    .err{background:#f8d7da;color:#721c24}
+  </style>
+</head>
+<body>
+  <h1>bloom — Authenticate with Passkey</h1>
+  <p>This page completes passkey authentication for your bloom wallet.</p>
+  <div id="status">Starting authentication…</div>
+<script>
+var TK=new URLSearchParams(location.search).get('t')||'';
+function dec(s){
+  s=s.replace(/-/g,'+').replace(/_/g,'/');
+  while(s.length%4)s+='=';
+  return Uint8Array.from(atob(s),c=>c.charCodeAt(0));
+}
+function enc(b){
+  return btoa(String.fromCharCode(...new Uint8Array(b)))
+    .replace(/\+/g,'-').replace(/\//g,'_').replace(/=/g,'');
+}
+async function run(){
+  const st=document.getElementById('status');
+  if(!navigator.credentials||!navigator.credentials.get){
+    st.className='err';
+    st.textContent='WebAuthn is not available in this browser. Try Chrome or Safari on this device.';
+    return;
+  }
+  try{
+    const opts=await(await fetch('/challenge')).json();
+    opts.publicKey.challenge=dec(opts.publicKey.challenge);
+    if(opts.publicKey.allowCredentials)
+      opts.publicKey.allowCredentials=opts.publicKey.allowCredentials.map(c=>({...c,id:dec(c.id)}));
+    // Decode PRF salt if present (injected by server when unlocking a PRF wallet).
+    // Capture as a variable so the fallback path below can reuse it.
+    var prfSaltBytes=null;
+    if(opts.publicKey.extensions&&opts.publicKey.extensions.prf&&opts.publicKey.extensions.prf.eval&&opts.publicKey.extensions.prf.eval.first){
+      prfSaltBytes=dec(opts.publicKey.extensions.prf.eval.first);
+      opts.publicKey.extensions.prf.eval.first=prfSaltBytes;
+    }
+    st.textContent='Waiting for passkey interaction (Touch ID / security key)…';
+    const cred=await navigator.credentials.get(opts);
+
+    // Extract PRF output and send it before submitting the auth credential.
+    const ext=cred.getClientExtensionResults();
+    const prfFirst=ext&&ext.prf&&ext.prf.results&&ext.prf.results.first;
+    if(prfFirst){
+      await fetch('/prf-output',{method:'POST',headers:{'Content-Type':'application/json','x-bloom-token':TK},body:JSON.stringify({prf_output_b64:enc(prfFirst),client_data_json_b64:enc(cred.response.clientDataJSON)})});
+    }else if(prfSaltBytes&&ext&&ext.prf&&ext.prf.enabled){
+      // PRF is supported but output was not returned in the primary get() call.
+      // Run a secondary get() with a fresh challenge to extract the PRF output,
+      // then submit the original credential to /auth as usual.
+      st.textContent='Almost done — please authenticate once more to complete PRF extraction…';
+      const challengeData=await(await fetch('/auth-challenge')).json();
+      const fallbackChallenge=dec(challengeData.challenge);
+      const credId=new Uint8Array(cred.rawId);
+      const fallbackOpts={
+        publicKey:{
+          challenge:fallbackChallenge,
+          timeout:60000,
+          allowCredentials:[{id:credId,type:'public-key'}],
+          extensions:{prf:{eval:{first:prfSaltBytes}}}
+        }
+      };
+      const fallbackCred=await navigator.credentials.get(fallbackOpts);
+      const fallbackExt=fallbackCred.getClientExtensionResults();
+      const fallbackPrfFirst=fallbackExt&&fallbackExt.prf&&fallbackExt.prf.results&&fallbackExt.prf.results.first;
+      if(!fallbackPrfFirst){
+        st.className='err';
+        st.textContent='PRF output not available from your authenticator. Supported: Touch ID (macOS/iOS), YubiKey 5+, Windows Hello (Chrome 147+), security keys with hmac-secret. On Linux: Chromium has no built-in passkey manager — install Google Chrome instead.';
+        return;
+      }
+      await fetch('/prf-output',{method:'POST',headers:{'Content-Type':'application/json','x-bloom-token':TK},body:JSON.stringify({prf_output_b64:enc(fallbackPrfFirst),client_data_json_b64:enc(fallbackCred.response.clientDataJSON)})});
+    }
+
+    await fetch('/auth',{method:'POST',headers:{'Content-Type':'application/json','x-bloom-token':TK},body:JSON.stringify({
+      id:cred.id,rawId:enc(cred.rawId),type:cred.type,
+      response:{
+        authenticatorData:enc(cred.response.authenticatorData),
+        clientDataJSON:enc(cred.response.clientDataJSON),
+        signature:enc(cred.response.signature),
+        userHandle:cred.response.userHandle?enc(cred.response.userHandle):null
+      }
+    })});
+    st.className='ok';
+    st.textContent='✓ Authentication successful. You can close this tab.';
+  }catch(e){
+    st.className='err';
+    var m=e.message||'';
+    if(m.indexOf('connection')!==-1||m.indexOf('Receiving end')!==-1||m.indexOf('extension')!==-1){
+      st.innerHTML='A browser extension is interfering with passkey authentication.<br><br>Fix: in your browser extension settings, disable passkey management for Bitwarden (or whichever extension is intercepting). On Linux, do <b>not</b> use incognito — passkeys are not saved to the OS keychain from incognito mode. Alternatively, install Google Chrome (not Chromium) and disable Bitwarden passkeys there.<br><br>Error: '+m;
+    }else{
+      st.textContent='Error: '+m;
+    }
+  }
+}
+window.addEventListener('unhandledrejection',function(e){
+  const st=document.getElementById('status');
+  st.className='err';
+  st.textContent='Error: '+e.reason.message+' (disable extension passkey management, or install Google Chrome on Linux)';
+  e.preventDefault();
+});
+run().catch(function(e){
+  const st=document.getElementById('status');
+  st.className='err';
+  st.textContent='Error: '+e.message+' (disable extension passkey management, or install Google Chrome on Linux)';
+});
+</script>
+</body>
+</html>

--- a/crates/bloom-keystore/src/passkey_recovery.html
+++ b/crates/bloom-keystore/src/passkey_recovery.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>bloom — Recovery Key</title>
+  <style>
+    body{font-family:monospace;max-width:620px;margin:60px auto;padding:0 20px}
+    h1{font-size:1.1em;margin-bottom:0.2em}
+    .wallet{color:#888;font-size:0.9em;margin:0 0 1.4em}
+    .warning{background:#fff3cd;border:1px solid #ffc107;border-radius:4px;padding:1em 1.2em;margin-bottom:1.4em;line-height:1.6}
+    .warning strong{color:#856404}
+    .key-box{background:#1a1a2e;color:#e0e0e0;padding:1.2em;border-radius:6px;margin-bottom:1em;position:relative;word-break:break-all;font-size:0.82em;line-height:1.8;letter-spacing:0.04em}
+    .key-box .label{color:#888;font-size:0.75em;text-transform:uppercase;letter-spacing:0.08em;margin-bottom:0.6em}
+    .key-box .hex{display:block}
+    .copy-btn{position:absolute;top:0.8em;right:0.8em;font-family:monospace;font-size:0.8em;padding:0.3em 0.8em;background:#333;color:#ccc;border:1px solid #555;border-radius:3px;cursor:pointer}
+    .copy-btn:hover{background:#444}
+    .cmd{background:#f4f4f4;padding:0.7em 1em;border-radius:4px;font-size:0.85em;margin-bottom:1.4em;color:#333;word-break:break-all}
+    .cmd .label{font-size:0.7em;text-transform:uppercase;letter-spacing:0.08em;color:#888;margin-bottom:0.3em}
+    .confirm-row{display:flex;align-items:center;gap:0.6em;margin-bottom:1em}
+    .confirm-row input[type=checkbox]{width:16px;height:16px;cursor:pointer}
+    .confirm-row label{font-size:0.85em;color:#444;cursor:pointer}
+    button{font-family:monospace;font-size:0.95em;padding:0.55em 1.2em;background:#1a1a2e;color:#fff;border:none;border-radius:4px;cursor:pointer}
+    button:disabled{opacity:0.45;cursor:default}
+    #status{margin-top:1em;padding:0.8em 1em;border-radius:4px;line-height:1.5;display:none}
+    .ok{background:#d4edda;color:#155724;display:block!important}
+  </style>
+</head>
+<body>
+  <h1>bloom — Recovery Key</h1>
+  <p class="wallet" id="wallet-name">Loading…</p>
+
+  <div class="warning">
+    <strong>STORE THIS KEY SAFELY.</strong><br>
+    If you lose <strong>both</strong> your passkey device <strong>and</strong> this recovery key,
+    your wallet is <strong>permanently inaccessible</strong>. No one can recover it — not bloom, not anyone.
+    <br><br>
+    This page is shown <strong>once</strong>. Write the key down or save it in a password manager
+    before you continue.
+  </div>
+
+  <div class="key-box">
+    <div class="label">Recovery key</div>
+    <button class="copy-btn" id="copy-btn" onclick="copyKey()">Copy</button>
+    <span class="hex" id="key-text"></span>
+  </div>
+
+  <div class="cmd">
+    <div class="label">Recovery command</div>
+    <div id="cmd-text"></div>
+  </div>
+
+  <div class="confirm-row">
+    <input type="checkbox" id="saved" onchange="updateBtn()">
+    <label for="saved">I have securely stored this recovery key</label>
+  </div>
+
+  <button id="btn" disabled onclick="confirmKey()">Done — I have saved this key</button>
+  <div id="status"></div>
+
+<script>
+var TK=new URLSearchParams(location.search).get('t')||'';
+var recoveryKeyHex = '';
+function updateBtn(){
+  document.getElementById('btn').disabled = !document.getElementById('saved').checked;
+}
+function copyKey(){
+  navigator.clipboard.writeText(recoveryKeyHex).then(function(){
+    var b = document.getElementById('copy-btn');
+    b.textContent = 'Copied!';
+    setTimeout(function(){ b.textContent = 'Copy'; }, 2000);
+  }).catch(function(){
+    prompt('Copy this key:', recoveryKeyHex);
+  });
+}
+async function confirmKey(){
+  var btn = document.getElementById('btn');
+  var st = document.getElementById('status');
+  btn.disabled = true;
+  try{
+    var resp = await fetch('/done', {method:'POST',headers:{'x-bloom-token':TK}});
+    if(resp.ok){
+      st.className = 'ok';
+      st.textContent = '✓ Confirmed. You can close this tab.';
+    }else{
+      btn.disabled = false;
+      st.style.display = 'block';
+      st.className = '';
+      st.style.background = '#f8d7da';
+      st.style.color = '#721c24';
+      st.textContent = 'Something went wrong. Please try again.';
+    }
+  }catch(e){
+    btn.disabled = false;
+    st.style.display = 'block';
+    st.style.background = '#f8d7da';
+    st.style.color = '#721c24';
+    st.textContent = 'Error: ' + e.message;
+  }
+}
+async function init(){
+  try{
+    var resp = await fetch('/data', {headers:{'x-bloom-token':TK}});
+    var data = await resp.json();
+    document.getElementById('wallet-name').textContent = 'wallet: ' + data.wallet;
+    document.getElementById('key-text').textContent = data.recovery_key;
+    document.getElementById('cmd-text').textContent = data.recovery_command;
+    recoveryKeyHex = data.recovery_key;
+  }catch(e){
+    document.getElementById('wallet-name').textContent = 'Error loading key data.';
+  }
+}
+init();
+</script>
+</body>
+</html>

--- a/crates/bloom-keystore/src/passkey_register.html
+++ b/crates/bloom-keystore/src/passkey_register.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>bloom — Register Passkey</title>
+  <style>
+    body{font-family:monospace;max-width:620px;margin:60px auto;padding:0 20px}
+    h1{font-size:1.1em;margin-bottom:0.2em}
+    .wallet{color:#888;font-size:0.9em;margin:0 0 1.4em}
+    .section{margin-bottom:1.2em}
+    .section-label{font-size:0.75em;text-transform:uppercase;letter-spacing:0.08em;color:#888;margin:0 0 0.5em}
+    .field{display:flex;align-items:baseline;gap:0.6em;margin-bottom:0.4em}
+    .field label{font-size:0.85em;color:#444;min-width:220px}
+    .field input[type=number]{font-family:monospace;font-size:0.85em;width:90px;padding:0.2em 0.4em;border:1px solid #ccc;border-radius:3px}
+    .field input[type=checkbox]{width:14px;height:14px;cursor:pointer}
+    .field .unit{font-size:0.8em;color:#888}
+    .field .opt{font-size:0.75em;color:#aaa;margin-left:0.2em}
+    button{font-family:monospace;font-size:0.95em;padding:0.55em 1.2em;background:#1a1a2e;color:#fff;border:none;border-radius:4px;cursor:pointer;margin-top:0.6em}
+    button:disabled{opacity:0.45;cursor:default}
+    .hint{color:#888;font-size:0.8em;margin-top:0.4em}
+    #status{margin-top:1em;padding:0.8em 1em;border-radius:4px;line-height:1.5;display:none}
+    .ok{background:#d4edda;color:#155724;display:block!important}
+    .err{background:#f8d7da;color:#721c24;display:block!important}
+    hr{border:none;border-top:1px solid #e8e8e8;margin:1.2em 0}
+  </style>
+</head>
+<body>
+  <h1>bloom — Register Passkey</h1>
+  <p class="wallet" id="wallet-name">Loading…</p>
+
+  <div class="section">
+    <p class="section-label">Spend limits</p>
+    <div class="field">
+      <label>Hard cap per tx</label>
+      <input type="number" id="max_value_eth" min="0" step="0.01" placeholder="none">
+      <span class="unit">ETH</span><span class="opt">(optional)</span>
+    </div>
+    <div class="field">
+      <label>Require override above</label>
+      <input type="number" id="require_override_above_eth" min="0" step="0.01" placeholder="none">
+      <span class="unit">ETH</span><span class="opt">(optional)</span>
+    </div>
+    <div class="field">
+      <label>Require confirm above</label>
+      <input type="number" id="require_confirm_above_usd" min="0" step="1" placeholder="none">
+      <span class="unit">USD</span><span class="opt">(optional)</span>
+    </div>
+  </div>
+
+  <div class="section">
+    <p class="section-label">Swap protection</p>
+    <div class="field">
+      <label>Max slippage</label>
+      <input type="number" id="max_slippage_pct" min="0.01" max="50" step="0.01" value="1">
+      <span class="unit">%</span>
+    </div>
+    <div class="field">
+      <label>Fail on high-risk routes</label>
+      <input type="checkbox" id="fail_on_high_risk">
+    </div>
+  </div>
+
+  <div class="section">
+    <p class="section-label">Privacy</p>
+    <div class="field">
+      <label>Route via MEV Blocker</label>
+      <input type="checkbox" id="private_enabled">
+    </div>
+  </div>
+
+  <hr>
+  <button id="btn" disabled>Save policy &amp; register passkey</button>
+  <p class="hint">Your authenticator (Touch ID, security key, etc.) will be prompted after clicking.</p>
+  <div id="status"></div>
+
+<script>
+var TK=new URLSearchParams(location.search).get('t')||'';
+function dec(s){
+  s=s.replace(/-/g,'+').replace(/_/g,'/');
+  while(s.length%4)s+='=';
+  return Uint8Array.from(atob(s),c=>c.charCodeAt(0));
+}
+function enc(b){
+  return btoa(String.fromCharCode(...new Uint8Array(b)))
+    .replace(/\+/g,'-').replace(/\//g,'_').replace(/=/g,'');
+}
+function fval(id){return document.getElementById(id).value.trim();}
+function fchecked(id){return document.getElementById(id).checked;}
+function buildToml(){
+  var lines=['[caps]'];
+  var maxEth=fval('max_value_eth');
+  var overEth=fval('require_override_above_eth');
+  var confUsd=fval('require_confirm_above_usd');
+  if(maxEth)  lines.push('max_value_eth = '+parseFloat(maxEth));
+  if(overEth) lines.push('require_override_above_eth = '+parseFloat(overEth));
+  if(confUsd) lines.push('require_confirm_above_usd = '+parseFloat(confUsd));
+  var slippageBps=Math.round(parseFloat(fval('max_slippage_pct')||'1')*100);
+  lines.push('','[mev]',
+    'max_slippage_bps = '+slippageBps,
+    'fail_on_high_risk = '+(fchecked('fail_on_high_risk')?'true':'false'));
+  lines.push('','[private]',
+    'enabled = '+(fchecked('private_enabled')?'true':'false'),
+    'provider = "mev_blocker"');
+  lines.push('','[bump]',
+    'stuck_after_secs = 90',
+    'basefee_overrun_pct = 20');
+  return lines.join('\n');
+}
+function populateForm(toml){
+  function match(key){var m=toml.match(new RegExp(key+'\\s*=\\s*([^\\n]+)'));return m?m[1].trim():null;}
+  var maxEth=match('max_value_eth');         if(maxEth) document.getElementById('max_value_eth').value=maxEth;
+  var overEth=match('require_override_above_eth'); if(overEth) document.getElementById('require_override_above_eth').value=overEth;
+  var confUsd=match('require_confirm_above_usd'); if(confUsd) document.getElementById('require_confirm_above_usd').value=confUsd;
+  var bps=match('max_slippage_bps'); if(bps) document.getElementById('max_slippage_pct').value=(parseInt(bps)/100).toFixed(2);
+  var fhr=match('fail_on_high_risk'); if(fhr) document.getElementById('fail_on_high_risk').checked=(fhr==='true');
+  var priv=match('enabled'); if(priv) document.getElementById('private_enabled').checked=(priv==='true');
+}
+async function init(){
+  var name=await(await fetch('/name')).text();
+  document.getElementById('wallet-name').textContent='wallet: '+name;
+  var toml=await(await fetch('/policy')).text();
+  populateForm(toml);
+  document.getElementById('btn').disabled=false;
+}
+async function register(){
+  var btn=document.getElementById('btn');
+  var st=document.getElementById('status');
+  btn.disabled=true;
+  st.style.display='block';
+  st.className='';
+  if(!navigator.credentials||!navigator.credentials.create){
+    st.className='err';
+    st.textContent='WebAuthn is not available in this browser. Try Chrome or Safari on this device.';
+    return;
+  }
+  var toml=buildToml();
+  var upd=await fetch('/policy/update',{method:'POST',headers:{'Content-Type':'text/plain','x-bloom-token':TK},body:toml});
+  if(!upd.ok){
+    st.className='err';
+    st.textContent='Policy validation failed (invalid TOML). Please check your inputs.';
+    btn.disabled=false;
+    return;
+  }
+  st.textContent='Waiting for passkey interaction (Touch ID / security key)…';
+  try{
+    var opts=await(await fetch('/challenge')).json();
+    opts.publicKey.challenge=dec(opts.publicKey.challenge);
+    opts.publicKey.user.id=dec(opts.publicKey.user.id);
+    if(opts.publicKey.excludeCredentials)
+      opts.publicKey.excludeCredentials=opts.publicKey.excludeCredentials.map(function(c){return{...c,id:dec(c.id)};});
+    // Decode the PRF salt from base64url to ArrayBuffer for the WebAuthn API.
+    var prfSaltBytes=null;
+    if(opts.publicKey.extensions&&opts.publicKey.extensions.prf&&opts.publicKey.extensions.prf.eval&&opts.publicKey.extensions.prf.eval.first){
+      prfSaltBytes=dec(opts.publicKey.extensions.prf.eval.first);
+      opts.publicKey.extensions.prf.eval.first=prfSaltBytes;
+    }
+    var cred=await navigator.credentials.create(opts);
+    var ext=cred.getClientExtensionResults();
+    var prfFirst=ext&&ext.prf&&ext.prf.results&&ext.prf.results.first;
+
+    if(prfFirst){
+      // PRF output returned during create — most common path (macOS Touch ID + Chrome).
+      await fetch('/prf-output',{method:'POST',headers:{'Content-Type':'application/json','x-bloom-token':TK},body:JSON.stringify({prf_output_b64:enc(prfFirst),client_data_json_b64:enc(cred.response.clientDataJSON)})});
+    }else if(ext&&ext.prf&&ext.prf.enabled){
+      // PRF is supported but output only available during get(), not create().
+      // Run a secondary authentication to extract PRF output.
+      st.textContent='Almost done — please authenticate once more to complete PRF setup…';
+      var challengeData=await(await fetch('/auth-challenge')).json();
+      var fallbackChallenge=dec(challengeData.challenge);
+      var credId=new Uint8Array(cred.rawId);
+      var authOpts={
+        publicKey:{
+          challenge:fallbackChallenge,
+          timeout:60000,
+          allowCredentials:[{id:credId,type:'public-key'}],
+          extensions:{prf:{eval:{first:prfSaltBytes}}}
+        }
+      };
+      var authCred=await navigator.credentials.get(authOpts);
+      var authExt=authCred.getClientExtensionResults();
+      var authPrfFirst=authExt&&authExt.prf&&authExt.prf.results&&authExt.prf.results.first;
+      if(!authPrfFirst){
+        st.className='err';
+        st.textContent='PRF output not available from your authenticator. Supported: Touch ID (macOS/iOS), YubiKey 5+, Windows Hello (Chrome 147+), security keys with hmac-secret. On Linux: Chromium has no built-in passkey manager — install Google Chrome instead.';
+        btn.disabled=false;
+        return;
+      }
+      await fetch('/prf-output',{method:'POST',headers:{'Content-Type':'application/json','x-bloom-token':TK},body:JSON.stringify({prf_output_b64:enc(authPrfFirst),client_data_json_b64:enc(authCred.response.clientDataJSON)})});
+    }else{
+      // PRF not supported at all by this authenticator.
+      st.className='err';
+      st.textContent='Your authenticator does not support the PRF extension required by bloom passkey wallets. Supported: Touch ID (macOS/iOS), YubiKey 5+, Windows Hello (Chrome 147+), security keys with hmac-secret. On Linux: Chromium has no built-in passkey manager — install Google Chrome instead.';
+      btn.disabled=false;
+      return;
+    }
+
+    await fetch('/register',{method:'POST',headers:{'Content-Type':'application/json','x-bloom-token':TK},body:JSON.stringify({
+      id:cred.id,rawId:enc(cred.rawId),type:cred.type,
+      response:{
+        attestationObject:enc(cred.response.attestationObject),
+        clientDataJSON:enc(cred.response.clientDataJSON)
+      }
+    })});
+    st.className='ok';
+    st.textContent='✓ Passkey registered. You can close this tab.';
+    btn.style.display='none';
+  }catch(e){
+    btn.disabled=false;
+    st.className='err';
+    var m=e.message||'';
+    if(m.indexOf('connection')!==-1||m.indexOf('Receiving end')!==-1||m.indexOf('extension')!==-1){
+      st.innerHTML='A browser extension (e.g. Bitwarden) is interfering with passkey creation.<br><br>Fix: in the extension settings, disable passkey management for this browser. <b>Do not use incognito on Linux</b> — passkeys are not saved to the OS keychain from incognito mode. Alternatively, install Google Chrome and disable Bitwarden passkeys there.<br><br>Error: '+m;
+    }else{
+      st.textContent='Error: '+m;
+    }
+  }
+}
+document.getElementById('btn').addEventListener('click',function(){
+  register().catch(function(e){
+    var st=document.getElementById('status');
+    st.className='err';
+    st.textContent='Error: '+e.message;
+    document.getElementById('btn').disabled=false;
+  });
+});
+window.addEventListener('unhandledrejection',function(e){
+  var st=document.getElementById('status');
+  st.className='err';
+  st.textContent='Error: '+e.reason.message+' (if a browser extension is interfering, disable its passkey management in extension settings)';
+  e.preventDefault();
+});
+init().catch(function(e){
+  document.getElementById('btn').disabled=false;
+});
+</script>
+</body>
+</html>

--- a/crates/bloom-prices/src/lib.rs
+++ b/crates/bloom-prices/src/lib.rs
@@ -93,24 +93,31 @@ impl CoinId {
     }
 }
 
-/// Resolve a common ticker symbol to a wire id.
-///
-/// v1: hardcoded popular symbols. Caller-provided unknown symbols return
-/// `None`; the client surfaces these as [`PricesError::InvalidCoinId`].
+/// Single source of truth for built-in symbols: (lowercase ticker, wire id).
+pub const SYMBOL_MAP: &[(&str, &str)] = &[
+    ("eth", "coingecko:ethereum"),
+    ("btc", "coingecko:bitcoin"),
+    (
+        "usdc",
+        "ethereum:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+    ),
+    (
+        "usdt",
+        "ethereum:0xdac17f958d2ee523a2206206994597c13d831ec7",
+    ),
+    ("dai", "ethereum:0x6b175474e89094c44da98b954eedeac495271d0f"),
+    (
+        "weth",
+        "ethereum:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+    ),
+];
+
 fn resolve_symbol(sym: &str) -> Option<String> {
-    let s = sym.trim().to_ascii_uppercase();
-    Some(
-        match s.as_str() {
-            "ETH" => "coingecko:ethereum",
-            "BTC" => "coingecko:bitcoin",
-            "USDC" => "ethereum:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-            "USDT" => "ethereum:0xdac17f958d2ee523a2206206994597c13d831ec7",
-            "DAI" => "ethereum:0x6b175474e89094c44da98b954eedeac495271d0f",
-            "WETH" => "ethereum:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-            _ => return None,
-        }
-        .to_string(),
-    )
+    let s = sym.trim().to_ascii_lowercase();
+    SYMBOL_MAP
+        .iter()
+        .find(|(k, _)| *k == s.as_str())
+        .map(|(_, v)| v.to_string())
 }
 
 /// Resolve a native-chain identifier to a wire id (coingecko slug).

--- a/crates/bloom-proto/src/intent.rs
+++ b/crates/bloom-proto/src/intent.rs
@@ -125,6 +125,10 @@ pub struct RawIntent {
     /// Optional explicit nonce override (rarely useful).
     #[serde(default)]
     pub nonce: Option<u64>,
+    /// Gas limit hint from an external estimator (e.g. Enso). Used as
+    /// the fallback when `eth_estimateGas` fails at stage time.
+    #[serde(default)]
+    pub gas_limit_hint: Option<u64>,
 }
 
 /// A normalised concrete tx-intent (post-resolution): addresses parsed,

--- a/crates/bloom-tx/src/intent_parser.rs
+++ b/crates/bloom-tx/src/intent_parser.rs
@@ -159,6 +159,7 @@ impl LooseIntent {
             chain: self.chain,
             gas,
             nonce: self.nonce,
+            gas_limit_hint: None,
         })
     }
 }
@@ -198,6 +199,7 @@ pub fn parse(input: &str) -> Result<RawIntent, ParseError> {
                 _ => bloom_proto::GasStrategy::Auto,
             },
             nonce: None,
+            gas_limit_hint: None,
         });
     }
     if s.starts_with("nft ") {
@@ -318,6 +320,7 @@ fn parse_nft_shell(line: &str) -> Result<RawIntent, ParseError> {
         chain,
         gas: bloom_proto::GasStrategy::Auto,
         nonce: None,
+        gas_limit_hint: None,
     })
 }
 

--- a/crates/bloom-tx/src/outbox.rs
+++ b/crates/bloom-tx/src/outbox.rs
@@ -226,6 +226,44 @@ impl Outbox {
         Ok(path)
     }
 
+    /// Return the highest nonce among all `pending/<wallet>/<chain>/<id>/intent.json`
+    /// entries whose `from` address matches `addr`. Returns `None` when the pending
+    /// directory is empty or doesn't exist yet (no staged txs for this sender).
+    ///
+    /// Called by `TxEngine::stage()` under a per-(wallet, chain, from) async mutex
+    /// to compute the correct next nonce when multiple txs are staged before any
+    /// are broadcast.
+    ///
+    /// Scans all pending entries for `addr` on each call — acceptable for
+    /// single-user CLI where the pending queue is small.
+    pub fn highest_pending_nonce(
+        &self,
+        wallet: &str,
+        chain: &str,
+        addr: alloy::primitives::Address,
+    ) -> Result<Option<u64>, OutboxError> {
+        let dir = self.state_dir(wallet, chain, OutboxState::Pending)?;
+        if !dir.exists() {
+            return Ok(None);
+        }
+        let mut max_nonce: Option<u64> = None;
+        for entry in fs::read_dir(&dir)? {
+            let entry = entry?;
+            if !entry.file_type()?.is_dir() {
+                continue;
+            }
+            let intent_path = entry.path().join("intent.json");
+            if !intent_path.exists() {
+                continue;
+            }
+            let staged: StagedTx = serde_json::from_slice(&fs::read(&intent_path)?)?;
+            if staged.from.parse::<alloy::primitives::Address>().ok() == Some(addr) {
+                max_nonce = Some(max_nonce.map_or(staged.nonce, |m| m.max(staged.nonce)));
+            }
+        }
+        Ok(max_nonce)
+    }
+
     /// Search for `id` across pending/sent/failed and return the first hit.
     /// Prefer [`Self::read_in_state`] when the caller knows where the entry
     /// is supposed to be — this method exists for diagnostics and is the

--- a/crates/bloom-tx/src/tx_engine.rs
+++ b/crates/bloom-tx/src/tx_engine.rs
@@ -92,6 +92,10 @@ pub enum TxEngineError {
     PrivateProviderChainMismatch { provider: String, chain_id: u64 },
     #[error("tx '{id}' is in status {status}, expected pending or unmined sent")]
     InvalidTxStatus { id: String, status: String },
+    #[error(
+        "Enso quote is {age}s old (expires ~5 min) — re-run the intent for a fresh route, or write 'override' to broadcast anyway"
+    )]
+    EnsoQuoteStale { age: u64 },
 }
 
 /// In-memory cache for ERC-20 metadata keyed by `(chain_id, address)`.
@@ -156,6 +160,12 @@ struct TokenMeta {
     decimals: u8,
 }
 
+/// Per-(wallet, chain, from) stage-serialisation lock map.
+/// Outer lock: `parking_lot` (held microseconds for HashMap lookup/insert).
+/// Inner lock: `tokio` async mutex (held for the stage critical section).
+type NonceLocks =
+    Arc<parking_lot::Mutex<HashMap<(String, String, Address), Arc<tokio::sync::Mutex<()>>>>>;
+
 /// Stage / confirm the lifecycle.
 #[derive(Clone)]
 pub struct TxEngine {
@@ -177,6 +187,12 @@ pub struct TxEngine {
     /// signed raw txs privately when `policy.private.enabled` is set
     /// (mainnet only — see `MAINNET_CHAIN_ID`).
     private_rpcs: PrivateRpcs,
+    /// Per-(wallet, chain, from) async mutex that serialises the
+    /// read-chain-nonce → check-pending → write-pending critical section
+    /// in `stage()`. The outer `parking_lot::Mutex` is held for
+    /// microseconds only (HashMap lookup/insert); the inner
+    /// `tokio::sync::Mutex` is the actual per-sender stage lock.
+    nonce_locks: NonceLocks,
 }
 
 impl TxEngine {
@@ -190,7 +206,27 @@ impl TxEngine {
             price_oracle: None,
             mempool_indexes: Arc::new(RwLock::new(BTreeMap::new())),
             private_rpcs: Arc::new(RwLock::new(BTreeMap::new())),
+            nonce_locks: Arc::new(parking_lot::Mutex::new(HashMap::new())),
         }
+    }
+
+    /// Return (or create) the per-(wallet, chain, from) `tokio::sync::Mutex`
+    /// used to serialise nonce assignment in `stage()`. The outer
+    /// `parking_lot::Mutex` is held only for the HashMap lookup/insert
+    /// (~microseconds); callers then `.lock().await` the returned
+    /// `Arc<tokio::sync::Mutex<()>>` to cover the critical section.
+    fn nonce_lock_for(
+        &self,
+        wallet: &str,
+        chain: &str,
+        from: Address,
+    ) -> Arc<tokio::sync::Mutex<()>> {
+        let key = (wallet.to_string(), chain.to_string(), from);
+        self.nonce_locks
+            .lock()
+            .entry(key)
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
     }
 
     /// Register the `PendingTxIndex` for `chain`. Calling stage on this
@@ -742,9 +778,26 @@ impl TxEngine {
                 "tx.staging.session_degraded"
             );
         }
+        // Acquire a per-(wallet, chain, from) async mutex so concurrent
+        // stage() calls for the same sender serialise here. The guard
+        // lives until the end of stage(), covering write_pending, so two
+        // callers can't both read nonce=0 and commit pending entries with
+        // the same nonce.
+        let nonce_mutex = self.nonce_lock_for(wallet, &spec.name, from);
+        let _nonce_guard = nonce_mutex.lock().await;
         let nonce = match intent.nonce {
             Some(n) => n,
-            None => session.nonce(from).await?,
+            None => {
+                let chain_nonce = session.nonce(from).await?;
+                let pending_high = self
+                    .outbox
+                    .highest_pending_nonce(wallet, &spec.name, from)?;
+                // If there are staged-but-unconfirmed txs, use the slot
+                // after the highest pending nonce. After broadcast they
+                // move to sent/ and the chain RPC returns the updated
+                // next nonce — no stale-data risk once the queue drains.
+                pending_high.map_or(chain_nonce, |h| chain_nonce.max(h + 1))
+            }
         };
         // Check for an externally-observed pending tx at this (from, nonce).
         // Body is computed up-front but written only after write_pending
@@ -786,8 +839,15 @@ impl TxEngine {
                 buffered.max(21_000)
             }
             Err(e) => {
-                tracing::warn!(error = %e, "estimate_gas failed; using 500k fallback");
-                500_000
+                // Use the hint from the external estimator (e.g. Enso) when
+                // available, applying the same 25% buffer. Fall back to 500k
+                // only if no hint was provided.
+                let fallback = intent
+                    .gas_limit_hint
+                    .map(|h| (h.saturating_mul(125) / 100).min(30_000_000))
+                    .unwrap_or(500_000);
+                tracing::warn!(error = %e, fallback, "estimate_gas failed");
+                fallback
             }
         };
 
@@ -1041,6 +1101,16 @@ impl TxEngine {
                 "tx.policy_denied"
             );
             return Err(TxEngineError::PolicyDenied);
+        }
+
+        // Enso quotes embed a ~5-minute deadline. Warn before wasting gas.
+        const ENSO_QUOTE_MAX_AGE_SECS: u64 = 300;
+        let now_secs = (now_ms() / 1000) as u64;
+        if let Some(age) = enso_quote_age_secs(&staged.data_hex, now_secs)
+            && age > ENSO_QUOTE_MAX_AGE_SECS
+            && !override_text
+        {
+            return Err(TxEngineError::EnsoQuoteStale { age });
         }
 
         // Broadcast gate: never broadcast to mainnet by default.
@@ -1381,6 +1451,37 @@ fn decode_data(s: &str) -> Result<Bytes, TxEngineError> {
     let s = s.strip_prefix("0x").unwrap_or(s);
     let v = hex::decode(s).map_err(|e| TxEngineError::Amount(format!("data: {e}")))?;
     Ok(Bytes::from(v))
+}
+
+/// Parse the Enso quote age in seconds from calldata, if present.
+/// Enso appends a raw JSON blob starting with `{"Source":"Enso` to every
+/// route calldata. Returns `None` for non-Enso calldata or parse failures.
+fn enso_quote_age_secs(data_hex: &str, now_secs: u64) -> Option<u64> {
+    let bytes = hex::decode(data_hex.trim_start_matches("0x")).ok()?;
+    const MARKER: &[u8] = b"{\"Source\":\"Enso";
+    let pos = bytes.windows(MARKER.len()).position(|w| w == MARKER)?;
+    // Marker found — try to extract timestamp.
+    let v: serde_json::Value = match serde_json::Deserializer::from_slice(&bytes[pos..])
+        .into_iter()
+        .next()
+    {
+        Some(Ok(val)) => val,
+        other => {
+            tracing::warn!(?other, "enso.calldata.marker_found_parse_failed");
+            return None;
+        }
+    };
+    let ts = match v["Timestamp"].as_u64() {
+        Some(t) => t,
+        None => {
+            tracing::warn!(enso_json = %v, "enso.calldata.timestamp_missing");
+            return None;
+        }
+    };
+    now_secs.checked_sub(ts).or_else(|| {
+        tracing::warn!(enso_ts = ts, now = now_secs, "enso.quote.future_timestamp");
+        None
+    })
 }
 
 fn now_ms() -> u128 {
@@ -2086,7 +2187,7 @@ mod tests {
     /// an explicit erc721 hint we never dial the RPC. Selector must be
     /// the canonical ERC-721 approve (0x095ea7b3).
     #[tokio::test]
-    async fn resolve_intent_body_nft_approve_emits_erc721_approve_selector() {
+    async fn resolve_intent_body_nft_approve_errors_on_unreachable_rpc() {
         use bloom_proto::intent::RawIntentBody;
         // We have no hint on `NftApprove`, so the chain probe runs; with
         // an unreachable URL it errors. Use the resolver directly to
@@ -2212,6 +2313,103 @@ mod tests {
             Err(TxEngineError::PolicyDenied) => panic!("override token did not bypass warn"),
             Ok(_) => panic!("unexpected broadcast success on unreachable RPC"),
             Err(_) => {}
+        }
+    }
+
+    /// A hard-Deny policy check must block confirm() before broadcast,
+    /// return PolicyDenied, and move the outbox entry to Failed.
+    #[tokio::test]
+    async fn policy_hard_deny_blocks_confirm_and_marks_failed() {
+        use bloom_proto::policy::{PolicyCheck, PolicyOutcome};
+
+        let (engine, spec, _dir) = fake_engine(60_000);
+        let chain = bloom_chain::ChainClient::new(spec.clone()).unwrap();
+        let signer = alloy::signers::local::PrivateKeySigner::random();
+        let policy = bloom_proto::Policy::default();
+
+        let mut staged = fake_staged_1559("0001-test");
+        staged.expires_ms = now_ms() + 60_000;
+        staged.policy_checks = vec![PolicyCheck {
+            rule: "caps.max_value_eth".into(),
+            outcome: PolicyOutcome::Deny,
+            message: "value exceeds max".into(),
+        }];
+        engine.outbox.write_pending(&staged, "p").unwrap();
+
+        let r = engine
+            .confirm("alice", "anvil", "0001-test", &chain, &signer, &policy, "y")
+            .await;
+        assert!(
+            matches!(r, Err(TxEngineError::PolicyDenied)),
+            "expected PolicyDenied, got {r:?}"
+        );
+
+        // The outbox entry must have been moved to the `failed` state.
+        let entry = engine.outbox.read("alice", "anvil", "0001-test").unwrap();
+        assert_eq!(
+            entry.state,
+            crate::outbox::OutboxState::Failed,
+            "tx must be Failed after hard deny"
+        );
+    }
+
+    /// A soft-Warn check must block confirm() when no override sentinel is
+    /// given, and must pass the policy gate when the correct sentinel is
+    /// given. The outbox entry must stay Pending after a Warn rejection so
+    /// the user can retry with the override — it must NOT be moved to Failed.
+    #[tokio::test]
+    async fn policy_soft_warn_requires_override_sentinel() {
+        use bloom_proto::policy::{PolicyCheck, PolicyOutcome};
+
+        let (engine, spec, _dir) = fake_engine(60_000);
+        let chain = bloom_chain::ChainClient::new(spec.clone()).unwrap();
+        let signer = alloy::signers::local::PrivateKeySigner::random();
+        let policy = bloom_proto::Policy::default(); // override_sentinel() == "override"
+
+        let mut staged = fake_staged_1559("0001-test");
+        staged.expires_ms = now_ms() + 60_000;
+        staged.policy_checks = vec![PolicyCheck {
+            rule: "caps.warn_value_eth".into(),
+            outcome: PolicyOutcome::Warn,
+            message: "soft cap exceeded".into(),
+        }];
+        engine.outbox.write_pending(&staged, "p").unwrap();
+
+        // Wrong text — must be rejected.
+        let r = engine
+            .confirm("alice", "anvil", "0001-test", &chain, &signer, &policy, "y")
+            .await;
+        assert!(
+            matches!(r, Err(TxEngineError::PolicyDenied)),
+            "expected PolicyDenied without override, got {r:?}"
+        );
+
+        // After a Warn rejection the entry must still be Pending (not Failed).
+        let entry = engine.outbox.read("alice", "anvil", "0001-test").unwrap();
+        assert_eq!(
+            entry.state,
+            crate::outbox::OutboxState::Pending,
+            "tx must stay Pending after warn-without-override"
+        );
+
+        // Correct sentinel — gets past the policy gate; broadcast will fail
+        // on the unreachable RPC. Any error other than PolicyDenied means
+        // the policy gate was successfully passed.
+        let r = engine
+            .confirm(
+                "alice",
+                "anvil",
+                "0001-test",
+                &chain,
+                &signer,
+                &policy,
+                "override",
+            )
+            .await;
+        match r {
+            Err(TxEngineError::PolicyDenied) => panic!("override sentinel did not bypass warn"),
+            Ok(_) => panic!("unexpected broadcast success on unreachable RPC"),
+            Err(_) => {} // any other error means the policy gate was passed
         }
     }
 
@@ -2370,5 +2568,42 @@ mod tests {
             }
             other => panic!("expected PrivateNotSupportedOnChain, got {other:?}"),
         }
+    }
+
+    // -------------------------------------------------------------------
+    // enso_quote_age_secs
+    // -------------------------------------------------------------------
+
+    fn enso_hex(json: &str) -> String {
+        format!("0x{}", hex::encode(json.as_bytes()))
+    }
+
+    #[test]
+    fn enso_quote_age_parses_timestamp() {
+        let hex = enso_hex(r#"{"Source":"Enso","Timestamp":1700000000}"#);
+        assert_eq!(enso_quote_age_secs(&hex, 1700000300), Some(300));
+    }
+
+    #[test]
+    fn enso_quote_age_zero_for_current() {
+        let hex = enso_hex(r#"{"Source":"Enso","Timestamp":1700000000}"#);
+        assert_eq!(enso_quote_age_secs(&hex, 1700000000), Some(0));
+    }
+
+    #[test]
+    fn enso_quote_age_none_for_future() {
+        let hex = enso_hex(r#"{"Source":"Enso","Timestamp":1700000100}"#);
+        assert_eq!(enso_quote_age_secs(&hex, 1700000000), None);
+    }
+
+    #[test]
+    fn enso_quote_age_none_for_non_enso_calldata() {
+        assert_eq!(enso_quote_age_secs("0xdeadbeef", 1700000000), None);
+    }
+
+    #[test]
+    fn enso_quote_age_none_for_missing_timestamp() {
+        let hex = enso_hex(r#"{"Source":"Enso","Route":"0x1234"}"#);
+        assert_eq!(enso_quote_age_secs(&hex, 1700000000), None);
     }
 }

--- a/crates/bloom-vfs/src/handlers/defi.rs
+++ b/crates/bloom-vfs/src/handlers/defi.rs
@@ -329,6 +329,7 @@ impl DefiHandler {
                     chain: Some(chain_name.clone()),
                     gas: GasStrategy::Auto,
                     nonce: None,
+                    gas_limit_hint: None,
                 });
             }
         }
@@ -341,6 +342,7 @@ impl DefiHandler {
             chain: Some(chain_name.clone()),
             gas: GasStrategy::Auto,
             nonce: None,
+            gas_limit_hint: route.gas.as_deref().and_then(|g| g.parse().ok()),
         });
 
         let plan = render_plan_md(&body.intent, &chain_name, &req, &route, &intents);
@@ -831,6 +833,7 @@ mod tests {
             chain: Some("ethereum".into()),
             gas: GasStrategy::Auto,
             nonce: None,
+            gas_limit_hint: None,
         }];
         let md = render_plan_md("swap 1 ETH to USDC", "ethereum", &req, &route, &intents);
         assert!(md.contains("swap 1 ETH to USDC"));
@@ -879,6 +882,7 @@ mod tests {
                 chain: Some("ethereum".into()),
                 gas: GasStrategy::Auto,
                 nonce: None,
+                gas_limit_hint: None,
             },
             RawIntent {
                 body: RawIntentBody::Raw {
@@ -889,6 +893,7 @@ mod tests {
                 chain: Some("ethereum".into()),
                 gas: GasStrategy::Auto,
                 nonce: None,
+                gas_limit_hint: None,
             },
         ];
         let md = render_plan_md("swap 1 USDC to ETH", "ethereum", &req, &route, &intents);

--- a/crates/bloom-vfs/src/handlers/prices.rs
+++ b/crates/bloom-vfs/src/handlers/prices.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use bloom_prices::{CoinId, PricesClient, PricesError};
+use bloom_prices::{CoinId, PricesClient, PricesError, SYMBOL_MAP};
 
 use crate::handler::{Entry, Handler, HandlerError};
 use crate::path::VfsPath;
@@ -145,8 +145,9 @@ impl PricesHandler {
             return Ok(vec![Entry::dir("spot"), Entry::dir("change_24h")]);
         }
         match path.segments()[0].as_str() {
-            "spot" if path.segments().len() == 1 => Ok(vec![]),
-            "change_24h" if path.segments().len() == 1 => Ok(vec![]),
+            "spot" | "change_24h" if path.segments().len() == 1 => {
+                Ok(SYMBOL_MAP.iter().map(|(s, _)| Entry::file(s)).collect())
+            }
             _ => Err(HandlerError::NotADir(path.to_string_path())),
         }
     }
@@ -200,6 +201,19 @@ mod tests {
         let p = VfsPath::parse("/spot/eth.usd").unwrap();
         let bytes = h.read(&p).await.unwrap();
         assert_eq!(String::from_utf8_lossy(&bytes).trim(), "3500.5");
+    }
+
+    #[tokio::test]
+    async fn spot_dir_lists_well_known_symbols() {
+        let client = PricesClient::with_base_url("http://127.0.0.1:1");
+        let h = PricesHandler::new(client);
+        let p = VfsPath::parse("/spot").unwrap();
+        let entries = h.list(&p).await.unwrap();
+        assert_eq!(entries.len(), SYMBOL_MAP.len());
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        for (sym, _) in SYMBOL_MAP {
+            assert!(names.contains(sym), "spot listing missing {sym}");
+        }
     }
 
     #[tokio::test]

--- a/crates/bloom-vfs/src/handlers/wallets.rs
+++ b/crates/bloom-vfs/src/handlers/wallets.rs
@@ -26,7 +26,11 @@ use async_trait::async_trait;
 use bloom_chain::ChainRegistry;
 use bloom_keystore::Keystore;
 use bloom_proto::{AddressBook, RawIntent, format_units};
-use bloom_tx::{intent_parser, outbox::OutboxState, tx_engine::TxEngine};
+use bloom_tx::{
+    intent_parser,
+    outbox::OutboxState,
+    tx_engine::{TxEngine, TxEngineError},
+};
 
 use crate::handler::{Entry, Handler, HandlerError};
 use crate::path::VfsPath;
@@ -65,15 +69,19 @@ impl WalletsHandler {
         self
     }
 
-    fn wallet_dir_entries() -> Vec<Entry> {
-        vec![
+    fn wallet_dir_entries(kind: bloom_keystore::WalletKind) -> Vec<Entry> {
+        let mut entries = vec![
             Entry::file("address"),
             Entry::file("public_key"),
             Entry::file("kind"),
             Entry::file("policy.toml"),
             Entry::dir("chains"),
             Entry::dir("sign"),
-        ]
+        ];
+        if kind == bloom_keystore::WalletKind::PasskeyGated {
+            entries.push(Entry::writable_file("unlock-passkey"));
+        }
+        entries
     }
 
     fn sign_dir_entries() -> Vec<Entry> {
@@ -193,13 +201,16 @@ impl WalletsHandler {
             return Ok(Entry::writable_file("new"));
         }
         let wallet = &segs[0];
-        let _info = self.keystore.info(wallet).map_err(err_be)?;
+        let info = self.keystore.info(wallet).map_err(err_be)?;
         if segs.len() == 1 {
             return Ok(Entry::dir(wallet));
         }
         match segs[1].as_str() {
             "address" | "public_key" | "kind" => Ok(Entry::file(&segs[1])),
             "policy.toml" => Ok(Entry::writable_file("policy.toml")),
+            "unlock-passkey" if info.kind == bloom_keystore::WalletKind::PasskeyGated => {
+                Ok(Entry::writable_file("unlock-passkey"))
+            }
             "sign" => match segs.len() {
                 2 => Ok(Entry::dir("sign")),
                 3 if matches!(segs[2].as_str(), "message" | "hash" | "typed_data") => {
@@ -241,6 +252,7 @@ impl WalletsHandler {
                 let s = match info.kind {
                     bloom_keystore::WalletKind::Local => "local",
                     bloom_keystore::WalletKind::Watch => "watch",
+                    bloom_keystore::WalletKind::PasskeyGated => "passkey",
                 };
                 Ok(format!("{}\n", s).into_bytes())
             }
@@ -262,12 +274,29 @@ impl WalletsHandler {
             return self.write_new_wallet(data).await;
         }
         let wallet = &segs[0];
-        let _info = self.keystore.info(wallet).map_err(err_be)?;
+        let info = self.keystore.info(wallet).map_err(err_be)?;
         if segs.len() >= 4 && segs[1] == "chains" && segs[3] == "outbox" {
             return self.write_outbox(wallet, &segs[2], &segs[4..], data).await;
         }
         if segs.len() == 3 && segs[1] == "sign" {
             return self.write_sign(wallet, &segs[2], data).await;
+        }
+        if segs.len() == 2 && segs[1] == "policy.toml" {
+            self.keystore.write_policy(wallet, data).map_err(err_be)?;
+            return Ok(());
+        }
+        // PasskeyGated wallet: browser WebAuthn authentication ceremony.
+        if segs.len() == 2 && segs[1] == "unlock-passkey" {
+            if info.kind != bloom_keystore::WalletKind::PasskeyGated {
+                return Err(HandlerError::invalid(
+                    "unlock-passkey only applies to passkey wallets",
+                ));
+            }
+            if self.keystore.signer(wallet).is_ok() {
+                return Ok(()); // already unlocked — ceremony not needed
+            }
+            self.keystore.unlock_passkey(wallet).await.map_err(err_be)?;
+            return Ok(());
         }
         Err(HandlerError::PermissionDenied)
     }
@@ -281,9 +310,9 @@ impl WalletsHandler {
             return Ok(out);
         }
         let wallet = &segs[0];
-        let _info = self.keystore.info(wallet).map_err(err_be)?;
+        let info = self.keystore.info(wallet).map_err(err_be)?;
         match segs.len() {
-            1 => Ok(Self::wallet_dir_entries()),
+            1 => Ok(Self::wallet_dir_entries(info.kind)),
             2 if segs[1] == "chains" => Ok(self
                 .chains
                 .list_names()
@@ -714,7 +743,12 @@ impl WalletsHandler {
                         confirm_text,
                     )
                     .await
-                    .map_err(err_be)?;
+                    .map_err(|e| match e {
+                        TxEngineError::EnsoQuoteStale { .. } => {
+                            HandlerError::invalid(e.to_string())
+                        }
+                        other => err_be(other),
+                    })?;
                 Ok(())
             }
             // outbox/pending/<id>/cancel — fire a self-send replacement.
@@ -851,11 +885,22 @@ impl WalletsHandler {
             .unwrap_or("");
 
         let info = match spec.kind.as_str() {
-            "local" => self
-                .keystore
-                .create_local(&spec.name, pass)
-                .map_err(err_be)?,
+            "local" => {
+                if pass.is_empty() {
+                    return Err(HandlerError::invalid(
+                        "passphrase required (set BLOOM_PASSPHRASE or include 'passphrase' in the TOML spec)",
+                    ));
+                }
+                self.keystore
+                    .create_local(&spec.name, pass)
+                    .map_err(err_be)?
+            }
             "import" => {
+                if pass.is_empty() {
+                    return Err(HandlerError::invalid(
+                        "passphrase required (set BLOOM_PASSPHRASE or include 'passphrase' in the TOML spec)",
+                    ));
+                }
                 let key = spec
                     .private_key
                     .as_deref()
@@ -874,9 +919,26 @@ impl WalletsHandler {
                     .map_err(|e| HandlerError::invalid(format!("address: {e}")))?;
                 self.keystore.add_watch(&spec.name, addr).map_err(err_be)?
             }
+            // PasskeyGated: opens a browser WebAuthn registration ceremony.
+            "passkey" => self
+                .keystore
+                .create_passkey(&spec.name)
+                .await
+                .map_err(err_be)?,
+            // PasskeyGated from an existing hex private key.
+            "passkey-import" => {
+                let key = spec
+                    .private_key
+                    .as_deref()
+                    .ok_or_else(|| HandlerError::invalid("passkey-import requires private_key"))?;
+                self.keystore
+                    .import_passkey(&spec.name, key)
+                    .await
+                    .map_err(err_be)?
+            }
             other => {
                 return Err(HandlerError::invalid(format!(
-                    "unknown wallet kind '{other}'; expected local|import|watch"
+                    "unknown wallet kind '{other}'; expected local|import|watch|passkey|passkey-import"
                 )));
             }
         };
@@ -1139,12 +1201,32 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn write_new_wallet_plain_name_creates_local_wallet() {
+    async fn write_new_wallet_toml_creates_local_wallet() {
         let f = make_handler();
         let p = VfsPath::parse("/new").unwrap();
-        f.handler.write(&p, b"bob").await.unwrap();
+        f.handler
+            .write(
+                &p,
+                b"name = \"bob\"\nkind = \"local\"\npassphrase = \"p\"\n",
+            )
+            .await
+            .unwrap();
         let info = f.handler.keystore.info("bob").unwrap();
         assert!(matches!(info.kind, bloom_keystore::WalletKind::Local));
+    }
+
+    /// Writing a plain name string without BLOOM_PASSPHRASE or a TOML
+    /// passphrase must return an Invalid error — empty passphrases are
+    /// no longer accepted for local wallets.
+    #[tokio::test]
+    async fn write_new_wallet_plain_name_rejected_without_passphrase() {
+        let f = make_handler();
+        let p = VfsPath::parse("/new").unwrap();
+        let r = f.handler.write(&p, b"bob").await;
+        assert!(
+            matches!(r, Err(HandlerError::Invalid(_))),
+            "expected Invalid error for plain name without passphrase, got: {r:?}"
+        );
     }
 
     #[tokio::test]
@@ -1439,6 +1521,102 @@ mod tests {
         assert_eq!(v["observed_nonces"], serde_json::json!([3, 5]));
         // checksum address is non-empty hex
         assert!(v["address"].as_str().unwrap().starts_with("0x"));
+    }
+
+    /// Helper: construct a passkey wallet on disk (no browser ceremony needed).
+    /// Returns the wallet's address.
+    fn seed_passkey_wallet(f: &Fixture, name: &str) -> Address {
+        let addr: Address = "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"
+            .parse()
+            .unwrap();
+        let wallet_dir = f._tmp.path().join("keystore").join(name);
+        std::fs::create_dir_all(&wallet_dir).unwrap();
+        std::fs::write(
+            wallet_dir.join("address"),
+            bloom_proto::checksum_address(&addr).as_bytes(),
+        )
+        .unwrap();
+        std::fs::write(wallet_dir.join("pubkey"), b"").unwrap();
+        std::fs::write(wallet_dir.join("kind"), b"passkey").unwrap();
+        let policy = bloom_proto::Policy::default();
+        std::fs::write(
+            wallet_dir.join("policy.toml"),
+            toml::to_string_pretty(&policy).unwrap(),
+        )
+        .unwrap();
+        addr
+    }
+
+    /// Passkey wallet: dir lists `unlock-passkey`, lookup gives writable file,
+    /// and `kind` reads "passkey".
+    #[tokio::test]
+    async fn passkey_wallet_vfs_properties() {
+        let f = make_handler();
+        let _addr = seed_passkey_wallet(&f, "pk");
+
+        // listing includes unlock-passkey
+        let entries = f
+            .handler
+            .list(&VfsPath::parse("/pk").unwrap())
+            .await
+            .unwrap();
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&"unlock-passkey"), "names={names:?}");
+
+        // unlock-passkey is a writable file
+        let entry = f
+            .handler
+            .lookup(&VfsPath::parse("/pk/unlock-passkey").unwrap())
+            .await
+            .unwrap();
+        assert!(matches!(entry.kind, crate::handler::EntryKind::File));
+        assert_eq!(entry.mode, 0o644);
+
+        // kind reads "passkey"
+        let bytes = f
+            .handler
+            .read(&VfsPath::parse("/pk/kind").unwrap())
+            .await
+            .unwrap();
+        assert_eq!(String::from_utf8_lossy(&bytes).trim(), "passkey");
+    }
+
+    /// Local wallet: `kind` reads "local", `unlock-passkey` is not exposed
+    /// (lookup → NotFound, write → Invalid, list → absent).
+    #[tokio::test]
+    async fn local_wallet_passkey_properties() {
+        let f = make_handler();
+
+        // kind reads "local"
+        let bytes = f
+            .handler
+            .read(&VfsPath::parse("/alice/kind").unwrap())
+            .await
+            .unwrap();
+        assert_eq!(String::from_utf8_lossy(&bytes).trim(), "local");
+
+        // unlock-passkey resolves to NotFound
+        let r = f
+            .handler
+            .lookup(&VfsPath::parse("/alice/unlock-passkey").unwrap())
+            .await;
+        assert!(matches!(r, Err(HandlerError::NotFound(_))), "got {r:?}");
+
+        // writing to unlock-passkey is Invalid
+        let r = f
+            .handler
+            .write(&VfsPath::parse("/alice/unlock-passkey").unwrap(), b"unlock")
+            .await;
+        assert!(matches!(r, Err(HandlerError::Invalid(_))), "got {r:?}");
+
+        // listing does NOT contain unlock-passkey
+        let entries = f
+            .handler
+            .list(&VfsPath::parse("/alice").unwrap())
+            .await
+            .unwrap();
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert!(!names.contains(&"unlock-passkey"), "names={names:?}");
     }
 
     #[tokio::test]

--- a/crates/bloom/Cargo.toml
+++ b/crates/bloom/Cargo.toml
@@ -36,6 +36,7 @@ bloom-script.workspace = true
 bloom-objects.workspace = true
 anyhow.workspace = true
 clap.workspace = true
+clap_complete.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/bloom/src/main.rs
+++ b/crates/bloom/src/main.rs
@@ -17,11 +17,14 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use anyhow::{Context, Result};
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as B64;
 use bloom_daemon::Daemon;
 use bloom_daemon::ipc::{IpcClient, IpcServer, default_socket_path};
 use bloom_proto::HomeDir;
 use bloom_vfs::{VfsPath, handler::Handler};
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
+use clap_complete::{Shell, generate};
 use tracing::{debug, info, trace};
 use tracing_subscriber::EnvFilter;
 
@@ -101,6 +104,8 @@ enum Cmd {
         #[arg(long, value_name = "HEX")]
         gas_payer: String,
     },
+    /// Print a shell completion script.
+    Completions { shell: Shell },
 }
 
 #[derive(Subcommand, Debug)]
@@ -118,7 +123,10 @@ enum VfsCmd {
     /// `cat /bloom/<path>` — read a file via the VFS.
     Cat { path: String },
     /// `ls /bloom/<path>` — list a directory via the VFS.
-    Ls { path: String },
+    Ls {
+        #[arg(default_value = "/")]
+        path: String,
+    },
     /// Write data to a writable VFS path. Reads from stdin if `--data` is omitted.
     Write {
         path: String,
@@ -168,26 +176,33 @@ enum PetalsCmd {
 
 #[derive(Subcommand, Debug)]
 enum WalletCmd {
-    /// Create a new local wallet.
+    /// Create a new wallet. Pass `--passkey` for a browser WebAuthn ceremony;
+    /// defaults to passphrase-encrypted local wallet.
     New {
         name: String,
+        #[arg(long)]
+        passkey: bool,
         #[arg(long, env = "BLOOM_PASSPHRASE")]
-        passphrase: String,
+        passphrase: Option<String>,
     },
     /// Import a wallet from a hex private key.
     Import {
         name: String,
         private_key: String,
+        #[arg(long)]
+        passkey: bool,
         #[arg(long, env = "BLOOM_PASSPHRASE")]
-        passphrase: String,
+        passphrase: Option<String>,
     },
     /// List configured wallets.
     List,
     /// Unlock a wallet for the lifetime of the process.
+    /// For passkey wallets the passphrase is not needed — a browser
+    /// ceremony is opened instead.
     Unlock {
         name: String,
         #[arg(long, env = "BLOOM_PASSPHRASE")]
-        passphrase: String,
+        passphrase: Option<String>,
     },
     /// Stage a tx by writing an intent file. Convenience for the
     /// outbox flow.
@@ -207,12 +222,54 @@ enum WalletCmd {
         chain: String,
         id: String,
         #[arg(long, env = "BLOOM_PASSPHRASE")]
-        passphrase: String,
+        passphrase: Option<String>,
         /// Confirmation text (default "y"; "override" bypasses soft
         /// policy warnings).
         #[arg(long, default_value = "y")]
         text: String,
     },
+    /// Sign the current policy.toml for a passkey-gated wallet.
+    /// The wallet must already be unlocked (run `unlock` first).
+    SignPolicy { name: String },
+    /// Re-bind an existing PRF-based passkey wallet to a new passkey
+    /// credential. Unlocks with the current credential first to prove
+    /// ownership, then runs a fresh WebAuthn registration ceremony and
+    /// re-encrypts the private key under the new PRF output. The wallet
+    /// address does not change.
+    ///
+    /// Use this to rotate authenticators (e.g. new YubiKey or new device)
+    /// without moving funds. A recovery key is printed once after rebind.
+    RebindPasskey { name: String },
+    /// Permanently delete a wallet. All wallet files are removed from disk.
+    /// This cannot be undone — make sure you have the recovery key or the
+    /// private key stored elsewhere before deleting a passkey wallet.
+    Delete { name: String },
+}
+
+/// Print the recovery key to stdout and block until the user types "saved".
+///
+/// All tracing logs go to stderr; this prints to stdout, so it cannot be
+/// buried by ceremony log noise. The loop prevents the terminal from
+/// scrolling past the key unnoticed.
+fn acknowledge_recovery_key(name: &str, key: &str) {
+    use std::io::Write as _;
+    let line = "═".repeat(60);
+    println!("\n{line}");
+    println!("  ⚠  RECOVERY KEY — write this down before continuing.");
+    println!("  bloom will NEVER show this again.\n");
+    println!("  0x{key}\n");
+    println!("  To recover:  bloom wallet import {name} 0x<key>");
+    println!("{line}");
+    loop {
+        print!("\n  Type \"saved\" and press Enter to continue: ");
+        let _ = std::io::stdout().flush();
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input).unwrap_or(0);
+        if input.trim().eq_ignore_ascii_case("saved") {
+            break;
+        }
+    }
+    println!();
 }
 
 #[tokio::main]
@@ -232,6 +289,54 @@ async fn main() -> ExitCode {
             eprintln!("error: {:#}", e);
             ExitCode::FAILURE
         }
+    }
+}
+
+/// Returns `None` when no daemon socket is present (daemon not started),
+/// propagating all other errors normally. A stale socket (file exists but
+/// connection refused) is removed and surfaced as an error rather than
+/// silently falling back to in-process — a stale socket almost always
+/// means the daemon crashed and the caller should restart it explicitly.
+async fn try_ipc(
+    client: &IpcClient,
+    method: &str,
+    params: serde_json::Value,
+) -> std::io::Result<Option<serde_json::Value>> {
+    match client.call(method, params).await {
+        Ok(v) => Ok(Some(v)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            debug!(error = %e, "ipc.no_daemon_fallback");
+            Ok(None)
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::ConnectionRefused => {
+            // Only remove if it is actually a socket, not a regular
+            // file or symlink placed by another process.
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::FileTypeExt;
+                let removed = std::fs::symlink_metadata(client.socket())
+                    .is_ok_and(|m| m.file_type().is_socket())
+                    && std::fs::remove_file(client.socket()).is_ok();
+                let detail = if removed {
+                    "stale socket removed"
+                } else {
+                    "socket not responding"
+                };
+                Err(std::io::Error::other(format!(
+                    "daemon socket exists but is not responding ({detail}); \
+                     start the daemon with 'bloom serve'",
+                )))
+            }
+            #[cfg(not(unix))]
+            {
+                let _ = std::fs::remove_file(client.socket());
+                return Err(std::io::Error::other(
+                    "daemon socket exists but is not responding (stale socket removed); \
+                     start the daemon with 'bloom serve'",
+                ));
+            }
+        }
+        Err(e) => Err(e),
     }
 }
 
@@ -267,19 +372,16 @@ async fn run(cli: Cli) -> Result<()> {
         Cmd::Vfs(VfsCmd::Cat { path }) => {
             let socket = default_socket_path(home.root());
             let p = VfsPath::parse(&path).context("parse path")?;
-            let bytes = if socket.exists() {
+            let client = IpcClient::new(&socket);
+            let ipc_res = try_ipc(&client, "read", serde_json::json!({ "path": path }))
+                .await
+                .context("ipc read")?;
+            let bytes = if let Some(res) = ipc_res {
                 debug!(socket = %socket.display(), "cli.vfs.cat.via_ipc");
-                let client = IpcClient::new(&socket);
-                let res = client
-                    .call("read", serde_json::json!({ "path": path }))
-                    .await
-                    .context("ipc read")?;
                 let b64 = res
                     .get("bytes_b64")
                     .and_then(|v| v.as_str())
                     .context("ipc read: missing bytes_b64")?;
-                use base64::Engine as _;
-                use base64::engine::general_purpose::STANDARD as B64;
                 B64.decode(b64).context("ipc read: bad base64")?
             } else {
                 debug!("cli.vfs.cat.via_inproc: no daemon socket present");
@@ -292,13 +394,12 @@ async fn run(cli: Cli) -> Result<()> {
         Cmd::Vfs(VfsCmd::Ls { path }) => {
             let socket = default_socket_path(home.root());
             let p = VfsPath::parse(&path).context("parse path")?;
-            if socket.exists() {
+            let client = IpcClient::new(&socket);
+            let ipc_res = try_ipc(&client, "list", serde_json::json!({ "path": path }))
+                .await
+                .context("ipc list")?;
+            if let Some(res) = ipc_res {
                 debug!(socket = %socket.display(), "cli.vfs.ls.via_ipc");
-                let client = IpcClient::new(&socket);
-                let res = client
-                    .call("list", serde_json::json!({ "path": path }))
-                    .await
-                    .context("ipc list")?;
                 let arr = res.as_array().context("ipc list: expected array")?;
                 for e in arr {
                     let name = e.get("name").and_then(|v| v.as_str()).unwrap_or("?");
@@ -330,18 +431,16 @@ async fn run(cli: Cli) -> Result<()> {
                     buf
                 }
             };
-            if socket.exists() {
+            let client = IpcClient::new(&socket);
+            let ipc_res = try_ipc(
+                &client,
+                "write",
+                serde_json::json!({ "path": path, "bytes_b64": B64.encode(&body) }),
+            )
+            .await
+            .context("ipc write")?;
+            if ipc_res.is_some() {
                 debug!(socket = %socket.display(), "cli.vfs.write.via_ipc");
-                use base64::Engine as _;
-                use base64::engine::general_purpose::STANDARD as B64;
-                let client = IpcClient::new(&socket);
-                client
-                    .call(
-                        "write",
-                        serde_json::json!({ "path": path, "bytes_b64": B64.encode(&body) }),
-                    )
-                    .await
-                    .context("ipc write")?;
             } else {
                 debug!("cli.vfs.write.via_inproc: no daemon socket present");
                 let d = Daemon::from_home(home).context("build daemon")?;
@@ -349,20 +448,47 @@ async fn run(cli: Cli) -> Result<()> {
             }
             Ok(())
         }
-        Cmd::Wallet(WalletCmd::New { name, passphrase }) => {
+        Cmd::Wallet(WalletCmd::New {
+            name,
+            passkey,
+            passphrase,
+        }) => {
             let d = Daemon::from_home(home).context("build daemon")?;
-            let info = d.keystore.create_local(&name, &passphrase)?;
+            let info = if passkey {
+                d.keystore.create_passkey(&name).await?
+            } else {
+                let pass = passphrase.as_deref().unwrap_or("");
+                if pass.is_empty() {
+                    anyhow::bail!("passphrase required (use --passphrase or BLOOM_PASSPHRASE)");
+                }
+                d.keystore.create_local(&name, pass)?
+            };
             println!("created wallet '{}': {}", info.name, info.address);
+            if let Some(ref key) = info.recovery_key {
+                acknowledge_recovery_key(&info.name, key);
+            }
             Ok(())
         }
         Cmd::Wallet(WalletCmd::Import {
             name,
             private_key,
+            passkey,
             passphrase,
         }) => {
             let d = Daemon::from_home(home).context("build daemon")?;
-            let info = d.keystore.import_hex(&name, &private_key, &passphrase)?;
+            let info = if passkey {
+                d.keystore.import_passkey(&name, &private_key).await?
+            } else {
+                let pass = passphrase.as_deref().unwrap_or("");
+                if pass.is_empty() {
+                    anyhow::bail!("passphrase required (use --passphrase or BLOOM_PASSPHRASE)");
+                }
+                d.keystore.import_hex(&name, &private_key, pass)?
+            };
             println!("imported wallet '{}': {}", info.name, info.address);
+            if let Some(ref key) = info.recovery_key {
+                acknowledge_recovery_key(&info.name, key);
+            }
             Ok(())
         }
         Cmd::Wallet(WalletCmd::List) => {
@@ -371,6 +497,7 @@ async fn run(cli: Cli) -> Result<()> {
                 let kind = match info.kind {
                     bloom_keystore::WalletKind::Local => "local",
                     bloom_keystore::WalletKind::Watch => "watch",
+                    bloom_keystore::WalletKind::PasskeyGated => "passkey",
                 };
                 println!("{}\t{}\t{}", info.name, info.address, kind);
             }
@@ -378,8 +505,53 @@ async fn run(cli: Cli) -> Result<()> {
         }
         Cmd::Wallet(WalletCmd::Unlock { name, passphrase }) => {
             let d = Daemon::from_home(home).context("build daemon")?;
-            d.keystore.unlock(&name, &passphrase)?;
+            let info = d.keystore.info(&name)?;
+            match info.kind {
+                bloom_keystore::WalletKind::PasskeyGated => {
+                    d.keystore.unlock_passkey(&name).await?;
+                }
+                _ => {
+                    d.keystore
+                        .unlock(&name, passphrase.as_deref().unwrap_or(""))?;
+                }
+            }
             println!("unlocked '{}' (in-memory; ends with this process)", name);
+            Ok(())
+        }
+        Cmd::Wallet(WalletCmd::SignPolicy { name }) => {
+            let d = Daemon::from_home(home).context("build daemon")?;
+            // Auto-unlock passkey wallets so this command is self-contained.
+            let info = d.keystore.info(&name)?;
+            // Show the policy the user is about to sign, in the terminal,
+            // before the browser ceremony opens.
+            let policy_toml = toml::to_string_pretty(&info.policy)
+                .unwrap_or_else(|_| "(could not serialise policy)".into());
+            println!("Policy for '{name}':\n\n{policy_toml}");
+            if info.kind == bloom_keystore::WalletKind::PasskeyGated
+                && !d.keystore.is_unlocked(&name)
+            {
+                d.keystore.unlock_passkey(&name).await?;
+            }
+            d.keystore.sign_policy(&name)?;
+            println!("policy.toml signed for '{name}'");
+            Ok(())
+        }
+        Cmd::Wallet(WalletCmd::RebindPasskey { name }) => {
+            let d = Daemon::from_home(home).context("build daemon")?;
+            let info = d.keystore.rebind_passkey(&name).await?;
+            println!(
+                "✓ '{}' rebound to new passkey credential ({})",
+                info.name, info.address
+            );
+            if let Some(ref key) = info.recovery_key {
+                acknowledge_recovery_key(&info.name, key);
+            }
+            Ok(())
+        }
+        Cmd::Wallet(WalletCmd::Delete { name }) => {
+            let d = Daemon::from_home(home).context("build daemon")?;
+            d.keystore.delete(&name)?;
+            println!("✓ wallet '{name}' deleted");
             Ok(())
         }
         Cmd::Wallet(WalletCmd::Stage {
@@ -424,7 +596,16 @@ async fn run(cli: Cli) -> Result<()> {
             text,
         }) => {
             let d = Daemon::from_home(home).context("build daemon")?;
-            d.keystore.unlock(&wallet, &passphrase)?;
+            let info = d.keystore.info(&wallet)?;
+            match info.kind {
+                bloom_keystore::WalletKind::PasskeyGated => {
+                    d.keystore.unlock_passkey(&wallet).await?;
+                }
+                _ => {
+                    d.keystore
+                        .unlock(&wallet, passphrase.as_deref().unwrap_or(""))?;
+                }
+            }
             let signer = d.keystore.signer(&wallet)?;
             let info = d.keystore.info(&wallet)?;
             let client = d
@@ -464,10 +645,23 @@ async fn run(cli: Cli) -> Result<()> {
             let server = IpcServer::new(d.vfs.clone(), env!("CARGO_PKG_VERSION"), chains)
                 .with_petals(d.petals.clone());
             let server2 = server.clone();
-            // Trigger graceful shutdown on Ctrl-C.
+            // Trigger graceful shutdown on Ctrl-C or SIGTERM.
             let shutdown = tokio::spawn(async move {
-                let _ = tokio::signal::ctrl_c().await;
-                info!("cli.serve.ctrl_c_received");
+                #[cfg(unix)]
+                {
+                    use tokio::signal::unix::{SignalKind, signal};
+                    let mut sigterm = signal(SignalKind::terminate())
+                        .expect("SIGTERM handler registration failed");
+                    tokio::select! {
+                        _ = tokio::signal::ctrl_c() => info!("cli.serve.ctrl_c_received"),
+                        _ = sigterm.recv() => info!("cli.serve.sigterm_received"),
+                    }
+                }
+                #[cfg(not(unix))]
+                {
+                    let _ = tokio::signal::ctrl_c().await;
+                    info!("cli.serve.ctrl_c_received");
+                }
                 server2.trigger_shutdown();
             });
             let serve_result = server.serve(&socket).await.context("ipc serve");
@@ -493,6 +687,10 @@ async fn run(cli: Cli) -> Result<()> {
             let rpc_sock = home.root().join("chain").join("rpc.sock");
             let chain_dir = home.root().join("chain");
             commands::pipe::run(&rpc_sock, &chain_dir, &expr, &signers, &gas_payer).await
+        }
+        Cmd::Completions { shell } => {
+            generate(shell, &mut Cli::command(), "bloom", &mut std::io::stdout());
+            Ok(())
         }
         Cmd::Ipc(IpcCmd::Call { method, params }) => {
             let socket = default_socket_path(home.root());

--- a/docs/specs/passkey.md
+++ b/docs/specs/passkey.md
@@ -1,0 +1,139 @@
+# Passkey wallets
+
+Status: implemented — passkeys branch
+Date: 2026-05-28
+
+---
+
+## What WebAuthn passkeys actually are
+
+WebAuthn passkeys are a **public-key authentication mechanism**, not an
+encryption mechanism. When you register a passkey:
+
+1. The authenticator (Touch ID, Face ID, hardware security key, etc.) generates
+   an asymmetric keypair internally.
+2. The **public key** is returned to the relying party — stored in bloom's
+   `passkey.json`.
+3. The **private key never leaves the authenticator** — it is protected by
+   the device's secure enclave or hardware security module.
+
+During authentication, the authenticator signs a server-provided challenge.
+The relying party verifies the signature. That is the extent of what the
+authenticator can do for *authentication*: **sign challenges**.
+
+---
+
+## How bloom passkey wallets derive encryption keys (PRF extension)
+
+Bloom uses the WebAuthn **PRF extension** (Pseudo-Random Function, defined in
+the WebAuthn Level 3 spec on top of the CTAP2 `hmac-secret` extension) to
+derive an encryption key from the authenticator's internal secret.
+
+During each ceremony, the caller provides a `prf_salt`:
+
+> Provide an application-controlled salt → receive a deterministic 32-byte
+> secret derived from the authenticator's internal master secret. The
+> authenticator never exports the master secret; the same salt always yields
+> the same 32 bytes on the same authenticator.
+
+The browser JS extracts the PRF output and sends it to the local ceremony
+server. The Rust keystore then derives a wrap key:
+
+```
+prf_salt    — 32 random bytes, stored in prf.salt (public, not secret)
+prf_output  — PRF(authenticator_secret, prf_salt)  ←  derived live, never stored
+wrap_key    — blake3::derive_key("bloom passkey wrap key", prf_output)
+encrypted.key ← ChaCha20Poly1305(private_key, wrap_key)
+```
+
+Without the physical authenticator you cannot reproduce `prf_output`, therefore
+you cannot decrypt the private key. This is the intended security guarantee.
+
+### Recovery
+
+Since there is no plaintext `wrap.key` on disk, the wallet **cannot be
+recovered without the original authenticator**. Immediately after creation, a
+browser page opens at `localhost:18735` showing the recovery key (raw hex
+private key) with a copy button; the page requires an explicit "I've saved
+this" confirmation before closing. If the browser cannot be launched (headless
+env, port conflict), a terminal prompt on stdout is shown as fallback.
+Store the recovery key like a seed phrase — bloom will never show it again.
+
+To recover: `bloom wallet import <name> 0x<recovery-key>`
+
+---
+
+## Current wallet directory layout
+
+```
+~/.bloom/wallets/<name>/
+├── kind              — "passkey"
+├── prf.salt          — 64 hex chars (32 bytes), NOT secret
+├── encrypted.key     — JSON { nonce_hex, ciphertext_hex }
+├── passkey.json      — WebAuthn credential (public key + counter)
+├── policy.toml       — spend caps, routing policy
+└── policy.toml.sig   — BLAKE3(policy.toml) signed by the wallet key
+```
+
+No `wrap.key`. PRF output is never written to disk.
+
+---
+
+## PRF browser support
+
+| Platform | PRF support |
+|---|---|
+| Chrome ≥ 116 | ✅ |
+| Safari ≥ 18 | ✅ |
+| Firefox | ⚠️ — no built-in passkey manager on Linux; does not support WebAuthn PRF |
+| macOS Secure Enclave (Touch ID) | ✅ |
+| Windows Hello | ✅ (Chrome 147+) |
+| YubiKey 5 series | ✅ (via `hmac-secret`) |
+| Old FIDO U2F keys | ❌ — bloom rejects with clear error |
+
+---
+
+## PRF support in webauthn-rs
+
+webauthn-rs 0.5.5 does not implement the PRF extension natively. Bloom works
+around this by:
+
+1. Patching the WebAuthn challenge JSON to inject the PRF extension before
+   serving it to the browser (same technique already used for `residentKey`).
+2. Adding a `/prf-output` HTTP endpoint to the local ceremony server.
+3. The browser JS extracts the PRF output from `getClientExtensionResults()`
+   and POSTs it to `/prf-output` before submitting the credential.
+
+This is identical to how Bitwarden implements PRF-based vault encryption with
+WebAuthn passkeys.
+
+---
+
+## What is and is not protected
+
+| Threat | Protected? |
+|---|---|
+| AI agent calling `bloom` daemon and signing without user | ✅ blocked by WebAuthn ceremony |
+| Automated script calling `bloom` and signing without user | ✅ blocked |
+| Attacker who reads `~/.bloom/` from disk | ✅ cannot decrypt without authenticator |
+| Stolen laptop / disk image copy | ✅ cannot decrypt without authenticator |
+| Compromised user account (attacker runs as your user) | ✅ cannot decrypt without physical authenticator |
+| Malware active during unlock | ⚠️ could intercept PRF output at ceremony time |
+
+The remaining attack vector is malware that hooks the local ceremony server
+during an active unlock — it could intercept the PRF output as it is POSTed.
+This requires active compromise at the moment of signing, which is a much
+narrower attack surface than persistent disk access.
+
+---
+
+## Comparison to passphrase wallets
+
+| Property | Passphrase wallet | Passkey wallet |
+|---|---|---|
+| Private key at rest | Encrypted: argon2id(passphrase, salt) | Encrypted: wrap_key = BLAKE3(PRF(authenticator, prf_salt)) |
+| At-rest attacker needs | Crack the passphrase (argon2id, expensive) | Physical authenticator (impossible without device) |
+| Daemon signing without user | Not blocked | Blocked by WebAuthn ceremony |
+| AI agent can sign? | Yes, if passphrase is available to it | No — requires physical gesture |
+| Recovery if authenticator lost | Passphrase in head is the key | Recovery key shown once at creation |
+| Stolen disk exposure | Safe (passphrase in head only) | Safe (PRF output not on disk) |


### PR DESCRIPTION
## Passkey wallet support

Wallets created with `--passkey` encrypt the private key using the device
authenticator — Touch ID, Face ID, or a YubiKey — no passphrase required.

The encryption key is never stored. Instead, bloom uses the WebAuthn **PRF
extension** to request a deterministic 32-byte secret from the authenticator on
each unlock. That secret is fed into BLAKE3 to derive a wrap key, which decrypts
the private key via ChaCha20-Poly1305. The authenticator never exports its
internal secret — without the physical device, the wrap key cannot be reproduced
and the private key cannot be decrypted.

```
prf.salt      — 32 random bytes, stored on disk (not secret)
prf_output    — PRF(authenticator_secret, prf_salt)  derived live, never stored
wrap_key      — blake3::derive_key("bloom passkey wrap key", prf_output)
encrypted.key — ChaCha20Poly1305(private_key, wrap_key)
```

The recovery key (the wallet's raw private key as a hex string) is shown once in
a browser page at wallet creation, behind a confirmation step. Bloom never shows
it again. To recover: `bloom wallet import <name> 0x<key>`.

---

### Commands

```bash
bloom wallet new my-wallet --passkey    # Create  — opens browser for Touch ID / YubiKey ceremony
bloom wallet unlock my-wallet           # Unlock  — auto-detects passkey kind, opens browser ceremony
bloom wallet sign-policy my-wallet      # Re-sign on-disk policy.toml
bloom wallet rebind-passkey my-wallet   # Rotate  — bind to a new authenticator without moving funds
```

---

### Policy signing

Passkey wallets sign their `policy.toml` with the wallet's secp256k1 key,
creating a verifiable link between the wallet address and its spend limits. A
tampered policy file is rejected at read time. The hash is name-scoped —
`blake3("{name}:{policy}")` — so a valid signature from one wallet cannot be
transplanted to another.

---

### Security model

| Threat | Protected? |
|---|---|
| AI agent or script signs without user | ✅ ceremony required at first unlock each session |
| Attacker reads `~/.bloom/` from disk | ✅ cannot decrypt without authenticator |
| Stolen laptop or disk image | ✅ cannot decrypt without authenticator |
| Compromised user account | ✅ cannot decrypt without physical authenticator |
| Policy tampered on disk | ✅ signature verified on every read |
| Signature transplanted between wallets | ✅ policy hash is name-scoped |
| Partial wallet directory on crash | ✅ written to temp dir, atomically renamed into place |
| Local process forges PRF output during ceremony | ✅ `/prf-output` requires `clientDataJSON` bound to server-issued challenge |
| Malware active during unlock | ⚠️ could intercept PRF output at ceremony time |

> **Note:** once a wallet is unlocked, the signer is cached in the daemon for the
> lifetime of the process — no per-transaction re-authentication. The WebAuthn
> ceremony gates the first unlock per session, not every signature.

---

### Platform support

| Authenticator | PRF support |
|---|---|
| macOS Touch ID | ✅ |
| YubiKey 5 series | ✅ |
| Windows Hello | ✅ Chrome 147+ |
| Old FIDO U2F keys | ❌ rejected with clear error |

**Requirements:** Chrome ≥ 116 or Safari ≥ 18.

**Linux:** install **Google Chrome** (not Chromium, which has no built-in passkey
manager). Firefox on Linux does not support WebAuthn PRF and will show the
unsupported-authenticator error page.

---

### Incidental improvements

- **Per-sender nonce serialization** — concurrent `stage()` calls for the same wallet no longer race on nonce assignment
- **Enso quote staleness** — broadcasts of Enso routes older than 5 minutes are rejected
- **Gas limit fallback** — uses the route estimator's hint (with 25% buffer, capped at 30M) when `eth_estimateGas` fails
- **Stale IPC socket** — `ConnectionRefused` on an existing socket file is detected, the file removed, and a clear restart prompt shown
- **Socket cleanup on panic** — socket file is removed on drop, covering panic paths during `serve`
- **Price symbols** — `spot/` directory now lists known symbols; `SYMBOL_MAP` is public

---

### Breaking changes

- Empty passphrases for local wallets now error (previously silently accepted)
- `WalletKind` gains a `PasskeyGated` variant — exhaustive matches must handle it
- `verify_policy_sig` takes an additional `wallet_name: &str` parameter
- `--passphrase` is now `Option<String>`; passkey wallets skip it entirely
- Direct ERC-20 transfer path removed from the DeFi handler (dedicated VFS surface pending)

---

### Tests

```bash
# Keystore: PRF encryption round-trip, policy-signature verification,
# tamper detection, wrong-address rejection, passkey wallet info parsing
cargo test -p bloom-keystore -- passkey policy prf

# Tx engine: policy hard-deny (blocks confirm, marks failed),
# soft-warn (requires override sentinel to proceed)
cargo test -p bloom-tx -- policy_soft_warn policy_hard_deny
```