### PR TITLE
[codex] Speed up test harness setup

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -25,12 +25,16 @@ jobs:
         run: |
           rustup show
           rustup target add wasm32-unknown-unknown
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+      - name: Build bloom CLI for subprocess tests
+        run: cargo build -p bloom --bin bloom
       - name: Build workspace (release-ish; debug is fine for acceptance)
         run: cargo build --workspace --tests
       - name: Run --ignored acceptance tests
-        run: cargo test --workspace -- --ignored
+        run: cargo nextest run --workspace --ignored --no-fail-fast
 
   docker-petal-dex:
     name: docker petal DEX acceptance

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,12 +71,44 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-targets: false
-      - name: Build bloom CLI for subprocess tests
-        run: cargo build -p bloom --bin bloom
       - name: Run tests
-        run: cargo nextest run --workspace --no-fail-fast
+        run: cargo nextest run --workspace --no-fail-fast -E 'not (binary(chain_testnet_provision) | binary(chain_smoke))'
       - name: Run doctests
         run: cargo test --workspace --doc
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats
+
+  chain-subprocess-test:
+    name: chain subprocess test
+    runs-on: ubuntu-latest
+    env:
+      CARGO_BUILD_JOBS: "2"
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Rust toolchain
+        run: rustup show
+      - name: Free runner disk space
+        run: |
+          df -h
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/local/share/boost
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/share/dotnet
+          df -h
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: false
+      - name: Build bloom CLI for subprocess tests
+        run: cargo build -p bloom --bin bloom
+      - name: Run chain subprocess tests
+        run: cargo test -p bloom-it --test chain_testnet_provision
       - name: Show sccache stats
         if: always()
         run: sccache --show-stats

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install Rust toolchain
         run: rustup show
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
       - name: Free runner disk space
         run: |
           df -h
@@ -69,8 +71,12 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-targets: false
+      - name: Build bloom CLI for subprocess tests
+        run: cargo build -p bloom --bin bloom
       - name: Run tests
-        run: cargo test --workspace
+        run: cargo nextest run --workspace --no-fail-fast
+      - name: Run doctests
+        run: cargo test --workspace --doc
       - name: Show sccache stats
         if: always()
         run: sccache --show-stats

--- a/crates/bloom-it/tests/chain_smoke.rs
+++ b/crates/bloom-it/tests/chain_smoke.rs
@@ -25,7 +25,7 @@ const CONVERGE_TIMEOUT: Duration = Duration::from_secs(120);
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[ignore = "spawns 4 long-running validator processes; run with `--ignored` or in CI"]
 async fn four_validator_state_root_convergence() -> Result<()> {
-    ensure_bloom_built()?;
+    ensure_bloom_bin_available()?;
 
     let dir = tempdir()?;
     let parent: PathBuf = dir.path().to_path_buf();
@@ -141,13 +141,13 @@ fn tail_file(path: &std::path::Path, max_lines: usize) -> String {
     }
 }
 
