### PR TITLE
Implement first-class view functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2481,6 +2481,7 @@ dependencies = [
  "bloom-chain-state",
  "bloom-chain-types",
  "bloom-objects",
+ "bloom-petal-manifest",
  "bloom-proto",
  "bloom-script",
  "bloom-vfs",
@@ -2615,6 +2616,8 @@ dependencies = [
  "blake3",
  "bloom-chain-types",
  "bloom-objects",
+ "hex",
+ "serde_json",
  "thiserror 2.0.18",
 ]
 

--- a/crates/bloom-chain-node/src/consensus_driver.rs
+++ b/crates/bloom-chain-node/src/consensus_driver.rs
@@ -39,8 +39,8 @@ use bloom_keystore::xdsa::{XdsaPublicKey, XdsaSignature};
 use bloom_objects::{OWNER_KIND_ADDRESS, Owner, OwnershipIndexKey, TypeTag};
 use bloom_petal_fungible::ops::decode_coin_value;
 use bloom_script::{
-    CORE_FUNGIBLE_PATH, PtbError, SignatureVerifier, ValidationContext, loom_coin_type_tag,
-    validate_ptb,
+    CORE_FUNGIBLE_PATH, PtbError, SignatureVerifier, ValidationContext, ValidationMode,
+    loom_coin_type_tag, validate_ptb,
 };
 use parking_lot::Mutex;
 use tracing::{info, warn};
@@ -152,6 +152,7 @@ impl BalanceView for StateAdmissionView<'_> {
             outer_pubkey: &outer.pubkey,
         };
         let ctx = ValidationContext {
+            mode: ValidationMode::Commit,
             current_block: self.current_block,
             chain: &adapter,
             verifier: &verifier,

--- a/crates/bloom-chain-node/src/consensus_driver.rs
+++ b/crates/bloom-chain-node/src/consensus_driver.rs
@@ -1168,7 +1168,8 @@ impl<E: PetalExecutor> ConsensusDriver<E> {
             *self.state.lock() = execution.state.clone();
         }
         self.block_store.prune(height)?;
-        self.blob_store.gc(&[blob_hash])?;
+        let removed_blobs = self.blob_store.gc(&[blob_hash])?;
+        self.state_index.delete_blob_hashes(&removed_blobs)?;
 
         // Persist receipts so CLIs can distinguish a successful tx from a
         // silent revert. The consensus driver bumps the nonce *before*

--- a/crates/bloom-chain-node/src/node.rs
+++ b/crates/bloom-chain-node/src/node.rs
@@ -1655,7 +1655,8 @@ async fn apply_state_snapshot<E: PetalExecutor>(
     driver.block_store.put(height, &block)?;
     driver.state_index.put(height, &state_root, &blob_hash)?;
     driver.block_store.prune(height)?;
-    driver.blob_store.gc(&[blob_hash])?;
+    let removed_blobs = driver.blob_store.gc(&[blob_hash])?;
+    driver.state_index.delete_blob_hashes(&removed_blobs)?;
     {
         *driver.state.lock() = state;
     }

--- a/crates/bloom-chain-node/src/node.rs
+++ b/crates/bloom-chain-node/src/node.rs
@@ -418,6 +418,8 @@ impl Node {
         let rpc_server = RpcServer {
             state: Arc::clone(&shared_state),
             block_store: Arc::clone(&block_store),
+            blob_store: Arc::clone(&blob_store),
+            state_index: Arc::clone(&state_index),
             mempool_persist: Arc::clone(&mempool_persist),
             receipt_store: Arc::clone(&receipt_store),
             validator_set: Arc::new(validator_set.clone()),
@@ -426,6 +428,7 @@ impl Node {
             local_address,
             startup_height: latest_height,
             tx_submit: tx_submit_tx.clone(),
+            max_view_fuel_limit: cfg.fuel_limit,
         };
         let rpc_socket = chain_dir.join("rpc.sock");
         if rpc_uds_enabled() {

--- a/crates/bloom-chain-node/src/petal_executor.rs
+++ b/crates/bloom-chain-node/src/petal_executor.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use bloom_chain_consensus::tx_admission::{MAX_CHAIN_WASM_BYTES, deploy_petal_fuel_for_bytes};
-use bloom_chain_state::State;
+use bloom_chain_state::{State, StateSnapshot};
 use bloom_chain_types::{
     receipt::Log,
     tx::{Tx, TxKind},
@@ -27,7 +27,8 @@ use bloom_petal_fungible::ops::{coin_payload, decode_coin_value, rewrite_value};
 use bloom_petal_manifest::extract_petal_manifest_v0;
 use bloom_petals::{BlockCtx as PetalBlockCtx, PetalVm};
 use bloom_script::{
-    AlwaysOkVerifier, CORE_FUNGIBLE_PATH, PetalManifestStub, SignatureVerifier, ValidationContext,
+    AlwaysOkVerifier, CORE_FUNGIBLE_PATH, PetalManifestStub, PtbError, SignatureVerifier,
+    ValidatedPtb, ValidationContext, ValidationMode,
     executor::{LogEntry as PtbLogEntry, PtbExecutor},
     host_ctx::PtbHostCtx,
     loom_coin_type_tag, validate_ptb,
@@ -481,6 +482,84 @@ fn resolve_fungible_petal_hash_from_state(state: &State) -> Result<Hash32, Strin
     })
 }
 
+/// Result of running a PTB through the shared validate + execute core.
+pub(crate) struct RunPtbOutput {
+    /// Complete PTB execution report.
+    pub report: bloom_script::ExecutionReport,
+    /// Snapshot after execution. Callers decide whether and how to commit it.
+    pub snapshot: StateSnapshot,
+}
+
+/// Shared PTB execution core for commit and read-only paths.
+///
+/// Snapshot selection is deliberately outside this helper: callers pass the
+/// exact [`State`] they want evaluated, and the helper has no height selector
+/// or historical-read concept.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn run_ptb(
+    state: &State,
+    block_number: u64,
+    block_ctx: PetalBlockCtx,
+    sender: Address,
+    ptb: &bloom_script::PtbTx,
+    loom_coin_type: TypeTag,
+    fungible_petal_hash: Hash32,
+    verifier: &dyn SignatureVerifier,
+    manifests: Option<&HashMap<Hash32, PetalManifestStub>>,
+    mode: ValidationMode,
+    prepare_snapshot: impl FnOnce(&ValidatedPtb, StateSnapshot) -> Result<StateSnapshot, PtbError>,
+) -> Result<RunPtbOutput, PtbError> {
+    let validated = {
+        let adapter = match manifests {
+            Some(m) => PtbChainAdapter::with_overrides(state, block_number, m),
+            None => PtbChainAdapter::new(state, block_number),
+        };
+        let ctx = ValidationContext {
+            mode,
+            current_block: block_number,
+            chain: &adapter,
+            verifier,
+            loom_coin_type: loom_coin_type.clone(),
+        };
+        validate_ptb(ptb, &ctx)?
+    };
+
+    let host_ctx = {
+        let mut c = PtbHostCtx::new();
+        c.signers = validated.tx.signers.clone();
+        Arc::new(Mutex::new(c))
+    };
+    let snapshot = prepare_snapshot(&validated, state.snapshot())?;
+    let petals_owned = ChainPetalRunner::petals_from_validated(&validated.petals);
+    let runner = ChainPetalRunner::new(
+        petals_owned,
+        Arc::clone(&host_ctx),
+        snapshot,
+        block_ctx,
+        sender,
+    );
+
+    let report = {
+        let adapter = match manifests {
+            Some(m) => PtbChainAdapter::with_overrides(state, block_number, m),
+            None => PtbChainAdapter::new(state, block_number),
+        };
+        let mut exec = PtbExecutor::with_ctx_arc(
+            &adapter,
+            &runner,
+            loom_coin_type,
+            fungible_petal_hash,
+            Arc::clone(&host_ctx),
+        );
+        exec.execute(validated)
+    };
+
+    Ok(RunPtbOutput {
+        report,
+        snapshot: runner.into_snapshot(),
+    })
+}
+
 /// Shared `PetalExecutor::execute_tx` body. The trailing `manifests`
 /// parameter is an optional per-petal manifest **override** map the
 /// PTB validator consults *before* the wasm custom-section path
@@ -617,62 +696,6 @@ fn execute_tx_impl(
                     };
                     let loom_coin_type = loom_coin_type_tag(fungible_petal_hash);
 
-                    // Capture per-PTB scratch we need across the
-                    // immutable borrow of `state` (validate) and
-                    // the mutable borrow (commit) below.
-                    let signers = ptb.signers.clone();
-
-                    let validated = {
-                        let adapter = match manifests {
-                            Some(m) => PtbChainAdapter::with_overrides(state, block_number, m),
-                            None => PtbChainAdapter::new(state, block_number),
-                        };
-                        let production_verifier;
-                        let always_ok_verifier;
-                        let verifier: &dyn SignatureVerifier = match signature_policy {
-                            PtbSignaturePolicy::ProductionXdsa => {
-                                production_verifier = XdsaPtbVerifier::new(state);
-                                &production_verifier
-                            }
-                            PtbSignaturePolicy::AlwaysOk => {
-                                always_ok_verifier = AlwaysOkVerifier;
-                                &always_ok_verifier
-                            }
-                        };
-                        let ctx = ValidationContext {
-                            current_block: block_number,
-                            chain: &adapter,
-                            verifier,
-                            loom_coin_type: loom_coin_type.clone(),
-                        };
-                        match validate_ptb(&ptb, &ctx) {
-                            Ok(v) => v,
-                            Err(e) => {
-                                warn!(
-                                    sender = %hex::encode(tx.sender.0),
-                                    err = %e,
-                                    "SubmitPtb validation failed"
-                                );
-                                return ExecOutput {
-                                    success: false,
-                                    fuel_used: 0,
-                                    return_data: format!("ptb validation error: {e}").into_bytes(),
-                                    logs: vec![],
-                                    write_set: None,
-                                };
-                            }
-                        }
-                    };
-
-                    // Build the host-context + snapshot the runner
-                    // and §16.2 imports share.
-                    let host_ctx = {
-                        let mut c = PtbHostCtx::new();
-                        c.signers = signers;
-                        Arc::new(Mutex::new(c))
-                    };
-                    let mut snapshot = state.snapshot();
-
                     // P0-5: pre-execution gas reservation (spec §7.2
                     // step 6 + §9.4). The validator already verified
                     // that the gas-payer `Coin<LOOM>` exists, is
@@ -708,79 +731,75 @@ fn execute_tx_impl(
                             };
                         }
                     };
-                    let pre_exec_gas_payer = validated
-                        .objects
-                        .get(&gas_payer_id.0)
-                        .cloned()
-                        .expect("validator inserted gas_payer object");
-                    if reservation > 0 {
-                        // Apply pre-debit. `version` is monotonic on
-                        // every mutation (spec §4.4).
-                        let pre_value = decode_coin_value(&pre_exec_gas_payer.payload)
-                            .expect("validator decoded coin value");
-                        let debited = pre_value
-                            .checked_sub(reservation)
-                            .expect("reservation bounds debit");
-                        let new_payload = rewrite_value(&pre_exec_gas_payer.payload, debited)
-                            .expect("rewrite Coin<LOOM> payload");
-                        let mut debited_obj = pre_exec_gas_payer.clone();
-                        debited_obj.version = next_object_version(debited_obj.version);
-                        debited_obj.payload = new_payload;
-                        snapshot.insert_object(debited_obj);
-                    }
-
-                    let petals_owned = ChainPetalRunner::petals_from_validated(&validated.petals);
-                    let runner = ChainPetalRunner::new(
-                        petals_owned,
-                        Arc::clone(&host_ctx),
-                        snapshot,
+                    let production_verifier;
+                    let always_ok_verifier;
+                    let verifier: &dyn SignatureVerifier = match signature_policy {
+                        PtbSignaturePolicy::ProductionXdsa => {
+                            production_verifier = XdsaPtbVerifier::new(state);
+                            &production_verifier
+                        }
+                        PtbSignaturePolicy::AlwaysOk => {
+                            always_ok_verifier = AlwaysOkVerifier;
+                            &always_ok_verifier
+                        }
+                    };
+                    let mut pre_exec_gas_payer = None;
+                    let run = match run_ptb(
+                        state,
+                        block_number,
                         block_ctx.clone(),
                         tx.sender,
-                    );
-
-                    // The ChainStateIface adapter the executor
-                    // hands to its built-in commands needs a
-                    // borrow of `state`; create it inside this
-                    // scope so we drop it before reclaiming
-                    // ownership of the snapshot.
-                    //
-                    // CRITICAL (P0-2): the executor MUST share the
-                    // same `Arc<Mutex<PtbHostCtx>>` as the wasm
-                    // host imports. Without this, `object.borrow`
-                    // can't see pre-loaded objects, and
-                    // `object.create` rows land in a ctx the
-                    // executor never reads. We thread `host_ctx`
-                    // via `with_ctx_arc(...)` so the executor's
-                    // pre-load + diff-check + linearity-check
-                    // operate on the *same* borrow table the host
-                    // imports mutate.
-                    let report = {
-                        let adapter = match manifests {
-                            Some(m) => PtbChainAdapter::with_overrides(state, block_number, m),
-                            None => PtbChainAdapter::new(state, block_number),
-                        };
-                        let mut exec = PtbExecutor::with_ctx_arc(
-                            &adapter,
-                            &runner,
-                            loom_coin_type.clone(),
-                            fungible_petal_hash,
-                            Arc::clone(&host_ctx),
-                        );
-                        exec.execute(validated)
+                        &ptb,
+                        loom_coin_type.clone(),
+                        fungible_petal_hash,
+                        verifier,
+                        manifests,
+                        ValidationMode::Commit,
+                        |validated, mut snapshot| {
+                            let gas_obj = validated
+                                .objects
+                                .get(&gas_payer_id.0)
+                                .cloned()
+                                .expect("validator inserted gas_payer object");
+                            if reservation > 0 {
+                                // Apply pre-debit. `version` is monotonic on
+                                // every mutation (spec §4.4).
+                                let pre_value = decode_coin_value(&gas_obj.payload)
+                                    .expect("validator decoded coin value");
+                                let debited = pre_value
+                                    .checked_sub(reservation)
+                                    .expect("reservation bounds debit");
+                                let new_payload = rewrite_value(&gas_obj.payload, debited)
+                                    .expect("rewrite Coin<LOOM> payload");
+                                let mut debited_obj = gas_obj.clone();
+                                debited_obj.version = next_object_version(debited_obj.version);
+                                debited_obj.payload = new_payload;
+                                snapshot.insert_object(debited_obj);
+                            }
+                            pre_exec_gas_payer = Some(gas_obj);
+                            Ok(snapshot)
+                        },
+                    ) {
+                        Ok(run) => run,
+                        Err(e) => {
+                            warn!(
+                                sender = %hex::encode(tx.sender.0),
+                                err = %e,
+                                "SubmitPtb validation failed"
+                            );
+                            return ExecOutput {
+                                success: false,
+                                fuel_used: 0,
+                                return_data: format!("ptb validation error: {e}").into_bytes(),
+                                logs: vec![],
+                                write_set: None,
+                            };
+                        }
                     };
-
-                    // The executor drains the ctx itself at the
-                    // end of `execute(...)` (success path) and
-                    // folds host-attributed entries (created
-                    // objects, host deletes, host ownership
-                    // changes, logs) into the
-                    // `ExecutionReport`. We don't need a separate
-                    // drain step here — the host_ctx behind the
-                    // Arc has already been std::mem::take'n.
-
-                    // Reclaim the snapshot the runner threaded
-                    // through the calls.
-                    let mut snapshot = runner.into_snapshot();
+                    let pre_exec_gas_payer =
+                        pre_exec_gas_payer.expect("run_ptb prepared commit gas snapshot");
+                    let report = run.report;
+                    let mut snapshot = run.snapshot;
 
                     // Clamp fuel actually charged to the inner
                     // budget — defence-in-depth in case the

--- a/crates/bloom-chain-node/src/rpc.rs
+++ b/crates/bloom-chain-node/src/rpc.rs
@@ -22,6 +22,7 @@
 //! - `chain_query_code` — look up code bytes by 32-byte content hash.
 //! - `chain_resolve_path` — resolve a signed manifest module path to a petal hash.
 //! - `chain_ls_objects` — scan objects filtered by owner address or type name.
+//! - `chain_view_call` — execute one read-only petal call against a snapshot.
 //! - `chain_ls_validators` — list the current validator set.
 
 use std::io::ErrorKind;
@@ -38,9 +39,14 @@ use bloom_chain_types::{
     tx::Tx,
     types::{Address, Hash32},
 };
-use bloom_objects::Object;
+use bloom_objects::{AccessMode, Object, ObjectId, TypeTag};
 use bloom_petal_manifest::{extract_petal_manifest_v0, to_petal_manifest_stub};
-use bloom_script::{ChainStateIface, PetalManifestStub};
+use bloom_script::{
+    ArgDeclStub, CORE_FUNGIBLE_PATH, ChainStateIface, PetalManifestStub, decode_json_const,
+    decode_json_type_tag, decode_return_json, loom_coin_type_tag,
+    types::{Arg, Command, ExpectedVersion, MoveCmd, PetalRef, PtbTx},
+    validator::{SignatureVerifier, ValidationMode},
+};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -51,10 +57,15 @@ use tracing::{debug, error, warn};
 
 use crate::block_store::BlockStore;
 use crate::mempool_persist::MempoolPersist;
+use crate::petal_executor::run_ptb;
+use crate::ptb_chain_iface::PtbChainAdapter;
+use crate::state_blob::StateBlobStore;
+use crate::state_index::StateIndex;
 
 pub const RPC_MAX_REQUEST_BYTES: usize = 2 * 1024 * 1024;
 pub const RPC_MAX_RESPONSE_BYTES: usize = 2 * 1024 * 1024;
 pub const RPC_MAX_TX_BYTES: usize = 1024 * 1024;
+const DEFAULT_VIEW_FUEL_LIMIT: u64 = 1_000_000;
 const RPC_MAX_TCP_CONNECTIONS: usize = 128;
 const RPC_READ_TIMEOUT: Duration = Duration::from_secs(10);
 const RPC_WRITE_TIMEOUT: Duration = Duration::from_secs(10);
@@ -104,6 +115,56 @@ impl JsonRpcResponse {
     }
 }
 
+#[derive(Deserialize, Debug)]
+struct ViewCallParams {
+    #[serde(default)]
+    commands: Vec<ViewCommandParams>,
+    #[serde(default)]
+    path: Option<String>,
+    #[serde(default)]
+    function: Option<String>,
+    #[serde(default)]
+    hash: Option<String>,
+    #[serde(default)]
+    type_args: Vec<Value>,
+    #[serde(default)]
+    args: Vec<Value>,
+    #[serde(default)]
+    signers: Vec<String>,
+    #[serde(default)]
+    at_block: Option<u64>,
+    #[serde(default)]
+    fuel_limit: Option<u64>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+struct ViewCommandParams {
+    path: String,
+    function: String,
+    #[serde(default)]
+    hash: Option<String>,
+    #[serde(default)]
+    type_args: Vec<Value>,
+    #[serde(default)]
+    args: Vec<Value>,
+}
+
+#[derive(Debug)]
+struct ViewSnapshot {
+    state: State,
+    height: u64,
+    block_ctx: bloom_petals::BlockCtx,
+    chain_head: u64,
+}
+
+struct ViewNoSignatureVerifier;
+
+impl SignatureVerifier for ViewNoSignatureVerifier {
+    fn verify(&self, _digest: &[u8; 32], _pubkey: &[u8; 32], _signature: &[u8]) -> bool {
+        unreachable!("ReadOnly validation must not verify signatures")
+    }
+}
+
 // ---------------------------------------------------------------------------
 // RpcServer
 // ---------------------------------------------------------------------------
@@ -113,6 +174,8 @@ impl JsonRpcResponse {
 pub struct RpcServer {
     pub state: Arc<Mutex<State>>,
     pub block_store: Arc<BlockStore>,
+    pub blob_store: Arc<StateBlobStore>,
+    pub state_index: Arc<StateIndex>,
     pub mempool_persist: Arc<MempoolPersist>,
     pub receipt_store: Arc<crate::receipt_store::ReceiptStore>,
     pub validator_set: Arc<ValidatorSet>,
@@ -132,6 +195,8 @@ pub struct RpcServer {
         Tx,
         tokio::sync::oneshot::Sender<std::result::Result<(), String>>,
     )>,
+    /// Node-side maximum for standalone view fuel.
+    pub max_view_fuel_limit: u64,
 }
 
 impl RpcServer {
@@ -284,6 +349,7 @@ impl RpcServer {
             "chain_query_code" => self.handle_query_code(params),
             "chain_resolve_path" => self.handle_resolve_path(params),
             "chain_ls_objects" => self.handle_ls_objects(params),
+            "chain_view_call" => self.handle_view_call(params),
             "chain_ls_validators" => self.handle_ls_validators(),
             "chain_tip" => self.handle_tip(),
             "chain_health" => self.handle_health(),
@@ -567,6 +633,265 @@ impl RpcServer {
         }))
     }
 
+    fn handle_view_call(&self, params: &Value) -> Result<Value> {
+        let params: ViewCallParams = serde_json::from_value(params.clone())
+            .context("chain_view_call: invalid params shape")?;
+        let requested_commands = view_commands_from_params(&params)?;
+        let snapshot = self.resolve_view_snapshot(params.at_block)?;
+        let state = snapshot.state;
+        let adapter = PtbChainAdapter::new(&state, snapshot.height);
+
+        let signers = view_signers(&params)?;
+        let mut commands = Vec::with_capacity(requested_commands.len());
+        let mut response_meta = Vec::with_capacity(requested_commands.len());
+        let mut declared_returns = Vec::with_capacity(requested_commands.len());
+
+        for (cmd_idx, cmd) in requested_commands.iter().enumerate() {
+            if cmd.path.is_empty() {
+                return Err(anyhow!(
+                    "chain_view_call: command {cmd_idx}: path must not be empty"
+                ));
+            }
+            if cmd.function.is_empty() {
+                return Err(anyhow!(
+                    "chain_view_call: command {cmd_idx}: function must not be empty"
+                ));
+            }
+            let bound_hash = adapter
+                .resolve_path(&cmd.path)
+                .ok_or_else(|| anyhow!("chain_view_call: path not deployed: {}", cmd.path))?;
+            let petal_hash = match cmd.hash.as_deref() {
+                Some(hash) => {
+                    let pinned = parse_hash_hex(hash).with_context(|| {
+                        format!("chain_view_call: command {cmd_idx}: decode hash")
+                    })?;
+                    if pinned != bound_hash {
+                        return Err(anyhow!(
+                            "chain_view_call: petal hash mismatch for path {}",
+                            cmd.path
+                        ));
+                    }
+                    pinned
+                }
+                None => bound_hash,
+            };
+            if bound_hash != petal_hash {
+                return Err(anyhow!(
+                    "chain_view_call: petal hash mismatch for path {}",
+                    cmd.path
+                ));
+            }
+            let manifest = adapter
+                .load_manifest(&petal_hash)
+                .ok_or_else(|| anyhow!("chain_view_call: manifest not found for {}", cmd.path))?;
+            let function = manifest.function(&cmd.function).ok_or_else(|| {
+                anyhow!(
+                    "chain_view_call: function {} not found in {}",
+                    cmd.function,
+                    cmd.path
+                )
+            })?;
+            if !function.view {
+                return Err(anyhow!("FunctionNotAView: {}::{}", cmd.path, cmd.function));
+            }
+            let type_args = cmd
+                .type_args
+                .iter()
+                .enumerate()
+                .map(|(idx, value)| {
+                    decode_json_type_tag(value).with_context(|| {
+                        format!("chain_view_call: command {cmd_idx}: type_arg {idx}")
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+            let args = decode_view_args(cmd_idx, &cmd.args, &function.args, &type_args, &state)?;
+            declared_returns.push(
+                function
+                    .returns
+                    .iter()
+                    .map(|t| {
+                        resolve_self_type_refs(&substitute_type_args(t, &type_args), petal_hash.0)
+                    })
+                    .collect::<Vec<_>>(),
+            );
+            response_meta.push((cmd.path.clone(), cmd.function.clone(), petal_hash));
+            commands.push(Command::Move(MoveCmd {
+                petal: PetalRef {
+                    path: cmd.path.clone(),
+                    hash: Some(petal_hash),
+                },
+                function: cmd.function.clone(),
+                type_args,
+                args,
+            }));
+        }
+
+        let fuel_limit = params
+            .fuel_limit
+            .unwrap_or(DEFAULT_VIEW_FUEL_LIMIT)
+            .min(self.max_view_fuel_limit.max(1));
+        let fungible_petal_hash = state.vfs_lookup(CORE_FUNGIBLE_PATH).ok_or_else(|| {
+            anyhow!("chain_view_call: missing required VFS binding for {CORE_FUNGIBLE_PATH}")
+        })?;
+        let loom_coin_type = loom_coin_type_tag(fungible_petal_hash);
+        let tx = PtbTx {
+            signers,
+            commands,
+            gas_payer: ObjectId([0u8; 32]),
+            gas_budget: fuel_limit,
+            gas_price: 0,
+            expiry_block: snapshot.height,
+            signatures: vec![],
+        };
+
+        let verifier = ViewNoSignatureVerifier;
+        let sender = Address(tx.signers.first().copied().unwrap_or([0u8; 32]));
+        let run = run_ptb(
+            &state,
+            snapshot.height,
+            snapshot.block_ctx,
+            sender,
+            &tx,
+            loom_coin_type,
+            fungible_petal_hash,
+            &verifier,
+            None,
+            ValidationMode::ReadOnly,
+            |_validated, snapshot| Ok(snapshot),
+        )
+        .context("chain_view_call: validation/execution failed")?;
+        let report = run.report;
+
+        if !report.success {
+            let reason = report
+                .reverted_with
+                .as_ref()
+                .map(|e| e.to_string())
+                .unwrap_or_else(|| "view call reverted".to_string());
+            return Err(anyhow!("chain_view_call: {reason}"));
+        }
+        if !report.object_writes.is_empty()
+            || !report.object_deletes.is_empty()
+            || !report.ownership_changes.is_empty()
+            || !report.publish_events.is_empty()
+        {
+            return Err(anyhow!(
+                "chain_view_call: view attempted state changes (writes={}, deletes={}, ownership_changes={}, publish_events={})",
+                report.object_writes.len(),
+                report.object_deletes.len(),
+                report.ownership_changes.len(),
+                report.publish_events.len(),
+            ));
+        }
+
+        let mut out_commands = Vec::with_capacity(response_meta.len());
+        for (idx, (path, function, petal_hash)) in response_meta.into_iter().enumerate() {
+            let outputs = report.command_outputs.get(idx).cloned().unwrap_or_default();
+            let raw = outputs.iter().map(hex::encode).collect::<Vec<_>>();
+            let mut typed = Vec::with_capacity(outputs.len());
+            for (ret_idx, bytes) in outputs.iter().enumerate() {
+                let Some(tag) = declared_returns.get(idx).and_then(|v| v.get(ret_idx)) else {
+                    typed.push(Value::Null);
+                    continue;
+                };
+                typed.push(decode_return_json(tag, bytes)?.unwrap_or(Value::Null));
+            }
+            out_commands.push(json!({
+                "path": path,
+                "function": function,
+                "petal_hash": hex::encode(petal_hash.0),
+                "returns": typed,
+                "returns_raw": raw,
+                "logs": [],
+            }));
+        }
+
+        Ok(json!({
+            "at_block": snapshot.height,
+            "chain_head": snapshot.chain_head,
+            "fuel_used": report.fuel_used,
+            "commands": out_commands,
+            "logs": report.logs.iter().map(|l| json!({
+                "petal": hex::encode(l.petal.0),
+                "topic": hex::encode(&l.topic),
+                "data": hex::encode(&l.data),
+            })).collect::<Vec<_>>(),
+        }))
+    }
+
+    fn resolve_view_snapshot(&self, at_block: Option<u64>) -> Result<ViewSnapshot> {
+        let block_head = self.block_store.latest_height()?.unwrap_or(0);
+        let indexed_head = self.state_index.latest_height()?.unwrap_or(0);
+        let chain_head = block_head.max(indexed_head);
+        let height = at_block.unwrap_or(if indexed_head > 0 {
+            indexed_head
+        } else {
+            block_head
+        });
+        if height > chain_head {
+            return Err(anyhow!(
+                "HeightUnavailable {{ requested: {height}, oldest_retained: {}, head: {chain_head} }}",
+                self.state_index.oldest_height()?.unwrap_or(chain_head)
+            ));
+        }
+
+        let block_ctx = if height == 0 {
+            bloom_petals::BlockCtx {
+                number: 0,
+                timestamp_ms: 0,
+                prevhash: Hash32([0u8; 32]),
+            }
+        } else {
+            let oldest_retained = self.state_index.oldest_height()?.unwrap_or(chain_head);
+            let block = self.block_store.get(height)?.ok_or_else(|| {
+                anyhow!(
+                    "HeightUnavailable {{ requested: {height}, oldest_retained: {}, head: {chain_head} }}",
+                    oldest_retained
+                )
+            })?;
+            bloom_petals::BlockCtx {
+                number: height,
+                timestamp_ms: block.header.timestamp_ms,
+                prevhash: block.header.parent_hash,
+            }
+        };
+
+        let state = if height == 0 && chain_head == 0 && self.state_index.get(0)?.is_none() {
+            self.state.lock().clone()
+        } else {
+            self.load_indexed_state(height, chain_head)?
+        };
+
+        Ok(ViewSnapshot {
+            state,
+            height,
+            block_ctx,
+            chain_head,
+        })
+    }
+
+    fn load_indexed_state(&self, height: u64, chain_head: u64) -> Result<State> {
+        let oldest_retained = self.state_index.oldest_height()?.unwrap_or(chain_head);
+        let Some((state_root, blob_hash)) = self.state_index.get(height)? else {
+            return Err(anyhow!(
+                "HeightUnavailable {{ requested: {height}, oldest_retained: {oldest_retained}, head: {chain_head} }}"
+            ));
+        };
+        let Some(blob) = self.blob_store.get(&blob_hash)? else {
+            return Err(anyhow!(
+                "HeightUnavailable {{ requested: {height}, oldest_retained: {oldest_retained}, head: {chain_head} }}"
+            ));
+        };
+        let actual_blob_hash = State::blob_hash(&blob);
+        if actual_blob_hash != blob_hash {
+            return Err(anyhow!(
+                "chain_view_call: state blob hash mismatch at height {height}"
+            ));
+        }
+        State::from_blob(&blob, state_root)
+            .with_context(|| format!("chain_view_call: restore state at height {height}"))
+    }
+
     fn handle_tip(&self) -> Result<Value> {
         let h = self.block_store.latest_height()?.unwrap_or(0);
         Ok(json!({ "height": h }))
@@ -615,6 +940,242 @@ impl RpcServer {
             "latest_block_hash": latest_block.as_ref().map(|block| hex::encode(block.header.block_hash().0)),
             "validator_set_hash": hex::encode(self.validator_set.validator_set_hash().0),
         }))
+    }
+}
+
+fn view_commands_from_params(params: &ViewCallParams) -> Result<Vec<ViewCommandParams>> {
+    if !params.commands.is_empty() {
+        return Ok(params.commands.clone());
+    }
+    let path = params
+        .path
+        .clone()
+        .ok_or_else(|| anyhow!("chain_view_call: provide commands or path/function"))?;
+    let function = params
+        .function
+        .clone()
+        .ok_or_else(|| anyhow!("chain_view_call: provide commands or path/function"))?;
+    Ok(vec![ViewCommandParams {
+        path,
+        function,
+        hash: params.hash.clone(),
+        type_args: params.type_args.clone(),
+        args: params.args.clone(),
+    }])
+}
+
+fn view_signers(params: &ViewCallParams) -> Result<Vec<[u8; 32]>> {
+    params
+        .signers
+        .iter()
+        .map(|s| parse_address(s).map(|a| a.0))
+        .collect()
+}
+
+fn decode_view_args(
+    cmd_idx: usize,
+    values: &[Value],
+    decls: &[ArgDeclStub],
+    type_args: &[TypeTag],
+    state: &State,
+) -> Result<Vec<Arg>> {
+    if values.len() != decls.len() {
+        return Err(anyhow!(
+            "chain_view_call: command {cmd_idx}: arg count mismatch: got {}, expected {}",
+            values.len(),
+            decls.len()
+        ));
+    }
+    values
+        .iter()
+        .zip(decls.iter())
+        .enumerate()
+        .map(|(arg_idx, (value, decl))| match decl {
+            ArgDeclStub::Signer => parse_signer_arg(cmd_idx, arg_idx, value),
+            ArgDeclStub::Const(tag) => parse_const_arg(cmd_idx, arg_idx, tag, type_args, value),
+            ArgDeclStub::Object { .. } => parse_object_arg(cmd_idx, arg_idx, value, state),
+            ArgDeclStub::TypeArg(idx) => {
+                let tag = if let Some(tag) = type_args.get(*idx as usize) {
+                    tag.clone()
+                } else {
+                    decode_json_type_tag(value).with_context(|| {
+                        format!("chain_view_call: command {cmd_idx}: arg {arg_idx}: TypeTag")
+                    })?
+                };
+                Ok(Arg::TypeArg(tag))
+            }
+        })
+        .collect()
+}
+
+fn parse_signer_arg(cmd_idx: usize, arg_idx: usize, value: &Value) -> Result<Arg> {
+    let index = if let Some(index) = value.as_u64() {
+        index
+    } else if let Some(index) = value.get("signer").and_then(Value::as_u64) {
+        index
+    } else if value.get("kind").and_then(Value::as_str) == Some("signer") {
+        value.get("index").and_then(Value::as_u64).ok_or_else(|| {
+            anyhow!("chain_view_call: command {cmd_idx}: arg {arg_idx}: signer index missing")
+        })?
+    } else {
+        return Err(anyhow!(
+            "chain_view_call: command {cmd_idx}: arg {arg_idx}: expected signer index"
+        ));
+    };
+    Ok(Arg::Signer(index.try_into().map_err(|_| {
+        anyhow!("chain_view_call: command {cmd_idx}: arg {arg_idx}: signer index out of range")
+    })?))
+}
+
+fn parse_const_arg(
+    cmd_idx: usize,
+    arg_idx: usize,
+    tag: &TypeTag,
+    type_args: &[TypeTag],
+    value: &Value,
+) -> Result<Arg> {
+    if value.get("kind").and_then(Value::as_str) == Some("const")
+        && let Some(hex) = value.get("hex").and_then(Value::as_str)
+    {
+        return Ok(Arg::Const(hex::decode(hex).with_context(|| {
+            format!("chain_view_call: command {cmd_idx}: arg {arg_idx}: const hex")
+        })?));
+    }
+    if let Some(use_ref) = parse_use_arg(value)? {
+        return Ok(Arg::Use {
+            cmd_idx: use_ref.0,
+            ret_idx: use_ref.1,
+        });
+    }
+    let resolved = substitute_type_args(tag, type_args);
+    Ok(Arg::Const(
+        decode_json_const(&resolved, value).with_context(|| {
+            format!("chain_view_call: command {cmd_idx}: arg {arg_idx}: decode typed const")
+        })?,
+    ))
+}
+
+fn parse_object_arg(cmd_idx: usize, arg_idx: usize, value: &Value, state: &State) -> Result<Arg> {
+    if let Some(use_ref) = parse_use_arg(value)? {
+        return Ok(Arg::Use {
+            cmd_idx: use_ref.0,
+            ret_idx: use_ref.1,
+        });
+    }
+    let obj = if value.get("kind").and_then(Value::as_str) == Some("object") {
+        value
+    } else {
+        value.get("object").unwrap_or(value)
+    };
+    let id_str = obj
+        .get("id")
+        .and_then(Value::as_str)
+        .or_else(|| obj.as_str())
+        .ok_or_else(|| {
+            anyhow!("chain_view_call: command {cmd_idx}: arg {arg_idx}: object id missing")
+        })?;
+    let id = parse_object_id_hex(id_str)?;
+    let expected_version = match obj.get("version").and_then(Value::as_u64) {
+        Some(version) => ExpectedVersion(version),
+        None => {
+            let obj = state
+                .get_object(&id)
+                .ok_or_else(|| anyhow!("object {} not found for view arg", hex::encode(id.0)))?;
+            ExpectedVersion(obj.version)
+        }
+    };
+    Ok(Arg::Object {
+        id,
+        expected_version,
+        access_mode: AccessMode::ReadOnly,
+    })
+}
+
+fn parse_use_arg(value: &Value) -> Result<Option<(u16, u16)>> {
+    let Some(use_value) = value.get("use") else {
+        return Ok(None);
+    };
+    let cmd = use_value
+        .get("cmd")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| anyhow!("view use-ref missing cmd"))?;
+    let ret = use_value
+        .get("ret")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| anyhow!("view use-ref missing ret"))?;
+    Ok(Some((
+        cmd.try_into()
+            .map_err(|_| anyhow!("view use-ref cmd out of range"))?,
+        ret.try_into()
+            .map_err(|_| anyhow!("view use-ref ret out of range"))?,
+    )))
+}
+
+fn parse_hash_hex(s: &str) -> Result<Hash32> {
+    let bytes = hex::decode(s).context("decode hash hex")?;
+    if bytes.len() != 32 {
+        return Err(anyhow!("hash must be 32 bytes (got {})", bytes.len()));
+    }
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&bytes);
+    Ok(Hash32(out))
+}
+
+fn parse_object_id_hex(s: &str) -> Result<ObjectId> {
+    let bytes = hex::decode(s).context("decode object id hex")?;
+    if bytes.len() != 32 {
+        return Err(anyhow!("object id must be 32 bytes (got {})", bytes.len()));
+    }
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&bytes);
+    Ok(ObjectId(out))
+}
+
+fn substitute_type_args(t: &TypeTag, type_args: &[TypeTag]) -> TypeTag {
+    match t {
+        TypeTag::Generic { idx } => type_args
+            .get(*idx as usize)
+            .cloned()
+            .unwrap_or_else(|| t.clone()),
+        TypeTag::Concrete {
+            petal_hash,
+            type_name,
+            type_args: inner,
+        } => TypeTag::Concrete {
+            petal_hash: *petal_hash,
+            type_name: type_name.clone(),
+            type_args: inner
+                .iter()
+                .map(|x| substitute_type_args(x, type_args))
+                .collect(),
+        },
+        TypeTag::External { .. } => t.clone(),
+    }
+}
+
+fn resolve_self_type_refs(t: &TypeTag, self_hash: [u8; 32]) -> TypeTag {
+    match t {
+        TypeTag::Concrete {
+            petal_hash,
+            type_name,
+            type_args,
+        } => TypeTag::Concrete {
+            petal_hash: if petal_hash == &[0u8; 32] && type_name != "Coin" {
+                self_hash
+            } else {
+                *petal_hash
+            },
+            type_name: type_name.clone(),
+            type_args: if type_name == "Coin" {
+                type_args.clone()
+            } else {
+                type_args
+                    .iter()
+                    .map(|x| resolve_self_type_refs(x, self_hash))
+                    .collect()
+            },
+        },
+        TypeTag::Generic { .. } | TypeTag::External { .. } => t.clone(),
     }
 }
 
