### PR TITLE
docs: document block and tx VFS reads

### DIFF
--- a/crates/bloom-vfs/src/docs/README.md
+++ b/crates/bloom-vfs/src/docs/README.md
@@ -55,7 +55,7 @@ Reads are RPC / API queries. Examples:
 
 ```sh
 cat /bloom/chains/anvil/head/number
-cat /bloom/chains/ethereum/blocks/19000000/json
+cat /bloom/chains/ethereum/blocks/19000000/full.json
 cat /bloom/wallets/alice/chains/anvil/balance.eth
 cat /bloom/wallets/alice/chains/ethereum/history.json
 cat /bloom/tools/keccak/hello
@@ -65,6 +65,25 @@ cat /bloom/ens/vitalik.eth/avatar
 cat /bloom/ens/vitalik.eth/text/url
 cat /bloom/prices/spot/eth.usd
 cat /bloom/addressbook/alice
+```
+
+Some virtual collections, such as `chains/<chain>/blocks/`, are too large to
+enumerate. Address known block numbers directly; each block directory exposes
+`full.json`.
+
+Transaction-by-hash reads expose a small directory of receipt and transaction
+views:
+
+```sh
+TX=0x...
+ls /bloom/chains/ethereum/tx/$TX/
+cat /bloom/chains/ethereum/tx/$TX/status
+cat /bloom/chains/ethereum/tx/$TX/gas_used
+cat /bloom/chains/ethereum/tx/$TX/block_number
+cat /bloom/chains/ethereum/tx/$TX/full.json
+cat /bloom/chains/ethereum/tx/$TX/receipt.json
+cat /bloom/chains/ethereum/tx/$TX/logs.json
+cat /bloom/chains/ethereum/tx/$TX/error.json
 ```
 
 NFT reads (auto-detects ERC-721 vs ERC-1155 via ERC-165):

--- a/crates/bloom-vfs/src/handlers/chains.rs
+++ b/crates/bloom-vfs/src/handlers/chains.rs
@@ -12,7 +12,7 @@
 //! - `chains/<chain>/addresses/<addr>/nonce`
 //! - `chains/<chain>/addresses/<addr>/code` (hex bytecode)
 //! - `chains/<chain>/addresses/<addr>/tokens/<token>/{balance,balance.raw,balance.formatted,symbol,decimals}`
-//! - `chains/<chain>/tx/<hash>/{receipt.json,status,block_number,gas_used,logs.json,full.json}`
+//! - `chains/<chain>/tx/<hash>/{receipt.json,status,block_number,gas_used,logs.json,full.json,error.json}`
 //! - `chains/<chain>/gas/current.json`
 //!
 //! Etherscan-backed (only mounted when an etherscan client is provided):
@@ -434,6 +434,8 @@ const ADDRESS_FILES_ETHERSCAN: &[&str] = &["txs", "internal_txs", "erc20_txs", "
 const ADDRESS_FILES_ENS: &[&str] = &["ens"];
 
 const CONTRACT_FILES_ETHERSCAN: &[&str] = &["source", "abi"];
+
+const BLOCK_FILES: &[&str] = &["full.json"];
 
 const TX_FILES: &[&str] = &[
     "receipt.json",
@@ -1082,6 +1084,10 @@ impl ChainsHandler {
                 Entry::file("timestamp"),
                 Entry::file("full.json"),
             ]),
+            3 if segs[1] == "blocks" => {
+                // /chains/<chain>/blocks/<number>
+                Ok(BLOCK_FILES.iter().map(|n| Entry::file(n)).collect())
+            }
             2 if segs[1] == "gas" => Ok(vec![Entry::file("current.json")]),
             3 if segs[1] == "addresses" => {
                 // /chains/<chain>/addresses/<addr>
@@ -1570,6 +1576,40 @@ mod tests {
     fn etherscan_to(addr: SocketAddr) -> Arc<EtherscanClient> {
         let url = Url::parse(&format!("http://{addr}/api")).unwrap();
         Arc::new(EtherscanClient::with_base_url("test_key".into(), url))
+    }
+
+    #[tokio::test]
+    async fn block_number_dir_lists_full_json_leaf() {
+        let h = ChainsHandler::new(anvil_registry());
+        let chain_name = h.registry.list_names()[0].clone();
+        let p = VfsPath::parse(&format!("/{chain}/blocks/2", chain = chain_name)).unwrap();
+
+        let entries = h.list(&p).await.unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "full.json");
+        assert_eq!(entries[0].kind, crate::handler::EntryKind::File);
+    }
+
+    #[tokio::test]
+    async fn tx_hash_dir_lists_documented_leaves() {
+        let h = ChainsHandler::new(anvil_registry());
+        let chain_name = h.registry.list_names()[0].clone();
+        let p = VfsPath::parse(&format!(
+            "/{chain}/tx/0x0000000000000000000000000000000000000000000000000000000000000000",
+            chain = chain_name
+        ))
+        .unwrap();
+
+        let names: Vec<String> = h
+            .list(&p)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|e| e.name)
+            .collect();
+
+        assert_eq!(names, TX_FILES);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- fix embedded VFS docs to use `blocks/<number>/full.json` instead of the nonexistent `blocks/<number>/json`
- document the implemented `chains/<chain>/tx/<hash>/` transaction-by-hash leaves: `status`, `gas_used`, `block_number`, `full.json`, `receipt.json`, `logs.json`, and `error.json`
- make `chains/<chain>/blocks/<number>/` enumerate its `full.json` leaf so agents can discover the block file after addressing a known block number
- add a docs note that unbounded collections like `chains/<chain>/blocks/` do not enumerate block numbers and should be addressed by exact path

## Verification
- `cargo test -p bloom-vfs block_number_dir_lists_full_json_leaf`
- `cargo test -p bloom-vfs tx_hash_dir_lists_documented_leaves`
- `cargo test -p bloom-vfs --lib`
- `BLOOM_HOME=/tmp/bloom-doc-fix cargo run -q -p bloom -- vfs cat /docs/README.md | grep -E 'blocks/19000000|Transaction-by-hash|full.json' -n`
- `BLOOM_HOME=/tmp/bloom-doc-fix cargo run -q -p bloom -- vfs ls /chains/anvil/blocks/2`
- `BLOOM_HOME=/tmp/bloom-doc-fix cargo run -q -p bloom -- vfs ls /chains/anvil/tx/0x0000000000000000000000000000000000000000000000000000000000000000`
- `git diff --check`