-fn ensure_bloom_built() -> Result<()> {
-    let status = std::process::Command::new("cargo")
-        .args(["build", "-p", "bloom", "--bin", "bloom"])
-        .status()
-        .context("invoke `cargo build -p bloom`")?;
-    if !status.success() {
-        return Err(anyhow!("`cargo build -p bloom` failed"));
+fn ensure_bloom_bin_available() -> Result<()> {
+    let bin = chain_harness::bloom_bin();
+    if !bin.is_file() {
+        return Err(anyhow!(
+            "bloom binary not found at {}; build it first with `cargo build -p bloom --bin bloom` or set BLOOM_BIN",
+            bin.display()
+        ));
     }
     Ok(())
 }

--- a/examples/petal-dex/tests/bloom-petal-dex-it/src/dex_harness.rs
+++ b/examples/petal-dex/tests/bloom-petal-dex-it/src/dex_harness.rs
@@ -15,6 +15,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::process::Command as OsCommand;
+use std::sync::{Mutex, OnceLock};
 
 use bloom_chain_node::{
     consensus_driver::{ExecOutput, PetalExecutor},
@@ -306,16 +307,38 @@ pub fn addr(b: u8) -> Address {
 // builds on the same proven foundation.
 // ---------------------------------------------------------------------------
 
-/// Build a workspace crate for `wasm32-unknown-unknown` (default features —
-/// i.e. *with* the `__petal_*` entrypoints) and return the path to the
-/// emitted release `<artifact>.wasm`. Live-chain tests deploy these blobs
-/// through the same chain admission path as operators; debug WASM artifacts are
-/// several MiB and intentionally exceed the protocol's max code-size cap.
+static WASM_ARTIFACT_CACHE: OnceLock<Mutex<HashMap<String, PathBuf>>> = OnceLock::new();
+
+/// Build or resolve a workspace crate's `wasm32-unknown-unknown` release
+/// artifact (default features — i.e. *with* the `__petal_*` entrypoints).
+///
+/// Resolution order:
+/// 1. An explicit per-petal env var such as `BLOOM_PETAL_DEX_POOL_WASM`.
+/// 2. `BLOOM_PETAL_DEX_WASM_DIR/<artifact>.wasm`.
+/// 3. `BLOOM_DOCKER_PREBUILT_WASM_DIR/<artifact>.wasm`.
+/// 4. A cached fallback `cargo build --release --target wasm32-unknown-unknown`.
+///
+/// For admin-specific faucet builds, shared directory lookup is only used for
+/// the harness's default PTB signer admin. Custom-admin tests must either set
+/// `BLOOM_PETAL_DEX_FAUCET_WASM` explicitly or fall back to Cargo.
 fn build_petal_wasm_with_env(
     crate_name: &str,
     artifact_stem: &str,
     envs: &[(&str, String)],
 ) -> PathBuf {
+    let cache_key = wasm_cache_key(crate_name, artifact_stem, envs);
+    let cache = WASM_ARTIFACT_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut cache = cache.lock().expect("wasm artifact cache poisoned");
+
+    if let Some(cached) = cache.get(&cache_key) {
+        return cached.clone();
+    }
+
+    if let Some(prebuilt) = prebuilt_wasm_path(artifact_stem, envs) {
+        cache.insert(cache_key, prebuilt.clone());
+        return prebuilt;
+    }
+
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let mut cmd = OsCommand::new(env!("CARGO"));
     cmd.args([
@@ -352,7 +375,81 @@ fn build_petal_wasm_with_env(
         "expected wasm artifact at {}",
         artifact.display()
     );
+    cache.insert(cache_key, artifact.clone());
     artifact
+}
+
+fn wasm_cache_key(crate_name: &str, artifact_stem: &str, envs: &[(&str, String)]) -> String {
+    let mut key = format!("{crate_name}:{artifact_stem}");
+    for (name, value) in envs {
+        key.push('|');
+        key.push_str(name);
+        key.push('=');
+        key.push_str(value);
+    }
+    key
+}
+
+fn prebuilt_wasm_path(artifact_stem: &str, envs: &[(&str, String)]) -> Option<PathBuf> {
+    for env_key in prebuilt_wasm_env_keys(artifact_stem) {
+        if let Some(path) = existing_wasm_path_from_env(env_key) {
+            return Some(path);
+        }
+    }
+
+    if !shared_wasm_dir_allowed(artifact_stem, envs) {
+        return None;
+    }
+
+    for env_key in ["BLOOM_PETAL_DEX_WASM_DIR", "BLOOM_DOCKER_PREBUILT_WASM_DIR"] {
+        let Ok(dir) = std::env::var(env_key) else {
+            continue;
+        };
+        let path = PathBuf::from(dir).join(format!("{artifact_stem}.wasm"));
+        assert!(
+            path.is_file(),
+            "{env_key} is set but {} does not exist",
+            path.display()
+        );
+        return Some(path);
+    }
+
+    None
+}
+
+fn prebuilt_wasm_env_keys(artifact_stem: &str) -> &'static [&'static str] {
+    match artifact_stem {
+        "bloom_petal_dex_pool" => &["BLOOM_PETAL_DEX_POOL_WASM"],
+        "bloom_petal_dex_wallet" => &["BLOOM_PETAL_DEX_WALLET_WASM"],
+        "bloom_petal_dex_faucet" => &["BLOOM_PETAL_DEX_FAUCET_WASM"],
+        "bloom_petal_dex_router" => &["BLOOM_PETAL_DEX_ROUTER_WASM"],
+        "bloom_petal_dex_cpmm" => &["BLOOM_PETAL_DEX_CPMM_WASM"],
+        _ => &[],
+    }
+}
+
+fn existing_wasm_path_from_env(env_key: &str) -> Option<PathBuf> {
+    let Ok(raw) = std::env::var(env_key) else {
+        return None;
+    };
+    let path = PathBuf::from(raw);
+    assert!(
+        path.is_file(),
+        "{env_key} is set but {} does not exist",
+        path.display()
+    );
+    Some(path)
+}
+
+fn shared_wasm_dir_allowed(artifact_stem: &str, envs: &[(&str, String)]) -> bool {
+    if artifact_stem != "bloom_petal_dex_faucet" {
+        return envs.is_empty();
+    }
+
+    matches!(
+        envs,
+        [("BLOOM_DEX_FAUCET_ADMIN_HEX", admin_hex)] if admin_hex == &ptb_signer_pubkey_hex()
+    )
 }
 
 fn build_petal_wasm(crate_name: &str, artifact_stem: &str) -> PathBuf {


### PR DESCRIPTION
## Summary

- Remove the hidden `cargo build -p bloom --bin bloom` from `chain_smoke`; the test now requires a prebuilt `BLOOM_BIN` or `target/debug/bloom` and fails fast with an actionable message.
- Add env/prebuilt path resolution and in-process caching for petal DEX WASM artifacts so ignored tests do not rebuild the same release WASM repeatedly.
- Switch CI and acceptance Rust test execution to `cargo nextest`, while keeping doctest coverage under `cargo test --workspace --doc`.

## Notes

- CI now explicitly builds the `bloom` CLI before subprocess-style tests.
- Deferred test-runtime cleanup is tracked in #33.

## Validation

- `cargo fmt --check`
- `cargo test -p bloom-petal-dex-it --lib --no-run`
- `cargo test -p bloom-it --test chain_smoke --no-run`
- `cargo nextest run -p bloom-it --test chain_smoke --no-run`
- `cargo nextest run -p bloom-petal-dex-it --lib --no-run`
- `git diff --check`