@@ -963,6 +1524,9 @@ mod tests {
     use bloom_chain_types::block::{Block, BlockHeader};
     use bloom_chain_types::vote::Commit;
     use bloom_objects::{Object, ObjectId, Owner, TypeTag};
+    use bloom_petal_manifest::codec;
+    use bloom_petal_manifest::types::{FunctionDecl, PetalManifestV0, SCHEMA_VERSION, SemVer};
+    use bloom_script::DEFAULT_FUNGIBLE_PETAL_HASH;
     use bloom_test_util::{make_validator_set_signed, make_validator_with_keypair};
 
     /// Build an `RpcServer` over an in-memory `State` (with tempdir-backed
@@ -971,18 +1535,28 @@ mod tests {
     fn make_server() -> (RpcServer, tempfile::TempDir) {
         let tmp = tempfile::tempdir().unwrap();
         let block_store = Arc::new(BlockStore::open(&tmp.path().join("blocks")).unwrap());
+        let blob_store = Arc::new(
+            crate::state_blob::StateBlobStore::open(&tmp.path().join("state_blobs")).unwrap(),
+        );
+        let state_index = Arc::new(
+            crate::state_index::StateIndex::open(&tmp.path().join("state_index.sqlite")).unwrap(),
+        );
         let receipt_store = Arc::new(
             crate::receipt_store::ReceiptStore::open(&tmp.path().join("receipts")).unwrap(),
         );
         let mempool_persist =
             Arc::new(MempoolPersist::open(&tmp.path().join("mempool.sled")).unwrap());
-        let state = Arc::new(Mutex::new(State::new()));
+        let mut initial_state = State::new();
+        initial_state.set_vfs_binding(CORE_FUNGIBLE_PATH.to_string(), DEFAULT_FUNGIBLE_PETAL_HASH);
+        let state = Arc::new(Mutex::new(initial_state));
         let v = make_validator_with_keypair();
         let validator_set = Arc::new(make_validator_set_signed(&[&v], 100));
         let (tx_submit, _rx) = tokio::sync::mpsc::channel(8);
         let server = RpcServer {
             state,
             block_store,
+            blob_store,
+            state_index,
             mempool_persist,
             receipt_store,
             validator_set,
@@ -991,6 +1565,7 @@ mod tests {
             local_address: v.addr,
             startup_height: 0,
             tx_submit,
+            max_view_fuel_limit: DEFAULT_VIEW_FUEL_LIMIT,
         };
         (server, tmp)
     }
@@ -1038,6 +1613,64 @@ mod tests {
             version: 7,
             payload: vec![0xDE, 0xAD, 0xBE, 0xEF],
         }
+    }
+
+    fn leb128(out: &mut Vec<u8>, mut v: u64) {
+        loop {
+            let b = (v & 0x7f) as u8;
+            v >>= 7;
+            if v == 0 {
+                out.push(b);
+                return;
+            }
+            out.push(b | 0x80);
+        }
+    }
+
+    fn custom_section(name: &str, payload: &[u8]) -> Vec<u8> {
+        let mut body = Vec::new();
+        leb128(&mut body, name.len() as u64);
+        body.extend_from_slice(name.as_bytes());
+        body.extend_from_slice(payload);
+        body
+    }
+
+    fn section(out: &mut Vec<u8>, id: u8, body: &[u8]) {
+        out.push(id);
+        leb128(out, body.len() as u64);
+        out.extend_from_slice(body);
+    }
+
+    fn append_manifest(mut wasm: Vec<u8>, manifest: PetalManifestV0) -> Vec<u8> {
+        let bytes = codec::encode(&manifest).expect("manifest encodes");
+        let custom = custom_section("bloom_petal_manifest_v0", &bytes);
+        section(&mut wasm, 0, &custom);
+        wasm
+    }
+
+    fn u128_tag() -> TypeTag {
+        TypeTag::Concrete {
+            petal_hash: [0u8; 32],
+            type_name: "u128".to_string(),
+            type_args: vec![],
+        }
+    }
+
+    fn view_manifest(path: &str, functions: Vec<FunctionDecl>) -> PetalManifestV0 {
+        PetalManifestV0 {
+            schema_version: SCHEMA_VERSION,
+            module_path: path.to_string(),
+            framework_version: SemVer::new(0, 1, 0),
+            functions,
+            ..Default::default()
+        }
+    }
+
+    fn install_view_wasm(server: &RpcServer, path: &str, wasm: &[u8]) -> Hash32 {
+        let mut state = server.state.lock();
+        let hash = state.insert_code(wasm);
+        state.set_vfs_binding(path.to_string(), hash);
+        hash
     }
 
     #[test]
@@ -1093,6 +1726,243 @@ mod tests {
             .handle_query_object(&json!({ "id": "deadbeef" }))
             .unwrap_err();
         assert!(err.to_string().contains("32 bytes"), "got: {err}");
+    }
+
+    #[test]
+    fn view_call_executes_read_only_petal_without_committing_state() {
+        let (server, _tmp) = make_server();
+        let wasm = wat::parse_str(
+            r#"
+            (module
+              (import "chain" "petal.return" (func $ret (param i32 i32)))
+              (import "chain" "msg.calldata.read" (func $read (param i32 i32 i32) (result i32)))
+              (memory (export "memory") 1)
+              ;; count=1, len=16, u128=42
+              (data (i32.const 0) "\00\00\00\01\00\00\00\10\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\2a")
+              (func (export "__petal_answer") (param i32 i32) (result i32)
+                (call $ret (i32.const 0) (i32.const 24))
+                i32.const 0)
+            )
+            "#,
+        )
+        .unwrap();
+        let path = "/bloom/test/view";
+        let wasm = append_manifest(
+            wasm,
+            view_manifest(
+                path,
+                vec![FunctionDecl {
+                    name: "answer".to_string(),
+                    view: true,
+                    returns: vec![u128_tag()],
+                    ..Default::default()
+                }],
+            ),
+        );
+        let hash = install_view_wasm(&server, path, &wasm);
+
+        let res = server
+            .handle_view_call(&json!({
+                "path": path,
+                "function": "answer"
+            }))
+            .unwrap();
+
+        assert_eq!(res["at_block"], 0);
+        assert_eq!(res["chain_head"], 0);
+        assert_eq!(res["commands"][0]["path"], path);
+        assert_eq!(res["commands"][0]["function"], "answer");
+        assert_eq!(res["commands"][0]["petal_hash"], hex::encode(hash.0));
+        assert_eq!(res["commands"][0]["returns"][0], "42");
+        assert_eq!(
+            res["commands"][0]["returns_raw"][0],
+            "0000000000000000000000000000002a"
+        );
+        assert!(server.state.lock().iter_objects().next().is_none());
+    }
+
+    #[test]
+    fn view_call_composes_multiple_commands_with_use_refs() {
+        let (server, _tmp) = make_server();
+        let path = "/bloom/test/view-compose";
+        let wasm = wat::parse_str(
+            r#"
+            (module
+              (import "chain" "petal.return" (func $ret (param i32 i32)))
+              (import "chain" "msg.calldata.read" (func $read (param i32 i32 i32) (result i32)))
+              (memory (export "memory") 1)
+              ;; count=1, len=16, u128=42
+              (data (i32.const 0) "\00\00\00\01\00\00\00\10\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\2a")
+              (data (i32.const 64) "\00\00\00\01\00\00\00\10")
+              (func (export "__petal_answer") (param i32 i32) (result i32)
+                (call $ret (i32.const 0) (i32.const 24))
+                i32.const 0)
+              (func (export "__petal_echo") (param $ptr i32) (param $len i32) (result i32)
+                ;; Args buffer: count(4), tag(1), len(4), payload(16). Return count/len + payload.
+                (drop (call $read (i32.const 128) (i32.const 0) (i32.const 25)))
+                (memory.copy (i32.const 72) (i32.const 137) (i32.const 16))
+                (call $ret (i32.const 64) (i32.const 24))
+                i32.const 0)
+            )
+            "#,
+        )
+        .unwrap();
+        let wasm = append_manifest(
+            wasm,
+            view_manifest(
+                path,
+                vec![
+                    FunctionDecl {
+                        name: "answer".to_string(),
+                        view: true,
+                        returns: vec![u128_tag()],
+                        ..Default::default()
+                    },
+                    FunctionDecl {
+                        name: "echo".to_string(),
+                        view: true,
+                        args: vec![bloom_petal_manifest::types::ArgDecl {
+                            name: "value".to_string(),
+                            kind: bloom_petal_manifest::types::ArgKind::Const(u128_tag()),
+                        }],
+                        returns: vec![u128_tag()],
+                        ..Default::default()
+                    },
+                ],
+            ),
+        );
+        install_view_wasm(&server, path, &wasm);
+
+        let res = server
+            .handle_view_call(&json!({
+                "commands": [
+                    { "path": path, "function": "answer" },
+                    { "path": path, "function": "echo", "args": [ { "use": { "cmd": 0, "ret": 0 } } ] }
+                ]
+            }))
+            .unwrap();
+
+        assert_eq!(res["commands"][0]["returns"][0], "42");
+        assert_eq!(res["commands"][1]["returns"][0], "42");
+        assert_eq!(
+            res["commands"][1]["returns_raw"][0],
+            "0000000000000000000000000000002a"
+        );
+    }
+
+    #[test]
+    fn view_call_at_block_uses_retained_snapshot() {
+        let (server, _tmp) = make_server();
+        let path = "/bloom/test/historical-view";
+        let wasm_old = wat::parse_str(
+            r#"
+            (module
+              (import "chain" "petal.return" (func $ret (param i32 i32)))
+              (memory (export "memory") 1)
+              (data (i32.const 0) "\00\00\00\01\00\00\00\10\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\2a")
+              (func (export "__petal_answer") (param i32 i32) (result i32)
+                (call $ret (i32.const 0) (i32.const 24))
+                i32.const 0)
+            )
+            "#,
+        )
+        .unwrap();
+        let wasm_new = wat::parse_str(
+            r#"
+            (module
+              (import "chain" "petal.return" (func $ret (param i32 i32)))
+              (memory (export "memory") 1)
+              (data (i32.const 0) "\00\00\00\01\00\00\00\10\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\63")
+              (func (export "__petal_answer") (param i32 i32) (result i32)
+                (call $ret (i32.const 0) (i32.const 24))
+                i32.const 0)
+            )
+            "#,
+        )
+        .unwrap();
+        let wasm_old = append_manifest(
+            wasm_old,
+            view_manifest(
+                path,
+                vec![FunctionDecl {
+                    name: "answer".to_string(),
+                    view: true,
+                    returns: vec![u128_tag()],
+                    ..Default::default()
+                }],
+            ),
+        );
+        let wasm_new = append_manifest(
+            wasm_new,
+            view_manifest(
+                path,
+                vec![FunctionDecl {
+                    name: "answer".to_string(),
+                    view: true,
+                    returns: vec![u128_tag()],
+                    ..Default::default()
+                }],
+            ),
+        );
+
+        let mut old_state = State::new();
+        old_state.set_vfs_binding(CORE_FUNGIBLE_PATH.to_string(), DEFAULT_FUNGIBLE_PETAL_HASH);
+        let old_hash = old_state.insert_code(&wasm_old);
+        old_state.set_vfs_binding(path.to_string(), old_hash);
+        let old_root = old_state.state_root();
+        let block1 = test_block_with_timestamp(1, 10);
+        server.block_store.put(1, &block1).unwrap();
+        let (blob, blob_hash) = old_state.to_blob(1, block1.header.parent_hash);
+        server.blob_store.put(&blob).unwrap();
+        server.state_index.put(1, &old_root, &blob_hash).unwrap();
+
+        let current_root = {
+            let mut current = server.state.lock();
+            let new_hash = current.insert_code(&wasm_new);
+            current.set_vfs_binding(path.to_string(), new_hash);
+            current.state_root()
+        };
+        let block2 = test_block_with_timestamp(2, 20);
+        server.block_store.put(2, &block2).unwrap();
+        let current_state = server.state.lock().clone();
+        let (blob2, blob2_hash) = current_state.to_blob(2, block2.header.parent_hash);
+        server.blob_store.put(&blob2).unwrap();
+        server
+            .state_index
+            .put(2, &current_root, &blob2_hash)
+            .unwrap();
+
+        let historical = server
+            .handle_view_call(&json!({
+                "path": path,
+                "function": "answer",
+                "at_block": 1
+            }))
+            .unwrap();
+        let tip = server
+            .handle_view_call(&json!({
+                "path": path,
+                "function": "answer"
+            }))
+            .unwrap();
+
+        assert_eq!(historical["at_block"], 1);
+        assert_eq!(historical["chain_head"], 2);
+        assert_eq!(historical["commands"][0]["returns"][0], "42");
+        assert_eq!(tip["commands"][0]["returns"][0], "99");
+
+        let genesis = server
+            .handle_view_call(&json!({
+                "path": path,
+                "function": "answer",
+                "at_block": 0
+            }))
+            .unwrap_err();
+        let msg = genesis.to_string();
+        assert!(
+            msg.contains("HeightUnavailable") && msg.contains("requested: 0"),
+            "unexpected error: {msg}"
+        );
     }
 
     #[test]

--- a/crates/bloom-chain-node/src/rpc.rs
+++ b/crates/bloom-chain-node/src/rpc.rs
@@ -823,11 +823,7 @@ impl RpcServer {
         let block_head = self.block_store.latest_height()?.unwrap_or(0);
         let indexed_head = self.state_index.latest_height()?.unwrap_or(0);
         let chain_head = block_head.max(indexed_head);
-        let height = at_block.unwrap_or(if indexed_head > 0 {
-            indexed_head
-        } else {
-            block_head
-        });
+        let height = at_block.unwrap_or(block_head);
         if height > chain_head {
             return Err(anyhow!(
                 "HeightUnavailable {{ requested: {height}, oldest_retained: {}, head: {chain_head} }}",
@@ -856,7 +852,9 @@ impl RpcServer {
             }
         };
 
-        let state = if height == 0 && chain_head == 0 && self.state_index.get(0)?.is_none() {
+        let state = if at_block.is_none() && height == block_head {
+            self.state.lock().clone()
+        } else if height == 0 && chain_head == 0 && self.state_index.get(0)?.is_none() {
             self.state.lock().clone()
         } else {
             self.load_indexed_state(height, chain_head)?
@@ -1916,21 +1914,13 @@ mod tests {
         server.blob_store.put(&blob).unwrap();
         server.state_index.put(1, &old_root, &blob_hash).unwrap();
 
-        let current_root = {
+        {
             let mut current = server.state.lock();
             let new_hash = current.insert_code(&wasm_new);
             current.set_vfs_binding(path.to_string(), new_hash);
-            current.state_root()
-        };
+        }
         let block2 = test_block_with_timestamp(2, 20);
         server.block_store.put(2, &block2).unwrap();
-        let current_state = server.state.lock().clone();
-        let (blob2, blob2_hash) = current_state.to_blob(2, block2.header.parent_hash);
-        server.blob_store.put(&blob2).unwrap();
-        server
-            .state_index
-            .put(2, &current_root, &blob2_hash)
-            .unwrap();
 
         let historical = server
             .handle_view_call(&json!({
@@ -1949,6 +1939,8 @@ mod tests {
         assert_eq!(historical["at_block"], 1);
         assert_eq!(historical["chain_head"], 2);
         assert_eq!(historical["commands"][0]["returns"][0], "42");
+        assert_eq!(tip["at_block"], 2);
+        assert_eq!(tip["chain_head"], 2);
         assert_eq!(tip["commands"][0]["returns"][0], "99");
 
         let genesis = server

--- a/crates/bloom-chain-node/src/state_blob.rs
+++ b/crates/bloom-chain-node/src/state_blob.rs
@@ -78,7 +78,10 @@ impl StateBlobStore {
     ///
     /// `pinned`: set of hashes to keep regardless of age.  The implementation
     /// keeps the `BLOB_RETENTION` most recently modified files.
-    pub fn gc(&self, pinned: &[Hash32]) -> Result<()> {
+    ///
+    /// Returns the valid blob hashes removed during this pass so callers can
+    /// keep secondary indexes in sync.
+    pub fn gc(&self, pinned: &[Hash32]) -> Result<Vec<Hash32>> {
         let pinned_set: std::collections::HashSet<String> =
             pinned.iter().map(|h| hex::encode(h.0)).collect();
 
@@ -95,13 +98,14 @@ impl StateBlobStore {
 
         let retention = blob_retention();
         if entries.len() <= retention {
-            return Ok(());
+            return Ok(Vec::new());
         }
 
         // Sort newest first.
         entries.sort_by_key(|b| std::cmp::Reverse(b.0));
 
         // Remove files beyond retention, unless pinned.
+        let mut removed = Vec::new();
         for (_, path) in entries.into_iter().skip(retention) {
             let name = path
                 .file_name()
@@ -111,11 +115,29 @@ impl StateBlobStore {
             if pinned_set.contains(&name) {
                 continue;
             }
-            let _ = std::fs::remove_file(&path);
-            debug!(blob = %name, "state_blob.gc");
+            let removed_file = match std::fs::remove_file(&path) {
+                Ok(()) => true,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
+                Err(_) => false,
+            };
+            if removed_file {
+                if let Some(hash) = hash_from_blob_filename(&name) {
+                    removed.push(hash);
+                }
+                debug!(blob = %name, "state_blob.gc");
+            }
         }
-        Ok(())
+        Ok(removed)
     }
+}
+
+fn hash_from_blob_filename(name: &str) -> Option<Hash32> {
+    if name.len() != 64 {
+        return None;
+    }
+    let bytes = hex::decode(name).ok()?;
+    let arr: [u8; 32] = bytes.try_into().ok()?;
+    Some(Hash32(arr))
 }
 
 fn write_atomic(tmp_path: &Path, final_path: &Path, bytes: &[u8]) -> Result<()> {

--- a/crates/bloom-chain-node/src/state_index.rs
+++ b/crates/bloom-chain-node/src/state_index.rs
@@ -75,4 +75,12 @@ impl StateIndex {
         let h: Option<i64> = stmt.query_row([], |row| row.get(0))?;
         Ok(h.map(|v| v as u64))
     }
+
+    /// Return the lowest indexed height, or `None` if empty.
+    pub fn oldest_height(&self) -> Result<Option<u64>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn.prepare_cached("SELECT MIN(height) FROM state_index")?;
+        let h: Option<i64> = stmt.query_row([], |row| row.get(0))?;
+        Ok(h.map(|v| v as u64))
+    }
 }

--- a/crates/bloom-chain-node/src/state_index.rs
+++ b/crates/bloom-chain-node/src/state_index.rs
@@ -83,4 +83,49 @@ impl StateIndex {
         let h: Option<i64> = stmt.query_row([], |row| row.get(0))?;
         Ok(h.map(|v| v as u64))
     }
+
+    /// Delete rows that point at blobs removed from the content-addressed store.
+    pub fn delete_blob_hashes(&self, blob_hashes: &[Hash32]) -> Result<usize> {
+        if blob_hashes.is_empty() {
+            return Ok(0);
+        }
+
+        let mut conn = self.conn.lock();
+        let tx = conn.transaction().context("begin state_index prune")?;
+        let mut deleted = 0usize;
+        for blob_hash in blob_hashes {
+            deleted += tx
+                .execute(
+                    "DELETE FROM state_index WHERE blob_hash = ?1",
+                    params![&blob_hash.0[..]],
+                )
+                .context("delete pruned state_index rows")?;
+        }
+        tx.commit().context("commit state_index prune")?;
+        debug!(deleted, "state_index.prune_pruned_blobs");
+        Ok(deleted)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn delete_blob_hashes_updates_oldest_height() {
+        let tmp = tempfile::tempdir().unwrap();
+        let index = StateIndex::open(&tmp.path().join("state_index.sqlite")).unwrap();
+        let root1 = Hash32([0x11; 32]);
+        let root2 = Hash32([0x22; 32]);
+        let blob1 = Hash32([0xAA; 32]);
+        let blob2 = Hash32([0xBB; 32]);
+
+        index.put(1, &root1, &blob1).unwrap();
+        index.put(2, &root2, &blob2).unwrap();
+        assert_eq!(index.oldest_height().unwrap(), Some(1));
+
+        assert_eq!(index.delete_blob_hashes(&[blob1]).unwrap(), 1);
+        assert_eq!(index.get(1).unwrap(), None);
+        assert_eq!(index.oldest_height().unwrap(), Some(2));
+    }
 }

--- a/crates/bloom-chain-node/tests/ptb_gas_reservation.rs
+++ b/crates/bloom-chain-node/tests/ptb_gas_reservation.rs
@@ -161,6 +161,7 @@ fn manifest_with_nullary_fn(fn_name: &str) -> PetalManifestStub {
     PetalManifestStub {
         module_path: "/test/p0-5".to_string(),
         functions: vec![FunctionDeclStub {
+            view: false,
             name: fn_name.to_string(),
             type_params: vec![],
             args: vec![],

--- a/crates/bloom-chain-node/tests/ptb_ownership_index_rebuild.rs
+++ b/crates/bloom-chain-node/tests/ptb_ownership_index_rebuild.rs
@@ -156,6 +156,7 @@ fn manifest_for(obj_type: TypeTag) -> PetalManifestStub {
         module_path: "/test/p1-2".to_string(),
         functions: vec![
             FunctionDeclStub {
+                view: false,
                 name: "xfer".to_string(),
                 type_params: vec![],
                 args: vec![ArgDeclStub::Object {
@@ -166,6 +167,7 @@ fn manifest_for(obj_type: TypeTag) -> PetalManifestStub {
                 attached_invariants: vec![],
             },
             FunctionDeclStub {
+                view: false,
                 name: "del".to_string(),
                 type_params: vec![],
                 args: vec![ArgDeclStub::Object {

--- a/crates/bloom-chain-node/tests/ptb_submit_e2e.rs
+++ b/crates/bloom-chain-node/tests/ptb_submit_e2e.rs
@@ -243,6 +243,7 @@ fn manifest_with_nullary_fn_returns(fn_name: &str, returns: Vec<TypeTag>) -> Pet
     PetalManifestStub {
         module_path: "/test/e2e".to_string(),
         functions: vec![FunctionDeclStub {
+            view: false,
             name: fn_name.to_string(),
             type_params: vec![],
             args: vec![],
@@ -695,6 +696,7 @@ fn object_create_then_transfer_round_trips_through_unified_ctx() {
         PetalManifestStub {
             module_path: "/test/e2e".to_string(),
             functions: vec![FunctionDeclStub {
+                view: false,
                 name: "create_and_transfer".to_string(),
                 type_params: vec![],
                 args: vec![ArgDeclStub::Const(new_obj_type.clone())],

--- a/crates/bloom-chain-node/tests/rpc_query_block_by_hash.rs
+++ b/crates/bloom-chain-node/tests/rpc_query_block_by_hash.rs
@@ -16,6 +16,8 @@ use std::sync::Arc;
 use bloom_chain_node::block_store::BlockStore;
 use bloom_chain_node::mempool_persist::MempoolPersist;
 use bloom_chain_node::receipt_store::ReceiptStore;
+use bloom_chain_node::state_blob::StateBlobStore;
+use bloom_chain_node::state_index::StateIndex;
 use bloom_chain_node::{RpcClient, RpcServer};
 use bloom_chain_state::State;
 use bloom_chain_types::{
@@ -63,6 +65,11 @@ async fn chain_query_block_by_hash_matches_by_height() {
         Arc::new(BlockStore::open(&tmp.path().join("blocks")).expect("open BlockStore"));
     let receipt_store =
         Arc::new(ReceiptStore::open(&tmp.path().join("receipts")).expect("open ReceiptStore"));
+    let blob_store =
+        Arc::new(StateBlobStore::open(&tmp.path().join("state_blobs")).expect("open blob store"));
+    let state_index = Arc::new(
+        StateIndex::open(&tmp.path().join("state_index.sqlite")).expect("open state index"),
+    );
     let mempool_persist = Arc::new(
         MempoolPersist::open(&tmp.path().join("mempool.sled")).expect("open MempoolPersist"),
     );
@@ -85,6 +92,8 @@ async fn chain_query_block_by_hash_matches_by_height() {
     let server = RpcServer {
         state,
         block_store: Arc::clone(&block_store),
+        blob_store,
+        state_index,
         mempool_persist,
         receipt_store,
         validator_set,
@@ -93,6 +102,7 @@ async fn chain_query_block_by_hash_matches_by_height() {
         local_address: v.addr,
         startup_height: 0,
         tx_submit,
+        max_view_fuel_limit: 1_000_000,
     };
 
     // Bind serve_tcp on an OS-assigned port. We resolve the port by binding

--- a/crates/bloom-petal-it/src/harness.rs
+++ b/crates/bloom-petal-it/src/harness.rs
@@ -282,6 +282,7 @@ pub fn manifest_nullary(fn_name: &str) -> PetalManifestStub {
     PetalManifestStub {
         module_path: "/test/petal-it".to_string(),
         functions: vec![FunctionDeclStub {
+            view: false,
             name: fn_name.to_string(),
             type_params: vec![],
             args: vec![],

--- a/crates/bloom-petal-it/tests/determinism.rs
+++ b/crates/bloom-petal-it/tests/determinism.rs
@@ -74,6 +74,7 @@ fn apply_ptb_split_transfer(
         PetalManifestStub {
             module_path: "/test/loader".to_string(),
             functions: vec![FunctionDeclStub {
+                view: false,
                 name: "load_coin".to_string(),
                 type_params: vec![],
                 args: vec![ArgDeclStub::Object {

--- a/crates/bloom-petal-it/tests/linearity_and_cap_reverts.rs
+++ b/crates/bloom-petal-it/tests/linearity_and_cap_reverts.rs
@@ -131,6 +131,7 @@ fn linearity_violation_reverts_atomically() {
             PetalManifestStub {
                 module_path: "/test/linearity".to_string(),
                 functions: vec![FunctionDeclStub {
+                    view: false,
                     name: "load_coin".to_string(),
                     type_params: vec![],
                     args: vec![ArgDeclStub::Object {
@@ -427,6 +428,7 @@ fn revert_atomicity_state_is_unchanged() {
             PetalManifestStub {
                 module_path: "/test/lin".to_string(),
                 functions: vec![FunctionDeclStub {
+                    view: false,
                     name: "load_coin".to_string(),
                     type_params: vec![],
                     args: vec![ArgDeclStub::Object {

--- a/crates/bloom-petal-it/tests/ptb_fungible_flow.rs
+++ b/crates/bloom-petal-it/tests/ptb_fungible_flow.rs
@@ -128,6 +128,7 @@ fn move_split_transfer_happy_path() {
         PetalManifestStub {
             module_path: "/test/loader".to_string(),
             functions: vec![FunctionDeclStub {
+                view: false,
                 name: "load_coin".to_string(),
                 type_params: vec![],
                 args: vec![ArgDeclStub::Object {

--- a/crates/bloom-petal-manifest/src/codec.rs
+++ b/crates/bloom-petal-manifest/src/codec.rs
@@ -21,7 +21,7 @@ use bloom_objects::{AbilitySet, AccessMode, TypeTag};
 use crate::types::{
     ArgDecl, ArgKind, CapabilityDecl, ExternalTypeRef, FieldDecl, FuelHints, FunctionDecl,
     HostImportDecl, InvariantDecl, InvariantTarget, ObjectTypeDecl, PetalManifestV0, PredicateAst,
-    SemVer, TypeParamDecl, TypeParamKind, WasmFuncSig, WasmValType,
+    SCHEMA_VERSION, SemVer, TypeParamDecl, TypeParamKind, WasmFuncSig, WasmValType,
 };
 
 // ===========================================================================
@@ -37,13 +37,20 @@ pub fn encode(manifest: &PetalManifestV0) -> Result<Vec<u8>, CodecError> {
 
 /// Canonical-encode the manifest into an existing buffer.
 pub fn encode_into(manifest: &PetalManifestV0, buf: &mut Vec<u8>) -> Result<(), CodecError> {
+    if !matches!(manifest.schema_version, 1 | SCHEMA_VERSION) {
+        return Err(CodecError::InvalidLength(manifest.schema_version as u64));
+    }
     write_u32_be(buf, manifest.schema_version);
     write_string(buf, &manifest.module_path)?;
     write_semver(buf, &manifest.framework_version);
     write_option_hash(buf, manifest.parent_version.as_ref());
     write_list(buf, &manifest.object_types, write_object_type_decl)?;
     write_list(buf, &manifest.capability_types, write_capability_decl)?;
-    write_list(buf, &manifest.functions, write_function_decl)?;
+    match manifest.schema_version {
+        1 => write_list(buf, &manifest.functions, write_function_decl_v1)?,
+        SCHEMA_VERSION => write_list(buf, &manifest.functions, write_function_decl_v2)?,
+        other => return Err(CodecError::InvalidLength(other as u64)),
+    }
     write_list(buf, &manifest.invariants, write_invariant_decl)?;
     write_list(buf, &manifest.required_host_imports, write_host_import_decl)?;
     write_list(buf, &manifest.external_type_refs, write_external_type_ref)?;
@@ -62,12 +69,19 @@ pub fn decode(bytes: &[u8]) -> Result<PetalManifestV0, CodecError> {
 /// Decode from a cursor (allows trailing bytes; used when nested).
 pub fn decode_from(rdr: &mut &[u8]) -> Result<PetalManifestV0, CodecError> {
     let schema_version = read_u32_be(rdr)?;
+    if !matches!(schema_version, 1 | SCHEMA_VERSION) {
+        return Err(CodecError::InvalidLength(schema_version as u64));
+    }
     let module_path = read_string(rdr)?;
     let framework_version = read_semver(rdr)?;
     let parent_version = read_option_hash(rdr)?;
     let object_types = read_list(rdr, read_object_type_decl)?;
     let capability_types = read_list(rdr, read_capability_decl)?;
-    let functions = read_list(rdr, read_function_decl)?;
+    let functions = match schema_version {
+        1 => read_list(rdr, read_function_decl_v1)?,
+        SCHEMA_VERSION => read_list(rdr, read_function_decl_v2)?,
+        other => return Err(CodecError::InvalidLength(other as u64)),
+    };
     let invariants = read_list(rdr, read_invariant_decl)?;
     let required_host_imports = read_list(rdr, read_host_import_decl)?;
     let external_type_refs = read_list(rdr, read_external_type_ref)?;
@@ -266,7 +280,7 @@ fn read_arg_decl(rdr: &mut &[u8]) -> Result<ArgDecl, CodecError> {
     Ok(ArgDecl { name, kind })
 }
 
-fn write_function_decl(buf: &mut Vec<u8>, f: &FunctionDecl) -> Result<(), CodecError> {
+fn write_function_decl_v1(buf: &mut Vec<u8>, f: &FunctionDecl) -> Result<(), CodecError> {
     write_string(buf, &f.name)?;
     write_list(buf, &f.type_params, write_type_param)?;
     write_list(buf, &f.args, write_arg_decl)?;
@@ -282,7 +296,13 @@ fn write_function_decl(buf: &mut Vec<u8>, f: &FunctionDecl) -> Result<(), CodecE
     Ok(())
 }
 
-fn read_function_decl(rdr: &mut &[u8]) -> Result<FunctionDecl, CodecError> {
+fn write_function_decl_v2(buf: &mut Vec<u8>, f: &FunctionDecl) -> Result<(), CodecError> {
+    write_function_decl_v1(buf, f)?;
+    write_u8(buf, u8::from(f.view));
+    Ok(())
+}
+
+fn read_function_decl_v1(rdr: &mut &[u8]) -> Result<FunctionDecl, CodecError> {
     let name = read_string(rdr)?;
     let type_params = read_list(rdr, read_type_param)?;
     let args = read_list(rdr, read_arg_decl)?;
@@ -296,6 +316,7 @@ fn read_function_decl(rdr: &mut &[u8]) -> Result<FunctionDecl, CodecError> {
     }
     Ok(FunctionDecl {
         name,
+        view: false,
         type_params,
         args,
         returns,
@@ -303,6 +324,16 @@ fn read_function_decl(rdr: &mut &[u8]) -> Result<FunctionDecl, CodecError> {
         required_capabilities,
         attached_invariants,
     })
+}
+
+fn read_function_decl_v2(rdr: &mut &[u8]) -> Result<FunctionDecl, CodecError> {
+    let mut f = read_function_decl_v1(rdr)?;
+    f.view = match read_u8(rdr)? {
+        0 => false,
+        1 => true,
+        other => return Err(CodecError::InvalidDiscriminant(other)),
+    };
+    Ok(f)
 }
 
 fn write_invariant_decl(buf: &mut Vec<u8>, inv: &InvariantDecl) -> Result<(), CodecError> {
@@ -549,6 +580,7 @@ mod tests {
             }],
             functions: vec![FunctionDecl {
                 name: "swap".to_string(),
+                view: false,
                 type_params: vec![],
                 args: vec![
                     ArgDecl {
@@ -643,16 +675,16 @@ mod tests {
 
     #[test]
     fn snapshot_minimal_first_bytes() {
-        // schema_version (1) || module_path ("/x" = 2 bytes)
+        // schema_version (2) || module_path ("/x" = 2 bytes)
         let m = PetalManifestV0 {
-            schema_version: 1,
+            schema_version: SCHEMA_VERSION,
             module_path: "/x".to_string(),
             framework_version: SemVer::new(0, 1, 0),
             ..Default::default()
         };
         let bytes = encode(&m).unwrap();
-        // [0,0,0,1] schema || [0,2] len || "/x" || semver [0,0,0,1,0,0] || option none [0] || 6 empty lists of u32 zero || fuel_hints len 0 || default none 0
-        assert_eq!(&bytes[..4], &[0, 0, 0, 1]);
+        // [0,0,0,2] schema || [0,2] len || "/x" || semver [0,0,0,1,0,0] || option none [0] || 6 empty lists of u32 zero || fuel_hints len 0 || default none 0
+        assert_eq!(&bytes[..4], &[0, 0, 0, 2]);
         assert_eq!(&bytes[4..6], &[0, 2]);
         assert_eq!(&bytes[6..8], b"/x");
         assert_eq!(&bytes[8..14], &[0, 0, 0, 1, 0, 0]);
@@ -685,6 +717,7 @@ mod tests {
                 module_path: "/p".to_string(),
                 functions: vec![FunctionDecl {
                     name: "f".to_string(),
+                    view: false,
                     args: vec![ArgDecl {
                         name: "o".to_string(),
                         kind: ArgKind::Object {
@@ -767,5 +800,41 @@ mod tests {
         };
         let back = decode(&encode(&m).unwrap()).unwrap();
         assert_eq!(back, m);
+    }
+
+    #[test]
+    fn function_view_round_trips_in_schema_v2() {
+        let m = PetalManifestV0 {
+            schema_version: SCHEMA_VERSION,
+            module_path: "/p".to_string(),
+            functions: vec![FunctionDecl {
+                name: "quote".to_string(),
+                view: true,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let back = decode(&encode(&m).unwrap()).unwrap();
+        assert_eq!(back.functions[0].name, "quote");
+        assert!(back.functions[0].view);
+    }
+
+    #[test]
+    fn schema_v1_function_decodes_with_view_false() {
+        let m = PetalManifestV0 {
+            schema_version: 1,
+            module_path: "/p".to_string(),
+            functions: vec![FunctionDecl {
+                name: "legacy".to_string(),
+                view: true,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let bytes = encode(&m).unwrap();
+        let back = decode(&bytes).unwrap();
+        assert_eq!(back.schema_version, 1);
+        assert_eq!(back.functions[0].name, "legacy");
+        assert!(!back.functions[0].view);
     }
 }

--- a/crates/bloom-petal-manifest/src/stub.rs
+++ b/crates/bloom-petal-manifest/src/stub.rs
@@ -52,6 +52,7 @@ pub fn to_petal_manifest_stub(m: &PetalManifestV0) -> PetalManifestStub {
 fn project_function(f: &FunctionDecl) -> FunctionDeclStub {
     FunctionDeclStub {
         name: f.name.clone(),
+        view: f.view,
         type_params: f.type_params.iter().map(project_type_param).collect(),
         args: f
             .args
@@ -143,6 +144,7 @@ mod tests {
             module_path: "/bloom/test".into(),
             functions: vec![FunctionDecl {
                 name: "f".into(),
+                view: true,
                 type_params: vec![TypeParamDecl {
                     name: "T".into(),
                     kind: TypeParamKind::Phantom,
@@ -181,6 +183,7 @@ mod tests {
         assert_eq!(s.functions.len(), 1);
         let f = &s.functions[0];
         assert_eq!(f.name, "f");
+        assert!(f.view);
         assert_eq!(f.type_params.len(), 1);
         assert!(f.type_params[0].phantom);
         assert_eq!(f.args.len(), 4);

--- a/crates/bloom-petal-manifest/src/types.rs
+++ b/crates/bloom-petal-manifest/src/types.rs
@@ -10,13 +10,13 @@ use bloom_objects::{AbilitySet, AccessMode, TypeTag};
 
 /// Schema version this crate produces. Bumped when the manifest layout
 /// changes incompatibly.
-pub const SCHEMA_VERSION: u32 = 1;
+pub const SCHEMA_VERSION: u32 = 2;
 
 /// Custom section name embedded into every new-framework petal (spec §8.1).
 pub const MANIFEST_CUSTOM_SECTION: &str = "bloom_petal_manifest_v0";
 
 /// Top-level manifest emitted by `#[bloom::petal]`.
-#[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PetalManifestV0 {
     /// `= SCHEMA_VERSION` for this crate's emission.
     pub schema_version: u32,
@@ -40,6 +40,24 @@ pub struct PetalManifestV0 {
     pub external_type_refs: Vec<ExternalTypeRef>,
     /// Declared per-function fuel ceilings (opt-in).
     pub fuel_hints: FuelHints,
+}
+
+impl Default for PetalManifestV0 {
+    fn default() -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            module_path: String::new(),
+            framework_version: SemVer::default(),
+            parent_version: None,
+            object_types: Vec::new(),
+            capability_types: Vec::new(),
+            functions: Vec::new(),
+            invariants: Vec::new(),
+            required_host_imports: Vec::new(),
+            external_type_refs: Vec::new(),
+            fuel_hints: FuelHints::default(),
+        }
+    }
 }
 
 /// Semantic version triple. Carried in the manifest so chain/explorers
@@ -127,6 +145,8 @@ pub struct CapabilityDecl {
 pub struct FunctionDecl {
     /// Function name (`__petal_<name>` wasm export drops the prefix).
     pub name: String,
+    /// True if this function is declared read-only and may be called as a view.
+    pub view: bool,
     /// Generic parameters in declaration order.
     pub type_params: Vec<TypeParamDecl>,
     /// Argument decls in source order.
@@ -291,8 +311,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn schema_version_is_one() {
-        assert_eq!(SCHEMA_VERSION, 1);
+    fn schema_version_is_two() {
+        assert_eq!(SCHEMA_VERSION, 2);
     }
 
     #[test]
@@ -306,7 +326,7 @@ mod tests {
     #[test]
     fn default_manifest_is_empty() {
         let m = PetalManifestV0::default();
-        assert_eq!(m.schema_version, 0);
+        assert_eq!(m.schema_version, SCHEMA_VERSION);
         assert!(m.functions.is_empty());
         assert!(m.object_types.is_empty());
     }

--- a/crates/bloom-petal-manifest/tests/view_function_manifest.rs
+++ b/crates/bloom-petal-manifest/tests/view_function_manifest.rs
@@ -1,0 +1,117 @@
+use bloom_petal_manifest::types::{FunctionDecl, SemVer};
+use bloom_petal_manifest::{PetalManifestV0, SCHEMA_VERSION, codec};
+
+fn write_u32_be(out: &mut Vec<u8>, value: u32) {
+    out.extend_from_slice(&value.to_be_bytes());
+}
+
+fn write_u16_be(out: &mut Vec<u8>, value: u16) {
+    out.extend_from_slice(&value.to_be_bytes());
+}
+
+fn write_u8(out: &mut Vec<u8>, value: u8) {
+    out.push(value);
+}
+
+fn write_string(out: &mut Vec<u8>, value: &str) {
+    write_u16_be(out, value.len() as u16);
+    out.extend_from_slice(value.as_bytes());
+}
+
+fn write_empty_list(out: &mut Vec<u8>) {
+    write_u32_be(out, 0);
+}
+
+fn legacy_schema_v1_manifest_bytes_with_one_function() -> Vec<u8> {
+    let mut out = Vec::new();
+
+    write_u32_be(&mut out, 1); // schema_version
+    write_string(&mut out, "/bloom/test/legacy-view");
+    write_u16_be(&mut out, 0); // framework_version.major
+    write_u16_be(&mut out, 1); // framework_version.minor
+    write_u16_be(&mut out, 0); // framework_version.patch
+    write_u8(&mut out, 0); // parent_version = None
+
+    write_empty_list(&mut out); // object_types
+    write_empty_list(&mut out); // capability_types
+
+    write_u32_be(&mut out, 1); // functions
+    write_string(&mut out, "read_counter");
+    write_empty_list(&mut out); // type_params
+    write_empty_list(&mut out); // args
+    write_empty_list(&mut out); // returns
+    write_u8(&mut out, 0); // required_signers
+    write_empty_list(&mut out); // required_capabilities
+    write_empty_list(&mut out); // attached_invariants
+
+    write_empty_list(&mut out); // invariants
+    write_empty_list(&mut out); // required_host_imports
+    write_empty_list(&mut out); // external_type_refs
+    write_empty_list(&mut out); // fuel_hints.per_function
+    write_u8(&mut out, 0); // fuel_hints.default = None
+
+    out
+}
+
+#[test]
+fn schema_v1_manifest_fixture_decodes_after_view_schema_bump() {
+    let decoded = codec::decode(&legacy_schema_v1_manifest_bytes_with_one_function())
+        .expect("schema-v1 manifests must remain decodable");
+
+    assert_eq!(decoded.schema_version, 1);
+    assert_eq!(decoded.module_path, "/bloom/test/legacy-view");
+    assert_eq!(decoded.functions.len(), 1);
+    assert_eq!(decoded.functions[0].name, "read_counter");
+    assert!(!decoded.functions[0].view);
+}
+
+#[test]
+fn manifest_encoder_uses_declared_schema_version_prefix() {
+    let manifest = PetalManifestV0 {
+        schema_version: SCHEMA_VERSION,
+        module_path: "/bloom/test/schema-prefix".to_string(),
+        ..Default::default()
+    };
+
+    let encoded = codec::encode(&manifest).expect("manifest encodes");
+
+    assert_eq!(&encoded[..4], &SCHEMA_VERSION.to_be_bytes());
+}
+
+#[test]
+fn function_decl_view_flag_round_trips() {
+    let manifest = PetalManifestV0 {
+        schema_version: SCHEMA_VERSION,
+        module_path: "/bloom/test/view-roundtrip".to_string(),
+        framework_version: SemVer::new(0, 1, 0),
+        functions: vec![
+            FunctionDecl {
+                name: "read_counter".to_string(),
+                view: true,
+                ..Default::default()
+            },
+            FunctionDecl {
+                name: "increment".to_string(),
+                view: false,
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+
+    let decoded = codec::decode(&codec::encode(&manifest).expect("manifest encodes"))
+        .expect("manifest decodes");
+
+    assert_eq!(decoded.functions[0].name, "read_counter");
+    assert!(decoded.functions[0].view);
+    assert_eq!(decoded.functions[1].name, "increment");
+    assert!(!decoded.functions[1].view);
+}
+
+#[test]
+fn schema_version_is_bumped_for_view_function_layout() {
+    assert!(
+        SCHEMA_VERSION >= 2,
+        "adding FunctionDecl.view changes the positional manifest layout"
+    );
+}

--- a/crates/bloom-petal-manifest/tests/view_function_manifest.rs
+++ b/crates/bloom-petal-manifest/tests/view_function_manifest.rs
@@ -110,8 +110,10 @@ fn function_decl_view_flag_round_trips() {
 
 #[test]
 fn schema_version_is_bumped_for_view_function_layout() {
+    let manifest = PetalManifestV0::default();
+
     assert!(
-        SCHEMA_VERSION >= 2,
+        manifest.schema_version >= 2,
         "adding FunctionDecl.view changes the positional manifest layout"
     );
 }

--- a/crates/bloom-petals/Cargo.toml
+++ b/crates/bloom-petals/Cargo.toml
@@ -11,6 +11,7 @@ bloom-vfs.workspace = true
 bloom-chain-types.workspace = true
 bloom-chain-state.workspace = true
 bloom-objects.workspace = true
+bloom-petal-manifest.workspace = true
 bloom-script.workspace = true
 wasmparser = "0.218"
 async-trait.workspace = true

--- a/crates/bloom-petals/src/chain_vm.rs
+++ b/crates/bloom-petals/src/chain_vm.rs
@@ -13,6 +13,7 @@
 //! | `wasm_simd` | `true` | Standard deterministic SIMD is allowed. |
 //! | `wasm_multi_memory` | `false` | Multiple memories are non-deterministic in ordering; banned per spec. |
 //! | `wasm_bulk_memory` | `true` | Bulk-memory is deterministic and useful; allowed. |
+//! | `wasm_tail_call` | `false` | Tail calls add alternate control-flow opcodes; chain mode rejects them. |
 //! | `wasm_threads` | `false` | Shared-memory threads break determinism; banned. |
 //! | `async_support` | `false` | Chain calls are fully synchronous (§7.6). |
 //! | `cranelift_opt_level` | `Speed` | Same as the existing engine; deterministic across runs. |
@@ -37,7 +38,10 @@
 //! 1. `return_data` / `revert_reason` are only set by their respective imports.
 //! 2. Any other trap leaves both `None`, so the dispatch can distinguish them.
 
-use std::sync::{Arc, Mutex, OnceLock};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{Arc, Mutex, OnceLock},
+};
 
 use wasmtime::{Caller, Config, Engine, Linker, Module, OptLevel, Store};
 
@@ -50,6 +54,7 @@ use bloom_objects::{
     AccessMode, OWNER_KIND_ADDRESS, OWNER_KIND_IMMUTABLE, OWNER_KIND_OBJECT, OWNER_KIND_SHARED,
     Object, ObjectId, Owner, TypeTag,
 };
+use bloom_petal_manifest::{extract_petal_manifest_v0, types::PetalManifestV0};
 use bloom_script::{
     BorrowRow, CORE_FUNGIBLE_PATH,
     executor::LogEntry as PtbLogEntry,
@@ -180,6 +185,9 @@ fn chain_engine() -> Result<&'static Engine, PetalError> {
         config.wasm_multi_memory(false);
         // Bulk-memory (memory.copy, memory.fill) is deterministic; allowed.
         config.wasm_bulk_memory(true);
+        // Tail-call opcodes are disabled in chain mode; the deploy-time verifier
+        // still rejects them explicitly when reachable from a view export.
+        config.wasm_tail_call(false);
         config.cranelift_opt_level(OptLevel::Speed);
         Engine::new(&config).map_err(|e| e.to_string())
     });
@@ -195,6 +203,9 @@ fn chain_engine() -> Result<&'static Engine, PetalError> {
 /// `"chain"` is retained only for the PTB calldata/return/revert shim used by
 /// the resource runtime. The other modules are the Bloom-native PTB surface.
 const CHAIN_ALLOWED_IMPORT_MODULES: &[&str] = &["chain", "object", "cap", "signer", "ptb", "log"];
+
+const VIEW_MUTATING_OBJECT_IMPORTS: &[&str] =
+    &["create", "transfer", "share", "freeze", "delete", "mutate"];
 
 /// Validate a wasm binary for chain-mode admission.
 ///
@@ -273,7 +284,177 @@ pub fn validate_chain_wasm(bytes: &[u8]) -> Result<(), PetalError> {
                     }
                 }
             }
+            Payload::StartSection { func, .. } => {
+                return Err(PetalError::InvalidWasm(format!(
+                    "chain petal declares start function {func}; start sections are not allowed"
+                )));
+            }
             _ => {}
+        }
+    }
+    if let Some(manifest) = extract_petal_manifest_v0(bytes) {
+        validate_view_functions_are_pure(bytes, &manifest)?;
+    }
+    Ok(())
+}
+
+#[derive(Debug, Default)]
+struct StaticCallGraph {
+    exports: HashMap<String, u32>,
+    import_targets: HashMap<u32, (String, String)>,
+    calls: HashMap<u32, Vec<u32>>,
+    functions_with_indirect_calls: HashMap<u32, &'static str>,
+}
+
+fn validate_view_functions_are_pure(
+    bytes: &[u8],
+    manifest: &PetalManifestV0,
+) -> Result<(), PetalError> {
+    let graph = parse_static_call_graph(bytes)?;
+    for f in manifest.functions.iter().filter(|f| f.view) {
+        let export_name = format!("__petal_{}", f.name);
+        let start = graph.exports.get(&export_name).copied().ok_or_else(|| {
+            PetalError::InvalidWasm(format!(
+                "view function '{}' export '{export_name}' missing from wasm",
+                f.name
+            ))
+        })?;
+        reject_view_reachable_mutation(&graph, &f.name, start)?;
+    }
+    Ok(())
+}
+
+fn parse_static_call_graph(bytes: &[u8]) -> Result<StaticCallGraph, PetalError> {
+    use wasmparser::{ExternalKind, Operator, Parser, Payload, TypeRef};
+
+    let mut graph = StaticCallGraph::default();
+    let mut next_func_index = 0u32;
+    let mut defined_func_indices = Vec::<u32>::new();
+    let mut code_index = 0usize;
+
+    for payload in Parser::new(0).parse_all(bytes) {
+        let payload = payload.map_err(|e| PetalError::InvalidWasm(e.to_string()))?;
+        match payload {
+            Payload::ImportSection(reader) => {
+                for import in reader {
+                    let import = import.map_err(|e| PetalError::InvalidWasm(e.to_string()))?;
+                    if matches!(import.ty, TypeRef::Func(_)) {
+                        graph.import_targets.insert(
+                            next_func_index,
+                            (import.module.to_string(), import.name.to_string()),
+                        );
+                        next_func_index = next_func_index.checked_add(1).ok_or_else(|| {
+                            PetalError::InvalidWasm("function index overflow".into())
+                        })?;
+                    }
+                }
+            }
+            Payload::FunctionSection(reader) => {
+                for ty in reader {
+                    ty.map_err(|e| PetalError::InvalidWasm(e.to_string()))?;
+                    defined_func_indices.push(next_func_index);
+                    next_func_index = next_func_index
+                        .checked_add(1)
+                        .ok_or_else(|| PetalError::InvalidWasm("function index overflow".into()))?;
+                }
+            }
+            Payload::ExportSection(reader) => {
+                for export in reader {
+                    let export = export.map_err(|e| PetalError::InvalidWasm(e.to_string()))?;
+                    if export.kind == ExternalKind::Func {
+                        graph.exports.insert(export.name.to_string(), export.index);
+                    }
+                }
+            }
+            Payload::CodeSectionEntry(body) => {
+                let func_idx = *defined_func_indices.get(code_index).ok_or_else(|| {
+                    PetalError::InvalidWasm("code section has more bodies than functions".into())
+                })?;
+                code_index += 1;
+
+                let mut calls = Vec::new();
+                let operators = body
+                    .get_operators_reader()
+                    .map_err(|e| PetalError::InvalidWasm(e.to_string()))?;
+                for op in operators {
+                    match op.map_err(|e| PetalError::InvalidWasm(e.to_string()))? {
+                        Operator::Call { function_index } => calls.push(function_index),
+                        Operator::ReturnCall { function_index } => calls.push(function_index),
+                        Operator::CallIndirect { .. } => {
+                            graph
+                                .functions_with_indirect_calls
+                                .entry(func_idx)
+                                .or_insert("call_indirect");
+                        }
+                        Operator::ReturnCallIndirect { .. } => {
+                            graph
+                                .functions_with_indirect_calls
+                                .entry(func_idx)
+                                .or_insert("return_call_indirect");
+                        }
+                        Operator::CallRef { .. } => {
+                            graph
+                                .functions_with_indirect_calls
+                                .entry(func_idx)
+                                .or_insert("call_ref");
+                        }
+                        Operator::ReturnCallRef { .. } => {
+                            graph
+                                .functions_with_indirect_calls
+                                .entry(func_idx)
+                                .or_insert("return_call_ref");
+                        }
+                        _ => {}
+                    }
+                }
+                if !calls.is_empty() {
+                    graph.calls.insert(func_idx, calls);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if code_index != defined_func_indices.len() {
+        return Err(PetalError::InvalidWasm(format!(
+            "code section body count {} does not match function count {}",
+            code_index,
+            defined_func_indices.len()
+        )));
+    }
+
+    Ok(graph)
+}
+
+fn reject_view_reachable_mutation(
+    graph: &StaticCallGraph,
+    view_name: &str,
+    start: u32,
+) -> Result<(), PetalError> {
+    let mut seen = HashSet::new();
+    let mut stack = vec![start];
+    while let Some(func_idx) = stack.pop() {
+        if !seen.insert(func_idx) {
+            continue;
+        }
+
+        if let Some(op) = graph.functions_with_indirect_calls.get(&func_idx) {
+            return Err(PetalError::InvalidWasm(format!(
+                "view function '{view_name}' reaches {op} in function index {func_idx}"
+            )));
+        }
+
+        if let Some((module, name)) = graph.import_targets.get(&func_idx) {
+            if module == "object" && VIEW_MUTATING_OBJECT_IMPORTS.contains(&name.as_str()) {
+                return Err(PetalError::InvalidWasm(format!(
+                    "view function '{view_name}' reaches mutating host import object.{name}"
+                )));
+            }
+            continue;
+        }
+
+        if let Some(calls) = graph.calls.get(&func_idx) {
+            stack.extend(calls.iter().copied());
         }
     }
     Ok(())

--- a/crates/bloom-petals/src/chain_vm.rs
+++ b/crates/bloom-petals/src/chain_vm.rs
@@ -186,7 +186,7 @@ fn chain_engine() -> Result<&'static Engine, PetalError> {
         // Bulk-memory (memory.copy, memory.fill) is deterministic; allowed.
         config.wasm_bulk_memory(true);
         // Tail-call opcodes are disabled in chain mode; the deploy-time verifier
-        // still rejects them explicitly when reachable from a view export.
+        // rejects them globally so admission matches this engine config.
         config.wasm_tail_call(false);
         config.cranelift_opt_level(OptLevel::Speed);
         Engine::new(&config).map_err(|e| e.to_string())
@@ -234,7 +234,7 @@ fn is_ptb_petal_export(name: &str) -> bool {
 }
 
 pub fn validate_chain_wasm(bytes: &[u8]) -> Result<(), PetalError> {
-    use wasmparser::{ExternalKind, Parser, Payload};
+    use wasmparser::{ExternalKind, Operator, Parser, Payload};
 
     let parser = Parser::new(0);
     for payload in parser.parse_all(bytes) {
@@ -288,6 +288,32 @@ pub fn validate_chain_wasm(bytes: &[u8]) -> Result<(), PetalError> {
                 return Err(PetalError::InvalidWasm(format!(
                     "chain petal declares start function {func}; start sections are not allowed"
                 )));
+            }
+            Payload::CodeSectionEntry(body) => {
+                let operators = body
+                    .get_operators_reader()
+                    .map_err(|e| PetalError::InvalidWasm(e.to_string()))?;
+                for op in operators {
+                    match op.map_err(|e| PetalError::InvalidWasm(e.to_string()))? {
+                        Operator::ReturnCall { .. } => {
+                            return Err(PetalError::InvalidWasm(
+                                "chain petal uses disabled tail-call opcode return_call".into(),
+                            ));
+                        }
+                        Operator::ReturnCallIndirect { .. } => {
+                            return Err(PetalError::InvalidWasm(
+                                "chain petal uses disabled tail-call opcode return_call_indirect"
+                                    .into(),
+                            ));
+                        }
+                        Operator::ReturnCallRef { .. } => {
+                            return Err(PetalError::InvalidWasm(
+                                "chain petal uses disabled tail-call opcode return_call_ref".into(),
+                            ));
+                        }
+                        _ => {}
+                    }
+                }
             }
             _ => {}
         }

--- a/crates/bloom-petals/tests/view_function_verifier_contract.rs
+++ b/crates/bloom-petals/tests/view_function_verifier_contract.rs
@@ -1,0 +1,176 @@
+use bloom_petal_manifest::{
+    codec,
+    types::{FunctionDecl, MANIFEST_CUSTOM_SECTION, PetalManifestV0},
+};
+use bloom_petals::chain_vm::validate_chain_wasm;
+
+fn wasm_with_manifest(wat_src: &str, functions: Vec<FunctionDecl>) -> Vec<u8> {
+    let mut wasm = wat::parse_str(wat_src).expect("wat parses");
+    let manifest = PetalManifestV0 {
+        module_path: "/bloom/test/view".to_string(),
+        functions,
+        ..Default::default()
+    };
+    append_custom_section(
+        &mut wasm,
+        MANIFEST_CUSTOM_SECTION,
+        &codec::encode(&manifest).expect("manifest encodes"),
+    );
+    wasm
+}
+
+fn append_custom_section(wasm: &mut Vec<u8>, name: &str, data: &[u8]) {
+    wasm.push(0);
+    let mut body = Vec::new();
+    leb128(&mut body, name.len() as u64);
+    body.extend_from_slice(name.as_bytes());
+    body.extend_from_slice(data);
+    leb128(wasm, body.len() as u64);
+    wasm.extend_from_slice(&body);
+}
+
+fn leb128(out: &mut Vec<u8>, mut v: u64) {
+    loop {
+        let mut b = (v & 0x7f) as u8;
+        v >>= 7;
+        if v != 0 {
+            b |= 0x80;
+        }
+        out.push(b);
+        if v == 0 {
+            return;
+        }
+    }
+}
+
+fn func(name: &str, view: bool) -> FunctionDecl {
+    FunctionDecl {
+        name: name.to_string(),
+        view,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn view_reaching_direct_mutating_import_is_rejected() {
+    let wasm = wasm_with_manifest(
+        r#"(module
+            (import "object" "create" (func $create))
+            (func $__petal_quote (call $create))
+            (export "__petal_quote" (func $__petal_quote))
+        )"#,
+        vec![func("quote", true)],
+    );
+
+    let err = validate_chain_wasm(&wasm).unwrap_err().to_string();
+    assert!(err.contains("view function 'quote'"));
+    assert!(err.contains("object.create"));
+}
+
+#[test]
+fn view_reaching_transitive_mutating_import_is_rejected() {
+    let wasm = wasm_with_manifest(
+        r#"(module
+            (import "object" "delete" (func $delete))
+            (func $helper (call $delete))
+            (func $__petal_quote (call $helper))
+            (export "__petal_quote" (func $__petal_quote))
+        )"#,
+        vec![func("quote", true)],
+    );
+
+    let err = validate_chain_wasm(&wasm).unwrap_err().to_string();
+    assert!(err.contains("view function 'quote'"));
+    assert!(err.contains("object.delete"));
+}
+
+#[test]
+fn reachable_call_indirect_in_view_is_rejected() {
+    let wasm = wasm_with_manifest(
+        r#"(module
+            (type $t (func))
+            (table 1 funcref)
+            (func $helper)
+            (elem (i32.const 0) $helper)
+            (func $__petal_quote
+              (i32.const 0)
+              (call_indirect (type $t)))
+            (export "__petal_quote" (func $__petal_quote))
+        )"#,
+        vec![func("quote", true)],
+    );
+
+    let err = validate_chain_wasm(&wasm).unwrap_err().to_string();
+    assert!(err.contains("call_indirect"));
+}
+
+#[test]
+fn reachable_return_call_to_mutating_import_is_rejected() {
+    let wasm = wasm_with_manifest(
+        r#"(module
+            (import "object" "mutate" (func $mutate))
+            (func $__petal_quote
+              (return_call $mutate))
+            (export "__petal_quote" (func $__petal_quote))
+        )"#,
+        vec![func("quote", true)],
+    );
+
+    let err = validate_chain_wasm(&wasm).unwrap_err().to_string();
+    assert!(err.contains("view function 'quote'"));
+    assert!(err.contains("object.mutate"));
+}
+
+#[test]
+fn reachable_return_call_indirect_in_view_is_rejected() {
+    let wasm = wasm_with_manifest(
+        r#"(module
+            (type $t (func))
+            (table 1 funcref)
+            (func $helper)
+            (elem (i32.const 0) $helper)
+            (func $__petal_quote
+              (i32.const 0)
+              (return_call_indirect (type $t)))
+            (export "__petal_quote" (func $__petal_quote))
+        )"#,
+        vec![func("quote", true)],
+    );
+
+    let err = validate_chain_wasm(&wasm).unwrap_err().to_string();
+    assert!(err.contains("return_call_indirect"));
+}
+
+#[test]
+fn start_section_is_rejected_before_view_purity_claims() {
+    let wasm = wasm_with_manifest(
+        r#"(module
+            (import "object" "mutate" (func $mutate))
+            (func $start (call $mutate))
+            (start $start)
+            (func $__petal_quote)
+            (export "__petal_quote" (func $__petal_quote))
+        )"#,
+        vec![func("quote", true)],
+    );
+
+    let err = validate_chain_wasm(&wasm).unwrap_err().to_string();
+    assert!(err.contains("start function"));
+    assert!(err.contains("not allowed"));
+}
+
+#[test]
+fn pure_view_passes_and_mixed_mutating_non_view_deploys() {
+    let wasm = wasm_with_manifest(
+        r#"(module
+            (import "object" "mutate" (func $mutate))
+            (func $__petal_quote)
+            (func $__petal_update (call $mutate))
+            (export "__petal_quote" (func $__petal_quote))
+            (export "__petal_update" (func $__petal_update))
+        )"#,
+        vec![func("quote", true), func("update", false)],
+    );
+
+    validate_chain_wasm(&wasm).expect("pure view plus mutating non-view should pass");
+}

--- a/crates/bloom-petals/tests/view_function_verifier_contract.rs
+++ b/crates/bloom-petals/tests/view_function_verifier_contract.rs
@@ -117,8 +117,7 @@ fn reachable_return_call_to_mutating_import_is_rejected() {
     );
 
     let err = validate_chain_wasm(&wasm).unwrap_err().to_string();
-    assert!(err.contains("view function 'quote'"));
-    assert!(err.contains("object.mutate"));
+    assert!(err.contains("return_call"));
 }
 
 #[test]
@@ -139,6 +138,22 @@ fn reachable_return_call_indirect_in_view_is_rejected() {
 
     let err = validate_chain_wasm(&wasm).unwrap_err().to_string();
     assert!(err.contains("return_call_indirect"));
+}
+
+#[test]
+fn tail_call_in_non_view_export_is_rejected() {
+    let wasm = wasm_with_manifest(
+        r#"(module
+            (func $helper)
+            (func $__petal_update
+              (return_call $helper))
+            (export "__petal_update" (func $__petal_update))
+        )"#,
+        vec![func("update", false)],
+    );
+
+    let err = validate_chain_wasm(&wasm).unwrap_err().to_string();
+    assert!(err.contains("return_call"));
 }
 
 #[test]

--- a/crates/bloom-ptb-builder/src/session.rs
+++ b/crates/bloom-ptb-builder/src/session.rs
@@ -43,8 +43,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use bloom_objects::{Object, TypeTag, ValidationOutcome, validate_canonical_bytes};
 use bloom_script::{
     AlwaysOkVerifier, Arg, ArgDeclStub, ChainStateIface, Command, MoveCmd, PetalRef, PqPubkey,
-    PqSignature, PtbError, PtbTx, SignatureVerifier, UseRef, ValidationContext, loom_coin_type_tag,
-    validate_ptb,
+    PqSignature, PtbError, PtbTx, SignatureVerifier, UseRef, ValidationContext, ValidationMode,
+    loom_coin_type_tag, validate_ptb,
 };
 
 use crate::error::BuildError;
@@ -549,6 +549,7 @@ impl<'a> PtbSession<'a> {
         validate_ptb(
             &for_validation,
             &ValidationContext {
+                mode: ValidationMode::Commit,
                 current_block: self.chain.current_block(),
                 chain: self.chain,
                 verifier: &verifier as &dyn SignatureVerifier,

--- a/crates/bloom-ptb-builder/src/tests.rs
+++ b/crates/bloom-ptb-builder/src/tests.rs
@@ -86,6 +86,7 @@ fn concrete(name: &str) -> TypeTag {
 
 fn func(name: &str, args: Vec<ArgDeclStub>, returns: Vec<TypeTag>) -> FunctionDeclStub {
     FunctionDeclStub {
+        view: false,
         name: name.to_string(),
         type_params: vec![],
         args,
@@ -279,6 +280,7 @@ fn append_object_arg_with_version_and_mode() {
 #[test]
 fn append_type_arg_for_generic_endpoint() {
     let chain = chain_with_pool(vec![FunctionDeclStub {
+        view: false,
         name: "identity".to_string(),
         type_params: vec![TypeParamDeclStub {
             name: "T".to_string(),
@@ -303,6 +305,7 @@ fn append_type_arg_for_generic_endpoint() {
 #[test]
 fn append_call_type_arg_for_generic_endpoint_without_type_arg_value() {
     let chain = chain_with_pool(vec![FunctionDeclStub {
+        view: false,
         name: "identity".to_string(),
         type_params: vec![TypeParamDeclStub {
             name: "T".to_string(),

--- a/crates/bloom-resource-macros/src/petal.rs
+++ b/crates/bloom-resource-macros/src/petal.rs
@@ -220,8 +220,10 @@ fn handle_fn(f: &ItemFn, m: &mut PetalManifestV0) -> syn::Result<Option<PetalShi
     }
 
     // Process #[invariant] first so the function decl can record the
-    // invariant index.
+    // invariant index. A bare #[view] marks the exported function as
+    // statically read-only for chain admission.
     let mut attached: Vec<u16> = Vec::new();
+    let mut view = false;
     for a in &f.attrs {
         if attr_is_named(a, "invariant") {
             let inv_attr = InvariantAttr::parse(meta_tokens(a)?)?;
@@ -229,6 +231,11 @@ fn handle_fn(f: &ItemFn, m: &mut PetalManifestV0) -> syn::Result<Option<PetalShi
             let decl = crate::invariant::build_decl(&inv_attr, f, idx);
             m.invariants.push(decl);
             attached.push(idx);
+        } else if attr_is_named(a, "view") {
+            if !meta_tokens(a)?.is_empty() {
+                return Err(err_spanned(a, "`#[view]` does not accept arguments"));
+            }
+            view = true;
         }
     }
 
@@ -363,6 +370,7 @@ fn handle_fn(f: &ItemFn, m: &mut PetalManifestV0) -> syn::Result<Option<PetalShi
 
     m.functions.push(FunctionDecl {
         name: fn_name_s.clone(),
+        view,
         type_params,
         args,
         returns: returns.clone(),
@@ -562,7 +570,8 @@ pub(crate) fn expand(attr: TokenStream, item: TokenStream) -> syn::Result<TokenS
                         .retain(|a| !attr_is_named(a, "object") && !attr_is_named(a, "capability"));
                 }
                 Item::Fn(f) => {
-                    f.attrs.retain(|a| !attr_is_named(a, "invariant"));
+                    f.attrs
+                        .retain(|a| !attr_is_named(a, "invariant") && !attr_is_named(a, "view"));
                 }
                 _ => {}
             }
@@ -651,6 +660,33 @@ mod tests {
         assert_eq!(manifest.module_path, "/p");
         assert_eq!(manifest.functions.len(), 1);
         assert_eq!(manifest.functions[0].name, "noop");
+        assert!(!manifest.functions[0].view);
+    }
+
+    #[test]
+    fn build_manifest_records_view_attr() {
+        let m = parse_mod(quote! {
+            pub mod p {
+                #[view]
+                pub fn quote() -> u128 { 7 }
+            }
+        });
+        let attr = PetalAttr::parse(quote! { path = "/p" }).unwrap();
+        let manifest = build_manifest(&attr, &m).unwrap();
+        assert_eq!(manifest.functions[0].name, "quote");
+        assert!(manifest.functions[0].view);
+    }
+
+    #[test]
+    fn build_manifest_rejects_view_attr_args() {
+        let m = parse_mod(quote! {
+            pub mod p {
+                #[view(true)]
+                pub fn quote() {}
+            }
+        });
+        let attr = PetalAttr::parse(quote! { path = "/p" }).unwrap();
+        assert!(build_manifest(&attr, &m).is_err());
     }
 
     #[test]

--- a/crates/bloom-script/Cargo.toml
+++ b/crates/bloom-script/Cargo.toml
@@ -12,6 +12,8 @@ bloom-objects.workspace = true
 bloom-chain-types.workspace = true
 blake3.workspace = true
 thiserror.workspace = true
+serde_json.workspace = true
+hex.workspace = true
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/crates/bloom-script/src/abi_json.rs
+++ b/crates/bloom-script/src/abi_json.rs
@@ -1,0 +1,546 @@
+//! JSON codec for Bloom-native view-call arguments and returns.
+//!
+//! This module intentionally sits beside the PTB wire codec so RPC, CLI and
+//! tests use one TypeTag-driven mapping between human JSON and canonical bytes.
+
+use bloom_objects::{TypeTag, ValidationOutcome, validate_canonical_bytes};
+use serde_json::{Value, json};
+use thiserror::Error;
+
+/// Error returned while converting typed JSON to or from canonical ABI bytes.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum JsonAbiError {
+    /// The requested type is not one this JSON codec can encode.
+    #[error("unsupported type tag for JSON ABI: {0}")]
+    UnsupportedType(String),
+    /// The JSON value does not match the declared type.
+    #[error("type mismatch for {type_tag}: {reason}")]
+    TypeMismatch {
+        /// Human-readable TypeTag label.
+        type_tag: String,
+        /// Reason the value was rejected.
+        reason: String,
+    },
+    /// A hex string was malformed.
+    #[error("invalid hex for {type_tag}: {reason}")]
+    InvalidHex {
+        /// Human-readable TypeTag label.
+        type_tag: String,
+        /// Hex decoder error.
+        reason: String,
+    },
+    /// Numeric input could not fit the declared type.
+    #[error("numeric value out of range for {0}")]
+    IntegerRange(String),
+    /// Canonical bytes failed the low-level primitive validator.
+    #[error("canonical bytes rejected for {type_tag}: {reason}")]
+    InvalidCanonical {
+        /// Human-readable TypeTag label.
+        type_tag: String,
+        /// Validator reason.
+        reason: String,
+    },
+    /// TypeTag JSON was malformed.
+    #[error("invalid TypeTag JSON: {0}")]
+    InvalidTypeTag(String),
+}
+
+/// Convert typed JSON to canonical bytes for a declared TypeTag.
+pub fn decode_json_const(tag: &TypeTag, value: &Value) -> Result<Vec<u8>, JsonAbiError> {
+    let bytes = encode_value(tag, value)?;
+    match validate_canonical_bytes(tag, &bytes) {
+        ValidationOutcome::Ok | ValidationOutcome::Unknown => Ok(bytes),
+        ValidationOutcome::Invalid(reason) => Err(JsonAbiError::InvalidCanonical {
+            type_tag: type_tag_label(tag),
+            reason: reason.to_string(),
+        }),
+    }
+}
+
+/// Decode one return slot. Unknown/custom types degrade to `Ok(None)` so callers
+/// can still surface the raw slot.
+pub fn decode_return_json(tag: &TypeTag, bytes: &[u8]) -> Result<Option<Value>, JsonAbiError> {
+    decode_value(tag, bytes).map(Some).or_else(|err| match err {
+        JsonAbiError::UnsupportedType(_) => Ok(None),
+        other => Err(other),
+    })
+}
+
+/// Decode a TypeTag from JSON.
+///
+/// Accepted forms:
+/// - canonical TypeTag hex string;
+/// - primitive label string such as `"u128"` or `"vector<u64>"`;
+/// - object form: `{ "concrete": { "petal_hash": "...", "type_name": "...", "type_args": [] } }`;
+/// - object form: `{ "generic": 0 }` or `{ "external": 0 }`.
+pub fn decode_json_type_tag(value: &Value) -> Result<TypeTag, JsonAbiError> {
+    match value {
+        Value::String(s) => decode_type_tag_string(s),
+        Value::Object(map) => {
+            if let Some(v) = map.get("concrete") {
+                let obj = v.as_object().ok_or_else(|| {
+                    JsonAbiError::InvalidTypeTag("concrete must be an object".to_string())
+                })?;
+                let type_name = obj
+                    .get("type_name")
+                    .or_else(|| obj.get("name"))
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| {
+                        JsonAbiError::InvalidTypeTag("concrete.type_name missing".to_string())
+                    })?
+                    .to_string();
+                let petal_hash = match obj.get("petal_hash").or_else(|| obj.get("hash")) {
+                    Some(Value::String(s)) => parse_hex32(s).map_err(|reason| {
+                        JsonAbiError::InvalidTypeTag(format!("invalid petal_hash: {reason}"))
+                    })?,
+                    None => [0u8; 32],
+                    _ => {
+                        return Err(JsonAbiError::InvalidTypeTag(
+                            "concrete.petal_hash must be a hex string".to_string(),
+                        ));
+                    }
+                };
+                let type_args = match obj.get("type_args") {
+                    Some(Value::Array(items)) => items
+                        .iter()
+                        .map(decode_json_type_tag)
+                        .collect::<Result<Vec<_>, _>>()?,
+                    Some(_) => {
+                        return Err(JsonAbiError::InvalidTypeTag(
+                            "concrete.type_args must be an array".to_string(),
+                        ));
+                    }
+                    None => Vec::new(),
+                };
+                Ok(TypeTag::Concrete {
+                    petal_hash,
+                    type_name,
+                    type_args,
+                })
+            } else if let Some(v) = map.get("generic") {
+                Ok(TypeTag::Generic {
+                    idx: u16_from_json(v, "generic")?,
+                })
+            } else if let Some(v) = map.get("external") {
+                Ok(TypeTag::External {
+                    ref_idx: u16_from_json(v, "external")?,
+                })
+            } else {
+                Err(JsonAbiError::InvalidTypeTag(
+                    "expected concrete/generic/external".to_string(),
+                ))
+            }
+        }
+        _ => Err(JsonAbiError::InvalidTypeTag(
+            "TypeTag must be a string or object".to_string(),
+        )),
+    }
+}
+
+/// Human-readable JSON projection of a TypeTag.
+pub fn encode_type_tag_json(tag: &TypeTag) -> Value {
+    match tag {
+        TypeTag::Concrete {
+            petal_hash,
+            type_name,
+            type_args,
+        } => json!({
+            "concrete": {
+                "petal_hash": hex::encode(petal_hash),
+                "type_name": type_name,
+                "type_args": type_args.iter().map(encode_type_tag_json).collect::<Vec<_>>(),
+            }
+        }),
+        TypeTag::Generic { idx } => json!({ "generic": idx }),
+        TypeTag::External { ref_idx } => json!({ "external": ref_idx }),
+    }
+}
+
+fn encode_value(tag: &TypeTag, value: &Value) -> Result<Vec<u8>, JsonAbiError> {
+    let TypeTag::Concrete {
+        type_name,
+        type_args,
+        ..
+    } = tag
+    else {
+        return Err(JsonAbiError::UnsupportedType(type_tag_label(tag)));
+    };
+    match (type_name.as_str(), type_args.as_slice()) {
+        ("bool", []) => Ok(vec![
+            value
+                .as_bool()
+                .ok_or_else(|| mismatch(tag, "expected bool"))? as u8,
+        ]),
+        ("u8", []) => Ok(vec![u64_value(tag, value, u8::MAX as u64)? as u8]),
+        ("u16", []) => Ok((u64_value(tag, value, u16::MAX as u64)? as u16)
+            .to_be_bytes()
+            .to_vec()),
+        ("u32", []) => Ok((u64_value(tag, value, u32::MAX as u64)? as u32)
+            .to_be_bytes()
+            .to_vec()),
+        ("u64", []) => Ok(u64_value(tag, value, u64::MAX)?.to_be_bytes().to_vec()),
+        ("u128", []) => Ok(u128_value(tag, value)?.to_be_bytes().to_vec()),
+        ("address" | "Address" | "ObjectId" | "Hash32", []) => {
+            Ok(parse_hex32_json(tag, value)?.to_vec())
+        }
+        ("bytes", []) => Ok(parse_hex_json(tag, value)?),
+        ("string", []) => string_value(tag, value).map(|s| s.into_bytes()),
+        ("String", []) => {
+            let s = string_value(tag, value)?;
+            let len: u16 = s.len().try_into().map_err(|_| JsonAbiError::TypeMismatch {
+                type_tag: type_tag_label(tag),
+                reason: "string exceeds u16 length prefix".to_string(),
+            })?;
+            let mut out = Vec::with_capacity(2 + s.len());
+            out.extend_from_slice(&len.to_be_bytes());
+            out.extend_from_slice(s.as_bytes());
+            Ok(out)
+        }
+        ("TypeTag", []) => decode_json_type_tag(value).and_then(|t| {
+            t.encode_canonical()
+                .map_err(|e| JsonAbiError::InvalidTypeTag(e.to_string()))
+        }),
+        ("vector", [elem]) => encode_vector(tag, elem, value),
+        _ => Err(JsonAbiError::UnsupportedType(type_tag_label(tag))),
+    }
+}
+
+fn decode_value(tag: &TypeTag, bytes: &[u8]) -> Result<Value, JsonAbiError> {
+    let TypeTag::Concrete {
+        type_name,
+        type_args,
+        ..
+    } = tag
+    else {
+        return Err(JsonAbiError::UnsupportedType(type_tag_label(tag)));
+    };
+    match (type_name.as_str(), type_args.as_slice()) {
+        ("bool", []) => {
+            let b = one_byte(tag, bytes)?;
+            match b {
+                0 => Ok(Value::Bool(false)),
+                1 => Ok(Value::Bool(true)),
+                _ => Err(mismatch(tag, "bool byte must be 0 or 1")),
+            }
+        }
+        ("u8", []) => Ok(json!(one_byte(tag, bytes)?)),
+        ("u16", []) => Ok(json!(u16::from_be_bytes(fixed(tag, bytes)?))),
+        ("u32", []) => Ok(json!(u32::from_be_bytes(fixed(tag, bytes)?))),
+        ("u64", []) => Ok(json!(u64::from_be_bytes(fixed(tag, bytes)?).to_string())),
+        ("u128", []) => Ok(json!(u128::from_be_bytes(fixed(tag, bytes)?).to_string())),
+        ("address" | "Address" | "ObjectId" | "Hash32", []) => {
+            let a: [u8; 32] = fixed(tag, bytes)?;
+            Ok(json!(hex::encode(a)))
+        }
+        ("bytes", []) => Ok(json!(hex::encode(bytes))),
+        ("string", []) => core::str::from_utf8(bytes)
+            .map(|s| json!(s))
+            .map_err(|_| mismatch(tag, "invalid utf-8")),
+        ("String", []) => {
+            if bytes.len() < 2 {
+                return Err(mismatch(tag, "missing u16 string length"));
+            }
+            let len = u16::from_be_bytes([bytes[0], bytes[1]]) as usize;
+            if bytes.len() != 2 + len {
+                return Err(mismatch(tag, "string length prefix does not match payload"));
+            }
+            core::str::from_utf8(&bytes[2..])
+                .map(|s| json!(s))
+                .map_err(|_| mismatch(tag, "invalid utf-8"))
+        }
+        ("TypeTag", []) => {
+            let tag = TypeTag::decode_canonical(bytes)
+                .map_err(|e| JsonAbiError::InvalidTypeTag(e.to_string()))?;
+            Ok(encode_type_tag_json(&tag))
+        }
+        ("vector", [elem]) => decode_vector(tag, elem, bytes),
+        _ => Err(JsonAbiError::UnsupportedType(type_tag_label(tag))),
+    }
+}
+
+fn encode_vector(tag: &TypeTag, elem: &TypeTag, value: &Value) -> Result<Vec<u8>, JsonAbiError> {
+    if fixed_width(elem).is_none() {
+        return Err(JsonAbiError::UnsupportedType(type_tag_label(tag)));
+    }
+    let items = value
+        .as_array()
+        .ok_or_else(|| mismatch(tag, "expected array"))?;
+    let count: u32 = items
+        .len()
+        .try_into()
+        .map_err(|_| mismatch(tag, "vector too long"))?;
+    let mut out = Vec::new();
+    out.extend_from_slice(&count.to_be_bytes());
+    for item in items {
+        out.extend_from_slice(&encode_value(elem, item)?);
+    }
+    Ok(out)
+}
+
+fn decode_vector(tag: &TypeTag, elem: &TypeTag, bytes: &[u8]) -> Result<Value, JsonAbiError> {
+    if bytes.len() < 4 {
+        return Err(mismatch(tag, "vector missing u32 count"));
+    }
+    let count = u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize;
+    let Some(width) = fixed_width(elem) else {
+        return Err(JsonAbiError::UnsupportedType(type_tag_label(tag)));
+    };
+    let expected = 4usize
+        .checked_add(
+            count
+                .checked_mul(width)
+                .ok_or_else(|| mismatch(tag, "vector length overflow"))?,
+        )
+        .ok_or_else(|| mismatch(tag, "vector length overflow"))?;
+    if bytes.len() != expected {
+        return Err(mismatch(tag, "vector payload length mismatch"));
+    }
+    let mut out = Vec::with_capacity(count);
+    let mut offset = 4;
+    for _ in 0..count {
+        out.push(decode_value(elem, &bytes[offset..offset + width])?);
+        offset += width;
+    }
+    Ok(Value::Array(out))
+}
+
+fn fixed_width(tag: &TypeTag) -> Option<usize> {
+    let TypeTag::Concrete {
+        type_name,
+        type_args,
+        ..
+    } = tag
+    else {
+        return None;
+    };
+    if !type_args.is_empty() {
+        return None;
+    }
+    match type_name.as_str() {
+        "bool" | "u8" => Some(1),
+        "u16" => Some(2),
+        "u32" => Some(4),
+        "u64" => Some(8),
+        "u128" => Some(16),
+        "address" | "Address" | "ObjectId" | "Hash32" => Some(32),
+        _ => None,
+    }
+}
+
+fn decode_type_tag_string(s: &str) -> Result<TypeTag, JsonAbiError> {
+    if let Ok(bytes) = hex::decode(strip_0x(s))
+        && let Ok(tag) = TypeTag::decode_canonical(&bytes)
+    {
+        return Ok(tag);
+    }
+    if let Some(inner) = s.strip_prefix("vector<").and_then(|v| v.strip_suffix('>')) {
+        return Ok(TypeTag::Concrete {
+            petal_hash: [0u8; 32],
+            type_name: "vector".to_string(),
+            type_args: vec![decode_type_tag_string(inner.trim())?],
+        });
+    }
+    if s.is_empty() {
+        return Err(JsonAbiError::InvalidTypeTag("empty type tag".to_string()));
+    }
+    Ok(TypeTag::Concrete {
+        petal_hash: [0u8; 32],
+        type_name: s.to_string(),
+        type_args: Vec::new(),
+    })
+}
+
+fn string_value(tag: &TypeTag, value: &Value) -> Result<String, JsonAbiError> {
+    value
+        .as_str()
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| mismatch(tag, "expected string"))
+}
+
+fn u64_value(tag: &TypeTag, value: &Value, max: u64) -> Result<u64, JsonAbiError> {
+    let n = match value {
+        Value::Number(n) => n
+            .as_u64()
+            .ok_or_else(|| mismatch(tag, "expected unsigned integer"))?,
+        Value::String(s) => s
+            .parse::<u64>()
+            .map_err(|_| mismatch(tag, "expected unsigned integer string"))?,
+        _ => return Err(mismatch(tag, "expected unsigned integer")),
+    };
+    if n > max {
+        return Err(JsonAbiError::IntegerRange(type_tag_label(tag)));
+    }
+    Ok(n)
+}
+
+fn u128_value(tag: &TypeTag, value: &Value) -> Result<u128, JsonAbiError> {
+    match value {
+        Value::Number(n) => n
+            .as_u64()
+            .map(u128::from)
+            .ok_or_else(|| mismatch(tag, "expected unsigned integer")),
+        Value::String(s) => s
+            .parse::<u128>()
+            .map_err(|_| mismatch(tag, "expected unsigned integer string")),
+        _ => Err(mismatch(tag, "expected unsigned integer")),
+    }
+}
+
+fn parse_hex32_json(tag: &TypeTag, value: &Value) -> Result<[u8; 32], JsonAbiError> {
+    let s = value
+        .as_str()
+        .ok_or_else(|| mismatch(tag, "expected hex string"))?;
+    parse_hex32(s).map_err(|reason| JsonAbiError::InvalidHex {
+        type_tag: type_tag_label(tag),
+        reason,
+    })
+}
+
+fn parse_hex_json(tag: &TypeTag, value: &Value) -> Result<Vec<u8>, JsonAbiError> {
+    let s = value
+        .as_str()
+        .ok_or_else(|| mismatch(tag, "expected hex string"))?;
+    hex::decode(strip_0x(s)).map_err(|e| JsonAbiError::InvalidHex {
+        type_tag: type_tag_label(tag),
+        reason: e.to_string(),
+    })
+}
+
+fn parse_hex32(s: &str) -> Result<[u8; 32], String> {
+    let bytes = hex::decode(strip_0x(s)).map_err(|e| e.to_string())?;
+    if bytes.len() != 32 {
+        return Err(format!("expected 32 bytes, got {}", bytes.len()));
+    }
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&bytes);
+    Ok(out)
+}
+
+fn strip_0x(s: &str) -> &str {
+    s.strip_prefix("0x").unwrap_or(s)
+}
+
+fn u16_from_json(value: &Value, label: &str) -> Result<u16, JsonAbiError> {
+    let n = value
+        .as_u64()
+        .ok_or_else(|| JsonAbiError::InvalidTypeTag(format!("{label} must be a u16")))?;
+    n.try_into()
+        .map_err(|_| JsonAbiError::InvalidTypeTag(format!("{label} out of range")))
+}
+
+fn one_byte(tag: &TypeTag, bytes: &[u8]) -> Result<u8, JsonAbiError> {
+    if bytes.len() != 1 {
+        return Err(mismatch(tag, "expected 1 byte"));
+    }
+    Ok(bytes[0])
+}
+
+fn fixed<const N: usize>(tag: &TypeTag, bytes: &[u8]) -> Result<[u8; N], JsonAbiError> {
+    if bytes.len() != N {
+        return Err(mismatch(tag, &format!("expected {N} bytes")));
+    }
+    let mut out = [0u8; N];
+    out.copy_from_slice(bytes);
+    Ok(out)
+}
+
+fn mismatch(tag: &TypeTag, reason: impl Into<String>) -> JsonAbiError {
+    JsonAbiError::TypeMismatch {
+        type_tag: type_tag_label(tag),
+        reason: reason.into(),
+    }
+}
+
+fn type_tag_label(tag: &TypeTag) -> String {
+    match tag {
+        TypeTag::Concrete {
+            type_name,
+            type_args,
+            ..
+        } if type_args.is_empty() => type_name.clone(),
+        TypeTag::Concrete {
+            type_name,
+            type_args,
+            ..
+        } => {
+            let args = type_args
+                .iter()
+                .map(type_tag_label)
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("{type_name}<{args}>")
+        }
+        TypeTag::Generic { idx } => format!("T{idx}"),
+        TypeTag::External { ref_idx } => format!("$external_{ref_idx}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn prim(name: &str) -> TypeTag {
+        TypeTag::Concrete {
+            petal_hash: [0u8; 32],
+            type_name: name.to_string(),
+            type_args: vec![],
+        }
+    }
+
+    #[test]
+    fn u128_uses_decimal_json_string() {
+        let tag = prim("u128");
+        let bytes =
+            decode_json_const(&tag, &json!("340282366920938463463374607431768211455")).unwrap();
+        assert_eq!(bytes, u128::MAX.to_be_bytes());
+        assert_eq!(
+            decode_return_json(&tag, &bytes).unwrap(),
+            Some(json!(u128::MAX.to_string()))
+        );
+    }
+
+    #[test]
+    fn address_hex_round_trips() {
+        let tag = prim("Address");
+        let input = "11".repeat(32);
+        let bytes = decode_json_const(&tag, &json!(input)).unwrap();
+        assert_eq!(bytes, vec![0x11; 32]);
+        assert_eq!(
+            decode_return_json(&tag, &bytes).unwrap(),
+            Some(json!(input))
+        );
+    }
+
+    #[test]
+    fn vector_u64_round_trips() {
+        let tag = TypeTag::Concrete {
+            petal_hash: [0u8; 32],
+            type_name: "vector".to_string(),
+            type_args: vec![prim("u64")],
+        };
+        let bytes = decode_json_const(&tag, &json!([1, "2"])).unwrap();
+        assert_eq!(
+            decode_return_json(&tag, &bytes).unwrap(),
+            Some(json!(["1", "2"]))
+        );
+    }
+
+    #[test]
+    fn vector_variable_width_elements_are_unsupported() {
+        let tag = TypeTag::Concrete {
+            petal_hash: [0u8; 32],
+            type_name: "vector".to_string(),
+            type_args: vec![prim("string")],
+        };
+        assert!(matches!(
+            decode_json_const(&tag, &json!(["a"])),
+            Err(JsonAbiError::UnsupportedType(_))
+        ));
+    }
+
+    #[test]
+    fn unknown_return_degrades_to_none() {
+        let tag = prim("Custom");
+        assert_eq!(decode_return_json(&tag, &[1, 2, 3]).unwrap(), None);
+    }
+}

--- a/crates/bloom-script/src/abi_json.rs
+++ b/crates/bloom-script/src/abi_json.rs
@@ -437,7 +437,7 @@ fn one_byte(tag: &TypeTag, bytes: &[u8]) -> Result<u8, JsonAbiError> {
 
 fn fixed<const N: usize>(tag: &TypeTag, bytes: &[u8]) -> Result<[u8; N], JsonAbiError> {
     if bytes.len() != N {
-        return Err(mismatch(tag, &format!("expected {N} bytes")));
+        return Err(mismatch(tag, format!("expected {N} bytes")));
     }
     let mut out = [0u8; N];
     out.copy_from_slice(bytes);

--- a/crates/bloom-script/src/chain_iface.rs
+++ b/crates/bloom-script/src/chain_iface.rs
@@ -55,6 +55,8 @@ impl PetalManifestStub {
 pub struct FunctionDeclStub {
     /// Function name (PTB `MoveCmd::function` must equal this).
     pub name: String,
+    /// True if this function is declared read-only and may be called as a view.
+    pub view: bool,
     /// Generic type parameters.
     pub type_params: Vec<TypeParamDeclStub>,
     /// Declared argument kinds (in order).

--- a/crates/bloom-script/src/executor.rs
+++ b/crates/bloom-script/src/executor.rs
@@ -1323,7 +1323,7 @@ mod tests {
         Arg, Command, ExpectedVersion, MoveCmd, PetalRef, PqSignature, PtbTx, PublishCmd, UseRef,
         loom_coin_type_tag,
     };
-    use crate::validator::{AlwaysOkVerifier, ValidationContext, validate_ptb};
+    use crate::validator::{AlwaysOkVerifier, ValidationContext, ValidationMode, validate_ptb};
     use bloom_chain_types::Hash32;
     use bloom_objects::{Object, Owner};
     use std::cell::RefCell;
@@ -1517,6 +1517,7 @@ mod tests {
     fn run(chain: &MockChain, runner: &MockPetalRunner, tx: PtbTx) -> ExecutionReport {
         let verifier = AlwaysOkVerifier;
         let ctx = ValidationContext {
+            mode: ValidationMode::Commit,
             current_block: chain.block,
             chain,
             verifier: &verifier,
@@ -1551,6 +1552,7 @@ mod tests {
             PetalManifestStub {
                 module_path: "/p".to_string(),
                 functions: vec![FunctionDeclStub {
+                    view: false,
                     name: "f".to_string(),
                     type_params: vec![],
                     args: vec![],
@@ -1589,6 +1591,7 @@ mod tests {
         let manifest = PetalManifestStub {
             module_path: "/p".to_string(),
             functions: vec![FunctionDeclStub {
+                view: false,
                 name: "mint".to_string(),
                 type_params: vec![],
                 args: vec![],
@@ -1665,6 +1668,7 @@ mod tests {
             PetalManifestStub {
                 module_path: "/p".to_string(),
                 functions: vec![FunctionDeclStub {
+                    view: false,
                     name: "f".to_string(),
                     type_params: vec![],
                     args: vec![],
@@ -1708,6 +1712,7 @@ mod tests {
             PetalManifestStub {
                 module_path: "/p".to_string(),
                 functions: vec![FunctionDeclStub {
+                    view: false,
                     name: "f".to_string(),
                     type_params: vec![],
                     args: vec![],
@@ -1756,6 +1761,7 @@ mod tests {
             PetalManifestStub {
                 module_path: "/p".to_string(),
                 functions: vec![FunctionDeclStub {
+                    view: false,
                     name: "f".to_string(),
                     type_params: vec![],
                     args: vec![],
@@ -1799,6 +1805,7 @@ mod tests {
             PetalManifestStub {
                 module_path: "/p".to_string(),
                 functions: vec![FunctionDeclStub {
+                    view: false,
                     name: "f".to_string(),
                     type_params: vec![],
                     args: vec![],
@@ -1855,6 +1862,7 @@ mod tests {
             PetalManifestStub {
                 module_path: "/p".to_string(),
                 functions: vec![FunctionDeclStub {
+                    view: false,
                     name: "generic".to_string(),
                     type_params: vec![TypeParamDeclStub {
                         name: "T".to_string(),
@@ -1908,6 +1916,7 @@ mod tests {
             PetalManifestStub {
                 module_path: "/p".to_string(),
                 functions: vec![FunctionDeclStub {
+                    view: false,
                     name: "load".to_string(),
                     type_params: vec![],
                     args: vec![],
@@ -1934,6 +1943,7 @@ mod tests {
         let mut manifest_with_arg = PetalManifestStub {
             module_path: "/p".to_string(),
             functions: vec![FunctionDeclStub {
+                view: false,
                 name: "load".to_string(),
                 type_params: vec![],
                 args: vec![ArgDeclStub::Object {
@@ -2014,6 +2024,7 @@ mod tests {
             PetalManifestStub {
                 module_path: "/p".to_string(),
                 functions: vec![FunctionDeclStub {
+                    view: false,
                     name: "load".to_string(),
                     type_params: vec![],
                     args: vec![ArgDeclStub::Object {
@@ -2056,6 +2067,7 @@ mod tests {
 
         let verifier = AlwaysOkVerifier;
         let vctx = ValidationContext {
+            mode: ValidationMode::Commit,
             current_block: chain.block,
             chain: &chain,
             verifier: &verifier,
@@ -2080,6 +2092,7 @@ mod tests {
             PetalManifestStub {
                 module_path: "/p".to_string(),
                 functions: vec![FunctionDeclStub {
+                    view: false,
                     name: "load".to_string(),
                     type_params: vec![],
                     args: vec![ArgDeclStub::Object {
@@ -2150,6 +2163,7 @@ mod tests {
             PetalManifestStub {
                 module_path: "/p".to_string(),
                 functions: vec![FunctionDeclStub {
+                    view: false,
                     name: "load".to_string(),
                     type_params: vec![],
                     args: vec![ArgDeclStub::Object {
@@ -2215,6 +2229,7 @@ mod tests {
             PetalManifestStub {
                 module_path: "/p".to_string(),
                 functions: vec![FunctionDeclStub {
+                    view: false,
                     name: "load".to_string(),
                     type_params: vec![],
                     args: vec![ArgDeclStub::Object {
@@ -2300,6 +2315,7 @@ mod tests {
             PetalManifestStub {
                 module_path: "/p".to_string(),
                 functions: vec![FunctionDeclStub {
+                    view: false,
                     name: "noop".to_string(),
                     type_params: vec![],
                     args: vec![],
@@ -2356,6 +2372,7 @@ mod tests {
             PetalManifestStub {
                 module_path: "/p".to_string(),
                 functions: vec![FunctionDeclStub {
+                    view: false,
                     name: "load_two".to_string(),
                     type_params: vec![],
                     args: vec![
@@ -2444,6 +2461,7 @@ mod tests {
             PetalManifestStub {
                 module_path: "/p".to_string(),
                 functions: vec![FunctionDeclStub {
+                    view: false,
                     name: "load_two".to_string(),
                     type_params: vec![],
                     args: vec![
@@ -2528,6 +2546,7 @@ mod tests {
             PetalManifestStub {
                 module_path: "/p".to_string(),
                 functions: vec![FunctionDeclStub {
+                    view: false,
                     name: "load_two".to_string(),
                     type_params: vec![],
                     args: vec![
@@ -2588,6 +2607,7 @@ mod tests {
 
         let verifier = AlwaysOkVerifier;
         let vctx = ValidationContext {
+            mode: ValidationMode::Commit,
             current_block: chain.block,
             chain: &chain,
             verifier: &verifier,
@@ -2607,6 +2627,7 @@ mod tests {
         let mut manifest = PetalManifestStub {
             module_path: "/p".to_string(),
             functions: vec![FunctionDeclStub {
+                view: false,
                 name: "f".to_string(),
                 type_params: vec![],
                 args: vec![],
@@ -2658,6 +2679,7 @@ mod tests {
             PetalManifestStub {
                 module_path: "/p".to_string(),
                 functions: vec![FunctionDeclStub {
+                    view: false,
                     name: "f".to_string(),
                     type_params: vec![],
                     args: vec![],
@@ -2717,6 +2739,7 @@ mod tests {
         );
         let verifier = AlwaysOkVerifier;
         let ctx = ValidationContext {
+            mode: ValidationMode::Commit,
             current_block: chain.block,
             chain: &chain,
             verifier: &verifier,
@@ -2880,6 +2903,7 @@ mod tests {
             PetalManifestStub {
                 module_path: "/p".to_string(),
                 functions: vec![FunctionDeclStub {
+                    view: false,
                     name: "f".to_string(),
                     type_params: vec![],
                     args: vec![ArgDeclStub::Object {
@@ -2920,6 +2944,7 @@ mod tests {
 
         let verifier = AlwaysOkVerifier;
         let vctx = ValidationContext {
+            mode: ValidationMode::Commit,
             current_block: chain.block,
             chain: &chain,
             verifier: &verifier,
@@ -2950,6 +2975,7 @@ mod tests {
                 module_path: "/p".to_string(),
                 functions: vec![
                     FunctionDeclStub {
+                        view: false,
                         name: "mut".to_string(),
                         type_params: vec![],
                         args: vec![ArgDeclStub::Object {
@@ -2960,6 +2986,7 @@ mod tests {
                         attached_invariants: vec![],
                     },
                     FunctionDeclStub {
+                        view: false,
                         name: "ro".to_string(),
                         type_params: vec![],
                         args: vec![ArgDeclStub::Object {
@@ -3016,6 +3043,7 @@ mod tests {
 
         let verifier = AlwaysOkVerifier;
         let vctx = ValidationContext {
+            mode: ValidationMode::Commit,
             current_block: chain.block,
             chain: &chain,
             verifier: &verifier,
@@ -3045,6 +3073,7 @@ mod tests {
             PetalManifestStub {
                 module_path: "/p".to_string(),
                 functions: vec![FunctionDeclStub {
+                    view: false,
                     name: "mint".to_string(),
                     type_params: vec![],
                     args: vec![],
@@ -3108,6 +3137,7 @@ mod tests {
 
         let verifier = AlwaysOkVerifier;
         let vctx = ValidationContext {
+            mode: ValidationMode::Commit,
             current_block: chain.block,
             chain: &chain,
             verifier: &verifier,
@@ -3148,6 +3178,7 @@ mod tests {
             PetalManifestStub {
                 module_path: "/p".to_string(),
                 functions: vec![FunctionDeclStub {
+                    view: false,
                     name: "f".to_string(),
                     type_params: vec![],
                     args: vec![],
@@ -3179,6 +3210,7 @@ mod tests {
 
         let verifier = AlwaysOkVerifier;
         let vctx = ValidationContext {
+            mode: ValidationMode::Commit,
             current_block: chain.block,
             chain: &chain,
             verifier: &verifier,

--- a/crates/bloom-script/src/lib.rs
+++ b/crates/bloom-script/src/lib.rs
@@ -41,6 +41,7 @@
 
 #![deny(missing_docs)]
 
+pub mod abi_json;
 pub mod borrow_table;
 pub mod chain_iface;
 pub mod encode;
@@ -51,6 +52,9 @@ pub mod host_ctx;
 pub mod types;
 pub mod validator;
 
+pub use abi_json::{
+    JsonAbiError, decode_json_const, decode_json_type_tag, decode_return_json, encode_type_tag_json,
+};
 pub use borrow_table::{BorrowRow, BorrowTable, RowState};
 pub use chain_iface::{
     ArgDeclStub, ChainStateIface, ExternalTypeRefStub, FunctionDeclStub, InvariantDeclStub,
@@ -70,5 +74,6 @@ pub use types::{
     loom_marker_type_tag, resolve_fungible_petal_hash,
 };
 pub use validator::{
-    AlwaysOkVerifier, SignatureVerifier, ValidatedPtb, ValidationContext, validate_ptb,
+    AlwaysOkVerifier, SignatureVerifier, ValidatedPtb, ValidationContext, ValidationMode,
+    validate_ptb,
 };

--- a/crates/bloom-script/src/validator.rs
+++ b/crates/bloom-script/src/validator.rs
@@ -15,6 +15,15 @@ use crate::chain_iface::{ArgDeclStub, ChainStateIface, FunctionDeclStub, PetalMa
 use crate::error::PtbError;
 use crate::types::{Arg, Command, ExpectedVersion, MoveCmd, PtbTx, UseRef};
 
+/// Validation policy for a PTB.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ValidationMode {
+    /// Validate a PTB that may be committed to chain state.
+    Commit,
+    /// Validate a PTB for read-only execution against an existing snapshot.
+    ReadOnly,
+}
+
 /// Verifies an xDSA signature against (`digest`, `pubkey`).
 ///
 /// The real implementation lives in `bloom-keystore` (composite
@@ -44,6 +53,8 @@ impl SignatureVerifier for AlwaysOkVerifier {
 /// well-known `Coin<LOOM>` type tag the validator uses to recognise
 /// the gas payer.
 pub struct ValidationContext<'a> {
+    /// Whether validation is for commit or read-only execution.
+    pub mode: ValidationMode,
     /// Current block height.
     pub current_block: u64,
     /// Chain reader.
@@ -77,22 +88,29 @@ pub struct ValidatedPtb {
 
 /// Run the full validation pipeline (spec §7.2 steps 1–6).
 pub fn validate_ptb(tx: &PtbTx, ctx: &ValidationContext<'_>) -> Result<ValidatedPtb, PtbError> {
+    let tx = match ctx.mode {
+        ValidationMode::Commit => tx.clone(),
+        ValidationMode::ReadOnly => read_only_ptb(tx),
+    };
+
     // Step 1: signature check.
-    if tx.signers.is_empty() {
-        return Err(PtbError::NoSigners);
-    }
-    if tx.signatures.len() != tx.signers.len() {
-        return Err(PtbError::SignatureCountMismatch {
-            expected: tx.signers.len(),
-            got: tx.signatures.len(),
-        });
-    }
-    let digest = tx.signing_digest();
-    for (i, (pk, sig)) in tx.signers.iter().zip(tx.signatures.iter()).enumerate() {
-        if !ctx.verifier.verify(&digest, pk, &sig.0) {
-            return Err(PtbError::BadSignature {
-                signer_idx: i as u16,
+    if ctx.mode == ValidationMode::Commit {
+        if tx.signers.is_empty() {
+            return Err(PtbError::NoSigners);
+        }
+        if tx.signatures.len() != tx.signers.len() {
+            return Err(PtbError::SignatureCountMismatch {
+                expected: tx.signers.len(),
+                got: tx.signatures.len(),
             });
+        }
+        let digest = tx.signing_digest();
+        for (i, (pk, sig)) in tx.signers.iter().zip(tx.signatures.iter()).enumerate() {
+            if !ctx.verifier.verify(&digest, pk, &sig.0) {
+                return Err(PtbError::BadSignature {
+                    signer_idx: i as u16,
+                });
+            }
         }
     }
 
@@ -128,7 +146,7 @@ pub fn validate_ptb(tx: &PtbTx, ctx: &ValidationContext<'_>) -> Result<Validated
     // built-in output" and cannot be consumed where a concrete type is
     // required).
     let mut objects: HashMap<[u8; 32], Object> = HashMap::new();
-    let first_signer_addr = tx.signers[0];
+    let first_signer_addr = tx.signers.first().copied().unwrap_or([0; 32]);
     let mut cmd_return_types: Vec<Vec<Option<TypeTag>>> = Vec::with_capacity(tx.commands.len());
     let mut consumed_use_refs: HashSet<UseRef> = HashSet::new();
     for (cmd_idx, cmd) in tx.commands.iter().enumerate() {
@@ -308,48 +326,50 @@ pub fn validate_ptb(tx: &PtbTx, ctx: &ValidationContext<'_>) -> Result<Validated
     }
 
     // Step 6: gas-payer prep.
-    let gas_obj = ctx
-        .chain
-        .load_object(&tx.gas_payer)
-        .ok_or(PtbError::ObjectNotFound { id: tx.gas_payer })?;
-    if objects.contains_key(&tx.gas_payer.0) {
-        return Err(PtbError::InvalidGasPayer {
-            id: tx.gas_payer,
-            reason: "gas payer cannot also be used as a PTB object input".to_string(),
-        });
+    if ctx.mode == ValidationMode::Commit {
+        let gas_obj = ctx
+            .chain
+            .load_object(&tx.gas_payer)
+            .ok_or(PtbError::ObjectNotFound { id: tx.gas_payer })?;
+        if objects.contains_key(&tx.gas_payer.0) {
+            return Err(PtbError::InvalidGasPayer {
+                id: tx.gas_payer,
+                reason: "gas payer cannot also be used as a PTB object input".to_string(),
+            });
+        }
+        if gas_obj.owner != Owner::Address(first_signer_addr) {
+            return Err(PtbError::InvalidGasPayer {
+                id: tx.gas_payer,
+                reason: format!(
+                    "gas payer is not owned by first signer ({})",
+                    hex_encode(&first_signer_addr)
+                ),
+            });
+        }
+        if gas_obj.type_tag != ctx.loom_coin_type {
+            return Err(PtbError::InvalidGasPayer {
+                id: tx.gas_payer,
+                reason: "gas payer is not a Coin<LOOM>".to_string(),
+            });
+        }
+        let coin_value = decode_coin_value(&gas_obj.payload)?;
+        let needed = tx
+            .checked_gas_reservation()
+            .ok_or(PtbError::GasReservationOverflow {
+                gas_budget: tx.gas_budget,
+                gas_price: tx.gas_price,
+            })?;
+        if coin_value < needed {
+            return Err(PtbError::InsufficientGas {
+                needed,
+                available: coin_value,
+            });
+        }
+        objects.insert(gas_obj.id.0, gas_obj);
     }
-    if gas_obj.owner != Owner::Address(first_signer_addr) {
-        return Err(PtbError::InvalidGasPayer {
-            id: tx.gas_payer,
-            reason: format!(
-                "gas payer is not owned by first signer ({})",
-                hex_encode(&first_signer_addr)
-            ),
-        });
-    }
-    if gas_obj.type_tag != ctx.loom_coin_type {
-        return Err(PtbError::InvalidGasPayer {
-            id: tx.gas_payer,
-            reason: "gas payer is not a Coin<LOOM>".to_string(),
-        });
-    }
-    let coin_value = decode_coin_value(&gas_obj.payload)?;
-    let needed = tx
-        .checked_gas_reservation()
-        .ok_or(PtbError::GasReservationOverflow {
-            gas_budget: tx.gas_budget,
-            gas_price: tx.gas_price,
-        })?;
-    if coin_value < needed {
-        return Err(PtbError::InsufficientGas {
-            needed,
-            available: coin_value,
-        });
-    }
-    objects.insert(gas_obj.id.0, gas_obj);
 
     Ok(ValidatedPtb {
-        tx: tx.clone(),
+        tx,
         objects,
         petals,
         manifests,
@@ -360,6 +380,20 @@ pub fn validate_ptb(tx: &PtbTx, ctx: &ValidationContext<'_>) -> Result<Validated
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+fn read_only_ptb(tx: &PtbTx) -> PtbTx {
+    let mut tx = tx.clone();
+    for cmd in &mut tx.commands {
+        if let Command::Move(m) = cmd {
+            for arg in &mut m.args {
+                if let Arg::Object { access_mode, .. } = arg {
+                    *access_mode = AccessMode::ReadOnly;
+                }
+            }
+        }
+    }
+    tx
+}
 
 fn resolve_petal(
     petal: &crate::types::PetalRef,
@@ -1094,10 +1128,29 @@ mod tests {
         }
     }
 
+    fn pool_tt() -> TypeTag {
+        TypeTag::Concrete {
+            petal_hash: [0xAB; 32],
+            type_name: "Pool".to_string(),
+            type_args: vec![],
+        }
+    }
+
+    fn pool_obj(id_byte: u8, owner: Owner, version: u64) -> Object {
+        Object {
+            id: ObjectId([id_byte; 32]),
+            type_tag: pool_tt(),
+            owner,
+            version,
+            payload: vec![0xCA, 0xFE],
+        }
+    }
+
     fn sample_manifest() -> PetalManifestStub {
         PetalManifestStub {
             module_path: "/bloom/dex/pool".to_string(),
             functions: vec![FunctionDeclStub {
+                view: false,
                 name: "swap".to_string(),
                 type_params: vec![],
                 args: vec![ArgDeclStub::Signer],
@@ -1112,6 +1165,26 @@ mod tests {
             }],
             external_type_refs: vec![],
         }
+    }
+
+    fn object_manifest(mode: AccessMode) -> PetalManifestStub {
+        let mut manifest = sample_manifest();
+        manifest.functions = vec![FunctionDeclStub {
+            view: false,
+            name: "inspect".to_string(),
+            type_params: vec![],
+            args: vec![ArgDeclStub::Object {
+                ty: TypeTag::Concrete {
+                    petal_hash: [0; 32],
+                    type_name: "Pool".to_string(),
+                    type_args: vec![],
+                },
+                mode,
+            }],
+            returns: vec![],
+            attached_invariants: vec![],
+        }];
+        manifest
     }
 
     fn sample_ptb(signer: [u8; 32], gas_payer_id: ObjectId, expiry: u64) -> PtbTx {
@@ -1146,10 +1219,32 @@ mod tests {
 
     fn ctx<'a>(chain: &'a MockChain, verifier: &'a dyn SignatureVerifier) -> ValidationContext<'a> {
         ValidationContext {
+            mode: ValidationMode::Commit,
             current_block: chain.block,
             chain,
             verifier,
             loom_coin_type: loom_coin_tt(),
+        }
+    }
+
+    fn read_only_ctx<'a>(
+        chain: &'a MockChain,
+        verifier: &'a dyn SignatureVerifier,
+    ) -> ValidationContext<'a> {
+        ValidationContext {
+            mode: ValidationMode::ReadOnly,
+            current_block: chain.block,
+            chain,
+            verifier,
+            loom_coin_type: loom_coin_tt(),
+        }
+    }
+
+    struct PanicVerifier;
+
+    impl SignatureVerifier for PanicVerifier {
+        fn verify(&self, _: &[u8; 32], _: &[u8; 32], _: &[u8]) -> bool {
+            panic!("read-only validation must not verify signatures")
         }
     }
 
@@ -1168,10 +1263,104 @@ mod tests {
     }
 
     #[test]
+    fn read_only_accepts_absent_signatures_and_no_gas_payer_coin() {
+        let chain = MockChain::new();
+        let obj = pool_obj(0x44, Owner::Address([0x99; 32]), 7);
+        chain.put_object(obj.clone());
+        chain.put_petal(
+            Hash32([0xAB; 32]),
+            vec![1, 2, 3],
+            object_manifest(AccessMode::ReadOnly),
+        );
+        chain.put_path("/bloom/dex/pool", Hash32([0xAB; 32]));
+        let tx = PtbTx {
+            signers: vec![],
+            commands: vec![Command::Move(MoveCmd {
+                petal: PetalRef {
+                    path: "/bloom/dex/pool".to_string(),
+                    hash: Some(Hash32([0xAB; 32])),
+                },
+                function: "inspect".to_string(),
+                type_args: vec![],
+                args: vec![Arg::Object {
+                    id: obj.id,
+                    expected_version: ExpectedVersion(7),
+                    access_mode: AccessMode::Mutable,
+                }],
+            })],
+            gas_payer: ObjectId([0xFE; 32]),
+            gas_budget: 100,
+            gas_price: 1,
+            expiry_block: 100,
+            signatures: vec![],
+        };
+
+        let validated = validate_ptb(&tx, &read_only_ctx(&chain, &PanicVerifier)).unwrap();
+        assert!(validated.objects.contains_key(&obj.id.0));
+        assert!(!validated.objects.contains_key(&tx.gas_payer.0));
+        let Command::Move(m) = &validated.tx.commands[0] else {
+            panic!("expected Move command");
+        };
+        let Arg::Object { access_mode, .. } = &m.args[0] else {
+            panic!("expected Object arg");
+        };
+        assert_eq!(*access_mode, AccessMode::ReadOnly);
+    }
+
+    #[test]
+    fn read_only_allows_supplied_signer_without_signature_verification() {
+        let (chain, signer, gas_id) = setup();
+        let mut tx = sample_ptb(signer, gas_id, 100);
+        tx.signatures.clear();
+
+        assert!(validate_ptb(&tx, &read_only_ctx(&chain, &PanicVerifier)).is_ok());
+    }
+
+    #[test]
+    fn read_only_coercion_rejects_mutable_object_declarations() {
+        let chain = MockChain::new();
+        let obj = pool_obj(0x44, Owner::Address([0x99; 32]), 7);
+        chain.put_object(obj.clone());
+        chain.put_petal(
+            Hash32([0xAB; 32]),
+            vec![1, 2, 3],
+            object_manifest(AccessMode::Mutable),
+        );
+        chain.put_path("/bloom/dex/pool", Hash32([0xAB; 32]));
+        let tx = PtbTx {
+            signers: vec![],
+            commands: vec![Command::Move(MoveCmd {
+                petal: PetalRef {
+                    path: "/bloom/dex/pool".to_string(),
+                    hash: Some(Hash32([0xAB; 32])),
+                },
+                function: "inspect".to_string(),
+                type_args: vec![],
+                args: vec![Arg::Object {
+                    id: obj.id,
+                    expected_version: ExpectedVersion(7),
+                    access_mode: AccessMode::Mutable,
+                }],
+            })],
+            gas_payer: ObjectId([0xFE; 32]),
+            gas_budget: 100,
+            gas_price: 1,
+            expiry_block: 100,
+            signatures: vec![],
+        };
+
+        let err = validate_ptb(&tx, &read_only_ctx(&chain, &PanicVerifier)).unwrap_err();
+        assert!(
+            matches!(err, PtbError::TypeMismatch { reason, .. } if reason.contains("access mode ReadOnly"))
+        );
+    }
+
+    #[test]
     fn rejects_duplicate_linear_use_ref_consumption() {
         let (chain, signer, gas_id) = setup();
         let mut m = sample_manifest();
         m.functions.push(FunctionDeclStub {
+            view: false,
             name: "mint".to_string(),
             type_params: vec![],
             args: vec![],
@@ -1392,6 +1581,7 @@ mod tests {
         // Add a function with an Object arg to swap into the manifest.
         let mut manifest = sample_manifest();
         manifest.functions.push(FunctionDeclStub {
+            view: false,
             name: "use_obj".to_string(),
             type_params: vec![],
             args: vec![ArgDeclStub::Object {
@@ -1434,6 +1624,7 @@ mod tests {
 
         let mut manifest = sample_manifest();
         manifest.functions.push(FunctionDeclStub {
+            view: false,
             name: "touch_child".to_string(),
             type_params: vec![],
             args: vec![ArgDeclStub::Object {
@@ -1481,6 +1672,7 @@ mod tests {
 
         let mut manifest = sample_manifest();
         manifest.functions.push(FunctionDeclStub {
+            view: false,
             name: "touch_pair".to_string(),
             type_params: vec![],
             args: vec![
@@ -1540,6 +1732,7 @@ mod tests {
 
         let mut manifest = sample_manifest();
         manifest.functions.push(FunctionDeclStub {
+            view: false,
             name: "read_parent_mutate_child".to_string(),
             type_params: vec![],
             args: vec![
@@ -1596,6 +1789,7 @@ mod tests {
         });
         let mut manifest = sample_manifest();
         manifest.functions.push(FunctionDeclStub {
+            view: false,
             name: "mutate".to_string(),
             type_params: vec![],
             args: vec![ArgDeclStub::Object {
@@ -1707,6 +1901,7 @@ mod tests {
         });
         let mut manifest = sample_manifest();
         manifest.functions.push(FunctionDeclStub {
+            view: false,
             name: "touch".to_string(),
             type_params: vec![],
             args: vec![ArgDeclStub::Object {
@@ -1763,6 +1958,7 @@ mod tests {
     fn install_fn(chain: &MockChain, name: &str, args: Vec<ArgDeclStub>, returns: Vec<TypeTag>) {
         let mut m = sample_manifest();
         m.functions.push(FunctionDeclStub {
+            view: false,
             name: name.to_string(),
             type_params: vec![],
             args,
@@ -1894,6 +2090,7 @@ mod tests {
         // Const u128. Hooking them up with a Use should fail.
         let mut m = sample_manifest();
         m.functions.push(FunctionDeclStub {
+            view: false,
             name: "producer".to_string(),
             type_params: vec![],
             args: vec![],
@@ -1901,6 +2098,7 @@ mod tests {
             attached_invariants: vec![],
         });
         m.functions.push(FunctionDeclStub {
+            view: false,
             name: "consumer".to_string(),
             type_params: vec![],
             args: vec![ArgDeclStub::Const(concrete("u128"))],
@@ -1954,6 +2152,7 @@ mod tests {
         let (chain, signer, gas_id) = setup();
         let mut m = sample_manifest();
         m.functions.push(FunctionDeclStub {
+            view: false,
             name: "producer".to_string(),
             type_params: vec![],
             args: vec![],
@@ -1961,6 +2160,7 @@ mod tests {
             attached_invariants: vec![],
         });
         m.functions.push(FunctionDeclStub {
+            view: false,
             name: "consumer".to_string(),
             type_params: vec![],
             args: vec![ArgDeclStub::Const(concrete("u64"))],
@@ -2033,6 +2233,7 @@ mod tests {
         };
         let mut m = sample_manifest();
         m.functions.push(FunctionDeclStub {
+            view: false,
             name: "generic".to_string(),
             type_params: vec![crate::chain_iface::TypeParamDeclStub {
                 name: "T".to_string(),
@@ -2111,6 +2312,7 @@ mod tests {
         };
         let mut m = sample_manifest();
         m.functions.push(FunctionDeclStub {
+            view: false,
             name: "producer".to_string(),
             type_params: vec![],
             args: vec![],
@@ -2118,6 +2320,7 @@ mod tests {
             attached_invariants: vec![],
         });
         m.functions.push(FunctionDeclStub {
+            view: false,
             name: "consumer".to_string(),
             type_params: vec![],
             args: vec![ArgDeclStub::Object {
@@ -2179,6 +2382,7 @@ mod tests {
         let (chain, signer, gas_id) = setup();
         let mut m = sample_manifest();
         m.functions.push(FunctionDeclStub {
+            view: false,
             name: "producer".to_string(),
             type_params: vec![],
             args: vec![],
@@ -2186,6 +2390,7 @@ mod tests {
             attached_invariants: vec![],
         });
         m.functions.push(FunctionDeclStub {
+            view: false,
             name: "consumer".to_string(),
             type_params: vec![],
             args: vec![ArgDeclStub::Object {
@@ -2252,6 +2457,7 @@ mod tests {
         };
         let mut m = sample_manifest();
         m.functions.push(FunctionDeclStub {
+            view: false,
             name: "producer".to_string(),
             type_params: vec![],
             args: vec![],
@@ -2308,6 +2514,7 @@ mod tests {
         });
         let mut m = sample_manifest();
         m.functions.push(FunctionDeclStub {
+            view: false,
             name: "touch".to_string(),
             type_params: vec![],
             args: vec![ArgDeclStub::Object {
@@ -2356,6 +2563,7 @@ mod tests {
         });
         let mut m = sample_manifest();
         m.functions.push(FunctionDeclStub {
+            view: false,
             name: "touch".to_string(),
             type_params: vec![],
             args: vec![ArgDeclStub::Object {
@@ -2397,6 +2605,7 @@ mod tests {
         });
         let mut m = sample_manifest();
         m.functions.push(FunctionDeclStub {
+            view: false,
             name: "touch".to_string(),
             type_params: vec![],
             args: vec![ArgDeclStub::Object {
@@ -2441,6 +2650,7 @@ mod tests {
         let mut m = sample_manifest();
         m.object_types.clear();
         m.functions.push(FunctionDeclStub {
+            view: false,
             name: "quote".to_string(),
             type_params: vec![],
             args: vec![ArgDeclStub::Object {
@@ -2471,6 +2681,7 @@ mod tests {
         let mut producer = PetalManifestStub {
             module_path: "/evil".to_string(),
             functions: vec![FunctionDeclStub {
+                view: false,
                 name: "forge".to_string(),
                 type_params: vec![],
                 args: vec![],
@@ -2492,6 +2703,7 @@ mod tests {
             type_args.push(concrete("FaucetAdmin"));
         }
         consumer.functions.push(FunctionDeclStub {
+            view: false,
             name: "mint".to_string(),
             type_params: vec![],
             args: vec![ArgDeclStub::Object {
@@ -2548,6 +2760,7 @@ mod tests {
         let (chain, signer, gas_id) = setup();
         let mut m = sample_manifest();
         m.functions.push(FunctionDeclStub {
+            view: false,
             name: "gf".to_string(),
             type_params: vec![crate::chain_iface::TypeParamDeclStub {
                 name: "T".to_string(),

--- a/crates/bloom-script/tests/view_function_security.rs
+++ b/crates/bloom-script/tests/view_function_security.rs
@@ -1,0 +1,256 @@
+use std::collections::HashMap;
+
+use bloom_chain_types::types::Hash32;
+use bloom_objects::{Object, ObjectId, Owner, TypeTag};
+use bloom_script::chain_iface::{
+    ArgDeclStub, ChainStateIface, FunctionDeclStub, PetalManifestStub,
+};
+use bloom_script::encode::{decode_ptb, encode_ptb};
+use bloom_script::validator::{AlwaysOkVerifier, ValidationContext, ValidationMode, validate_ptb};
+use bloom_script::{
+    Command, MoveCmd, PetalRef, PqSignature, PtbTx,
+    types::{Arg, ExpectedVersion},
+};
+
+static ALWAYS_OK: AlwaysOkVerifier = AlwaysOkVerifier;
+
+fn sample_view_marked_move_shape_ptb() -> PtbTx {
+    PtbTx {
+        signers: vec![[0x11; 32]],
+        commands: vec![Command::Move(MoveCmd {
+            petal: PetalRef {
+                path: "/bloom/test/view".to_string(),
+                hash: Some(Hash32([0x22; 32])),
+            },
+            function: "read_counter".to_string(),
+            type_args: vec![],
+            args: vec![Arg::Object {
+                id: ObjectId([0x33; 32]),
+                expected_version: ExpectedVersion(7),
+                access_mode: bloom_objects::AccessMode::ReadOnly,
+            }],
+        })],
+        gas_payer: ObjectId([0x44; 32]),
+        gas_budget: 1_000,
+        gas_price: 1,
+        expiry_block: 99,
+        signatures: vec![PqSignature(vec![0x55; 64])],
+    }
+}
+
+#[derive(Default)]
+struct TestChain {
+    block: u64,
+    objects: HashMap<ObjectId, Object>,
+    petals: HashMap<Hash32, Vec<u8>>,
+    manifests: HashMap<Hash32, PetalManifestStub>,
+    paths: HashMap<String, Hash32>,
+}
+
+impl ChainStateIface for TestChain {
+    fn load_object(&self, id: &ObjectId) -> Option<Object> {
+        self.objects.get(id).cloned()
+    }
+
+    fn load_petal(&self, hash: &Hash32) -> Option<Vec<u8>> {
+        self.petals.get(hash).cloned()
+    }
+
+    fn load_manifest(&self, hash: &Hash32) -> Option<PetalManifestStub> {
+        self.manifests.get(hash).cloned()
+    }
+
+    fn resolve_path(&self, path: &str) -> Option<Hash32> {
+        self.paths.get(path).copied()
+    }
+
+    fn current_block(&self) -> u64 {
+        self.block
+    }
+}
+
+fn counter_type() -> TypeTag {
+    TypeTag::Concrete {
+        petal_hash: [0x22; 32],
+        type_name: "Counter".to_string(),
+        type_args: vec![],
+    }
+}
+
+fn loom_coin_type() -> TypeTag {
+    bloom_script::loom_coin_type_tag(Hash32([0; 32]))
+}
+
+fn readonly_validation_ctx<'a>(chain: &'a TestChain) -> ValidationContext<'a> {
+    ValidationContext {
+        mode: ValidationMode::ReadOnly,
+        current_block: chain.current_block(),
+        chain,
+        verifier: &ALWAYS_OK,
+        loom_coin_type: loom_coin_type(),
+    }
+}
+
+fn readonly_manifest(args: Vec<ArgDeclStub>) -> PetalManifestStub {
+    PetalManifestStub {
+        module_path: "/bloom/test/view".to_string(),
+        functions: vec![FunctionDeclStub {
+            name: "read_counter".to_string(),
+            args,
+            ..Default::default()
+        }],
+        ..Default::default()
+    }
+}
+
+fn readonly_ptb(args: Vec<Arg>) -> PtbTx {
+    PtbTx {
+        signers: vec![],
+        commands: vec![Command::Move(MoveCmd {
+            petal: PetalRef {
+                path: "/bloom/test/view".to_string(),
+                hash: Some(Hash32([0x22; 32])),
+            },
+            function: "read_counter".to_string(),
+            type_args: vec![],
+            args,
+        })],
+        gas_payer: ObjectId([0xFE; 32]),
+        gas_budget: 0,
+        gas_price: 0,
+        expiry_block: 10,
+        signatures: vec![],
+    }
+}
+
+#[test]
+fn committed_ptb_wire_rejects_trailing_at_block_height() {
+    let ptb = sample_view_marked_move_shape_ptb();
+    let mut encoded = encode_ptb(&ptb).expect("ptb encodes");
+
+    encoded.extend_from_slice(&42u64.to_be_bytes());
+
+    assert!(
+        decode_ptb(&encoded).is_err(),
+        "committed PTB decoding must reject any out-of-band at_block payload"
+    );
+}
+
+#[test]
+fn committed_ptb_round_trip_has_no_snapshot_selector() {
+    let ptb = sample_view_marked_move_shape_ptb();
+
+    let decoded = decode_ptb(&encode_ptb(&ptb).expect("ptb encodes")).expect("ptb decodes");
+
+    assert_eq!(decoded, ptb);
+    assert_eq!(decoded.expiry_block, 99);
+    assert_eq!(decoded.commands.len(), 1);
+}
+
+#[test]
+fn ptb_wire_types_do_not_define_at_block() {
+    let types_rs = include_str!("../src/types.rs");
+    let encode_rs = include_str!("../src/encode.rs");
+
+    assert!(!types_rs.contains("at_block"));
+    assert!(!encode_rs.contains("at_block"));
+}
+
+#[test]
+fn readonly_validation_allows_absent_signatures_and_no_gas_payer_coin() {
+    let mut chain = TestChain {
+        block: 1,
+        ..Default::default()
+    };
+    chain
+        .petals
+        .insert(Hash32([0x22; 32]), vec![0, 97, 115, 109]);
+    chain
+        .manifests
+        .insert(Hash32([0x22; 32]), readonly_manifest(vec![]));
+    chain
+        .paths
+        .insert("/bloom/test/view".to_string(), Hash32([0x22; 32]));
+
+    let validated = validate_ptb(&readonly_ptb(vec![]), &readonly_validation_ctx(&chain))
+        .expect("ReadOnly validation should not require signatures or a gas coin");
+
+    assert!(validated.tx.signers.is_empty());
+    assert!(validated.tx.signatures.is_empty());
+    assert!(!validated.objects.contains_key(&[0xFE; 32]));
+}
+
+#[test]
+fn readonly_validation_coerces_object_args_to_readonly() {
+    let mut chain = TestChain {
+        block: 1,
+        ..Default::default()
+    };
+    let object_id = ObjectId([0x33; 32]);
+    chain.objects.insert(
+        object_id,
+        Object {
+            id: object_id,
+            type_tag: counter_type(),
+            owner: Owner::Address([0xAA; 32]),
+            version: 7,
+            payload: vec![],
+        },
+    );
+    chain
+        .petals
+        .insert(Hash32([0x22; 32]), vec![0, 97, 115, 109]);
+    chain.manifests.insert(
+        Hash32([0x22; 32]),
+        readonly_manifest(vec![ArgDeclStub::Object {
+            ty: counter_type(),
+            mode: bloom_objects::AccessMode::ReadOnly,
+        }]),
+    );
+    chain
+        .paths
+        .insert("/bloom/test/view".to_string(), Hash32([0x22; 32]));
+
+    let validated = validate_ptb(
+        &readonly_ptb(vec![Arg::Object {
+            id: object_id,
+            expected_version: ExpectedVersion(7),
+            access_mode: bloom_objects::AccessMode::Mutable,
+        }]),
+        &readonly_validation_ctx(&chain),
+    )
+    .expect("ReadOnly validation should coerce object args to ReadOnly");
+
+    let Command::Move(move_cmd) = &validated.tx.commands[0] else {
+        panic!("expected Move command");
+    };
+    let Arg::Object { access_mode, .. } = &move_cmd.args[0] else {
+        panic!("expected object arg");
+    };
+    assert_eq!(*access_mode, bloom_objects::AccessMode::ReadOnly);
+}
+
+#[test]
+fn type_tag_json_codec_round_trips_supported_values_and_degrades_unknown_returns() {
+    let u128_tag = TypeTag::Concrete {
+        petal_hash: [0; 32],
+        type_name: "u128".to_string(),
+        type_args: vec![],
+    };
+    let bytes = bloom_script::decode_json_const(&u128_tag, &serde_json::json!("42")).unwrap();
+    assert_eq!(bytes, 42u128.to_be_bytes());
+    assert_eq!(
+        bloom_script::decode_return_json(&u128_tag, &bytes).unwrap(),
+        Some(serde_json::json!("42"))
+    );
+
+    let unknown = TypeTag::Concrete {
+        petal_hash: [0; 32],
+        type_name: "Opaque".to_string(),
+        type_args: vec![],
+    };
+    assert_eq!(
+        bloom_script::decode_return_json(&unknown, &[1, 2, 3]).unwrap(),
+        None
+    );
+}

--- a/crates/bloom-vfs/src/tx_handler.rs
+++ b/crates/bloom-vfs/src/tx_handler.rs
@@ -645,6 +645,7 @@ mod tests {
 
     fn func(name: &str, args: Vec<ArgDeclStub>, returns: Vec<TypeTag>) -> FunctionDeclStub {
         FunctionDeclStub {
+            view: false,
             name: name.to_string(),
             type_params: vec![],
             args,

--- a/crates/bloom/src/commands/chain.rs
+++ b/crates/bloom/src/commands/chain.rs
@@ -74,6 +74,40 @@ pub enum ChainCmd {
         #[arg(long, value_name = "N", default_value_t = 30u64)]
         wait_timeout_secs: u64,
     },
+    /// Execute one read-only petal call against the latest committed snapshot.
+    View {
+        /// Composed view command array as JSON. When set, --path/--function/--arg are ignored.
+        #[arg(long, value_name = "JSON")]
+        commands: Option<String>,
+        /// Deployed petal path, e.g. `/bloom/apps/bloombook`.
+        #[arg(long)]
+        path: Option<String>,
+        /// Petal function name, e.g. `counts`.
+        #[arg(long)]
+        function: Option<String>,
+        /// Optional pinned petal hash. If omitted, the node resolves `--path`.
+        #[arg(long)]
+        hash: Option<String>,
+        /// JSON argument descriptor. Repeat for each argument.
+        ///
+        /// Examples:
+        /// `--arg '{"kind":"object","id":"<object-id>"}'`
+        /// `--arg '{"kind":"const","hex":"0000000000000000000000000000002a"}'`
+        #[arg(long = "arg", value_name = "JSON")]
+        args: Vec<String>,
+        /// Canonical TypeTag bytes as hex. Repeat for generic functions.
+        #[arg(long = "type-arg", value_name = "HEX")]
+        type_args: Vec<String>,
+        /// Signer address to expose to `&Signer` args. Repeat as needed.
+        #[arg(long = "signer", value_name = "ADDR")]
+        signers: Vec<String>,
+        /// Evaluate against a retained historical block height.
+        #[arg(long, value_name = "HEIGHT")]
+        at_block: Option<u64>,
+        /// Fuel cap for the non-committing execution.
+        #[arg(long, value_name = "N", default_value_t = 1_000_000u64)]
+        fuel_limit: u64,
+    },
     /// Query chain state.
     #[command(subcommand)]
     Query(QueryCmd),
@@ -351,6 +385,60 @@ pub async fn run_chain(home: &bloom_proto::HomeDir, cmd: ChainCmd) -> Result<()>
                     json!({ "address": addr, "key": key_hex }),
                 )
                 .await?;
+            println!("{}", serde_json::to_string_pretty(&result)?);
+            Ok(())
+        }
+
+        // ── view petal call ──────────────────────────────────────────────────
+        ChainCmd::View {
+            commands,
+            path,
+            function,
+            hash,
+            args,
+            type_args,
+            signers,
+            at_block,
+            fuel_limit,
+        } => {
+            let parsed_args = args
+                .iter()
+                .map(|arg| {
+                    serde_json::from_str::<serde_json::Value>(arg)
+                        .with_context(|| format!("parse --arg JSON: {arg}"))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            let parsed_commands = commands
+                .as_deref()
+                .map(|commands| {
+                    serde_json::from_str::<serde_json::Value>(commands)
+                        .with_context(|| format!("parse --commands JSON: {commands}"))
+                })
+                .transpose()?;
+            let client = make_client();
+            let params = if let Some(commands) = parsed_commands {
+                json!({
+                    "commands": commands,
+                    "signers": signers,
+                    "at_block": at_block,
+                    "fuel_limit": fuel_limit,
+                })
+            } else {
+                let path = path.context("--path is required unless --commands is set")?;
+                let function =
+                    function.context("--function is required unless --commands is set")?;
+                json!({
+                    "path": path,
+                    "function": function,
+                    "hash": hash,
+                    "args": parsed_args,
+                    "type_args": type_args,
+                    "signers": signers,
+                    "at_block": at_block,
+                    "fuel_limit": fuel_limit,
+                })
+            };
+            let result = client.call("chain_view_call", params).await?;
             println!("{}", serde_json::to_string_pretty(&result)?);
             Ok(())
         }

--- a/crates/bloom/src/commands/pipe.rs
+++ b/crates/bloom/src/commands/pipe.rs
@@ -463,6 +463,7 @@ mod tests {
 
     fn func(name: &str, args: Vec<ArgDeclStub>, returns: Vec<TypeTag>) -> FunctionDeclStub {
         FunctionDeclStub {
+            view: false,
             name: name.to_string(),
             type_params: vec![],
             args,

--- a/docs/superpowers/specs/2026-05-29-view-functions-design.md
+++ b/docs/superpowers/specs/2026-05-29-view-functions-design.md
@@ -1,0 +1,203 @@
+# View Functions — Read-Only Petal Calls
+
+**Status:** design, approved for planning
+**Date:** 2026-05-29
+**Branch:** `feat/view-functions`
+**Supersedes:** the current hacked `chain_view_call` (staged, uncommitted) in `crates/bloom-chain-node/src/rpc.rs`
+**Scope of this spec:** a first-class, read-only "view" call for petal functions — usable both standalone over RPC/CLI and as composed commands inside ordinary mutating PTBs. Bloombook is a downstream consumer, not part of this spec.
+
+---
+
+## 1. Goal
+
+Give Bloom a real notion of a **view function** — a petal function that performs no state mutation — the way Solidity has `view`/`pure`. A view can be:
+
+1. **Called standalone** over RPC/CLI against a chosen state snapshot (chain head, or a past block within the node's retention window), returning typed values and committing nothing.
+2. **Composed inside a normal mutating PTB**, where its return values feed later commands, and where the PTB's signatures authenticate any `&Signer` args.
+
+"View" is a **purity property of the function** (no writes), *not* a statement about how it is called. It does not forbid `&Signer` args.
+
+## 2. Why the current implementation is wrong
+
+The staged `chain_view_call` forges a mutating `PtbTx` and runs it through the commit pipeline, then rejects writes after the fact. That approach has structural problems this spec exists to fix:
+
+- **No first-class view concept.** `FunctionDecl` has no purity marker, so clients can't discover which functions are safe to call as views; "view-ness" is asserted post-hoc by running the body and hoping it didn't write.
+- **Forked execution pipeline.** The handler hand-rolls a second copy of `execute_tx_impl`'s `validate → execute → drain` sequence. The two *will* drift — and for a view, drift is a **correctness bug**: a view's whole job is to report what the chain would compute. If it diverges, it lies silently.
+- **Synthetic-gas / fake-LOOM hacks.** It fabricates a zero-value gas coin and a fake `Coin<LOOM>` type (`petal_hash = [0u8;32]`) purely to satisfy the mutating validator's gas-payer requirement. A read has no business needing a gas coin, and the fake type diverges from the real chain's LOOM type.
+- **Spoofable signers via `AlwaysOkVerifier`.** Caller-named addresses are unauthenticated, inviting false-trust mistakes.
+- **Untyped return blobs.** Returns are raw hex; every consumer re-implements the layout by hand.
+- **Single-command, tip-only, unmetered.** No composition, no historical reads, and free caller-controlled fuel (DoS surface).
+
+## 3. Architecture
+
+A view call is a **read-only PTB** evaluated against a chosen state snapshot, producing typed return values and never committing. Four layers, each with one job:
+
+```
+            manifest `view` flag            (the declared contract / discovery)
+                    │
+ deploy time:  call-graph verifier          (proves the claim, statically)
+                    │
+ call time:    view orchestrator            (RPC/CLI: snapshot select, arg decode,
+                    │                         fuel cap, effect assertion, return decode)
+                    │
+ shared core:  validate_ptb(ReadOnly)  +  run_ptb(...) helper
+                                            (one source of truth, shared with commit path)
+```
+
+The consensus core, state, and the PTB *executor* do not change semantically. We add a read-only validation mode, extract a shared execution helper out of the existing commit path, and add a view orchestrator on top.
+
+### 3.1 Components
+
+**PROTOCOL — new/changed in `crates/`:**
+
+| Unit | Responsibility | Builds on |
+|---|---|---|
+| `view` flag on `FunctionDecl` (`bloom-petal-manifest`) | Per-function purity marker; bumps `SCHEMA_VERSION`, defaults `false`. The discovery/contract mechanism. | `PetalManifestV0.functions`, `codec` |
+| Call-graph view verifier (in `bloom-petals` chain-mode admission, alongside `CHAIN_ALLOWED_IMPORT_MODULES`) | At deploy, reject any `view`-marked function whose static call graph can reach a mutating host import, or that is not statically analyzable (`call_indirect`). | `chain_vm.rs` import/admission pass |
+| `ValidationMode { Commit, ReadOnly }` on `validate_ptb` (`bloom-script`) | `ReadOnly`: no gas-payer-Coin requirement; all object args coerced to `ReadOnly`; absent/zero signatures accepted. Makes read-only a first-class, tested property of the validator. | `validate_ptb`, `ValidationContext` |
+| `run_ptb(...)` shared helper (`bloom-chain-node`) | The extracted `validate → host_ctx → snapshot → ChainPetalRunner → PtbExecutor::with_ctx_arc → execute → drain` sequence, taking a state reference + validation mode, returning `ExecutionReport`. One execution core for both commit and view. | `PtbExecutor`, `ChainPetalRunner`, `PtbHostCtx` |
+| View orchestrator + `chain_view_call` RPC (`bloom-chain-node`) | Snapshot select (head / `at_block`) → typed-arg decode → `run_ptb(ReadOnly)` with node-clamped fuel → assert empty effect set → typed return decode → drop snapshot. | `run_ptb`, `state_index`, `StateBlobStore`, ABI codec |
+| `TypeTag`-driven JSON codec (`bloom-script` or sibling) | Bidirectional: typed JSON args → canonical bytes, and return-slot bytes → typed JSON. Single module so encode/decode can't disagree on layout. | canonical no-float object codec, `TypeTag` |
+
+**`bloom` CLI:** replace `bloom chain view` with the typed surface (`--at-block`, typed `--arg` JSON, pretty typed returns; `--commands <json>` for composed multi-command views).
+
+## 4. Enforcement (layered)
+
+### 4.1 Manifest `view` flag
+Per-function `view: bool` on `FunctionDecl`. Bumps `SCHEMA_VERSION`; defaults `false` so existing manifests decode as non-views. This is what lets a client discover callable views and what the RPC checks before agreeing to run one.
+
+Implementation constraint: the manifest codec is positional, so this is a version-aware schema change. New encoders write schema version 2 with the `view` byte in each function declaration. Decoders must still accept schema version 1 manifests by reading the old function layout and materializing `view = false`; version 2 reads the new layout. This is what makes the default meaningful for already-deployed or already-built petals.
+
+### 4.2 Deploy-time call-graph verifier
+During chain-mode petal admission, for each `view`-marked export walk its **direct static call graph** from `__petal_<name>`. Reject the deploy if the reachable set touches any **mutating host import**:
+
+`object.create`, `object.transfer`, `object.share`, `object.freeze`, `object.delete`, `object.mutate`.
+
+If the function uses indirect or function-reference calls such that the reachable set cannot be bounded statically, reject it too — views must be statically analyzable. This includes `call_indirect`, `return_call_indirect`, `call_ref`, and `return_call_ref`; direct `return_call` is treated as an ordinary static call edge. Chain-mode Wasmtime also disables the tail-call proposal so these opcodes cannot execute even outside view exports.
+
+Because wasm imports are **module-scoped**, a petal may legitimately hold both view and non-view functions sharing the same imports. The per-function call-graph walk (not a module-wide import ban) is precisely what makes per-function purity decidable.
+
+### 4.3 Always-on runtime backstop
+Independent of the flag, `ReadOnly` execution:
+- forces every object arg to `AccessMode::ReadOnly`, so `borrow_table.diff_check` rejects any in-memory mutation as `IllegalMutation`;
+- asserts the post-execution effect set (`object_writes`, `object_deletes`, `ownership_changes`, `publish_events`) is empty.
+
+A lying or buggy flag therefore still cannot produce or hide a state change. If the backstop ever fires it indicates a verifier/node bug and surfaces as a loud, specific error.
+
+## 5. Security invariant: historical snapshot selection is read-path-only
+
+**Block-height / snapshot selection is a property of the standalone read-only view orchestrator only. It is not expressible anywhere in the committed execution path.**
+
+- **`at_block` lives in the RPC request, never in `PtbTx` or any `Command`.** The wire format of a committed PTB has no "read this at height N" field. When a `SubmitPtb` executes for commit there is structurally no way to request anything but the in-flight head state. A view command composed inside a mutating PTB reads the *same single snapshot* (the block being produced) as every other command. The "trust a value the caller pinned to an old block" attack is impossible because the height cannot be encoded in a committed transaction.
+- **`validate_ptb` and `run_ptb` take a state reference, not a height.** They have no concept of "which block," so historical selection cannot leak into the shared core. The `ReadOnly` mode + historical snapshot combination only ever exists in the view orchestrator.
+- **One snapshot per evaluation, never per-command.** Even in the read path with multi-command composition, a single `at_block` applies to the whole view PTB.
+
+Second, independent reason this must hold: historical reads are served from the node-local state-blob retention window (`StateBlobStore`, last 256 by default, prunable, operator-configurable). Snapshot availability is non-deterministic across the validator set, so historical state could never participate in consensus-executed work regardless.
+
+**Enforced by:** (1) `at_block` is a field of the view RPC params struct only, never present in `bloom-chain-types` PtbTx/Command; (2) the read-only orchestrator rejects any PTB whose effect set is non-empty, so a mutating command cannot ride the historical path; (3) an explicit test that a committed `SubmitPtb` containing a view command always executes at head, and that no deserialization path carries a height into `validate_ptb`/`run_ptb`.
+
+## 6. Caller identity
+
+- **Standalone read (RPC/CLI):** there are no signatures. Any `signers` supplied are **unauthenticated caller-provided context**. This is safe because all object state is public — "read as if I'm address X" leaks nothing X could not already expose. There is no `AlwaysOkVerifier` shim claiming verification happened; the read path simply does not verify because there is nothing to verify.
+- **Composed inside a mutating PTB:** normal signature verification applies to the whole PTB envelope, so `&Signer` args inside a composed view are authenticated and the contract may trust them.
+
+The `view` flag never forbids `&Signer` args; authentication is a property of the calling context, not the function declaration.
+
+## 7. Execution: refactor-first seam
+
+**Step 1 — behavior-preserving, lands green before any view code.**
+- Add `ValidationMode { Commit, ReadOnly }` to `validate_ptb`. The single existing call site (`execute_tx_impl`) passes `Commit`. `ReadOnly` is defined but unused at this point.
+- Extract the inner `validate → build host_ctx → snapshot → ChainPetalRunner → PtbExecutor::with_ctx_arc → execute → drain` block out of `execute_tx_impl` into a shared `run_ptb(state_ref, mode, …) -> ExecutionReport` helper. The commit path calls `run_ptb(Commit)` and keeps its gas reservation (before) and settlement (after) exactly as today.
+- **Guard:** the full consensus + petal-integration suite passes unchanged. This is the proof that approach C did not perturb consensus.
+
+**Step 2 — the view path, built on the shared helper.**
+- The view orchestrator: resolve snapshot (head or `at_block`) → decode typed args → `run_ptb(ReadOnly)` with node-clamped fuel cap → assert empty effect set → decode typed returns → drop snapshot.
+
+Gas reservation/settlement stays only in the commit orchestrator, because that is the one thing that genuinely differs between commit and view. The validator rules and execution semantics — the two real sources of truth — are shared, so they cannot drift.
+
+## 8. Snapshot selection
+
+- **Tip (default):** the latest retained/indexed committed state. The in-memory `State` lock may be used only for an actually unprogressed bootstrap node (`head = 0`, no indexed snapshots); it must not stand in for an explicit or default historical height once the chain has progressed.
+- **`at_block` N:** resolve N through `state_index` (height → `state_root`, `blob_hash`), load the blob via `StateBlobStore`, reconstruct via `State::from_blob(bytes, expected_state_root)`.
+- **Out of retention:** clean `HeightUnavailable { requested, oldest_retained, head }` error.
+- **Genesis (height 0):** use a fixed/deterministic snapshot context — never wall-clock time (the current code's `unix_time_ms()` fallback is non-deterministic and is removed).
+
+Implementation constraint: the RPC server must be constructed with `StateIndex` and `StateBlobStore` handles. The in-memory `State` lock is sufficient only for the tip path; historical reads must not reconstruct their own storage paths or bypass the checkpoint verifier.
+
+## 9. Typed ABI
+
+- **Args in:** typed JSON, decoded to canonical bytes by the node using each arg's declared `ArgDecl`/`TypeTag`. Hex `const` remains a lower-level escape hatch. Prior-command outputs referenced via `{"use": {"cmd": i, "ret": j}}` (composition).
+- **Returns out:** each return slot decoded against the function's declared `returns` TypeTags into typed JSON — u128 → decimal string, address/hash → hex, vectors → arrays. The raw hex slot is included alongside (`returns_raw`) as an escape hatch; an unknown type degrades gracefully rather than failing the call.
+- Both directions share one `TypeTag`-driven codec module so arg-encoding and return-decoding cannot disagree about layout.
+
+Implementation constraint for the first landing: arbitrary nested struct JSON is not decoded from `TypeTag::Concrete` alone because the manifest does not yet carry canonical field layouts for non-object structs. The v0 codec supports primitives, addresses/object ids/hashes, bytes/string, type tags, and fixed-width vectors; custom/unknown concretes degrade to `returns_raw`. Manifest-backed struct layouts are deferred until that schema exists.
+
+## 10. RPC / CLI surface
+
+**RPC `chain_view_call`** params:
+
+```jsonc
+{
+  "commands": [                 // 1..N read-only commands (composition)
+    {
+      "path": "/bloom/apps/bloombook",
+      "function": "thread_view",
+      "hash": "…",              // optional pinned petal hash; else resolve path at snapshot
+      "type_args": [ <TypeTag> ],
+      "args": [ <typed-arg> ]   // typed JSON; may reference prior outputs via {"use":{cmd,ret}}
+    }
+  ],
+  "signers": ["<addr>", …],     // optional, UNAUTHENTICATED context (default none)
+  "at_block": 12345,            // optional; omitted = chain head. READ PATH ONLY.
+  "fuel_limit": 1000000         // optional; node clamps to configured max
+}
+```
+
+Response:
+
+```jsonc
+{
+  "at_block": 12345,
+  "chain_head": 12810,          // lets caller see how stale a historical read is
+  "fuel_used": 4210,
+  "commands": [
+    { "returns": [ <typed-json> ], "returns_raw": ["<hex>"], "logs": [ … ] }
+  ]
+}
+```
+
+**CLI `bloom chain view`:** thin wrapper. Single-command stays ergonomic (`--path/--function`, typed `--arg <json>`, `--type-arg`, `--at-block`, `--fuel-limit`); composed multi-command via `--commands <json>`. Pretty-prints typed returns.
+
+## 11. Error handling
+
+Distinct, actionable variants — not one flattened string:
+
+- `FunctionNotAView` — refused before execution (function not flagged `view`).
+- `HeightUnavailable { requested, oldest_retained, head }`.
+- `PathNotDeployed` / `PetalHashMismatch` — resolution failures at the chosen snapshot.
+- `ArgDecodeError { index, type_tag }` / `ReturnDecodeError { index, type_tag }`.
+- `FuelExceeded { limit }` — hit the (possibly clamped) fuel cap.
+- `Reverted { reason }` — petal called `petal.revert`; structured `PtbError` preserved.
+- `ViewProducedEffects { writes, deletes, ownership_changes, publish_events }` — runtime backstop fired (should be unreachable given the verifier; loud signal of a node/verifier bug).
+
+Implementation note: the first landing preserves the existing JSON-RPC envelope and carries these variants in actionable messages. A typed `error.data` envelope is a follow-up compatibility improvement, not part of the consensus/view safety boundary.
+
+## 12. Testing strategy
+
+- **Manifest/codec:** `view` flag round-trips; old manifests decode with `view = false`; schema-version bump respected.
+- **Verifier (unit):** view reaching a mutating import (directly and transitively) rejected; `call_indirect` in a view's reachable graph rejected; a genuinely pure view passes; a mixed petal (one pure view + one mutating non-view) deploys fine.
+- **Refactor guard (Step 1):** the entire existing consensus + petal-integration suite passes unchanged after extracting `run_ptb` and adding `ValidationMode` — proof that C did not perturb consensus.
+- **`ReadOnly` validation (unit):** no gas-payer Coin required; object args coerced to ReadOnly; absent signatures accepted.
+- **View execution (integration):** a real read-only petal returns correctly decoded typed values; multi-command composition threads outputs; a view force-fed a bad flag that tries to mutate is caught by `diff_check` (backstop).
+- **Security invariant (§5):** committed `SubmitPtb` with a view command always executes at head; no deserialization path carries a height into `validate_ptb`/`run_ptb`; historical `at_block` works via the read path and errors cleanly past retention.
+- **ABI codec:** property-style round-trips per supported TypeTag; unknown type degrades to `returns_raw` rather than failing.
+- **Determinism:** the same view at the same `at_block` yields identical results across repeated calls; genesis uses a fixed snapshot, not wall-clock.
+
+## 13. Out of scope (deferred)
+
+- Per-command historical heights (one snapshot per evaluation only).
+- Merkle/light-client proofs for view results.
+- View results beyond the state-blob retention window.
+- Persistent caching of view results.
+- Manifest-backed arbitrary struct JSON decoding.
+- Typed JSON-RPC `error.data` for view-call failures.

--- a/examples/petal-cap/tests/manifest.rs
+++ b/examples/petal-cap/tests/manifest.rs
@@ -66,7 +66,7 @@ struct Arg {
 
 fn decode(bytes: &[u8]) -> Manifest {
     let mut r = bytes;
-    let _schema_version = read_u32_be(&mut r).unwrap();
+    let schema_version = read_u32_be(&mut r).unwrap();
     let module_path = read_string(&mut r).unwrap();
     // semver (3 x u16)
     let _ = read_u16_be(&mut r).unwrap();
@@ -80,7 +80,7 @@ fn decode(bytes: &[u8]) -> Manifest {
 
     let object_types = decode_list(&mut r, decode_object_type);
     let capability_types = decode_list(&mut r, decode_capability);
-    let functions = decode_list(&mut r, decode_function);
+    let functions = decode_list(&mut r, |r| decode_function(r, schema_version));
 
     Manifest {
         module_path,
@@ -159,7 +159,7 @@ fn decode_arg(r: &mut &[u8]) -> Arg {
     }
 }
 
-fn decode_function(r: &mut &[u8]) -> Function {
+fn decode_function(r: &mut &[u8], schema_version: u32) -> Function {
     let name = read_string(r).unwrap();
     let _type_params = decode_list(r, decode_type_param);
     let args = decode_list(r, decode_arg);
@@ -172,6 +172,9 @@ fn decode_function(r: &mut &[u8]) -> Function {
     let n = read_u32_be(r).unwrap() as usize;
     for _ in 0..n {
         let _ = read_u16_be(r).unwrap();
+    }
+    if schema_version >= 2 {
+        let _view = read_u8(r).unwrap();
     }
     Function {
         name,

--- a/examples/petal-dex/tests/bloom-petal-dex-it/src/dex_harness.rs
+++ b/examples/petal-dex/tests/bloom-petal-dex-it/src/dex_harness.rs
@@ -266,6 +266,7 @@ pub fn manifest_nullary(fn_name: &str) -> PetalManifestStub {
     PetalManifestStub {
         module_path: "/dex/petal-it".to_string(),
         functions: vec![FunctionDeclStub {
+            view: false,
             name: fn_name.to_string(),
             type_params: vec![],
             args: vec![],

--- a/examples/petal-dex/tests/bloom-petal-dex-it/tests/ptb_atomicity.rs
+++ b/examples/petal-dex/tests/bloom-petal-dex-it/tests/ptb_atomicity.rs
@@ -159,6 +159,7 @@ fn ptb_second_command_abort_rolls_back_first() {
         PetalManifestStub {
             module_path: "/test/loader".to_string(),
             functions: vec![FunctionDeclStub {
+                view: false,
                 name: "load_coin".to_string(),
                 type_params: vec![],
                 args: vec![ArgDeclStub::Object {
@@ -291,6 +292,7 @@ fn ptb_orphaned_split_coin_rolls_back() {
         PetalManifestStub {
             module_path: "/dex/loader".to_string(),
             functions: vec![FunctionDeclStub {
+                view: false,
                 name: "load_coin".to_string(),
                 type_params: vec![],
                 args: vec![ArgDeclStub::Object {

--- a/examples/petal-dex/tests/bloom-petal-dex-it/tests/single_hop_swap.rs
+++ b/examples/petal-dex/tests/bloom-petal-dex-it/tests/single_hop_swap.rs
@@ -94,6 +94,7 @@ fn ptb_single_hop_swap_shape() {
         PetalManifestStub {
             module_path: "/dex/router-proxy".to_string(),
             functions: vec![FunctionDeclStub {
+                view: false,
                 name: "load_coin".to_string(),
                 type_params: vec![],
                 args: vec![ArgDeclStub::Object {


### PR DESCRIPTION
## Summary

Implements first-class Bloom view functions across the manifest, verifier, validation/execution core, RPC/CLI surface, typed ABI codec, and tests.

## What changed

- Adds a `view` flag to petal manifests with schema v1/v2 compatibility.
- Adds deploy-time purity checks for view exports, including mutating host import reachability, start-section rejection, indirect-call rejection, and tail-call handling.
- Introduces `ValidationMode::{Commit, ReadOnly}` and a shared `run_ptb` path so read-only calls do not fork execution semantics from commit execution.
- Reworks `chain_view_call` for typed JSON args/returns, multi-command composition, fuel clamping, path/hash checks, read-only effect assertions, and indexed snapshot reads with `at_block`.
- Adds CLI support for typed `bloom chain view` usage.
- Adds focused manifest, verifier, validation, ABI, historical snapshot, and RPC/security tests.
- Documents required spec amendments for manifest compatibility, snapshot selection, tail-call verification, the v0 ABI subset, and deferred typed JSON-RPC error data.

## Validation

- `cargo fmt`
- `cargo test -q -p bloom-chain-node --lib rpc::tests::view_call`
- `cargo test -q -p bloom-petals --test view_function_verifier_contract`
- `cargo test -q -p bloom-script abi_json --lib`
- `cargo test -q -p bloom-script --test view_function_security`
- `cargo test -q --workspace`
- `git diff --check`

Existing manual/docker/long-running ignored tests remain ignored by their repo annotations.

## Review

An adversarial review was run after implementation. It initially found two high-severity issues around explicit `at_block: 0` and tail-call verifier coverage; both were fixed and covered by tests. A final re-review approved the diff, and a small non-blocking ABI vector edge was also fixed and rechecked.