### PR TITLE
[codex] Fix acceptance CI dependencies

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -17,8 +17,14 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
-      - name: Install Rust toolchain
-        run: rustup show
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+      - name: Install Rust toolchain and WASM target
+        run: |
+          rustup show
+          rustup target add wasm32-unknown-unknown
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
       - name: Build workspace (release-ish; debug is fine for acceptance)
@@ -41,9 +47,11 @@ jobs:
             echo "available=false" >> "$GITHUB_OUTPUT"
             echo "::notice::docker not available on runner; skipping docker DEX gate"
           fi
-      - name: Install Rust toolchain
+      - name: Install Rust toolchain and WASM target
         if: steps.docker.outputs.available == 'true'
-        run: rustup show
+        run: |
+          rustup show
+          rustup target add wasm32-unknown-unknown
       - name: Cache cargo
         if: steps.docker.outputs.available == 'true'
         uses: Swatinem/rust-cache@v2

--- a/crates/bloom-it/tests/erc20_e2e.rs
+++ b/crates/bloom-it/tests/erc20_e2e.rs
@@ -10,7 +10,7 @@
 //! cargo test -p bloom-it -- --ignored
 //! ```
 //!
-//! They spawn a local `anvil` from `~/.foundry/bin/anvil`.
+//! They spawn a local `anvil` from `$PATH` (or `BLOOM_ANVIL_BIN`).
 
 use std::net::TcpListener;
 use std::process::Stdio;
@@ -24,8 +24,6 @@ use bloom_tx::tx_engine::{TxEngine, TxEngineError};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::time::timeout;
-
-const ANVIL_BIN: &str = "/Users/joshua/.foundry/bin/anvil";
 
 /// Anvil prefunded account #0.
 const ANVIL_PK0: &str = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
@@ -57,9 +55,13 @@ fn pick_free_port() -> Result<u16> {
     Ok(l.local_addr()?.port())
 }
 
+fn anvil_bin() -> String {
+    std::env::var("BLOOM_ANVIL_BIN").unwrap_or_else(|_| "anvil".to_string())
+}
+
 async fn spawn_anvil(no_mining: bool) -> Result<AnvilGuard> {
     let port = pick_free_port()?;
-    let mut cmd = Command::new(ANVIL_BIN);
+    let mut cmd = Command::new(anvil_bin());
     cmd.arg("--port")
         .arg(port.to_string())
         .arg("--host")

--- a/crates/bloom-watch/tests/anvil_watch.rs
+++ b/crates/bloom-watch/tests/anvil_watch.rs
@@ -9,8 +9,8 @@
 //! cargo test -p bloom-watch -- --ignored
 //! ```
 //!
-//! Requires Foundry's `anvil` and `cast` to be available at
-//! `~/.foundry/bin/{anvil,cast}` (matching the path used by `bloom-it`).
+//! Requires Foundry's `anvil` and `cast` on `$PATH` (or `BLOOM_ANVIL_BIN` /
+//! `BLOOM_CAST_BIN`).
 
 use std::net::TcpListener;
 use std::process::Stdio;
@@ -25,8 +25,6 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::time::{sleep, timeout};
 
-const ANVIL_BIN: &str = "/Users/joshua/.foundry/bin/anvil";
-const CAST_BIN: &str = "/Users/joshua/.foundry/bin/cast";
 const FUNDER_PRIV_KEY: &str = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 // Anvil prefunded account #1 — receives the funded watch.
 const ALICE_ADDR: &str = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
@@ -55,9 +53,17 @@ fn pick_free_port() -> Result<u16> {
     Ok(l.local_addr()?.port())
 }
 
+fn anvil_bin() -> String {
+    std::env::var("BLOOM_ANVIL_BIN").unwrap_or_else(|_| "anvil".to_string())
+}
+
+fn cast_bin() -> String {
+    std::env::var("BLOOM_CAST_BIN").unwrap_or_else(|_| "cast".to_string())
+}
+
 async fn spawn_anvil() -> Result<AnvilGuard> {
     let port = pick_free_port()?;
-    let mut cmd = Command::new(ANVIL_BIN);
+    let mut cmd = Command::new(anvil_bin());
     cmd.arg("--port")
         .arg(port.to_string())
         .arg("--host")
@@ -93,7 +99,7 @@ async fn spawn_anvil() -> Result<AnvilGuard> {
 }
 
 async fn fund(rpc_url: &str, to: &str, value_eth: u64) -> Result<()> {
-    let out = Command::new(CAST_BIN)
+    let out = Command::new(cast_bin())
         .arg("send")
         .arg("--private-key")
         .arg(FUNDER_PRIV_KEY)


### PR DESCRIPTION
## Summary

Fixes the failing `acceptance` workflow on `master` by installing the dependencies that the ignored and Docker acceptance tests require.

## What changed

- Install Foundry before running `cargo test --workspace -- --ignored`, so `anvil` and `cast` are available on CI.
- Install the `wasm32-unknown-unknown` Rust target in both acceptance jobs before tests build petal WASM artifacts.
- Update two ignored test harnesses to use Foundry from `$PATH`, with `BLOOM_ANVIL_BIN` / `BLOOM_CAST_BIN` overrides, instead of hard-coded local macOS paths.

## Root cause

The acceptance workflow only ran `rustup show`; it did not install Foundry or the WASM target. The ignored test suite also included two direct references to `/Users/joshua/.foundry/...`, which would fail on Ubuntu even after installing Foundry on `$PATH`.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p bloom-it --test erc20_e2e --no-run`
- `cargo test -p bloom-watch --test anvil_watch --no-run`
- Parsed `.github/workflows/acceptance.yml` as YAML locally
