### PR TITLE
Fix Docker DEX acceptance consensus timeout

### DIFF
--- a/crates/bloom-chain-consensus/src/lib.rs
+++ b/crates/bloom-chain-consensus/src/lib.rs
@@ -35,6 +35,6 @@ pub use engine::ConsensusEngine;
 pub use error::ConsensusError;
 pub use mempool::Mempool;
 pub use signer::{NoopSigner, Signer};
-pub use state_machine::{Action, ConsensusState, Event, Step, TimeoutKind};
+pub use state_machine::{Action, ConsensusState, Event, ROUND_TIMEOUT, Step, TimeoutKind};
 pub use validator_set::{Validator, ValidatorSet};
 pub use verifier::{NoopVerifier, RejectAllVerifier, SigVerifier};

--- a/crates/bloom-chain-consensus/src/state_machine.rs
+++ b/crates/bloom-chain-consensus/src/state_machine.rs
@@ -169,7 +169,13 @@ impl VoteTally {
 // ConsensusState
 // ---------------------------------------------------------------------------
 
-const TIMEOUT: Duration = Duration::from_millis(500);
+/// Default per-round timeout for propose, prevote, and precommit steps.
+///
+/// Proposal construction validates and executes the candidate block before the
+/// proposal is broadcast. Real PETAL PTBs can take materially longer than a
+/// sub-second local-network timeout on shared CI runners, so keep enough budget
+/// for block execution before peers nil-prevote the round.
+pub const ROUND_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// The Tendermint-style BFT state machine for a single local validator.
 ///
@@ -257,7 +263,7 @@ impl ConsensusState {
     }
 
     /// Reset the state machine to begin consensus at `new_height`, round 0,
-    /// step Propose.  Returns a single `StartTimeout(Propose, TIMEOUT)` action
+    /// step Propose.  Returns a single `StartTimeout(Propose, ROUND_TIMEOUT)` action
     /// so the caller can drive the new round.
     ///
     /// All per-height state (locked/valid block, proposal, votes, committed
@@ -274,7 +280,7 @@ impl ConsensusState {
         self.precommits.clear();
         self.all_precommit_votes.clear();
         self.committed_block = None;
-        vec![Action::StartTimeout(TimeoutKind::Propose, TIMEOUT)]
+        vec![Action::StartTimeout(TimeoutKind::Propose, ROUND_TIMEOUT)]
     }
 
     /// If a proposal was previously stashed because its block was unknown,
@@ -382,7 +388,7 @@ impl ConsensusState {
                 self.step = Step::Prevote;
                 let actions = vec![
                     Action::Broadcast(ProposalOrVote::Vote(self.make_prevote(None))),
-                    Action::StartTimeout(TimeoutKind::Prevote, TIMEOUT),
+                    Action::StartTimeout(TimeoutKind::Prevote, ROUND_TIMEOUT),
                 ];
                 actions
             }
@@ -394,7 +400,7 @@ impl ConsensusState {
                 self.step = Step::Precommit;
                 let actions = vec![
                     Action::Broadcast(ProposalOrVote::Vote(self.make_precommit(None))),
-                    Action::StartTimeout(TimeoutKind::Precommit, TIMEOUT),
+                    Action::StartTimeout(TimeoutKind::Precommit, ROUND_TIMEOUT),
                 ];
                 actions
             }
@@ -457,7 +463,7 @@ impl ConsensusState {
 
         vec![
             Action::Broadcast(ProposalOrVote::Vote(prevote)),
-            Action::StartTimeout(TimeoutKind::Prevote, TIMEOUT),
+            Action::StartTimeout(TimeoutKind::Prevote, ROUND_TIMEOUT),
         ]
     }
 
@@ -608,7 +614,7 @@ impl ConsensusState {
                 self.locked_block = Some((self.round, hash));
                 vec![
                     Action::Broadcast(ProposalOrVote::Vote(precommit)),
-                    Action::StartTimeout(TimeoutKind::Precommit, TIMEOUT),
+                    Action::StartTimeout(TimeoutKind::Precommit, ROUND_TIMEOUT),
                 ]
             }
             Some(None) => {
@@ -618,7 +624,7 @@ impl ConsensusState {
                 let precommit = self.make_precommit(None);
                 vec![
                     Action::Broadcast(ProposalOrVote::Vote(precommit)),
-                    Action::StartTimeout(TimeoutKind::Precommit, TIMEOUT),
+                    Action::StartTimeout(TimeoutKind::Precommit, ROUND_TIMEOUT),
                 ]
             }
             None => vec![],
@@ -634,7 +640,7 @@ impl ConsensusState {
         self.step = Step::Propose;
         self.proposal = None;
 
-        let actions = vec![Action::StartTimeout(TimeoutKind::Propose, TIMEOUT)];
+        let actions = vec![Action::StartTimeout(TimeoutKind::Propose, ROUND_TIMEOUT)];
 
         // If this validator is the new proposer, they need to build and broadcast.
         // The engine layer handles building; here we just signal a propose timeout

--- a/crates/bloom-chain-node/src/node.rs
+++ b/crates/bloom-chain-node/src/node.rs
@@ -19,7 +19,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
 use bloom_chain_consensus::{
-    Action, ConsensusEngine, Mempool,
+    Action, ConsensusEngine, Mempool, ROUND_TIMEOUT,
     round_validation::judge_proposer_round,
     state_machine::{Event, TimeoutKind},
 };
@@ -405,7 +405,7 @@ impl Node {
         // the engine's *current* `(height, round)` and silently drops the
         // tick if they no longer match. Without this guard, stale timers
         // from earlier rounds/heights bleed across transitions: when a
-        // Precommit scheduled at h=N r=R fires 500ms later, the engine may
+        // Precommit scheduled at h=N r=R fires later, the engine may
         // already be at h=N r=R+1 in step Precommit again — `on_tick` would
         // see `step == Precommit` and call `advance_round`, skipping rounds
         // arbitrarily. Caught by the 4-validator docker DEX acceptance test
@@ -995,10 +995,7 @@ impl Node {
             let timeout_tx_kick = Arc::clone(&timeout_tx);
             tokio::spawn(async move {
                 tokio::time::sleep(Duration::from_millis(1000)).await;
-                let kickoff = vec![Action::StartTimeout(
-                    TimeoutKind::Propose,
-                    Duration::from_millis(500),
-                )];
+                let kickoff = vec![Action::StartTimeout(TimeoutKind::Propose, ROUND_TIMEOUT)];
                 process_actions(
                     Arc::clone(&driver_kick),
                     Arc::clone(&peer_pool_kick),
@@ -1134,7 +1131,7 @@ fn process_actions<E: crate::consensus_driver::PetalExecutor>(
                         &block_with_commit.txs,
                     );
                     // Enter the next height IMMEDIATELY. The state machine
-                    // returns a `StartTimeout(Propose, 500ms)` we deliberately
+                    // returns a `StartTimeout(Propose, ROUND_TIMEOUT)` we deliberately
                     // discard — we'll arm the propose timer after a full
                     // TIMEOUT_COMMIT (1s) below.
                     //
@@ -1145,7 +1142,7 @@ fn process_actions<E: crate::consensus_driver::PetalExecutor>(
                     // inbound-frame gate at `frame.vote recv` / `frame.proposal
                     // recv` drops frames whose height > my_height, so an
                     // entire round of votes for H+1 vanished. The validator
-                    // then sat in Propose step until its 500ms propose
+                    // then sat in Propose step until its propose
                     // timeout fired nil-prevote, by which point the rest of
                     // the network had moved on — repeated for every height,
                     // the trailing validator never recovers. Caught by the
@@ -1163,10 +1160,8 @@ fn process_actions<E: crate::consensus_driver::PetalExecutor>(
                     let timeout_tx_c = Arc::clone(&timeout_tx);
                     tokio::spawn(async move {
                         tokio::time::sleep(TIMEOUT_COMMIT).await;
-                        let kickoff = vec![Action::StartTimeout(
-                            TimeoutKind::Propose,
-                            Duration::from_millis(500),
-                        )];
+                        let kickoff =
+                            vec![Action::StartTimeout(TimeoutKind::Propose, ROUND_TIMEOUT)];
                         process_actions(
                             Arc::clone(&driver_c),
                             Arc::clone(&peer_pool_c),


### PR DESCRIPTION
## Summary
- raise the shared consensus round timeout to 5s
- reuse that timeout for node propose kickoffs instead of the remaining 500ms literals
- prevents CI runners from nil-prevoting before heavier PETAL DEX proposals finish constructing and broadcasting

## Verification
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- cargo build --release -p bloom --all-features --locked
- cargo build --workspace --tests
- cargo test --workspace -- --ignored
- BLOOM_DOCKER_LOG_DIR=/tmp/bloom-petal-dex-timeout-fix-logs scripts/test-docker-petal-dex.sh