### PR TITLE
Remove versioned petal manifest naming

### DIFF
--- a/crates/bloom-chain-node/src/chain_petal_runner.rs
+++ b/crates/bloom-chain-node/src/chain_petal_runner.rs
@@ -55,7 +55,7 @@ use std::sync::{Arc, Mutex};
 use bloom_chain_state::StateSnapshot;
 use bloom_chain_types::{Hash32, types::Address};
 use bloom_objects::TypeTag;
-use bloom_petal_manifest::extract_petal_manifest_v0;
+use bloom_petal_manifest::extract_petal_manifest;
 use bloom_petals::{BlockCtx, ChainCallInput, ChainEntry, PetalError, PetalVm};
 use bloom_script::{
     PtbError,
@@ -161,7 +161,7 @@ impl ChainPetalRunner {
             external_manifests: self
                 .petals
                 .iter()
-                .filter_map(|(hash, wasm)| extract_petal_manifest_v0(wasm).map(|m| (*hash, m)))
+                .filter_map(|(hash, wasm)| extract_petal_manifest(wasm).map(|m| (*hash, m)))
                 .collect(),
             entry: ChainEntry::Function(export_name),
             // contract_address is the petal's own address. PTB mode has no
@@ -268,7 +268,7 @@ impl ChainPetalRunner {
             external_manifests: self
                 .petals
                 .iter()
-                .filter_map(|(hash, wasm)| extract_petal_manifest_v0(wasm).map(|m| (*hash, m)))
+                .filter_map(|(hash, wasm)| extract_petal_manifest(wasm).map(|m| (*hash, m)))
                 .collect(),
             entry: ChainEntry::Function(export_name),
             contract_address: Address(petal_hash.0),

--- a/crates/bloom-chain-node/src/genesis.rs
+++ b/crates/bloom-chain-node/src/genesis.rs
@@ -40,7 +40,7 @@ use bloom_chain_types::types::{Address, Hash32, PubKeyBytes};
 use bloom_keystore::xdsa::XDSA_PK_LEN;
 use bloom_objects::{OWNER_KIND_ADDRESS, Object, ObjectId, Owner, OwnershipIndexKey, TypeTag};
 use bloom_petal_fungible::ops::coin_payload;
-use bloom_petal_manifest::extract_petal_manifest_v0;
+use bloom_petal_manifest::extract_petal_manifest;
 use bloom_script::{CORE_FUNGIBLE_PATH, loom_coin_type_tag};
 use serde::{Deserialize, Serialize};
 
@@ -216,9 +216,9 @@ impl Genesis {
             }
             validate_chain_petal_admission(&wasm, &petal.path)
                 .map_err(|e| NodeError::Genesis(format!("petal {}: {e}", petal.path)))?;
-            let manifest = extract_petal_manifest_v0(&wasm).ok_or_else(|| {
+            let manifest = extract_petal_manifest(&wasm).ok_or_else(|| {
                 NodeError::Genesis(format!(
-                    "petal {}: missing bloom_petal_manifest_v0",
+                    "petal {}: missing bloom_petal_manifest",
                     petal.path
                 ))
             })?;
@@ -604,7 +604,7 @@ mod tests {
 
     fn genesis_petal_wasm(path: &str) -> Vec<u8> {
         let manifest =
-            bloom_petal_manifest::codec::encode(&bloom_petal_manifest::types::PetalManifestV0 {
+            bloom_petal_manifest::codec::encode(&bloom_petal_manifest::types::PetalManifest {
                 schema_version: bloom_petal_manifest::types::SCHEMA_VERSION,
                 module_path: path.to_string(),
                 framework_version: bloom_petal_manifest::types::SemVer::new(0, 1, 0),
@@ -614,14 +614,14 @@ mod tests {
         let mut wasm = Vec::new();
         wasm.extend_from_slice(b"\0asm");
         wasm.extend_from_slice(&[0x01, 0x00, 0x00, 0x00]);
-        let custom = custom_section("bloom_petal_manifest_v0", &manifest);
+        let custom = custom_section("bloom_petal_manifest", &manifest);
         section(&mut wasm, 0, &custom);
         wasm
     }
 
     fn genesis_petal_wasm_with_function(path: &str, function: &str) -> Vec<u8> {
         let manifest =
-            bloom_petal_manifest::codec::encode(&bloom_petal_manifest::types::PetalManifestV0 {
+            bloom_petal_manifest::codec::encode(&bloom_petal_manifest::types::PetalManifest {
                 schema_version: bloom_petal_manifest::types::SCHEMA_VERSION,
                 module_path: path.to_string(),
                 framework_version: bloom_petal_manifest::types::SemVer::new(0, 1, 0),
@@ -649,7 +649,7 @@ mod tests {
         section(&mut wasm, 7, &exports);
         // one body: no locals; i32.const 0; end
         section(&mut wasm, 10, &[0x01, 0x04, 0x00, 0x41, 0x00, 0x0b]);
-        let custom = custom_section("bloom_petal_manifest_v0", &manifest);
+        let custom = custom_section("bloom_petal_manifest", &manifest);
         section(&mut wasm, 0, &custom);
         wasm
     }

--- a/crates/bloom-chain-node/src/petal_executor.rs
+++ b/crates/bloom-chain-node/src/petal_executor.rs
@@ -24,7 +24,7 @@ use bloom_objects::{
     WasmValType,
 };
 use bloom_petal_fungible::ops::{coin_payload, decode_coin_value, rewrite_value};
-use bloom_petal_manifest::extract_petal_manifest_v0;
+use bloom_petal_manifest::extract_petal_manifest;
 use bloom_petals::{BlockCtx as PetalBlockCtx, PetalVm};
 use bloom_script::{
     AlwaysOkVerifier, CORE_FUNGIBLE_PATH, PetalManifestStub, PtbError, SignatureVerifier,
@@ -49,7 +49,7 @@ use crate::sig_verifier::XdsaPtbVerifier;
 ///
 /// PTB-mode `Command::Move` dispatch is **chain-authoritative**: the
 /// validator's typecheck pulls each referenced petal's manifest by
-/// decoding the `bloom_petal_manifest_v0` wasm custom section (spec
+/// decoding the `bloom_petal_manifest` wasm custom section (spec
 /// §8.1, §11.1) on demand via [`PtbChainAdapter::new`]. No external
 /// manifest registry is required.
 pub struct ChainPetalExecutor;
@@ -185,8 +185,8 @@ pub(crate) fn validate_chain_petal_admission(
         ));
     }
     validate_chain_petal_module_path(module_path)?;
-    let manifest = extract_petal_manifest_v0(wasm_bytes)
-        .ok_or_else(|| "missing bloom_petal_manifest_v0".to_string())?;
+    let manifest = extract_petal_manifest(wasm_bytes)
+        .ok_or_else(|| "missing bloom_petal_manifest".to_string())?;
     if manifest.module_path != module_path {
         return Err(format!(
             "manifest module_path '{}' does not match command path '{}'",
@@ -260,7 +260,7 @@ fn validate_chain_petal_function_segment(function: &str) -> Result<(), String> {
 
 fn validate_chain_petal_vfs_collisions(
     state: &State,
-    manifest: &bloom_petal_manifest::types::PetalManifestV0,
+    manifest: &bloom_petal_manifest::types::PetalManifest,
 ) -> Result<(), String> {
     let new_rel = petal_path_segments(&manifest.module_path)?;
     for (existing_path, existing_hash) in state.iter_vfs() {
@@ -275,7 +275,7 @@ fn validate_chain_petal_vfs_collisions(
             && let Some(child_segment) = new_rel.get(existing_rel.len())
             && let Some(existing_manifest) = state
                 .get_code(existing_hash)
-                .and_then(extract_petal_manifest_v0)
+                .and_then(extract_petal_manifest)
             && existing_manifest
                 .functions
                 .iter()
@@ -302,8 +302,8 @@ fn validate_chain_petal_vfs_collisions(
 
 pub(crate) fn validate_chain_petal_vfs_collisions_with_pending(
     new_rel: &[String],
-    manifest: &bloom_petal_manifest::types::PetalManifestV0,
-    pending: &[(String, bloom_petal_manifest::types::PetalManifestV0)],
+    manifest: &bloom_petal_manifest::types::PetalManifest,
+    pending: &[(String, bloom_petal_manifest::types::PetalManifest)],
 ) -> Result<(), String> {
     for (existing_path, existing_manifest) in pending {
         if existing_path == &manifest.module_path {
@@ -351,7 +351,7 @@ pub(crate) fn petal_path_segments(path: &str) -> Result<Vec<String>, String> {
 
 fn validate_manifest_wasm_abi(
     wasm_bytes: &[u8],
-    manifest: &bloom_petal_manifest::types::PetalManifestV0,
+    manifest: &bloom_petal_manifest::types::PetalManifest,
 ) -> Result<(), String> {
     use std::collections::HashMap;
     use wasmparser::{ExternalKind, Parser, Payload, TypeRef, ValType};
@@ -794,14 +794,13 @@ fn execute_tx_impl(
                     write_set: None,
                 };
             }
-            let manifest = match extract_petal_manifest_v0(wasm_bytes) {
+            let manifest = match extract_petal_manifest(wasm_bytes) {
                 Some(m) => m,
                 None => {
                     return ExecOutput {
                         success: false,
                         fuel_used,
-                        return_data: b"deploy petal failed: missing bloom_petal_manifest_v0"
-                            .to_vec(),
+                        return_data: b"deploy petal failed: missing bloom_petal_manifest".to_vec(),
                         logs: vec![],
                         invariant_outcomes: Vec::new(),
                         write_set: None,
@@ -1276,7 +1275,7 @@ fn execute_tx_impl(
                                 write_set: ws_out,
                             };
                         }
-                        let event_manifest = match extract_petal_manifest_v0(&event.wasm_bytes) {
+                        let event_manifest = match extract_petal_manifest(&event.wasm_bytes) {
                             Some(manifest) => manifest,
                             None => {
                                 drop(snapshot);
@@ -1318,8 +1317,9 @@ fn execute_tx_impl(
                                 return ExecOutput {
                                     success: false,
                                     fuel_used: revert_charged_fuel,
-                                    return_data: b"ptb publish admission error: missing bloom_petal_manifest_v0"
-                                        .to_vec(),
+                                    return_data:
+                                        b"ptb publish admission error: missing bloom_petal_manifest"
+                                            .to_vec(),
                                     logs: vec![],
                                     invariant_outcomes: invariant_records(&report),
                                     write_set: ws_out,
@@ -1848,7 +1848,7 @@ mod tests {
 
     #[test]
     fn pending_petal_publishes_reject_path_function_collisions() {
-        let parent = bloom_petal_manifest::types::PetalManifestV0 {
+        let parent = bloom_petal_manifest::types::PetalManifest {
             module_path: "/bloom/petals/dex".to_string(),
             functions: vec![bloom_petal_manifest::types::FunctionDecl {
                 name: "pool".to_string(),
@@ -1856,7 +1856,7 @@ mod tests {
             }],
             ..Default::default()
         };
-        let child = bloom_petal_manifest::types::PetalManifestV0 {
+        let child = bloom_petal_manifest::types::PetalManifest {
             module_path: "/bloom/petals/dex/pool".to_string(),
             ..Default::default()
         };
@@ -1873,11 +1873,11 @@ mod tests {
 
     #[test]
     fn pending_petal_publishes_reject_duplicate_paths() {
-        let first = bloom_petal_manifest::types::PetalManifestV0 {
+        let first = bloom_petal_manifest::types::PetalManifest {
             module_path: "/bloom/petals/dex/pool".to_string(),
             ..Default::default()
         };
-        let second = bloom_petal_manifest::types::PetalManifestV0 {
+        let second = bloom_petal_manifest::types::PetalManifest {
             module_path: "/bloom/petals/dex/pool".to_string(),
             ..Default::default()
         };

--- a/crates/bloom-chain-node/src/ptb_chain_iface.rs
+++ b/crates/bloom-chain-node/src/ptb_chain_iface.rs
@@ -17,7 +17,7 @@
 //!
 //! 2. **On-chain wasm custom section** — the adapter pulls the wasm by
 //!    content hash via `state.get_code(...)`, walks it for the
-//!    `bloom_petal_manifest_v0` custom section (emitted by
+//!    `bloom_petal_manifest` custom section (emitted by
 //!    `#[bloom::petal]`, spec §8.1 / §11.1), decodes the bytes via the
 //!    canonical codec, and projects them down to the validator's
 //!    `PetalManifestStub` via
@@ -42,7 +42,7 @@ use std::collections::HashMap;
 use bloom_chain_state::State;
 use bloom_chain_types::Hash32;
 use bloom_objects::{Object, ObjectId};
-use bloom_petal_manifest::{extract_petal_manifest_v0, to_petal_manifest_stub};
+use bloom_petal_manifest::{extract_petal_manifest, to_petal_manifest_stub};
 use bloom_script::{ChainStateIface, PetalManifestStub};
 
 /// Adapter wrapping a borrowed [`State`] for PTB validation / execution.
@@ -63,7 +63,7 @@ pub struct PtbChainAdapter<'a> {
     overrides: Option<&'a HashMap<Hash32, PetalManifestStub>>,
     /// Per-adapter cache of stubs decoded from wasm custom sections.
     /// Keyed by petal content hash. `None` means "we tried and it
-    /// wasn't a v0 manifest"; absence means "we haven't tried yet".
+    /// wasn't a manifest"; absence means "we haven't tried yet".
     manifest_cache: RefCell<HashMap<Hash32, Option<PetalManifestStub>>>,
 }
 
@@ -137,7 +137,7 @@ impl ChainStateIface for PtbChainAdapter<'_> {
         }
 
         let stub = self.state.get_code(hash).and_then(|wasm| {
-            let m = extract_petal_manifest_v0(wasm)?;
+            let m = extract_petal_manifest(wasm)?;
             Some(to_petal_manifest_stub(&m))
         });
         self.manifest_cache.borrow_mut().insert(*hash, stub.clone());
@@ -248,17 +248,17 @@ mod tests {
     #[test]
     fn load_manifest_parses_wasm_custom_section() {
         use bloom_petal_manifest::codec;
-        use bloom_petal_manifest::types::{PetalManifestV0, SCHEMA_VERSION, SemVer};
+        use bloom_petal_manifest::types::{PetalManifest, SCHEMA_VERSION, SemVer};
 
-        // Build a minimal wasm with a `bloom_petal_manifest_v0` section.
-        let manifest = PetalManifestV0 {
+        // Build a minimal wasm with a `bloom_petal_manifest` section.
+        let manifest = PetalManifest {
             schema_version: SCHEMA_VERSION,
             module_path: "/bloom/test/petal".into(),
             framework_version: SemVer::new(0, 1, 0),
             ..Default::default()
         };
         let manifest_bytes = codec::encode(&manifest).unwrap();
-        let wasm = wasm_with_custom("bloom_petal_manifest_v0", &manifest_bytes);
+        let wasm = wasm_with_custom("bloom_petal_manifest", &manifest_bytes);
 
         let mut state = State::new();
         let hash = state.insert_code(&wasm);
@@ -275,16 +275,16 @@ mod tests {
         // Ensures the adapter only parses each wasm once across multiple
         // load_manifest calls for the same hash.
         use bloom_petal_manifest::codec;
-        use bloom_petal_manifest::types::{PetalManifestV0, SCHEMA_VERSION, SemVer};
+        use bloom_petal_manifest::types::{PetalManifest, SCHEMA_VERSION, SemVer};
 
-        let manifest = PetalManifestV0 {
+        let manifest = PetalManifest {
             schema_version: SCHEMA_VERSION,
             module_path: "/bloom/test/petal".into(),
             framework_version: SemVer::new(0, 1, 0),
             ..Default::default()
         };
         let manifest_bytes = codec::encode(&manifest).unwrap();
-        let wasm = wasm_with_custom("bloom_petal_manifest_v0", &manifest_bytes);
+        let wasm = wasm_with_custom("bloom_petal_manifest", &manifest_bytes);
 
         let mut state = State::new();
         let hash = state.insert_code(&wasm);
@@ -301,15 +301,15 @@ mod tests {
     #[test]
     fn overrides_win_over_wasm_section() {
         use bloom_petal_manifest::codec;
-        use bloom_petal_manifest::types::{PetalManifestV0, SCHEMA_VERSION, SemVer};
+        use bloom_petal_manifest::types::{PetalManifest, SCHEMA_VERSION, SemVer};
 
-        let real = PetalManifestV0 {
+        let real = PetalManifest {
             schema_version: SCHEMA_VERSION,
             module_path: "/wasm/path".into(),
             framework_version: SemVer::new(0, 1, 0),
             ..Default::default()
         };
-        let wasm = wasm_with_custom("bloom_petal_manifest_v0", &codec::encode(&real).unwrap());
+        let wasm = wasm_with_custom("bloom_petal_manifest", &codec::encode(&real).unwrap());
 
         let mut state = State::new();
         let hash = state.insert_code(&wasm);

--- a/crates/bloom-chain-node/src/rpc.rs
+++ b/crates/bloom-chain-node/src/rpc.rs
@@ -41,7 +41,7 @@ use bloom_chain_types::{
     types::{Address, Hash32},
 };
 use bloom_objects::{AccessMode, Object, ObjectId, TypeTag};
-use bloom_petal_manifest::{extract_petal_manifest_v0, to_petal_manifest_stub};
+use bloom_petal_manifest::{extract_petal_manifest, to_petal_manifest_stub};
 use bloom_script::{
     ArgDeclStub, CORE_FUNGIBLE_PATH, ChainStateIface, PetalManifestStub,
     decode_json_const_with_manifest_loader, decode_json_type_tag,
@@ -1522,7 +1522,7 @@ impl ChainStateIface for RpcChainAdapter {
 
     fn load_manifest(&self, hash: &Hash32) -> Option<PetalManifestStub> {
         let wasm = self.load_petal(hash)?;
-        let manifest = extract_petal_manifest_v0(&wasm)?;
+        let manifest = extract_petal_manifest(&wasm)?;
         Some(to_petal_manifest_stub(&manifest))
     }
 
@@ -1693,7 +1693,7 @@ mod tests {
     use bloom_chain_types::vote::Commit;
     use bloom_objects::{Object, ObjectId, Owner, TypeTag};
     use bloom_petal_manifest::codec;
-    use bloom_petal_manifest::types::{FunctionDecl, PetalManifestV0, SCHEMA_VERSION, SemVer};
+    use bloom_petal_manifest::types::{FunctionDecl, PetalManifest, SCHEMA_VERSION, SemVer};
     use bloom_script::DEFAULT_FUNGIBLE_PETAL_HASH;
     use bloom_test_util::{make_validator_set_signed, make_validator_with_keypair};
 
@@ -1809,9 +1809,9 @@ mod tests {
         out.extend_from_slice(body);
     }
 
-    fn append_manifest(mut wasm: Vec<u8>, manifest: PetalManifestV0) -> Vec<u8> {
+    fn append_manifest(mut wasm: Vec<u8>, manifest: PetalManifest) -> Vec<u8> {
         let bytes = codec::encode(&manifest).expect("manifest encodes");
-        let custom = custom_section("bloom_petal_manifest_v0", &bytes);
+        let custom = custom_section("bloom_petal_manifest", &bytes);
         section(&mut wasm, 0, &custom);
         wasm
     }
@@ -1824,8 +1824,8 @@ mod tests {
         }
     }
 
-    fn view_manifest(path: &str, functions: Vec<FunctionDecl>) -> PetalManifestV0 {
-        PetalManifestV0 {
+    fn view_manifest(path: &str, functions: Vec<FunctionDecl>) -> PetalManifest {
+        PetalManifest {
             schema_version: SCHEMA_VERSION,
             module_path: path.to_string(),
             framework_version: SemVer::new(0, 1, 0),

--- a/crates/bloom-chain-node/tests/petal_admission.rs
+++ b/crates/bloom-chain-node/tests/petal_admission.rs
@@ -4,7 +4,7 @@ use bloom_chain_state::State;
 use bloom_chain_types::tx::{Tx, TxKind};
 use bloom_chain_types::types::{Address, Hash32, PubKeyBytes, SigBytes};
 use bloom_petal_manifest::codec;
-use bloom_petal_manifest::types::{FunctionDecl, PetalManifestV0, SCHEMA_VERSION, SemVer};
+use bloom_petal_manifest::types::{FunctionDecl, PetalManifest, SCHEMA_VERSION, SemVer};
 
 fn deploy_tx(wasm_bytes: Vec<u8>) -> Tx {
     Tx {
@@ -20,7 +20,7 @@ fn deploy_tx(wasm_bytes: Vec<u8>) -> Tx {
 }
 
 fn manifest(path: &str) -> Vec<u8> {
-    codec::encode(&PetalManifestV0 {
+    codec::encode(&PetalManifest {
         schema_version: SCHEMA_VERSION,
         module_path: path.to_string(),
         framework_version: SemVer::new(0, 1, 0),
@@ -30,7 +30,7 @@ fn manifest(path: &str) -> Vec<u8> {
 }
 
 fn manifest_with_function(path: &str, function: &str) -> Vec<u8> {
-    codec::encode(&PetalManifestV0 {
+    codec::encode(&PetalManifest {
         schema_version: SCHEMA_VERSION,
         module_path: path.to_string(),
         framework_version: SemVer::new(0, 1, 0),
@@ -86,7 +86,7 @@ fn wasm_with_disallowed_import_and_manifest(path: &str) -> Vec<u8> {
     imports.push(0x00);
     section(&mut wasm, 2, &imports);
 
-    let custom = custom_section("bloom_petal_manifest_v0", &manifest(path));
+    let custom = custom_section("bloom_petal_manifest", &manifest(path));
     section(&mut wasm, 0, &custom);
     wasm
 }
@@ -109,7 +109,7 @@ fn wasm_with_unknown_allowed_module_import_and_manifest(path: &str) -> Vec<u8> {
     imports.push(0x00);
     section(&mut wasm, 2, &imports);
 
-    let custom = custom_section("bloom_petal_manifest_v0", &manifest(path));
+    let custom = custom_section("bloom_petal_manifest", &manifest(path));
     section(&mut wasm, 0, &custom);
     wasm
 }
@@ -137,7 +137,7 @@ fn wasm_with_non_function_import_and_manifest(path: &str, import_kind: u8) -> Ve
     }
     section(&mut wasm, 2, &imports);
 
-    let custom = custom_section("bloom_petal_manifest_v0", &manifest(path));
+    let custom = custom_section("bloom_petal_manifest", &manifest(path));
     section(&mut wasm, 0, &custom);
     wasm
 }
@@ -146,7 +146,7 @@ fn wasm_with_manifest(path: &str) -> Vec<u8> {
     let mut wasm = Vec::new();
     wasm.extend_from_slice(b"\0asm");
     wasm.extend_from_slice(&[0x01, 0x00, 0x00, 0x00]);
-    let custom = custom_section("bloom_petal_manifest_v0", &manifest(path));
+    let custom = custom_section("bloom_petal_manifest", &manifest(path));
     section(&mut wasm, 0, &custom);
     wasm
 }
@@ -156,7 +156,7 @@ fn wasm_with_function_manifest_missing_export(path: &str, function: &str) -> Vec
     wasm.extend_from_slice(b"\0asm");
     wasm.extend_from_slice(&[0x01, 0x00, 0x00, 0x00]);
     let custom = custom_section(
-        "bloom_petal_manifest_v0",
+        "bloom_petal_manifest",
         &manifest_with_function(path, function),
     );
     section(&mut wasm, 0, &custom);
@@ -205,7 +205,7 @@ fn wasm_with_chain_return_import_and_function(path: &str, function: &str) -> Vec
     section(&mut wasm, 10, &[0x01, 0x04, 0x00, 0x41, 0x00, 0x0b]);
 
     let custom = custom_section(
-        "bloom_petal_manifest_v0",
+        "bloom_petal_manifest",
         &manifest_with_function(path, function),
     );
     section(&mut wasm, 0, &custom);

--- a/crates/bloom-chain-node/tests/ptb_gas_reservation.rs
+++ b/crates/bloom-chain-node/tests/ptb_gas_reservation.rs
@@ -41,7 +41,7 @@ use bloom_objects::{AccessMode, OWNER_KIND_ADDRESS, Object, ObjectId, Owner, Own
 use bloom_petal_fungible::ops::{coin_payload, decode_coin_value};
 use bloom_petal_manifest::{
     codec,
-    types::{FunctionDecl, PetalManifestV0, SCHEMA_VERSION, SemVer},
+    types::{FunctionDecl, PetalManifest, SCHEMA_VERSION, SemVer},
 };
 use bloom_script::{
     CORE_FUNGIBLE_PATH, DEFAULT_FUNGIBLE_PETAL_HASH,
@@ -253,7 +253,7 @@ fn custom_section(name: &str, payload: &[u8]) -> Vec<u8> {
 
 fn wat_with_manifest(src: &str, function: &str) -> Vec<u8> {
     let mut wasm = wat(src);
-    let manifest = codec::encode(&PetalManifestV0 {
+    let manifest = codec::encode(&PetalManifest {
         schema_version: SCHEMA_VERSION,
         module_path: "/test/p0-5".to_string(),
         framework_version: SemVer::new(0, 1, 0),
@@ -264,7 +264,7 @@ fn wat_with_manifest(src: &str, function: &str) -> Vec<u8> {
         ..Default::default()
     })
     .expect("manifest encodes");
-    let custom = custom_section("bloom_petal_manifest_v0", &manifest);
+    let custom = custom_section("bloom_petal_manifest", &manifest);
     section(&mut wasm, 0, &custom);
     wasm
 }
@@ -273,7 +273,7 @@ fn minimal_wasm_with_manifest(manifest_bytes: &[u8]) -> Vec<u8> {
     let mut wasm = Vec::new();
     wasm.extend_from_slice(b"\0asm");
     wasm.extend_from_slice(&[0x01, 0x00, 0x00, 0x00]);
-    let custom = custom_section("bloom_petal_manifest_v0", manifest_bytes);
+    let custom = custom_section("bloom_petal_manifest", manifest_bytes);
     section(&mut wasm, 0, &custom);
     wasm
 }

--- a/crates/bloom-chain-node/tests/ptb_submit_e2e.rs
+++ b/crates/bloom-chain-node/tests/ptb_submit_e2e.rs
@@ -39,7 +39,7 @@ use bloom_petal_manifest::{
     codec,
     types::{
         ArgDecl, ArgKind, DataTypeDecl, FieldDecl, FunctionDecl, MANIFEST_CUSTOM_SECTION,
-        ObjectTypeDecl, PetalManifestV0, SCHEMA_VERSION, SemVer,
+        ObjectTypeDecl, PetalManifest, SCHEMA_VERSION, SemVer,
     },
 };
 use bloom_script::{
@@ -86,7 +86,7 @@ fn leb128(out: &mut Vec<u8>, mut v: u64) {
     }
 }
 
-fn append_manifest(mut wasm: Vec<u8>, manifest: PetalManifestV0) -> Vec<u8> {
+fn append_manifest(mut wasm: Vec<u8>, manifest: PetalManifest) -> Vec<u8> {
     let bytes = codec::encode(&manifest).expect("manifest encodes");
     let mut custom = Vec::new();
     leb128(&mut custom, MANIFEST_CUSTOM_SECTION.len() as u64);
@@ -796,13 +796,13 @@ fn derive_create_id_test(ptb_digest: [u8; 32], type_tag: &TypeTag, payload: &[u8
     ObjectId::derive_for_type_tag(&Hash32(ptb_digest), 0, type_tag, payload)
 }
 
-fn create_and_transfer_manifest() -> PetalManifestV0 {
+fn create_and_transfer_manifest() -> PetalManifest {
     let input_type = TypeTag::Concrete {
         petal_hash: [0u8; 32],
         type_name: "CreateAndTransfer".to_string(),
         type_args: vec![],
     };
-    PetalManifestV0 {
+    PetalManifest {
         schema_version: SCHEMA_VERSION,
         module_path: "/test/e2e".to_string(),
         framework_version: SemVer::new(0, 1, 0),

--- a/crates/bloom-chain-state/src/state.rs
+++ b/crates/bloom-chain-state/src/state.rs
@@ -211,7 +211,7 @@ pub struct State {
     /// pinning, §11.1 module_path).
     ///
     /// Populated by genesis and petal-publishing flows that decode the wasm's
-    /// `bloom_petal_manifest_v0` custom section to read the declared
+    /// `bloom_petal_manifest` custom section to read the declared
     /// `module_path`.
     ///
     /// VFS bindings are consensus-relevant because validators use them

--- a/crates/bloom-chain-types/src/tx.rs
+++ b/crates/bloom-chain-types/src/tx.rs
@@ -42,7 +42,7 @@ pub enum TxKind {
     SubmitPtb { ptb_bytes: Vec<u8> },
     /// Deploy a Bloom-native petal wasm module.
     ///
-    /// The wasm must carry a `bloom_petal_manifest_v0` custom section. The
+    /// The wasm must carry a `bloom_petal_manifest` custom section. The
     /// executor stores the code by content hash and binds the manifest's
     /// `module_path` in the chain VFS registry.
     DeployPetal { wasm_bytes: Vec<u8> },

--- a/crates/bloom-petal-it/src/harness.rs
+++ b/crates/bloom-petal-it/src/harness.rs
@@ -129,7 +129,7 @@ pub fn seed_coin(state: &mut State, id: ObjectId, owner: Address, value: u128) {
 /// `ExecOutput`.
 ///
 /// "Chain-authoritative" here means the manifest is decoded entirely
-/// from the `bloom_petal_manifest_v0` custom section of each petal's
+/// from the `bloom_petal_manifest` custom section of each petal's
 /// on-chain wasm bytes (layer 2 of `PtbChainAdapter::load_manifest`),
 /// exactly like the production node — the empty override map
 /// short-circuits layer 1. This pairs well with
@@ -208,7 +208,7 @@ pub fn wat_to_wasm(src: &str) -> Vec<u8> {
     wat::parse_str(src).expect("valid WAT")
 }
 
-/// Append a `bloom_petal_manifest_v0` custom section carrying
+/// Append a `bloom_petal_manifest` custom section carrying
 /// `manifest_bytes` to `wasm`. The caller is expected to pass canonical
 /// manifest bytes — typically the output of one of the real petals'
 /// macro-emitted `__bloom_manifest_bytes()` accessors.
@@ -223,7 +223,7 @@ pub fn wat_to_wasm(src: &str) -> Vec<u8> {
 /// The append is byte-level (matches the `wasm_with_custom` helper used
 /// in `bloom-chain-node`'s adapter tests); we don't re-parse the wasm.
 pub fn append_manifest_section(mut wasm: Vec<u8>, manifest_bytes: &[u8]) -> Vec<u8> {
-    let name = "bloom_petal_manifest_v0";
+    let name = "bloom_petal_manifest";
     // Body = name_len (LEB128) | name | payload.
     let mut body = Vec::new();
     leb128(&mut body, name.len() as u64);
@@ -237,7 +237,7 @@ pub fn append_manifest_section(mut wasm: Vec<u8>, manifest_bytes: &[u8]) -> Vec<
 }
 
 /// Convenience: compile `wat_src` and append the
-/// `bloom_petal_manifest_v0` custom section in one call.
+/// `bloom_petal_manifest` custom section in one call.
 pub fn wrap_with_real_manifest(wat_src: &str, manifest_bytes: &[u8]) -> Vec<u8> {
     let base = wat_to_wasm(wat_src);
     append_manifest_section(base, manifest_bytes)
@@ -256,9 +256,9 @@ fn leb128(out: &mut Vec<u8>, mut v: u64) {
     }
 }
 
-/// The canonical-encoded `PetalManifestV0` bytes embedded in the real
+/// The canonical-encoded `PetalManifest` bytes embedded in the real
 /// `/bloom/petals/core/fungible` petal — i.e. the exact same blob the macro
-/// emits into the wasm `bloom_petal_manifest_v0` custom section. Use
+/// emits into the wasm `bloom_petal_manifest` custom section. Use
 /// with [`wrap_with_real_manifest`] to build a chain-authoritative
 /// fixture for the fungible petal.
 pub fn real_fungible_manifest_bytes() -> &'static [u8] {

--- a/crates/bloom-petal-it/tests/ptb_fungible_flow.rs
+++ b/crates/bloom-petal-it/tests/ptb_fungible_flow.rs
@@ -288,7 +288,7 @@ fn smoke_ptb_log_emit_succeeds() {
 // Previously `#[ignore]`d pending `wasm32-unknown-unknown` + a pre-built
 // fungible petal wasm. With `wrap_with_real_manifest` we now pair a tiny
 // WAT body (no wasm32 toolchain required) with the **real** canonical
-// `PetalManifestV0` bytes the macro emits for `/bloom/petals/core/fungible` —
+// `PetalManifest` bytes the macro emits for `/bloom/petals/core/fungible` —
 // the validator sees the same chain-authoritative manifest the
 // production node would extract from the real petal's wasm custom
 // section. This exercises `PtbChainAdapter::load_manifest`'s layer-2

--- a/crates/bloom-petal-it/tests/real_mintcap_revert.rs
+++ b/crates/bloom-petal-it/tests/real_mintcap_revert.rs
@@ -8,7 +8,7 @@
 //! 1. Load the **real** macro-emitted manifest bytes from
 //!    `bloom_petal_fungible::fungible::__bloom_manifest_bytes()` and
 //!    install them on a synthetic WAT wasm via the
-//!    `bloom_petal_manifest_v0` custom section — i.e. the exact same
+//!    `bloom_petal_manifest` custom section — i.e. the exact same
 //!    manifest the production node decodes via `PtbChainAdapter::new`
 //!    from each petal's wasm.
 //!
@@ -68,7 +68,7 @@ fn seed_epoch_zero_cap(state: &mut State, id: ObjectId, owner: bloom_chain_types
 }
 
 /// Tiny WAT petal exporting `__petal_mint_genesis` as a noop. The
-/// `bloom_petal_manifest_v0` custom section appended by
+/// `bloom_petal_manifest` custom section appended by
 /// `wrap_with_real_manifest` carries the real macro-emitted manifest
 /// for `/bloom/petals/core/fungible`, so the validator sees the exact
 /// declared arg types for `mint_genesis`.

--- a/crates/bloom-petal-manifest/Cargo.toml
+++ b/crates/bloom-petal-manifest/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Canonical PetalManifestV0 schema, codec, wasm custom-section extractor, and validator-side stub projector for Bloom-native petals (spec §8, §11.1)."
+description = "Canonical PetalManifest schema, codec, wasm custom-section extractor, and validator-side stub projector for Bloom-native petals (spec §8, §11.1)."
 
 [dependencies]
 bloom-objects.workspace = true

--- a/crates/bloom-petal-manifest/src/codec.rs
+++ b/crates/bloom-petal-manifest/src/codec.rs
@@ -1,4 +1,4 @@
-//! Canonical encoder / decoder for [`crate::types::PetalManifestV0`].
+//! Canonical encoder / decoder for [`crate::types::PetalManifest`].
 //!
 //! Wire format (deterministic, BE):
 //! - 4-byte BE counts for lists.
@@ -21,7 +21,7 @@ use bloom_objects::{AbilitySet, AccessMode, TypeTag};
 use crate::types::{
     ArgDecl, ArgKind, ArithExpr, BoundedArithOp, CapabilityDecl, CmpOp, DataTypeDecl, EnumTypeDecl,
     ExternalTypeRef, FieldDecl, FuelHints, FunctionDecl, HostImportDecl, InvariantDecl,
-    InvariantTarget, ObjectTypeDecl, OverflowPolicy, PetalManifestV0, PredicateAst, SCHEMA_VERSION,
+    InvariantTarget, ObjectTypeDecl, OverflowPolicy, PetalManifest, PredicateAst, SCHEMA_VERSION,
     SemVer, TypeParamDecl, TypeParamKind, VariantDecl, VariantFieldsDecl, WasmFuncSig, WasmValType,
     Widening,
 };
@@ -33,14 +33,14 @@ const MAX_MANIFEST_LIST_ITEMS: usize = 16_384;
 // ===========================================================================
 
 /// Canonical-encode the manifest into a fresh `Vec<u8>`.
-pub fn encode(manifest: &PetalManifestV0) -> Result<Vec<u8>, CodecError> {
+pub fn encode(manifest: &PetalManifest) -> Result<Vec<u8>, CodecError> {
     let mut out = Vec::new();
     encode_into(manifest, &mut out)?;
     Ok(out)
 }
 
 /// Canonical-encode the manifest into an existing buffer.
-pub fn encode_into(manifest: &PetalManifestV0, buf: &mut Vec<u8>) -> Result<(), CodecError> {
+pub fn encode_into(manifest: &PetalManifest, buf: &mut Vec<u8>) -> Result<(), CodecError> {
     if manifest.schema_version != SCHEMA_VERSION {
         return Err(CodecError::InvalidLength(manifest.schema_version as u64));
     }
@@ -61,7 +61,7 @@ pub fn encode_into(manifest: &PetalManifestV0, buf: &mut Vec<u8>) -> Result<(), 
 }
 
 /// Canonical-decode a manifest from `bytes`, rejecting trailing data.
-pub fn decode(bytes: &[u8]) -> Result<PetalManifestV0, CodecError> {
+pub fn decode(bytes: &[u8]) -> Result<PetalManifest, CodecError> {
     let mut rdr = bytes;
     let m = decode_from(&mut rdr)?;
     codec::expect_eof(rdr)?;
@@ -69,7 +69,7 @@ pub fn decode(bytes: &[u8]) -> Result<PetalManifestV0, CodecError> {
 }
 
 /// Decode from a cursor (allows trailing bytes; used when nested).
-pub fn decode_from(rdr: &mut &[u8]) -> Result<PetalManifestV0, CodecError> {
+pub fn decode_from(rdr: &mut &[u8]) -> Result<PetalManifest, CodecError> {
     let schema_version = read_u32_be(rdr)?;
     if schema_version != SCHEMA_VERSION {
         return Err(CodecError::InvalidLength(schema_version as u64));
@@ -86,7 +86,7 @@ pub fn decode_from(rdr: &mut &[u8]) -> Result<PetalManifestV0, CodecError> {
     let required_host_imports = read_list(rdr, read_host_import_decl)?;
     let external_type_refs = read_list(rdr, read_external_type_ref)?;
     let fuel_hints = read_fuel_hints(rdr)?;
-    Ok(PetalManifestV0 {
+    Ok(PetalManifest {
         schema_version,
         module_path,
         framework_version,
@@ -802,8 +802,8 @@ mod tests {
     use super::*;
     use crate::types::*;
 
-    fn sample() -> PetalManifestV0 {
-        PetalManifestV0 {
+    fn sample() -> PetalManifest {
+        PetalManifest {
             schema_version: SCHEMA_VERSION,
             module_path: "/bloom/petals/dex/pool".to_string(),
             framework_version: SemVer::new(0, 1, 0),
@@ -950,7 +950,7 @@ mod tests {
 
     #[test]
     fn round_trip_empty() {
-        let m = PetalManifestV0 {
+        let m = PetalManifest {
             schema_version: SCHEMA_VERSION,
             module_path: "/p".to_string(),
             framework_version: SemVer::new(0, 0, 1),
@@ -972,7 +972,7 @@ mod tests {
     #[test]
     fn snapshot_minimal_first_bytes() {
         // schema_version (4) || module_path ("/x" = 2 bytes)
-        let m = PetalManifestV0 {
+        let m = PetalManifest {
             schema_version: SCHEMA_VERSION,
             module_path: "/x".to_string(),
             framework_version: SemVer::new(0, 1, 0),
@@ -996,7 +996,7 @@ mod tests {
 
     #[test]
     fn rejects_trailing_bytes() {
-        let m = PetalManifestV0::default();
+        let m = PetalManifest::default();
         let mut bytes = encode(&m).unwrap();
         bytes.push(0xFF);
         assert!(decode(&bytes).is_err());
@@ -1022,7 +1022,7 @@ mod tests {
             AccessMode::Mutable,
             AccessMode::Consume,
         ] {
-            let m = PetalManifestV0 {
+            let m = PetalManifest {
                 module_path: "/p".to_string(),
                 functions: vec![FunctionDecl {
                     name: "f".to_string(),
@@ -1114,7 +1114,7 @@ mod tests {
             ),
         ];
         for p in variants {
-            let m = PetalManifestV0 {
+            let m = PetalManifest {
                 module_path: "/p".to_string(),
                 invariants: vec![InvariantDecl {
                     name: "x".to_string(),
@@ -1143,7 +1143,7 @@ mod tests {
 
     #[test]
     fn fuel_hints_round_trip() {
-        let m = PetalManifestV0 {
+        let m = PetalManifest {
             module_path: "/p".to_string(),
             fuel_hints: FuelHints {
                 per_function: vec![("a".to_string(), 1_000), ("b".to_string(), 2_000)],
@@ -1157,7 +1157,7 @@ mod tests {
 
     #[test]
     fn function_view_round_trips_in_current_schema() {
-        let m = PetalManifestV0 {
+        let m = PetalManifest {
             schema_version: SCHEMA_VERSION,
             module_path: "/p".to_string(),
             functions: vec![FunctionDecl {
@@ -1174,7 +1174,7 @@ mod tests {
 
     #[test]
     fn schema_v1_manifest_is_rejected() {
-        let m = PetalManifestV0 {
+        let m = PetalManifest {
             schema_version: 1,
             module_path: "/p".to_string(),
             functions: vec![FunctionDecl {
@@ -1201,7 +1201,7 @@ mod tests {
 
     #[test]
     fn invariant_human_text_round_trips() {
-        let m = PetalManifestV0 {
+        let m = PetalManifest {
             module_path: "/p".to_string(),
             invariants: vec![InvariantDecl {
                 name: "x".to_string(),

--- a/crates/bloom-petal-manifest/src/extract.rs
+++ b/crates/bloom-petal-manifest/src/extract.rs
@@ -1,9 +1,9 @@
 //! Wasm custom-section extractor for the canonical petal manifest.
 //!
-//! Walks a wasm binary looking for the `bloom_petal_manifest_v0` custom
+//! Walks a wasm binary looking for the `bloom_petal_manifest` custom
 //! section emitted by `#[bloom::petal]` (spec §8.1, §11.1). On hit,
 //! decodes the bytes via [`crate::codec::decode`] and returns the
-//! [`crate::types::PetalManifestV0`]. Missing section or malformed
+//! [`crate::types::PetalManifest`]. Missing section or malformed
 //! bytes yield `None` — the caller decides whether absence is a hard
 //! error (the chain's `load_manifest` treats it as "no manifest, no
 //! Move dispatch" by surfacing `PetalNotFound`).
@@ -11,9 +11,9 @@
 use wasmparser::{Parser, Payload};
 
 use crate::codec;
-use crate::types::{MANIFEST_CUSTOM_SECTION, PetalManifestV0};
+use crate::types::{MANIFEST_CUSTOM_SECTION, PetalManifest};
 
-/// Extract and canonical-decode the `bloom_petal_manifest_v0` custom
+/// Extract and canonical-decode the `bloom_petal_manifest` custom
 /// section from `wasm`. Returns `None` if either:
 /// - the section is absent (legacy petals, hand-written wasm, …), or
 /// - the wasm parses but the section bytes do not round-trip through
@@ -22,16 +22,16 @@ use crate::types::{MANIFEST_CUSTOM_SECTION, PetalManifestV0};
 /// In both cases the chain falls back to "no manifest" and the validator
 /// rejects any `Command::Move` against this petal with `PetalNotFound`
 /// (which is the conservative, fail-closed behaviour we want).
-pub fn extract_petal_manifest_v0(wasm: &[u8]) -> Option<PetalManifestV0> {
-    let bytes = extract_petal_manifest_v0_bytes(wasm)?;
+pub fn extract_petal_manifest(wasm: &[u8]) -> Option<PetalManifest> {
+    let bytes = extract_petal_manifest_bytes(wasm)?;
     codec::decode(&bytes).ok()
 }
 
-/// Extract the raw bytes of the `bloom_petal_manifest_v0` custom
+/// Extract the raw bytes of the `bloom_petal_manifest` custom
 /// section without decoding. Useful for tooling that wants to compute a
 /// content hash over the section, or for callers that already trust the
 /// bytes and want to skip the round-trip overhead.
-pub fn extract_petal_manifest_v0_bytes(wasm: &[u8]) -> Option<Vec<u8>> {
+pub fn extract_petal_manifest_bytes(wasm: &[u8]) -> Option<Vec<u8>> {
     let parser = Parser::new(0);
     for payload in parser.parse_all(wasm) {
         let payload = payload.ok()?;
@@ -48,7 +48,7 @@ pub fn extract_petal_manifest_v0_bytes(wasm: &[u8]) -> Option<Vec<u8>> {
 mod tests {
     use super::*;
     use crate::codec;
-    use crate::types::{PetalManifestV0, SemVer};
+    use crate::types::{PetalManifest, SemVer};
 
     /// Build a minimal wasm with one custom section.
     /// We hand-emit the wasm preamble + a single CustomSection payload.
@@ -85,8 +85,8 @@ mod tests {
         }
     }
 
-    fn sample_manifest() -> PetalManifestV0 {
-        PetalManifestV0 {
+    fn sample_manifest() -> PetalManifest {
+        PetalManifest {
             schema_version: crate::types::SCHEMA_VERSION,
             module_path: "/bloom/test/x".into(),
             framework_version: SemVer::new(0, 1, 0),
@@ -99,7 +99,7 @@ mod tests {
         let m = sample_manifest();
         let encoded = codec::encode(&m).unwrap();
         let wasm = wasm_with_custom(MANIFEST_CUSTOM_SECTION, &encoded);
-        let back = extract_petal_manifest_v0(&wasm).expect("section must decode");
+        let back = extract_petal_manifest(&wasm).expect("section must decode");
         assert_eq!(back, m);
     }
 
@@ -107,20 +107,20 @@ mod tests {
     fn returns_none_when_section_missing() {
         // Wasm with a *different* custom section name.
         let wasm = wasm_with_custom("not_the_manifest", &[1, 2, 3]);
-        assert!(extract_petal_manifest_v0(&wasm).is_none());
+        assert!(extract_petal_manifest(&wasm).is_none());
     }
 
     #[test]
     fn returns_none_on_malformed_payload() {
         // Right section name, garbage payload.
         let wasm = wasm_with_custom(MANIFEST_CUSTOM_SECTION, &[0xFF, 0xFF, 0xFF]);
-        assert!(extract_petal_manifest_v0(&wasm).is_none());
+        assert!(extract_petal_manifest(&wasm).is_none());
     }
 
     #[test]
     fn returns_none_on_non_wasm_input() {
         let garbage = vec![0u8; 16];
-        assert!(extract_petal_manifest_v0(&garbage).is_none());
+        assert!(extract_petal_manifest(&garbage).is_none());
     }
 
     #[test]
@@ -128,7 +128,7 @@ mod tests {
         let m = sample_manifest();
         let encoded = codec::encode(&m).unwrap();
         let wasm = wasm_with_custom(MANIFEST_CUSTOM_SECTION, &encoded);
-        let raw = extract_petal_manifest_v0_bytes(&wasm).unwrap();
+        let raw = extract_petal_manifest_bytes(&wasm).unwrap();
         assert_eq!(raw, encoded);
     }
 }

--- a/crates/bloom-petal-manifest/src/lib.rs
+++ b/crates/bloom-petal-manifest/src/lib.rs
@@ -1,4 +1,4 @@
-//! `PetalManifestV0` — the canonical manifest schema for Bloom-native
+//! `PetalManifest` — the canonical manifest schema for Bloom-native
 //! petals (spec §8, §11.1) — plus its canonical codec, wasm
 //! custom-section extractor, and the projector that produces the
 //! validator-facing [`bloom_script::PetalManifestStub`].
@@ -7,7 +7,7 @@
 //!
 //! `bloom-resource-macros` is `proc-macro = true`, so it cannot export
 //! non-macro public items. The chain node needs the manifest schema
-//! and codec at runtime (to decode the `bloom_petal_manifest_v0`
+//! and codec at runtime (to decode the `bloom_petal_manifest`
 //! custom section from a freshly-deployed wasm and project it down
 //! to the validator's stub). Splitting the schema into this library
 //! crate lets both the proc-macros (compile-time encode) and the
@@ -15,10 +15,10 @@
 //!
 //! ## Public surface
 //!
-//! - [`types`] — the `PetalManifestV0` AST + variants.
+//! - [`types`] — the `PetalManifest` AST + variants.
 //! - [`codec`] — canonical encoder / decoder.
 //! - [`extract`] — wasm custom-section walker that returns the
-//!   decoded `PetalManifestV0` from a `&[u8]` wasm binary.
+//!   decoded `PetalManifest` from a `&[u8]` wasm binary.
 //! - [`stub`] — projection from the full manifest to the lean
 //!   `bloom_script::PetalManifestStub` the PTB validator consumes.
 
@@ -35,7 +35,7 @@ pub mod types;
 
 pub use boundary::{BoundaryConfig, BoundaryReport, boundary_check};
 pub use codec::{decode, decode_from, encode, encode_into};
-pub use extract::{extract_petal_manifest_v0, extract_petal_manifest_v0_bytes};
+pub use extract::{extract_petal_manifest, extract_petal_manifest_bytes};
 pub use interpret::{
     EvalOutcome, MAX_INVARIANT_PREDICATE_FUEL, Triviality, collect_field_refs, interpret_predicate,
     predicate_is_enforceable, predicate_max_fuel, predicate_triviality, predicate_uses_subtraction,
@@ -43,4 +43,4 @@ pub use interpret::{
 };
 pub use resolver::{ManifestResolver, validate_reserved_type_names};
 pub use stub::to_petal_manifest_stub;
-pub use types::{MANIFEST_CUSTOM_SECTION, PetalManifestV0, SCHEMA_VERSION};
+pub use types::{MANIFEST_CUSTOM_SECTION, PetalManifest, SCHEMA_VERSION};

--- a/crates/bloom-petal-manifest/src/resolver.rs
+++ b/crates/bloom-petal-manifest/src/resolver.rs
@@ -1,30 +1,30 @@
 //! Reflective type resolver for full petal manifests.
 //!
 //! The value codec is schema-driven and deliberately does not know this
-//! manifest crate. This module bridges a decoded [`PetalManifestV0`] into the
+//! manifest crate. This module bridges a decoded [`PetalManifest`] into the
 //! neutral [`bloom_value::Resolver`] interface.
 
 use bloom_objects::TypeTag;
 use bloom_value::{FieldShape, Resolver, TypeShape, ValueCodecError, VariantFields, VariantShape};
 
 use crate::types::{
-    CapabilityDecl, DataTypeDecl, EnumTypeDecl, FieldDecl, ObjectTypeDecl, PetalManifestV0,
+    CapabilityDecl, DataTypeDecl, EnumTypeDecl, FieldDecl, ObjectTypeDecl, PetalManifest,
     VariantFieldsDecl,
 };
 
 /// Full-manifest resolver for user-defined object/capability/data/enum types.
 #[derive(Clone, Debug)]
 pub struct ManifestResolver<'a> {
-    manifest: &'a PetalManifestV0,
+    manifest: &'a PetalManifest,
     self_hash: Option<[u8; 32]>,
-    external_manifests: &'a [([u8; 32], &'a PetalManifestV0)],
+    external_manifests: &'a [([u8; 32], &'a PetalManifest)],
 }
 
 impl<'a> ManifestResolver<'a> {
     /// Create a resolver for `manifest` without a known publish hash.
     ///
     /// This resolves macro-time self references (`petal_hash == [0; 32]`).
-    pub fn new(manifest: &'a PetalManifestV0) -> Self {
+    pub fn new(manifest: &'a PetalManifest) -> Self {
         Self {
             manifest,
             self_hash: None,
@@ -33,7 +33,7 @@ impl<'a> ManifestResolver<'a> {
     }
 
     /// Create a resolver that also treats `self_hash` as this manifest's hash.
-    pub fn with_self_hash(manifest: &'a PetalManifestV0, self_hash: [u8; 32]) -> Self {
+    pub fn with_self_hash(manifest: &'a PetalManifest, self_hash: [u8; 32]) -> Self {
         Self {
             manifest,
             self_hash: Some(self_hash),
@@ -44,9 +44,9 @@ impl<'a> ManifestResolver<'a> {
     /// Create a resolver that can structurally resolve foreign concrete tags
     /// through the supplied `(content_hash, manifest)` table.
     pub fn with_self_hash_and_external_manifests(
-        manifest: &'a PetalManifestV0,
+        manifest: &'a PetalManifest,
         self_hash: [u8; 32],
-        external_manifests: &'a [([u8; 32], &'a PetalManifestV0)],
+        external_manifests: &'a [([u8; 32], &'a PetalManifest)],
     ) -> Self {
         Self {
             manifest,
@@ -258,7 +258,7 @@ impl Resolver for ManifestResolver<'_> {
 
 /// Validate that manifest-defined declarations do not claim reserved built-in
 /// type names.
-pub fn validate_reserved_type_names(manifest: &PetalManifestV0) -> Result<(), ValueCodecError> {
+pub fn validate_reserved_type_names(manifest: &PetalManifest) -> Result<(), ValueCodecError> {
     for name in manifest
         .object_types
         .iter()
@@ -332,7 +332,7 @@ mod tests {
 
     #[test]
     fn resolves_object_fields_and_decodes_payload() {
-        let manifest = PetalManifestV0 {
+        let manifest = PetalManifest {
             object_types: vec![ObjectTypeDecl {
                 name: "Thing".to_string(),
                 abilities: AbilitySet::key_store(),
@@ -375,7 +375,7 @@ mod tests {
 
     #[test]
     fn substitutes_generic_type_args() {
-        let manifest = PetalManifestV0 {
+        let manifest = PetalManifest {
             data_types: vec![DataTypeDecl {
                 name: "Boxed".to_string(),
                 type_params: vec![TypeParamDecl {
@@ -409,7 +409,7 @@ mod tests {
 
     #[test]
     fn resolves_enum_variants() {
-        let manifest = PetalManifestV0 {
+        let manifest = PetalManifest {
             enum_types: vec![EnumTypeDecl {
                 name: "Side".to_string(),
                 type_params: vec![],
@@ -447,7 +447,7 @@ mod tests {
     #[test]
     fn resolves_external_type_refs_through_supplied_manifest() {
         let foreign_hash = [0xBB; 32];
-        let manifest = PetalManifestV0 {
+        let manifest = PetalManifest {
             external_type_refs: vec![ExternalTypeRef {
                 placeholder: "$external_0".to_string(),
                 declared_petal_path: "/foreign".to_string(),
@@ -466,7 +466,7 @@ mod tests {
             }],
             ..Default::default()
         };
-        let foreign = PetalManifestV0 {
+        let foreign = PetalManifest {
             data_types: vec![DataTypeDecl {
                 name: "Foreign".to_string(),
                 fields: vec![FieldDecl {
@@ -504,7 +504,7 @@ mod tests {
     #[test]
     fn external_type_refs_reject_without_supplied_manifest() {
         let foreign_hash = [0xBB; 32];
-        let manifest = PetalManifestV0 {
+        let manifest = PetalManifest {
             external_type_refs: vec![ExternalTypeRef {
                 placeholder: "$external_0".to_string(),
                 declared_petal_path: "/foreign".to_string(),
@@ -538,7 +538,7 @@ mod tests {
 
     #[test]
     fn rejects_reserved_declaration_names() {
-        let manifest = PetalManifestV0 {
+        let manifest = PetalManifest {
             data_types: vec![DataTypeDecl {
                 name: "String".to_string(),
                 ..Default::default()

--- a/crates/bloom-petal-manifest/src/stub.rs
+++ b/crates/bloom-petal-manifest/src/stub.rs
@@ -1,4 +1,4 @@
-//! Projector from the canonical [`crate::types::PetalManifestV0`] to the
+//! Projector from the canonical [`crate::types::PetalManifest`] to the
 //! validator-facing [`bloom_script::PetalManifestStub`].
 //!
 //! The full manifest carries everything a tool or social-layer reader
@@ -10,7 +10,7 @@
 //! - `external_type_refs` (so `TypeTag::External` refs can be resolved
 //!   at typecheck time)
 //!
-//! This projection is total — every `PetalManifestV0` produces a valid
+//! This projection is total — every `PetalManifest` produces a valid
 //! `PetalManifestStub`. It is *not* round-trippable; the back-projection
 //! requires the original manifest's invariant + fuel + host-import data.
 
@@ -26,17 +26,17 @@ use bloom_script::{
 use crate::types::{
     ArgKind, ArithExpr, BoundedArithOp, CapabilityDecl, CmpOp, DataTypeDecl, EnumTypeDecl,
     FieldDecl, FunctionDecl, InvariantDecl, InvariantTarget, ObjectTypeDecl, OverflowPolicy,
-    PetalManifestV0, PredicateAst, TypeParamDecl, TypeParamKind, VariantDecl, VariantFieldsDecl,
+    PetalManifest, PredicateAst, TypeParamDecl, TypeParamKind, VariantDecl, VariantFieldsDecl,
     Widening, is_numeric_invariant_field,
 };
 
 /// Project a full canonical manifest down to the validator-facing stub.
 ///
 /// Spec §8.2 + §11.4. The chain calls this immediately after decoding a
-/// `bloom_petal_manifest_v0` custom section so the validator can
+/// `bloom_petal_manifest` custom section so the validator can
 /// typecheck `Command::Move`s without re-parsing the full manifest on
 /// every PTB.
-pub fn to_petal_manifest_stub(m: &PetalManifestV0) -> PetalManifestStub {
+pub fn to_petal_manifest_stub(m: &PetalManifest) -> PetalManifestStub {
     PetalManifestStub {
         module_path: m.module_path.clone(),
         functions: m
@@ -294,7 +294,7 @@ fn project_overflow_policy(p: OverflowPolicy) -> OverflowPolicyStub {
 mod tests {
     use super::*;
     use crate::types::{
-        ArgDecl, FunctionDecl, InvariantDecl, InvariantTarget, ObjectTypeDecl, PetalManifestV0,
+        ArgDecl, FunctionDecl, InvariantDecl, InvariantTarget, ObjectTypeDecl, PetalManifest,
         PredicateAst, TypeParamDecl, TypeParamKind,
     };
     use bloom_objects::{AbilitySet, AccessMode, TypeTag};
@@ -309,7 +309,7 @@ mod tests {
 
     #[test]
     fn projects_module_path_and_functions() {
-        let m = PetalManifestV0 {
+        let m = PetalManifest {
             module_path: "/bloom/test".into(),
             functions: vec![FunctionDecl {
                 name: "f".into(),
@@ -384,7 +384,7 @@ mod tests {
 
     #[test]
     fn projects_object_types() {
-        let m = PetalManifestV0 {
+        let m = PetalManifest {
             module_path: "/p".into(),
             object_types: vec![ObjectTypeDecl {
                 name: "Pool".into(),
@@ -402,7 +402,7 @@ mod tests {
 
     #[test]
     fn object_field_layout_excludes_bool_from_numeric_invariant_scope() {
-        let m = PetalManifestV0 {
+        let m = PetalManifest {
             module_path: "/p".into(),
             object_types: vec![ObjectTypeDecl {
                 name: "Flags".into(),

--- a/crates/bloom-petal-manifest/src/types.rs
+++ b/crates/bloom-petal-manifest/src/types.rs
@@ -1,4 +1,4 @@
-//! `PetalManifestV0` — the canonical manifest schema emitted by
+//! `PetalManifest` — the canonical manifest schema emitted by
 //! `#[bloom::petal]` as a wasm custom section (spec §8, §8.2).
 //!
 //! These types are pure data; no `syn`/`quote` dependencies. The
@@ -13,11 +13,11 @@ use bloom_objects::{AbilitySet, AccessMode, TypeTag};
 pub const SCHEMA_VERSION: u32 = 4;
 
 /// Custom section name embedded into every new-framework petal (spec §8.1).
-pub const MANIFEST_CUSTOM_SECTION: &str = "bloom_petal_manifest_v0";
+pub const MANIFEST_CUSTOM_SECTION: &str = "bloom_petal_manifest";
 
 /// Top-level manifest emitted by `#[bloom::petal]`.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct PetalManifestV0 {
+pub struct PetalManifest {
     /// `= SCHEMA_VERSION` for this crate's emission.
     pub schema_version: u32,
     /// VFS path the petal lives at, e.g. `"/bloom/petals/dex/pool"`.
@@ -46,7 +46,7 @@ pub struct PetalManifestV0 {
     pub fuel_hints: FuelHints,
 }
 
-impl Default for PetalManifestV0 {
+impl Default for PetalManifest {
     fn default() -> Self {
         Self {
             schema_version: SCHEMA_VERSION,
@@ -293,7 +293,7 @@ pub struct FunctionDecl {
     pub required_signers: u8,
     /// Capability args, by their declared TypeTag.
     pub required_capabilities: Vec<TypeTag>,
-    /// Indices into `PetalManifestV0::invariants` that fire after this fn.
+    /// Indices into `PetalManifest::invariants` that fire after this fn.
     pub attached_invariants: Vec<u16>,
 }
 
@@ -551,7 +551,7 @@ mod tests {
 
     #[test]
     fn default_manifest_is_empty() {
-        let m = PetalManifestV0::default();
+        let m = PetalManifest::default();
         assert_eq!(m.schema_version, SCHEMA_VERSION);
         assert!(m.functions.is_empty());
         assert!(m.object_types.is_empty());

--- a/crates/bloom-petal-manifest/tests/view_function_manifest.rs
+++ b/crates/bloom-petal-manifest/tests/view_function_manifest.rs
@@ -1,5 +1,5 @@
 use bloom_petal_manifest::types::{FunctionDecl, SemVer};
-use bloom_petal_manifest::{PetalManifestV0, SCHEMA_VERSION, codec};
+use bloom_petal_manifest::{PetalManifest, SCHEMA_VERSION, codec};
 
 fn write_u32_be(out: &mut Vec<u8>, value: u32) {
     out.extend_from_slice(&value.to_be_bytes());
@@ -63,7 +63,7 @@ fn schema_v1_manifest_fixture_is_rejected_after_clean_break() {
 
 #[test]
 fn manifest_encoder_uses_declared_schema_version_prefix() {
-    let manifest = PetalManifestV0 {
+    let manifest = PetalManifest {
         schema_version: SCHEMA_VERSION,
         module_path: "/bloom/test/schema-prefix".to_string(),
         ..Default::default()
@@ -76,7 +76,7 @@ fn manifest_encoder_uses_declared_schema_version_prefix() {
 
 #[test]
 fn function_decl_view_flag_round_trips() {
-    let manifest = PetalManifestV0 {
+    let manifest = PetalManifest {
         schema_version: SCHEMA_VERSION,
         module_path: "/bloom/test/view-roundtrip".to_string(),
         framework_version: SemVer::new(0, 1, 0),
@@ -106,7 +106,7 @@ fn function_decl_view_flag_round_trips() {
 
 #[test]
 fn schema_version_is_bumped_for_view_function_layout() {
-    let manifest = PetalManifestV0::default();
+    let manifest = PetalManifest::default();
 
     assert!(
         manifest.schema_version >= 4,

--- a/crates/bloom-petals/src/chain_vm.rs
+++ b/crates/bloom-petals/src/chain_vm.rs
@@ -54,7 +54,7 @@ use bloom_objects::{
     AccessMode, OWNER_KIND_ADDRESS, OWNER_KIND_IMMUTABLE, OWNER_KIND_OBJECT, OWNER_KIND_SHARED,
     Object, ObjectId, Owner, TypeTag,
 };
-use bloom_petal_manifest::{ManifestResolver, extract_petal_manifest_v0, types::PetalManifestV0};
+use bloom_petal_manifest::{ManifestResolver, extract_petal_manifest, types::PetalManifest};
 use bloom_script::{
     BorrowRow, CORE_FUNGIBLE_PATH,
     executor::LogEntry as PtbLogEntry,
@@ -104,8 +104,8 @@ pub struct ChainCtx {
 pub struct ChainStoreData {
     pub chain_ctx: ChainCtx,
     pub petal_hash: Hash32,
-    pub manifest: Option<PetalManifestV0>,
-    pub external_manifests: Vec<(Hash32, PetalManifestV0)>,
+    pub manifest: Option<PetalManifest>,
+    pub external_manifests: Vec<(Hash32, PetalManifest)>,
     /// Per-PTB host context (spec §16.2 borrow table, signers, logs,
     /// host-created object state, ...) shared between the wasm host imports
     /// installed by `link_new_host_imports` and the surrounding `PtbExecutor`.
@@ -127,7 +127,7 @@ pub enum ChainEntry {
 
 pub struct ChainCallInput {
     pub wasm: Vec<u8>,
-    pub external_manifests: Vec<(Hash32, PetalManifestV0)>,
+    pub external_manifests: Vec<(Hash32, PetalManifest)>,
     pub entry: ChainEntry,
     pub contract_address: Address,
     pub msg_sender: Address,
@@ -329,7 +329,7 @@ pub fn validate_chain_wasm(bytes: &[u8]) -> Result<(), PetalError> {
             _ => {}
         }
     }
-    if let Some(manifest) = extract_petal_manifest_v0(bytes) {
+    if let Some(manifest) = extract_petal_manifest(bytes) {
         validate_view_functions_are_pure(bytes, &manifest)?;
         validate_invariant_attachments(&manifest)?;
         validate_object_field_layouts(&manifest)?;
@@ -454,7 +454,7 @@ pub fn validate_chain_wasm(bytes: &[u8]) -> Result<(), PetalError> {
     Ok(())
 }
 
-fn validate_object_field_layouts(manifest: &PetalManifestV0) -> Result<(), PetalError> {
+fn validate_object_field_layouts(manifest: &PetalManifest) -> Result<(), PetalError> {
     for obj in &manifest.object_types {
         let mut names = HashSet::new();
         let mut next_offset = Some(0u32);
@@ -505,7 +505,7 @@ fn validate_object_field_layouts(manifest: &PetalManifestV0) -> Result<(), Petal
 /// projection exactly once. The runtime stub projects only attached
 /// invariants, so a top-level declaration that is unattached or referenced by
 /// an invalid index would otherwise pass admission and then never fire.
-fn validate_invariant_attachments(manifest: &PetalManifestV0) -> Result<(), PetalError> {
+fn validate_invariant_attachments(manifest: &PetalManifest) -> Result<(), PetalError> {
     let mut counts = vec![0usize; manifest.invariants.len()];
     for function in &manifest.functions {
         for idx in &function.attached_invariants {
@@ -605,7 +605,7 @@ fn validate_invariant_arithmetic_metadata(
 /// v1 scope is an empty field table, so *any* field reference is rejected.
 fn validate_invariant_field_refs(
     inv: &bloom_petal_manifest::types::InvariantDecl,
-    manifest: &PetalManifestV0,
+    manifest: &PetalManifest,
 ) -> Result<(), PetalError> {
     use bloom_petal_manifest::types::InvariantTarget;
     let refs = bloom_petal_manifest::collect_field_refs(&inv.predicate);
@@ -762,7 +762,7 @@ struct StaticCallGraph {
 
 fn validate_view_functions_are_pure(
     bytes: &[u8],
-    manifest: &PetalManifestV0,
+    manifest: &PetalManifest,
 ) -> Result<(), PetalError> {
     let graph = parse_static_call_graph(bytes)?;
     for f in manifest.functions.iter().filter(|f| f.view) {
@@ -2053,9 +2053,9 @@ fn validate_object_payload(
 }
 
 fn validate_object_payload_bytes(
-    manifest: &PetalManifestV0,
+    manifest: &PetalManifest,
     self_hash: [u8; 32],
-    external_manifests: &[(Hash32, PetalManifestV0)],
+    external_manifests: &[(Hash32, PetalManifest)],
     tag: &TypeTag,
     payload: &[u8],
 ) -> Result<(), bloom_value::ValueCodecError> {
@@ -2063,7 +2063,7 @@ fn validate_object_payload_bytes(
         max_value_bytes: payload.len(),
         ..CodecLimits::default()
     };
-    let external_manifest_refs: Vec<([u8; 32], &PetalManifestV0)> = external_manifests
+    let external_manifest_refs: Vec<([u8; 32], &PetalManifest)> = external_manifests
         .iter()
         .map(|(hash, manifest)| (hash.0, manifest))
         .collect();
@@ -2199,7 +2199,7 @@ fn dispatch_chain_call_sync(
 
     let petal_hash = blake3_tagged(tags::PETAL, &input.wasm);
 
-    let manifest = extract_petal_manifest_v0(&input.wasm);
+    let manifest = extract_petal_manifest(&input.wasm);
 
     let chain_ctx = ChainCtx {
         snapshot: input.snapshot,
@@ -2438,7 +2438,7 @@ mod ptb_host_import_tests {
     use bloom_petal_manifest::codec;
     use bloom_petal_manifest::types::{
         ArithExpr, BoundedArithOp, CmpOp, DataTypeDecl, ExternalTypeRef, FieldDecl, FunctionDecl,
-        InvariantDecl, InvariantTarget, ObjectTypeDecl, OverflowPolicy, PetalManifestV0,
+        InvariantDecl, InvariantTarget, ObjectTypeDecl, OverflowPolicy, PetalManifest,
         PredicateAst, SCHEMA_VERSION, SemVer, TypeParamDecl, TypeParamKind, Widening,
     };
     use bloom_script::host_ctx::PtbHostCtx;
@@ -2460,10 +2460,10 @@ mod ptb_host_import_tests {
         }
     }
 
-    fn append_manifest(mut wasm: Vec<u8>, manifest: PetalManifestV0) -> Vec<u8> {
+    fn append_manifest(mut wasm: Vec<u8>, manifest: PetalManifest) -> Vec<u8> {
         let bytes = codec::encode(&manifest).expect("manifest encodes");
         let mut custom = Vec::new();
-        let name = "bloom_petal_manifest_v0";
+        let name = "bloom_petal_manifest";
         leb128(&mut custom, name.len() as u64);
         custom.extend_from_slice(name.as_bytes());
         custom.extend_from_slice(&bytes);
@@ -2481,8 +2481,8 @@ mod ptb_host_import_tests {
         }
     }
 
-    fn object_manifest(type_name: &str, fields: Vec<(&str, TypeTag)>) -> PetalManifestV0 {
-        PetalManifestV0 {
+    fn object_manifest(type_name: &str, fields: Vec<(&str, TypeTag)>) -> PetalManifest {
+        PetalManifest {
             schema_version: SCHEMA_VERSION,
             module_path: "/bloom/petals/test/object".to_string(),
             framework_version: SemVer::new(0, 1, 0),
@@ -2507,7 +2507,7 @@ mod ptb_host_import_tests {
         }
     }
 
-    fn generic_object_manifest(type_name: &str, fields: Vec<(&str, TypeTag)>) -> PetalManifestV0 {
+    fn generic_object_manifest(type_name: &str, fields: Vec<(&str, TypeTag)>) -> PetalManifest {
         let mut manifest = object_manifest(type_name, fields);
         manifest.object_types[0].type_params.push(TypeParamDecl {
             name: "T".to_string(),
@@ -2519,7 +2519,7 @@ mod ptb_host_import_tests {
 
     #[test]
     fn invariant_field_refs_reject_bool_numeric_domain() {
-        let manifest = PetalManifestV0 {
+        let manifest = PetalManifest {
             schema_version: SCHEMA_VERSION,
             module_path: "/bloom/petals/test/object".to_string(),
             framework_version: SemVer::new(0, 1, 0),
@@ -2570,7 +2570,7 @@ mod ptb_host_import_tests {
 
     #[test]
     fn admission_rejects_tampered_object_invariant_field_offset() {
-        let manifest = PetalManifestV0 {
+        let manifest = PetalManifest {
             schema_version: SCHEMA_VERSION,
             module_path: "/bloom/petals/test/object".to_string(),
             framework_version: SemVer::new(0, 1, 0),
@@ -2616,7 +2616,7 @@ mod ptb_host_import_tests {
 
     #[test]
     fn admission_rejects_duplicate_object_field_names() {
-        let manifest = PetalManifestV0 {
+        let manifest = PetalManifest {
             schema_version: SCHEMA_VERSION,
             module_path: "/bloom/petals/test/object".to_string(),
             framework_version: SemVer::new(0, 1, 0),
@@ -2712,7 +2712,7 @@ mod ptb_host_import_tests {
             },
             rhs: ArithExpr::Field("before.k".to_string()),
         };
-        let manifest = PetalManifestV0 {
+        let manifest = PetalManifest {
             schema_version: SCHEMA_VERSION,
             module_path: "/bloom/petals/test/object".to_string(),
             framework_version: SemVer::new(0, 1, 0),
@@ -2759,7 +2759,7 @@ mod ptb_host_import_tests {
             wasm_export: "__inv_0".to_string(),
             human_text: String::new(),
         };
-        let unattached = PetalManifestV0 {
+        let unattached = PetalManifest {
             schema_version: SCHEMA_VERSION,
             module_path: "/bloom/petals/test/object".to_string(),
             framework_version: SemVer::new(0, 1, 0),
@@ -2777,7 +2777,7 @@ mod ptb_host_import_tests {
             "unexpected error: {err}"
         );
 
-        let out_of_range = PetalManifestV0 {
+        let out_of_range = PetalManifest {
             schema_version: SCHEMA_VERSION,
             module_path: "/bloom/petals/test/object".to_string(),
             framework_version: SemVer::new(0, 1, 0),
@@ -2810,7 +2810,7 @@ mod ptb_host_import_tests {
             },
             rhs: ArithExpr::Field("before.count".to_string()),
         };
-        let manifest = PetalManifestV0 {
+        let manifest = PetalManifest {
             schema_version: SCHEMA_VERSION,
             module_path: "/bloom/petals/test/object".to_string(),
             framework_version: SemVer::new(0, 1, 0),
@@ -2861,7 +2861,7 @@ mod ptb_host_import_tests {
             declared_type_name: "Foreign".to_string(),
             declared_content_hash: Some(foreign_hash.0),
         });
-        let foreign_manifest = PetalManifestV0 {
+        let foreign_manifest = PetalManifest {
             schema_version: SCHEMA_VERSION,
             module_path: "/foreign".to_string(),
             framework_version: SemVer::new(0, 1, 0),
@@ -3057,7 +3057,7 @@ mod ptb_host_import_tests {
         );
         let wasm = append_manifest(
             wasm,
-            PetalManifestV0 {
+            PetalManifest {
                 schema_version: SCHEMA_VERSION,
                 module_path: "/bloom/petals/test/view-log".to_string(),
                 framework_version: SemVer::new(0, 1, 0),

--- a/crates/bloom-petals/tests/view_function_verifier_contract.rs
+++ b/crates/bloom-petals/tests/view_function_verifier_contract.rs
@@ -1,12 +1,12 @@
 use bloom_petal_manifest::{
     codec,
-    types::{FunctionDecl, MANIFEST_CUSTOM_SECTION, PetalManifestV0},
+    types::{FunctionDecl, MANIFEST_CUSTOM_SECTION, PetalManifest},
 };
 use bloom_petals::chain_vm::validate_chain_wasm;
 
 fn wasm_with_manifest(wat_src: &str, functions: Vec<FunctionDecl>) -> Vec<u8> {
     let mut wasm = wat::parse_str(wat_src).expect("wat parses");
-    let manifest = PetalManifestV0 {
+    let manifest = PetalManifest {
         module_path: "/bloom/test/view".to_string(),
         functions,
         ..Default::default()
@@ -240,7 +240,7 @@ fn wasm_with_invariant(predicate: bloom_petal_manifest::types::PredicateAst) -> 
         offset: Some(0),
         width: Some(32),
     };
-    let manifest = PetalManifestV0 {
+    let manifest = PetalManifest {
         module_path: "/bloom/test/inv".to_string(),
         functions: vec![FunctionDecl {
             name: "touch".to_string(),
@@ -371,7 +371,7 @@ fn function_exit_invariant_referencing_fields_is_rejected() {
     // A function-exit invariant gets an empty field table in v1, so any
     // field reference can't be enforced — reject at deploy (B2).
     let mut wasm = wat::parse_str("(module)").expect("wat parses");
-    let manifest = PetalManifestV0 {
+    let manifest = PetalManifest {
         module_path: "/bloom/test/inv".to_string(),
         functions: vec![FunctionDecl {
             name: "swap".to_string(),
@@ -526,7 +526,7 @@ fn semantically_always_false_predicate_rejected_at_deploy() {
         codec,
         types::{
             ArithExpr, CmpOp, FieldDecl, InvariantDecl, InvariantTarget, MANIFEST_CUSTOM_SECTION,
-            ObjectTypeDecl, PetalManifestV0, PredicateAst,
+            ObjectTypeDecl, PetalManifest, PredicateAst,
         },
     };
     // `after.x >= 256` on a u8 field (width=1, domain 0..255) — always
@@ -537,7 +537,7 @@ fn semantically_always_false_predicate_rejected_at_deploy() {
         rhs: ArithExpr::Literal(256),
     };
     let mut wasm = wat::parse_str("(module)").expect("wat parses");
-    let manifest = PetalManifestV0 {
+    let manifest = PetalManifest {
         module_path: "/bloom/test/inv".to_string(),
         functions: vec![FunctionDecl {
             name: "touch".to_string(),

--- a/crates/bloom-resource-macros/src/codegen.rs
+++ b/crates/bloom-resource-macros/src/codegen.rs
@@ -2,9 +2,9 @@
 //!
 //! These helpers produce `proc_macro2::TokenStream` fragments that:
 //!
-//! - Marshal `PetalManifestV0` instances into rust constants whose
+//! - Marshal `PetalManifest` instances into rust constants whose
 //!   canonical-encoded bytes get embedded as the
-//!   `bloom_petal_manifest_v0` wasm custom section (spec §8.1, §11.1).
+//!   `bloom_petal_manifest` wasm custom section (spec §8.1, §11.1).
 //! - Emit `__petal_<fn>` wasm exports with the spec §11.1 signature,
 //!   driving an [`bloom_resource::abi::ArgReader`] across the args
 //!   buffer, dispatching to the user fn, and writing typed return
@@ -19,7 +19,7 @@ use syn::{GenericArgument, Ident, LitByteStr, PathArguments, Type, TypePath};
 
 use bloom_petal_manifest::codec as manifest_codec;
 use bloom_petal_manifest::types::{
-    ArgKind, ArithExpr, BoundedArithOp, CmpOp, PetalManifestV0, PredicateAst,
+    ArgKind, ArithExpr, BoundedArithOp, CmpOp, PetalManifest, PredicateAst,
 };
 
 // ---------------------------------------------------------------------------
@@ -28,12 +28,12 @@ use bloom_petal_manifest::types::{
 
 /// Generate the `#[link_section]` bytes constant that embeds the
 /// canonical-encoded manifest into the wasm output as the
-/// `bloom_petal_manifest_v0` custom section.
+/// `bloom_petal_manifest` custom section.
 ///
 /// The macro emits the bytes as a `static [u8; N]` with a target-gated
 /// `#[link_section]` attribute that only fires on wasm targets.
 pub(crate) fn emit_manifest_section(
-    manifest: &PetalManifestV0,
+    manifest: &PetalManifest,
     section_unique_ident: &Ident,
 ) -> syn::Result<TokenStream> {
     let bytes = manifest_codec::encode(manifest).map_err(|e| {
@@ -53,11 +53,11 @@ pub(crate) fn emit_manifest_section(
     // section. On non-wasm targets we still emit the static so host-side
     // unit tests can inspect it.
     Ok(quote! {
-        /// Canonical-encoded `PetalManifestV0` blob. Embedded into the
-        /// wasm output as the `bloom_petal_manifest_v0` custom section
+        /// Canonical-encoded `PetalManifest` blob. Embedded into the
+        /// wasm output as the `bloom_petal_manifest` custom section
         /// (spec §8.1). Auto-generated; do not edit.
         #[cfg(all(target_arch = "wasm32", not(feature = "no-entrypoint")))]
-        #[unsafe(link_section = "bloom_petal_manifest_v0")]
+        #[unsafe(link_section = "bloom_petal_manifest")]
         #[used]
         pub static #section_unique_ident: [u8; #len] = [#(#byte_lits),*];
 
@@ -1051,7 +1051,7 @@ fn cmp_op_byte(op: CmpOp) -> u8 {
 /// and for tools that pre-flight a wasm before publishing.
 pub(crate) fn emit_manifest_accessor(section_ident: &Ident) -> TokenStream {
     quote! {
-        /// Returns the canonical-encoded `PetalManifestV0` bytes
+        /// Returns the canonical-encoded `PetalManifest` bytes
         /// embedded into this petal at compile time.
         #[cfg(any(not(target_arch = "wasm32"), not(feature = "no-entrypoint")))]
         pub fn __bloom_manifest_bytes() -> &'static [u8] {
@@ -1069,8 +1069,8 @@ mod tests {
     use super::*;
     use bloom_petal_manifest::types::*;
 
-    fn empty_manifest() -> PetalManifestV0 {
-        PetalManifestV0 {
+    fn empty_manifest() -> PetalManifest {
+        PetalManifest {
             schema_version: SCHEMA_VERSION,
             module_path: "/p".to_string(),
             framework_version: SemVer::new(0, 1, 0),
@@ -1096,7 +1096,7 @@ mod tests {
         let toks = emit_manifest_section(&m, &id).unwrap();
         let s = toks.to_string();
         assert!(s.contains("link_section"));
-        assert!(s.contains("bloom_petal_manifest_v0"));
+        assert!(s.contains("bloom_petal_manifest"));
         assert!(s.contains("__BLOOM_M"));
     }
 

--- a/crates/bloom-resource-macros/src/lib.rs
+++ b/crates/bloom-resource-macros/src/lib.rs
@@ -42,7 +42,7 @@ mod type_tag;
 
 /// Attribute applied to a `mod` declaration to mark it as a Bloom
 /// petal entry-point. Emits the `__petal_<fn>` wasm exports and the
-/// `bloom_petal_manifest_v0` custom section (spec §8 / §11.1).
+/// `bloom_petal_manifest` custom section (spec §8 / §11.1).
 #[proc_macro_attribute]
 pub fn petal(attr: TokenStream, item: TokenStream) -> TokenStream {
     petal::expand(attr.into(), item.into())

--- a/crates/bloom-resource-macros/src/petal.rs
+++ b/crates/bloom-resource-macros/src/petal.rs
@@ -14,8 +14,8 @@
 //!
 //! The macro orchestrates the inner `#[object]` / `#[capability]` /
 //! `#[invariant]` attributes: it walks the module body, recognises
-//! those attributes, builds a single [`PetalManifestV0`] from them, and
-//! emits one canonical-encoded blob (`bloom_petal_manifest_v0` custom
+//! those attributes, builds a single [`PetalManifest`] from them, and
+//! emits one canonical-encoded blob (`bloom_petal_manifest` custom
 //! section) plus one `__petal_<fn>` shim per `pub fn`.
 //!
 //! Because Rust's attribute-macro expansion order is bottom-up, the
@@ -44,7 +44,7 @@ use crate::invariant::InvariantAttr;
 use crate::object::ObjectAttr;
 use crate::type_tag::TypeTagCtx;
 use bloom_petal_manifest::types::{
-    ArgDecl, ArgKind, FunctionDecl, PetalManifestV0, SCHEMA_VERSION, SemVer, TypeParamDecl,
+    ArgDecl, ArgKind, FunctionDecl, PetalManifest, SCHEMA_VERSION, SemVer, TypeParamDecl,
     TypeParamKind,
 };
 
@@ -132,7 +132,7 @@ fn parse_semver(raw: &str, span: &impl syn::spanned::Spanned) -> syn::Result<Sem
 
 /// Walk a parsed module + accumulate every kind of declaration. Used
 /// in tests and from [`expand`].
-pub(crate) fn build_manifest(attr: &PetalAttr, module: &ItemMod) -> syn::Result<PetalManifestV0> {
+pub(crate) fn build_manifest(attr: &PetalAttr, module: &ItemMod) -> syn::Result<PetalManifest> {
     let (m, _) = build_manifest_with_asts(attr, module)?;
     Ok(m)
 }
@@ -143,8 +143,8 @@ pub(crate) fn build_manifest(attr: &PetalAttr, module: &ItemMod) -> syn::Result<
 pub(crate) fn build_manifest_with_asts(
     attr: &PetalAttr,
     module: &ItemMod,
-) -> syn::Result<(PetalManifestV0, Vec<PetalShimAst>)> {
-    let mut m = PetalManifestV0 {
+) -> syn::Result<(PetalManifest, Vec<PetalShimAst>)> {
+    let mut m = PetalManifest {
         schema_version: SCHEMA_VERSION,
         module_path: attr.resolved_path(module),
         framework_version: attr.resolved_version(),
@@ -225,7 +225,7 @@ fn collect_object_arg_type_names(items: &[Item]) -> HashSet<String> {
 
 /// Recognise a `#[capability]` or `#[object]` struct and push its decl
 /// into the manifest.
-fn handle_struct(s: &ItemStruct, m: &mut PetalManifestV0) -> syn::Result<()> {
+fn handle_struct(s: &ItemStruct, m: &mut PetalManifest) -> syn::Result<()> {
     let object_attr = find_attr(&s.attrs, "object");
     let capability_attr = find_attr(&s.attrs, "capability");
 
@@ -259,7 +259,7 @@ fn handle_struct(s: &ItemStruct, m: &mut PetalManifestV0) -> syn::Result<()> {
 }
 
 /// Recognise a plain `#[derive(BloomType)]` enum and push its decl.
-fn handle_enum(e: &ItemEnum, m: &mut PetalManifestV0) -> syn::Result<()> {
+fn handle_enum(e: &ItemEnum, m: &mut PetalManifest) -> syn::Result<()> {
     if crate::bloom_type::has_bloom_type_derive(&e.attrs) {
         m.enum_types.push(crate::bloom_type::build_enum_decl(e)?);
     }
@@ -273,7 +273,7 @@ fn handle_enum(e: &ItemEnum, m: &mut PetalManifestV0) -> syn::Result<()> {
 /// the function was skipped (non-`pub`).
 fn handle_fn(
     f: &ItemFn,
-    m: &mut PetalManifestV0,
+    m: &mut PetalManifest,
     bloom_value_types: &HashSet<String>,
     object_arg_types: &HashSet<String>,
 ) -> syn::Result<Option<PetalShimAst>> {
@@ -1065,7 +1065,7 @@ mod tests {
         .unwrap();
         let s = toks.to_string();
         assert!(s.contains("__BLOOM_PETAL_MANIFEST_BYTES"));
-        assert!(s.contains("bloom_petal_manifest_v0"));
+        assert!(s.contains("bloom_petal_manifest"));
         assert!(s.contains("__petal_noop"));
     }
 }

--- a/crates/bloom-script/src/chain_iface.rs
+++ b/crates/bloom-script/src/chain_iface.rs
@@ -8,12 +8,12 @@
 //!
 //! ## Manifest stubs
 //!
-//! The full `PetalManifestV0` (spec §8.2) lives in
+//! The full `PetalManifest` (spec §8.2) lives in
 //! `bloom-resource-macros` once that crate lands; the chain reads it
 //! out of the wasm custom section. For Phase 1 we model only the
 //! pieces the validator's type-check needs, in the form of
 //! [`PetalManifestStub`] + friends. The producer-side macros will emit
-//! `From<PetalManifestV0>` for the stub when the macro crate is wired
+//! `From<PetalManifest>` for the stub when the macro crate is wired
 //! in, so chain code does not need a second copy of the full schema.
 
 use bloom_chain_types::Hash32;
@@ -26,7 +26,7 @@ use crate::predicate::PredicateAstStub;
 // ---------------------------------------------------------------------------
 
 /// Minimal manifest projection the PTB validator consults at typecheck
-/// time. Mirrors the relevant subset of `PetalManifestV0` (spec §8.2).
+/// time. Mirrors the relevant subset of `PetalManifest` (spec §8.2).
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct PetalManifestStub {
     /// VFS path the petal is published at (mirrors the macro-emitted

--- a/crates/bloom-vfs/src/petals_handler.rs
+++ b/crates/bloom-vfs/src/petals_handler.rs
@@ -7,8 +7,8 @@ use async_trait::async_trait;
 use bloom_chain_types::Hash32;
 use bloom_objects::{Object, ObjectId, Owner, TypeTag};
 use bloom_petal_manifest::ManifestResolver;
-use bloom_petal_manifest::extract_petal_manifest_v0;
-use bloom_petal_manifest::types::{ObjectTypeDecl, PetalManifestV0};
+use bloom_petal_manifest::extract_petal_manifest;
+use bloom_petal_manifest::types::{ObjectTypeDecl, PetalManifest};
 use bloom_script::{ChainStateIface, PetalManifestStub};
 use bloom_value::{CodecLimits, decode_json};
 use serde_json::{Value, json};
@@ -63,15 +63,15 @@ impl PetalsEndpointHandler {
         self.chain.load_manifest(&binding.hash)
     }
 
-    fn full_manifest_for(&self, binding: &Binding) -> Option<PetalManifestV0> {
+    fn full_manifest_for(&self, binding: &Binding) -> Option<PetalManifest> {
         let wasm = self.chain.load_petal(&binding.hash)?;
-        extract_petal_manifest_v0(&wasm)
+        extract_petal_manifest(&wasm)
     }
 
     fn external_full_manifests_for(
         &self,
-        manifest: &PetalManifestV0,
-    ) -> Vec<(Hash32, PetalManifestV0)> {
+        manifest: &PetalManifest,
+    ) -> Vec<(Hash32, PetalManifest)> {
         let mut manifests = Vec::new();
         let mut visited = BTreeSet::new();
         self.collect_external_full_manifests(manifest, &mut manifests, &mut visited);
@@ -80,8 +80,8 @@ impl PetalsEndpointHandler {
 
     fn collect_external_full_manifests(
         &self,
-        manifest: &PetalManifestV0,
-        out: &mut Vec<(Hash32, PetalManifestV0)>,
+        manifest: &PetalManifest,
+        out: &mut Vec<(Hash32, PetalManifest)>,
         visited: &mut BTreeSet<[u8; 32]>,
     ) {
         for external in &manifest.external_type_refs {
@@ -95,7 +95,7 @@ impl PetalsEndpointHandler {
             let Some(wasm) = self.chain.load_petal(&hash) else {
                 continue;
             };
-            let Some(external_manifest) = extract_petal_manifest_v0(&wasm) else {
+            let Some(external_manifest) = extract_petal_manifest(&wasm) else {
                 continue;
             };
             self.collect_external_full_manifests(&external_manifest, out, visited);
@@ -596,7 +596,7 @@ fn object_matches(object: &Object, petal_hash: Hash32, type_name: &str) -> bool 
     )
 }
 
-fn object_type_decl<'a>(manifest: &'a PetalManifestV0, name: &str) -> Option<&'a ObjectTypeDecl> {
+fn object_type_decl<'a>(manifest: &'a PetalManifest, name: &str) -> Option<&'a ObjectTypeDecl> {
     if !is_endpoint_segment(name) {
         return None;
     }
@@ -610,10 +610,10 @@ fn decode_object_fields(
     petal_hash: Hash32,
     object: &Object,
     _object_type: &ObjectTypeDecl,
-    manifest: &PetalManifestV0,
-    external_manifests: &[(Hash32, PetalManifestV0)],
+    manifest: &PetalManifest,
+    external_manifests: &[(Hash32, PetalManifest)],
 ) -> Result<BTreeMap<String, Value>, HandlerError> {
-    let external_manifest_refs: Vec<([u8; 32], &PetalManifestV0)> = external_manifests
+    let external_manifest_refs: Vec<([u8; 32], &PetalManifest)> = external_manifests
         .iter()
         .map(|(hash, manifest)| (hash.0, manifest))
         .collect();
@@ -756,7 +756,7 @@ mod tests {
 
     use bloom_objects::{AbilitySet, BUILTIN_TYPE_HASH, Object, ObjectId};
     use bloom_petal_manifest::types::{
-        DataTypeDecl, ExternalTypeRef, FieldDecl, ObjectTypeDecl, PetalManifestV0, TypeParamDecl,
+        DataTypeDecl, ExternalTypeRef, FieldDecl, ObjectTypeDecl, PetalManifest, TypeParamDecl,
         TypeParamKind,
     };
     use bloom_script::FunctionDeclStub;
@@ -775,7 +775,7 @@ mod tests {
             self.manifests.lock().unwrap().insert(hash, manifest);
         }
 
-        fn bind_full(&self, path: &str, hash: Hash32, manifest: PetalManifestV0) {
+        fn bind_full(&self, path: &str, hash: Hash32, manifest: PetalManifest) {
             self.bindings.lock().unwrap().push((path.to_string(), hash));
             self.manifests.lock().unwrap().insert(
                 hash,
@@ -785,7 +785,7 @@ mod tests {
             self.code
                 .lock()
                 .unwrap()
-                .insert(hash, wasm_with_custom("bloom_petal_manifest_v0", &bytes));
+                .insert(hash, wasm_with_custom("bloom_petal_manifest", &bytes));
         }
 
         fn put_object(&self, object: Object) {
@@ -849,8 +849,8 @@ mod tests {
         }
     }
 
-    fn full_manifest(path: &str, object_types: Vec<ObjectTypeDecl>) -> PetalManifestV0 {
-        PetalManifestV0 {
+    fn full_manifest(path: &str, object_types: Vec<ObjectTypeDecl>) -> PetalManifest {
+        PetalManifest {
             module_path: path.to_string(),
             object_types,
             ..Default::default()
@@ -1373,7 +1373,7 @@ mod tests {
             declared_type_name: "Foreign".to_string(),
             declared_content_hash: Some(foreign_hash.0),
         });
-        let foreign_manifest = PetalManifestV0 {
+        let foreign_manifest = PetalManifest {
             module_path: "/bloom/petals/foreign".to_string(),
             data_types: vec![DataTypeDecl {
                 name: "Foreign".to_string(),
@@ -1416,7 +1416,7 @@ mod tests {
             declared_type_name: "Middle".to_string(),
             declared_content_hash: Some(middle_hash.0),
         });
-        let mut middle_manifest = PetalManifestV0 {
+        let mut middle_manifest = PetalManifest {
             module_path: "/bloom/petals/middle".to_string(),
             data_types: vec![DataTypeDecl {
                 name: "Middle".to_string(),
@@ -1436,7 +1436,7 @@ mod tests {
             declared_type_name: "Leaf".to_string(),
             declared_content_hash: Some(leaf_hash.0),
         });
-        let leaf_manifest = PetalManifestV0 {
+        let leaf_manifest = PetalManifest {
             module_path: "/bloom/petals/leaf".to_string(),
             data_types: vec![DataTypeDecl {
                 name: "Leaf".to_string(),
@@ -1525,7 +1525,7 @@ mod tests {
             declared_type_name: "Foreign".to_string(),
             declared_content_hash: Some(foreign_hash.0),
         });
-        let foreign_manifest = PetalManifestV0 {
+        let foreign_manifest = PetalManifest {
             module_path: "/bloom/petals/foreign".to_string(),
             data_types: vec![DataTypeDecl {
                 name: "Foreign".to_string(),

--- a/crates/bloom/src/commands/chain.rs
+++ b/crates/bloom/src/commands/chain.rs
@@ -71,7 +71,7 @@ pub enum ChainCmd {
     },
     /// Deploy a Bloom-native petal wasm module.
     Deploy {
-        /// Path to a `.wasm` file carrying a bloom_petal_manifest_v0 section.
+        /// Path to a `.wasm` file carrying a bloom_petal_manifest section.
         #[arg(value_name = "WASM")]
         wasm: PathBuf,
         /// Poll for the tx receipt after submitting and print it.

--- a/docs/research/formal-verification/02-architecture.md
+++ b/docs/research/formal-verification/02-architecture.md
@@ -483,7 +483,7 @@ Pruning is only as neutral as the evidence it adjudicates. A challenge or audit 
 ```
 ReplayWitness := {
   petal_hash,                 // exact deployed wasm artifact
-  manifest_hash,              // canonical PetalManifestV0
+  manifest_hash,              // canonical PetalManifest
   petal_version, inv_version, // version pinning (see §2)
   assertion_id,               // which InvariantDecl
   assertion_text_hash,        // ties to human_text (see §2)
@@ -809,7 +809,7 @@ For the implementing agent. All paths relative to `bloom/`.
 | `PredicateAst` enum (FieldGe/Le/Eq, StrategyKNonDecreasing, AllPoolsKNonDecreasing, Opaque) | `crates/bloom-petal-manifest/src/types.rs:203` |
 | `InvariantDecl { name, target, predicate, wasm_export }` | `…/types.rs:173` |
 | `InvariantTarget` {ObjectType, FunctionExit} | `…/types.rs:186` |
-| `PetalManifestV0.invariants`; `FunctionDecl.attached_invariants` | `…/types.rs:36`, `…:141` |
+| `PetalManifest.invariants`; `FunctionDecl.attached_invariants` | `…/types.rs:36`, `…:141` |
 | Closure → AST best-effort lowering (`predicate_ast_of`, `build_decl`, `expand`) | `crates/bloom-resource-macros/src/invariant.rs:104,128,198` |
 | `emit_invariant_shim` — the `__inv_<idx>(scope_ptr,scope_len)->i32` **`return 1` stub** | `crates/bloom-resource-macros/src/codegen.rs:787` |
 | `CHAIN_ALLOWED_IMPORT_MODULES` = [chain, object, cap, signer, ptb, log] | `crates/bloom-petals/src/chain_vm.rs:197` |

--- a/docs/research/formal-verification/03-open-questions.md
+++ b/docs/research/formal-verification/03-open-questions.md
@@ -397,8 +397,8 @@ field layout information today.
 - **Question:** Should the scope builder read field layout from the full manifest (available at
   deploy time and carried alongside the compiled Wasm), or should field layout be projected into
   the validator stub (which the executor holds)?
-- **Analysis:** The full `PetalManifestV0` is available at deploy time (stored in the petal
-  Wasm's custom section, extracted by `extract_petal_manifest_v0`). The executor currently uses
+- **Analysis:** The full `PetalManifest` is available at deploy time (stored in the petal
+  Wasm's custom section, extracted by `extract_petal_manifest`). The executor currently uses
   `PetalManifestStub`, which is a projected subset. Either: (a) extend the stub with a minimal
   `FieldLayoutStub` carrying `{name, offset, width}`, or (b) have the scope builder access the
   full manifest (not just the stub) for field layout. (a) is cleaner: it keeps the executor's

--- a/docs/research/formal-verification/04-decision-log.md
+++ b/docs/research/formal-verification/04-decision-log.md
@@ -475,7 +475,7 @@ prerequisite for the first real invariant.
    discards `fields`, so the executor's scope builder has no layout. **Decision:** extend
    `ObjectTypeDeclStub` with `field_layout: Vec<FieldLayoutStub { name, offset: Option<u32>, width:
    Option<u32> }>` — a minimal projection that gives the scope builder layout without pulling the
-   full `PetalManifestV0` into the execution hot path.
+   full `PetalManifest` into the execution hot path.
 
 **Consequences:** `FieldDecl` gains `offset: Option<u32>` and `width: Option<u32>`. The manifest
 codec (`bloom-petal-manifest/src/codec.rs`) serializes them. The `#[object]` macro's

--- a/docs/specs/2026-05-26-typed-cross-petal-calls.md
+++ b/docs/specs/2026-05-26-typed-cross-petal-calls.md
@@ -125,7 +125,7 @@ surface.
 ## Manifest And Dependency Identity
 
 Introduce a new manifest schema version or a versioned extension section. Do
-not append fields silently to the positional `PetalManifestV0` codec.
+not append fields silently to the positional `PetalManifest` codec.
 
 Add declared uses:
 

--- a/docs/superpowers/specs/2026-05-22-vfs-petal-pipes-defi-design.md
+++ b/docs/superpowers/specs/2026-05-22-vfs-petal-pipes-defi-design.md
@@ -16,7 +16,7 @@ The deep layers are already implemented and tested on a real chain:
 
 - **PTB = the transaction plan.** `bloom-script`'s `PtbTx{ commands, signers, gas_* }` with `Arg::Use{cmd_idx,ret_idx}` is exactly the handoff's "transaction plan", and `Use` is already a DAG edge, not just linear. Atomicity, snapshot rollback, gas reservation/refund, signature checks, and linearity (no double-spend) are implemented and pass end-to-end (`crates/bloom-chain-node/tests/ptb_submit_e2e.rs`, `ptb_atomicity.rs`, `examples/petal-dex/.../single_hop_swap.rs`).
 - **The petal ABI is already byte-in/byte-out.** `#[bloom::petal]` emits one `__petal_<fn>` export per public fn with a `(args_ptr,args_len,ret_ptr,ret_cap)` buffer ABI. Dispatch is by name, not a 4-byte selector.
-- **The VFS path is already in the manifest.** Each petal's signed `bloom_petal_manifest_v0` carries `module_path` (e.g. `/bloom/dex/pool`) plus its `functions`. `ChainStateIface::resolve_path(path) -> Option<Hash32>` already resolves path → petal.
+- **The VFS path is already in the manifest.** Each petal's signed `bloom_petal_manifest` carries `module_path` (e.g. `/bloom/dex/pool`) plus its `functions`. `ChainStateIface::resolve_path(path) -> Option<Hash32>` already resolves path → petal.
 - **Packets ≈ typed Objects.** `TypeTag::Concrete{type_name,type_args}` already expresses `Token<USDC>`; `Object{id,type_tag,owner,version}` + content-addressed `ObjectId` + the canonical no-float codec + handle-based linearity give the typed/linear packet core.
 
 What is missing is entirely the front door: an executable-endpoint surface, a builder that lowers composition into a `PtbTx`, a serialized packet envelope, bounded/paginated projection, and the agent-facing invocation surface. Plus one petal-side gap: the DEX swap is not yet a real wasm export.
@@ -51,7 +51,7 @@ PtbSession (bloom-ptb-builder)
 | Unit | Responsibility | Builds on |
 |---|---|---|
 | `bloom-ptb-builder` (new crate) | `PtbSession`: turn an ordered list of (endpoint-path, args, use-edges) into a **validated** `PtbTx`. Shared by CLI + tx-session — one source of truth. | `bloom-script` `PtbTx/Command/Arg/UseRef`, `validate_ptb` |
-| Endpoint resolver (extend `bloom-petal-manifest` and the `ChainStateIface` path hook) | `path → (petal_hash, fn, abi)` derived from the signed manifest (`module_path` + `functions`). Not a new source of truth. | `resolve_path` (`crates/bloom-script/src/chain_iface.rs:157`), `PetalManifestV0.functions` |
+| Endpoint resolver (extend `bloom-petal-manifest` and the `ChainStateIface` path hook) | `path → (petal_hash, fn, abi)` derived from the signed manifest (`module_path` + `functions`). Not a new source of truth. | `resolve_path` (`crates/bloom-script/src/chain_iface.rs:157`), `PetalManifest.functions` |
 | `tx` VFS handler (in `bloom-vfs`) | `/bloom/tx/new`, `/bloom/tx/<id>/{cmd,status,commit,abort}` backed by a `PtbSession`. Pure NFS read/write. | `Handler` trait (`crates/bloom-vfs/src/handler.rs`), `bloom-ptb-builder` |
 | Packet envelope (module in `bloom-objects`) | Canonical typed value crossing the pipe boundary as a **reference within the plan** — not bearer bytes. | `TypeTag`, object canonical codec |
 | Bounded projection / pagination primitive (in `bloom-vfs`) | `ls` returns bounded affordances; collections project as `page/000000`. Added now, lightly exercised by DeFi; Bloombook leans on it later. | `Handler::list` |

--- a/docs/superpowers/specs/2026-05-29-view-functions-design.md
+++ b/docs/superpowers/specs/2026-05-29-view-functions-design.md
@@ -52,7 +52,7 @@ The consensus core, state, and the PTB *executor* do not change semantically. We
 
 | Unit | Responsibility | Builds on |
 |---|---|---|
-| `view` flag on `FunctionDecl` (`bloom-petal-manifest`) | Per-function purity marker; bumps `SCHEMA_VERSION`, defaults `false`. The discovery/contract mechanism. | `PetalManifestV0.functions`, `codec` |
+| `view` flag on `FunctionDecl` (`bloom-petal-manifest`) | Per-function purity marker; bumps `SCHEMA_VERSION`, defaults `false`. The discovery/contract mechanism. | `PetalManifest.functions`, `codec` |
 | Call-graph view verifier (in `bloom-petals` chain-mode admission, alongside `CHAIN_ALLOWED_IMPORT_MODULES`) | At deploy, reject any `view`-marked function whose static call graph can reach a mutating host import, or that is not statically analyzable (`call_indirect`). | `chain_vm.rs` import/admission pass |
 | `ValidationMode { Commit, ReadOnly }` on `validate_ptb` (`bloom-script`) | `ReadOnly`: no gas-payer-Coin requirement; all object args coerced to `ReadOnly`; absent/zero signatures accepted. Makes read-only a first-class, tested property of the validator. | `validate_ptb`, `ValidationContext` |
 | `run_ptb(...)` shared helper (`bloom-chain-node`) | The extracted `validate → host_ctx → snapshot → ChainPetalRunner → PtbExecutor::with_ctx_arc → execute → drain` sequence, taking a state reference + validation mode, returning `ExecutionReport`. One execution core for both commit and view. | `PtbExecutor`, `ChainPetalRunner`, `PtbHostCtx` |

--- a/examples/petal-cap/src/lib.rs
+++ b/examples/petal-cap/src/lib.rs
@@ -80,7 +80,7 @@ pub fn is_active_logic(
 
 /// Petal body — every `pub fn` here becomes a `__petal_<name>` wasm
 /// export. The petal-level macro embeds a canonical-encoded
-/// `PetalManifestV0` (spec §8) as the `bloom_petal_manifest_v0`
+/// `PetalManifest` (spec §8) as the `bloom_petal_manifest`
 /// custom section.
 #[bloom::petal(path = "/bloom/petals/core/cap", version = "0.1.0")]
 pub mod cap {

--- a/examples/petal-cap/tests/manifest.rs
+++ b/examples/petal-cap/tests/manifest.rs
@@ -1,16 +1,16 @@
 //! Manifest-shape tests for the `/bloom/petals/core/cap` petal.
 //!
-//! These tests decode the wasm `bloom_petal_manifest_v0` custom-section
+//! These tests decode the wasm `bloom_petal_manifest` custom-section
 //! blob that `#[bloom::petal]` emits into a `static [u8; N]` and assert
 //! the petal's user-visible surface (object types, capability types,
 //! function entries, required-capability lists) match spec §5 + §18.
 //!
 use bloom_objects::{AccessMode, TypeTag};
 use bloom_petal_cap::cap;
-use bloom_petal_manifest::PetalManifestV0;
+use bloom_petal_manifest::PetalManifest;
 use bloom_petal_manifest::types::{ArgKind, TypeParamKind};
 
-fn decode(bytes: &[u8]) -> PetalManifestV0 {
+fn decode(bytes: &[u8]) -> PetalManifest {
     bloom_petal_manifest::codec::decode(bytes).unwrap()
 }
 

--- a/examples/petal-dex/crates/bloom-petal-dex-cpmm/src/lib.rs
+++ b/examples/petal-dex/crates/bloom-petal-dex-cpmm/src/lib.rs
@@ -23,7 +23,7 @@ pub use bloom_dex_math::{ConstantProduct, ConstantProductParams, MathError, Swap
 /// Petal body for `/bloom/petals/dex/strategy/cpmm`.
 ///
 /// Every `pub fn` inside this module becomes a `__petal_<name>` wasm
-/// export. The `#[bloom::petal]` macro embeds a `PetalManifestV0`
+/// export. The `#[bloom::petal]` macro embeds a `PetalManifest`
 /// custom section (spec §8) listing the types and entry points below.
 #[bloom::petal(path = "/bloom/petals/dex/strategy/cpmm", version = "0.1.0")]
 pub mod cpmm {

--- a/examples/petal-dex/tests/bloom-petal-dex-it/src/dex_harness.rs
+++ b/examples/petal-dex/tests/bloom-petal-dex-it/src/dex_harness.rs
@@ -190,14 +190,14 @@ pub fn wat_to_wasm(src: &str) -> Vec<u8> {
     wat::parse_str(src).expect("valid WAT")
 }
 
-/// Append a `bloom_petal_manifest_v0` custom section carrying
+/// Append a `bloom_petal_manifest` custom section carrying
 /// `manifest_bytes` to `wasm`. See [`crate::dex_harness`] / the
 /// `bloom-petal-it` mirror for the rationale: this pairs a real,
 /// chain-authoritative manifest (as the macro emits into the wasm
 /// custom section) with a hand-written WAT body so tests don't need
 /// `wasm32-unknown-unknown` at compile time.
 pub fn append_manifest_section(mut wasm: Vec<u8>, manifest_bytes: &[u8]) -> Vec<u8> {
-    let name = "bloom_petal_manifest_v0";
+    let name = "bloom_petal_manifest";
     let mut body = Vec::new();
     leb128(&mut body, name.len() as u64);
     body.extend_from_slice(name.as_bytes());
@@ -209,7 +209,7 @@ pub fn append_manifest_section(mut wasm: Vec<u8>, manifest_bytes: &[u8]) -> Vec<
 }
 
 /// Convenience: compile `wat_src` and append the
-/// `bloom_petal_manifest_v0` custom section in one call.
+/// `bloom_petal_manifest` custom section in one call.
 pub fn wrap_with_real_manifest(wat_src: &str, manifest_bytes: &[u8]) -> Vec<u8> {
     let base = wat_to_wasm(wat_src);
     append_manifest_section(base, manifest_bytes)
@@ -228,31 +228,31 @@ fn leb128(out: &mut Vec<u8>, mut v: u64) {
     }
 }
 
-/// The canonical-encoded `PetalManifestV0` bytes embedded in the real
+/// The canonical-encoded `PetalManifest` bytes embedded in the real
 /// `/bloom/petals/core/fungible` petal.
 pub fn real_fungible_manifest_bytes() -> &'static [u8] {
     bloom_petal_fungible::fungible::__bloom_manifest_bytes()
 }
 
-/// Canonical `PetalManifestV0` bytes embedded in the real
+/// Canonical `PetalManifest` bytes embedded in the real
 /// `/bloom/petals/dex/pool` petal.
 pub fn real_pool_manifest_bytes() -> &'static [u8] {
     bloom_petal_dex_pool::pool::__bloom_manifest_bytes()
 }
 
-/// Canonical `PetalManifestV0` bytes embedded in the real
+/// Canonical `PetalManifest` bytes embedded in the real
 /// `/bloom/petals/dex/wallet` petal.
 pub fn real_wallet_manifest_bytes() -> &'static [u8] {
     bloom_petal_dex_wallet::wallet::__bloom_manifest_bytes()
 }
 
-/// Canonical `PetalManifestV0` bytes embedded in the real
+/// Canonical `PetalManifest` bytes embedded in the real
 /// `/bloom/petals/dex/strategy/cpmm` petal.
 pub fn real_cpmm_manifest_bytes() -> &'static [u8] {
     bloom_petal_dex_cpmm::cpmm::__bloom_manifest_bytes()
 }
 
-/// Canonical `PetalManifestV0` bytes embedded in the real
+/// Canonical `PetalManifest` bytes embedded in the real
 /// `/bloom/petals/dex/router` petal.
 pub fn real_router_manifest_bytes() -> &'static [u8] {
     bloom_petal_dex_router::router::__bloom_manifest_bytes()

--- a/examples/petal-dex/tests/bloom-petal-dex-it/tests/docker_petal_dex.rs
+++ b/examples/petal-dex/tests/bloom-petal-dex-it/tests/docker_petal_dex.rs
@@ -46,9 +46,7 @@ use tokio::time::{sleep, timeout};
 
 use bloom_chain_node::rpc::RpcClient;
 use bloom_objects::{AbilitySet, AccessMode, Owner, TypeTag};
-use bloom_petal_manifest::types::{
-    ArgDecl, ArgKind, FunctionDecl, PetalManifestV0, SCHEMA_VERSION,
-};
+use bloom_petal_manifest::types::{ArgDecl, ArgKind, FunctionDecl, PetalManifest, SCHEMA_VERSION};
 use bloom_resource::BloomType;
 use bloom_script::{
     Arg, CORE_FUNGIBLE_PATH, Command as PtbCommand, ExpectedVersion, MoveCmd, PetalRef, PtbTx,
@@ -2396,7 +2394,7 @@ fn counter_type_tag(petal_hash: Hash32) -> TypeTag {
 
 fn view_probe_manifest() -> Vec<u8> {
     let self_counter = counter_type_tag(Hash32([0u8; 32]));
-    let manifest = PetalManifestV0 {
+    let manifest = PetalManifest {
         schema_version: SCHEMA_VERSION,
         module_path: PETAL_VFS_PROBE_PATH.to_string(),
         functions: vec![
@@ -2602,7 +2600,7 @@ fn view_probe_wasm() -> Vec<u8> {
 
 fn adversary_manifest(pool_hash: bloom_chain_types::types::Hash32) -> Vec<u8> {
     let pool_ty = pool_type_tag(pool_hash);
-    let manifest = PetalManifestV0 {
+    let manifest = PetalManifest {
         schema_version: SCHEMA_VERSION,
         module_path: ADVERSARY_PATH.to_string(),
         functions: vec![
@@ -2703,7 +2701,7 @@ fn adversary_wasm(
 
 fn loom_probe_manifest(fungible_hash: Hash32) -> Vec<u8> {
     let coin_ty = loom_coin_type_tag(fungible_hash);
-    let manifest = PetalManifestV0 {
+    let manifest = PetalManifest {
         schema_version: SCHEMA_VERSION,
         module_path: LOOM_PROBE_PATH.to_string(),
         functions: vec![

--- a/examples/petal-dex/tests/bloom-petal-dex-it/tests/lp_lifecycle.rs
+++ b/examples/petal-dex/tests/bloom-petal-dex-it/tests/lp_lifecycle.rs
@@ -179,7 +179,7 @@ fn real_pool_manifest_loads_via_chain_adapter() {
     }
 
     // Install a synthetic wasm carrying the real manifest in its
-    // `bloom_petal_manifest_v0` custom section and confirm the
+    // `bloom_petal_manifest` custom section and confirm the
     // production `PtbChainAdapter` finds it via layer 2 (wasm
     // custom-section parse + project). This is the **exact** path
     // the chain node uses for a deployed petal.

--- a/examples/petal-dex/tests/bloom-petal-dex-it/tests/two_hop_swap.rs
+++ b/examples/petal-dex/tests/bloom-petal-dex-it/tests/two_hop_swap.rs
@@ -129,7 +129,7 @@ use bloom_script::{Command, MoveCmd, PetalRef, PqSignature, PtbTx};
 #[test]
 fn router_manifest_decodes_and_publishes_via_wasm_section() {
     // Step 1: verify the macro-emitted bytes round-trip the canonical
-    // codec (i.e. they are valid `PetalManifestV0` bytes).
+    // codec (i.e. they are valid `PetalManifest` bytes).
     let bytes = real_router_manifest_bytes();
     let m = decode_manifest(bytes).expect("real router manifest must decode");
     assert_eq!(m.module_path, "/bloom/petals/dex/router");


### PR DESCRIPTION
Removes the stale versioned manifest surface now that the manifest schema is schema 4 and the network is still pre-testnet.\n\nChanges:\n- Rename PetalManifestV0 to PetalManifest.\n- Rename extract_petal_manifest_v0 APIs to unversioned extract_petal_manifest APIs.\n- Rename the wasm custom section from bloom_petal_manifest_v0 to bloom_petal_manifest.\n- Update affected docs, tests, examples, and call sites.\n\nValidation:\n- cargo fmt\n- cargo test -p bloom-petal-manifest\n- git diff --check\n- stale v3/v0 manifest-name search returned no matches.