### PR TITLE
feat: agentic-wallet polish — balance API, QR export, Polymarket surfaces, mount fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2097,6 +2097,7 @@ dependencies = [
  "dirs 5.0.1",
  "hex",
  "predicates",
+ "qrcode",
  "serde",
  "serde_json",
  "shellexpand 3.1.2",
@@ -6463,6 +6464,12 @@ dependencies = [
  "log",
  "sptr",
 ]
+
+[[package]]
+name = "qrcode"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
 
 [[package]]
 name = "quanta"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,10 @@ wasmparser = "0.218"
 webauthn-rs = { version = "0.5.5", features = ["danger-allow-state-serialisation"] }
 open = "5"
 axum = { version = "0.8", default-features = false, features = ["http1", "tokio", "json"] }
+# QR rendering for deposit addresses. `svg` is a dependency-free string renderer
+# (for `wallet address --qr-out`); we drop the heavy `image`/PNG renderer. The
+# built-in unicode renderer covers the terminal QR.
+qrcode = { version = "0.14", default-features = false, features = ["svg"] }
 
 # Ethereum stack
 alloy = { version = "2", features = ["full", "signer-local", "rpc-types", "providers", "provider-http", "consensus", "network", "rlp", "json-abi", "k256", "eips", "essentials", "contract", "transport-throttle", "json-rpc"] }

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -126,8 +126,9 @@ cat /bloom/chains/ethereum/head/full.json | jq '.header.baseFeePerGas'
 
 ```sh
 # vitalik.eth
-cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/balance       # wei (decimal)
-cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/balance.eth   # "1.234 ETH"
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/balance       # "1.234 ETH" (display, with symbol)
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/balance.raw   # wei (integer base units)
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/balance.json  # { symbol, decimals, raw, formatted, display }
 cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nonce
 cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/code          # 0x for EOA
 cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/is_contract   # true / false
@@ -148,13 +149,13 @@ Allowances are not exposed here — read them via the token contract's
 
 ```sh
 ls /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/
-# → balance, balance.raw, balance.formatted, symbol, decimals
+# → balance, balance.raw, balance.json, symbol, decimals
 
-cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/balance.formatted   # "1234.56 USDC"
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/balance   # "1234.56 USDC" (display, with symbol)
 cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/symbol            # → WETH
 
 # Same shape on Base (USDC on Base):
-cat /bloom/chains/base/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913/balance.formatted
+cat /bloom/chains/base/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913/balance
 ```
 
 ### Transactions and receipts
@@ -620,9 +621,9 @@ cat /bloom/wallets/alice/kind             # local | watch
 cat /bloom/wallets/alice/policy.toml      # current policy
 
 # Per-chain native balance + nonce.
-cat /bloom/wallets/alice/chains/base/balance       # raw wei
-cat /bloom/wallets/alice/chains/base/balance.eth   # human "0.123 ETH"
-cat /bloom/wallets/alice/chains/base/balance.raw
+cat /bloom/wallets/alice/chains/base/balance       # human "0.123 ETH" (display, with symbol)
+cat /bloom/wallets/alice/chains/base/balance.raw   # raw wei (integer base units)
+cat /bloom/wallets/alice/chains/base/balance.json  # { symbol, decimals, raw, formatted, display }
 cat /bloom/wallets/alice/chains/base/nonce
 ```
 
@@ -631,7 +632,7 @@ reader at `chains/<c>/addresses/<addr>/tokens/<token>/...`:
 
 ```sh
 ALICE=$(cat /bloom/wallets/alice/address)
-cat /bloom/chains/base/addresses/$ALICE/tokens/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913/balance.formatted
+cat /bloom/chains/base/addresses/$ALICE/tokens/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913/balance
 ```
 
 ### Signing

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -11,6 +11,21 @@ If you are delegating setup to an agent, the fastest path is:
 Read https://bloom.directory/SKILL.md and set up Bloom.
 ```
 
+## Agent-first shape
+
+Bloom's primary surface is the VFS. Use `init` to create the home directory,
+`wallet` commands for explicit key management, and `vfs cat|ls|write` for the
+same paths an agent sees through the mount. There is no separate top-level
+onboarding dashboard; first-run setup is just the same primitives in sequence:
+create a wallet, show its deposit QR, then inspect balances and staged actions
+through the VFS.
+
+Fund the deposit address, then review every staged plan before signing. Caps
+and allow/deny live in each wallet's `policy.toml`; value-moving actions still
+go through the stage → review → confirm outbox flow. Polymarket trading
+additionally requires `bloom polymarket onboard <wallet>` (see `AGENTS.md`).
+Re-display a deposit address any time with `bloom wallet address <name> --qr`.
+
 ## Prerequisites
 
 - Rust toolchain — pinned via `rust-toolchain.toml` (installed
@@ -179,7 +194,7 @@ it expire after the configured TTL) cancels the stage.
   and contract `source` / `abi`. Requires an `[etherscan]` block in
   `config.toml`.
 - **ERC-20 reads** — `chains/<c>/addresses/<a>/tokens/<token>/{balance,
-  balance.raw,balance.formatted,symbol,decimals}` (live `eth_call`).
+  balance.raw,balance.json,symbol,decimals}` (live `eth_call`).
 - **ENS** — recipient names like `vitalik.eth` resolve in tx intents
   via the canonical mainnet registry; forward resolution is also
   exposed at `ens/<name>.eth`.

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ network broadcasts are blocked, but reads, simulations, local devnet flows,
 and any explicitly enabled broadcast paths should still be treated as
 high-risk until the code has been independently audited.
 
-The shortest onboarding path is:
+The shortest agent setup path is:
 
 > Tell your agent: **"Read https://bloom.directory/SKILL.md and set up Bloom."**
 
-After that, your agent should know to mount Bloom, inspect the Bloom
-directory, explain what it can do, and use Bloom instead of writing
-custom Web3 SDK code.
+After that, your agent should know to create or inspect a wallet, show the
+deposit address, mount Bloom, inspect the Bloom directory, explain what it can
+do, and use Bloom instead of writing custom Web3 SDK code.
 
 ## What Bloom enables
 

--- a/crates/bloom-daemon/examples/mount_demo.rs
+++ b/crates/bloom-daemon/examples/mount_demo.rs
@@ -65,14 +65,15 @@ async fn main() -> anyhow::Result<()> {
     //                                  the in-memory unlock.
     if let Ok(name) = std::env::var("BLOOM_TEST_WALLET_NAME") {
         let pass = std::env::var("BLOOM_TEST_WALLET_PASSPHRASE").unwrap_or_default();
-        if let Ok(key) = std::env::var("BLOOM_TEST_WALLET_KEY") {
-            if !key.is_empty() && daemon.keystore.info(&name).is_err() {
-                daemon
-                    .keystore
-                    .import_hex(&name, &key, &pass)
-                    .map_err(|e| anyhow::anyhow!("import {}: {}", name, e))?;
-                tracing::info!(wallet = %name, "test fixture: wallet imported");
-            }
+        if let Ok(key) = std::env::var("BLOOM_TEST_WALLET_KEY")
+            && !key.is_empty()
+            && daemon.keystore.info(&name).is_err()
+        {
+            daemon
+                .keystore
+                .import_hex(&name, &key, &pass)
+                .map_err(|e| anyhow::anyhow!("import {}: {}", name, e))?;
+            tracing::info!(wallet = %name, "test fixture: wallet imported");
         }
         daemon
             .keystore

--- a/crates/bloom-it/tests/anvil_e2e.rs
+++ b/crates/bloom-it/tests/anvil_e2e.rs
@@ -84,7 +84,7 @@ async fn anvil_full_stage_confirm_flow() -> Result<()> {
     sleep(Duration::from_millis(250)).await;
 
     // 5. Verify the balance is reflected through the VFS.
-    let bal_path = VfsPath::parse("/wallets/alice/chains/anvil/balance.eth").unwrap();
+    let bal_path = VfsPath::parse("/wallets/alice/chains/anvil/balance").unwrap();
     let bal_bytes = daemon
         .vfs
         .read(&bal_path)
@@ -93,7 +93,7 @@ async fn anvil_full_stage_confirm_flow() -> Result<()> {
     let bal_str = String::from_utf8(bal_bytes)?;
     assert!(
         bal_str.contains("ETH"),
-        "balance.eth missing 'ETH' suffix: {bal_str:?}"
+        "balance missing native symbol suffix: {bal_str:?}"
     );
     assert!(
         bal_str.starts_with("10"),

--- a/crates/bloom-mempool/tests/it_alchemy_smoke.rs
+++ b/crates/bloom-mempool/tests/it_alchemy_smoke.rs
@@ -8,6 +8,7 @@ use futures::StreamExt;
 use std::time::Duration;
 
 #[tokio::test]
+#[ignore = "requires ALCHEMY_API_KEY env and network access"]
 async fn alchemy_yields_at_least_one_pending_tx_in_30s() {
     let key = std::env::var("ALCHEMY_API_KEY").expect("set ALCHEMY_API_KEY to run this test");
     let url = format!("wss://eth-mainnet.g.alchemy.com/v2/{key}");

--- a/crates/bloom-mount/src/adapter.rs
+++ b/crates/bloom-mount/src/adapter.rs
@@ -371,6 +371,13 @@ impl MountRenderCache {
         };
         self.inner.lock().put(path.clone(), entry);
     }
+
+    /// Drop any cached render for `path` — called after a successful write so a
+    /// follow-up GETATTR/READ/READDIR re-renders the live body instead of
+    /// serving the pre-write bytes still sitting in the cache within its TTL.
+    fn invalidate(&self, path: &VfsPath) {
+        self.inner.lock().pop(path);
+    }
 }
 
 /// Shared future type for in-flight render dedup. Concurrent GETATTR /
@@ -519,6 +526,8 @@ impl BloomFs {
         if let Some(bytes) = self.take_complete_buffer(path) {
             trace!(path = %path.to_string_path(), bytes = bytes.len(), "mount.adapter.flush");
             self.vfs.write(path, &bytes).await.map_err(map_err)?;
+            // The rendered view is now stale; drop it so the next read re-renders.
+            self.render_cache.invalidate(path);
         } else {
             trace!(path = %path.to_string_path(), "mount.adapter.flush.nothing_to_flush");
         }
@@ -660,28 +669,32 @@ impl FileSystem for BloomFs {
                 // critical to avoid a `stat` triggering a sign or
                 // broadcast.
                 let size = if self.should_render_for_attrs(path, &e) {
-                    match self.render_with_dedup(path).await {
-                        Ok(bytes) => {
-                            let len = bytes.len() as u64;
-                            self.render_cache.put(path, bytes, RENDER_CACHE_TTL);
-                            len
-                        }
-                        Err(_) => {
-                            // Render failed (timeout, backend error,
-                            // write-only sink that errors on read).
-                            // Falling through with `size = 0` keeps
-                            // metadata-only inspection (`stat`,
-                            // `ls -l`) working, but remember the
-                            // negative render so a follow-up READ can
-                            // surface EIO instead of looking like a
-                            // legitimate empty file.
-                            self.render_cache.put_error(path, RENDER_CACHE_TTL);
-                            warn!(
-                                path = %path.to_string_path(),
-                                "mount.adapter.getattr.render_failed_falling_back_to_size_0"
-                            );
-                            0
-                        }
+                    match self.render_cache.get(path) {
+                        Some(MountRenderResult::Bytes(bytes)) => bytes.len() as u64,
+                        Some(MountRenderResult::Error) => 0,
+                        None => match self.render_with_dedup(path).await {
+                            Ok(bytes) => {
+                                let len = bytes.len() as u64;
+                                self.render_cache.put(path, bytes, RENDER_CACHE_TTL);
+                                len
+                            }
+                            Err(_) => {
+                                // Render failed (timeout, backend error,
+                                // write-only sink that errors on read).
+                                // Falling through with `size = 0` keeps
+                                // metadata-only inspection (`stat`,
+                                // `ls -l`) working, but remember the
+                                // negative render so a follow-up READ can
+                                // surface EIO instead of looking like a
+                                // legitimate empty file.
+                                self.render_cache.put_error(path, RENDER_CACHE_TTL);
+                                warn!(
+                                    path = %path.to_string_path(),
+                                    "mount.adapter.getattr.render_failed_falling_back_to_size_0"
+                                );
+                                0
+                            }
+                        },
                     }
                 } else {
                     0
@@ -1010,6 +1023,8 @@ impl FileSystem for BloomFs {
 
         if let Some(payload) = complete_payload {
             self.vfs.write(&path, &payload).await.map_err(map_err)?;
+            // Persisted new bytes — invalidate any stale rendered view.
+            self.render_cache.invalidate(&path);
         }
 
         Ok(WriteResult {
@@ -1044,6 +1059,7 @@ impl FileSystem for BloomFs {
         let parent_path = Self::path_of(parent);
         let child = parent_path.join(&decoded);
         self.vfs.write(&child, &[]).await.map_err(map_err)?;
+        self.render_cache.invalidate(&child);
         let e = self.vfs.lookup(&child).await.map_err(map_err)?;
         // CREATE returns initial attrs; the file has just been written
         // empty (or with a zero-byte body). Report `e.size` so a
@@ -1261,7 +1277,7 @@ mod tests {
             .await
             .unwrap();
         let names: Vec<&str> = page.entries.iter().map(|e| e.name.as_str()).collect();
-        assert_eq!(names, vec!["echo"]);
+        assert_eq!(names, vec!["AGENTS.md", "CLAUDE.md", "echo"]);
         assert!(page.eof);
     }
 
@@ -1711,6 +1727,50 @@ mod tests {
         let attrs = fs.getattr(&ctx, &inbox).await.unwrap();
         assert_eq!(attrs.size, b"hello\n".len() as u64);
         assert_eq!(attrs.mode & 0o777, 0o644);
+    }
+
+    /// Regression: a write through the mount must invalidate the render cache,
+    /// so a follow-up GETATTR/READ reflects the new bytes instead of the
+    /// pre-write render still cached within `RENDER_CACHE_TTL`.
+    #[tokio::test]
+    async fn write_invalidates_render_cache() {
+        let recorder = RecordingHandler::new();
+        recorder.writes.lock().push(b"hello\n".to_vec());
+        let vfs = Vfs::builder().mount("box", recorder.clone()).build();
+        let fs = BloomFs::new(vfs);
+        let ctx = fake_ctx();
+        let dir = fs.lookup(&ctx, &BloomHandle::Root, "box").await.unwrap();
+        let inbox = fs.lookup(&ctx, &dir, "inbox").await.unwrap();
+
+        // Populate the render cache: GETATTR renders + caches "hello\n".
+        assert_eq!(
+            fs.getattr(&ctx, &inbox).await.unwrap().size,
+            b"hello\n".len() as u64
+        );
+
+        // Overwrite through the mount (complete FILE_SYNC write flushes to VFS).
+        let new = b"GOODBYE WORLD\n";
+        fs.write(
+            &ctx,
+            &inbox,
+            0,
+            Bytes::copy_from_slice(new),
+            WriteStability::FileSync,
+        )
+        .await
+        .unwrap();
+
+        // Pre-fix these would still see the cached "hello\n".
+        assert_eq!(
+            fs.getattr(&ctx, &inbox).await.unwrap().size,
+            new.len() as u64,
+            "GETATTR served a stale cached size after write"
+        );
+        assert_eq!(
+            &fs.read(&ctx, &inbox, 0, 4096).await.unwrap().data[..],
+            new,
+            "READ served stale cached bytes after write"
+        );
     }
 
     /// Handler exposing a writable file whose `read` errors out — the

--- a/crates/bloom-polymarket/src/eip712.rs
+++ b/crates/bloom-polymarket/src/eip712.rs
@@ -111,6 +111,7 @@ pub const DEPOSIT_WALLET_IMPLEMENTATION_AMOY: Address =
 /// pUSD — the V2 CLOB collateral (ERC-20, 6 dp). Replaced USDC.e on 2026-04-28;
 /// this is what the deposit wallet holds and what approvals target.
 pub const PUSD: Address = Address::new(hex_addr(b"C011a7E12a19f7B1f670d46F03B03f3342E82DFB"));
+pub const PUSD_DECIMALS: u8 = 6;
 /// USDC.e — the bridge token only (no longer the CLOB collateral).
 pub const USDC_E: Address = Address::new(hex_addr(b"2791Bca1f2de4661ED88A30C99A7a9449Aa84174"));
 /// Conditional Tokens Framework (ERC-1155).

--- a/crates/bloom-polymarket/src/order_store.rs
+++ b/crates/bloom-polymarket/src/order_store.rs
@@ -530,6 +530,15 @@ pub fn render_plan_md(d: &OrderDraft) -> String {
     use crate::order::format_micro;
     let mut s = String::new();
     s.push_str(&format!("# Polymarket order draft {}\n\n", d.id));
+    // Make the safety state unmissable and machine-greppable: a draft has not
+    // signed or posted anything. It is durable (persistent), so an agent can
+    // review it across invocations before confirming.
+    s.push_str(
+        "Status:    DRAFT — value_moved=false order_posted=false persistent_staged_action=true\n",
+    );
+    s.push_str(
+        "           nothing moved yet; review, then `bloom polymarket confirm <wallet> <draft-id>` to sign+post.\n",
+    );
     s.push_str(&format!("Wallet:    {} ({})\n", d.wallet, d.owner));
     s.push_str(&format!(
         "Maker:     {} (signatureType {}{})\n",

--- a/crates/bloom-revert/src/heimdall.rs
+++ b/crates/bloom-revert/src/heimdall.rs
@@ -141,14 +141,14 @@ impl HeimdallDecompileDecoder {
         if let Some(entry) = self.in_memory.read().await.get(&codehash).cloned() {
             return entry;
         }
-        if let Some(dir) = &self.cache_dir {
-            if let Some(abi) = read_disk_cache(dir, codehash) {
-                self.in_memory
-                    .write()
-                    .await
-                    .insert(codehash, Some(abi.clone()));
-                return Some(abi);
-            }
+        if let Some(dir) = &self.cache_dir
+            && let Some(abi) = read_disk_cache(dir, codehash)
+        {
+            self.in_memory
+                .write()
+                .await
+                .insert(codehash, Some(abi.clone()));
+            return Some(abi);
         }
 
         let abi = match self.run_decompile(code).await {
@@ -159,10 +159,10 @@ impl HeimdallDecompileDecoder {
             }
         };
 
-        if let Some(dir) = &self.cache_dir {
-            if let Err(e) = write_disk_cache(dir, codehash, &abi) {
-                tracing::debug!(error = %e, "heimdall.cache_write_failed");
-            }
+        if let Some(dir) = &self.cache_dir
+            && let Err(e) = write_disk_cache(dir, codehash, &abi)
+        {
+            tracing::debug!(error = %e, "heimdall.cache_write_failed");
         }
         self.in_memory
             .write()

--- a/crates/bloom-vfs/src/docs/README.md
+++ b/crates/bloom-vfs/src/docs/README.md
@@ -58,7 +58,7 @@ Reads are RPC / API queries. Examples:
 ```sh
 cat /bloom/chains/anvil/head/number
 cat /bloom/chains/ethereum/blocks/19000000/full.json
-cat /bloom/wallets/alice/chains/anvil/balance.eth
+cat /bloom/wallets/alice/chains/anvil/balance        # "1.5 ETH" (display); also balance.raw, balance.json
 cat /bloom/wallets/alice/chains/ethereum/history.json
 cat /bloom/tools/keccak/hello
 cat /bloom/tools/abi/decode/<sig>/<hex>

--- a/crates/bloom-vfs/src/handlers/balances.rs
+++ b/crates/bloom-vfs/src/handlers/balances.rs
@@ -1,0 +1,59 @@
+//! Shared balance rendering — the convention used by native and ERC-20 reads.
+//!
+//! - `balance`      → human display *with symbol* ("23739.58 POL")
+//! - `balance.raw`  → raw integer base units ("23739589974494571130021")
+//! - `balance.json` → structured facts (symbol, decimals, raw, formatted, display)
+//!
+//! Centralized so native (wallet + address) and token reads stay identical in
+//! shape and an agent never has to infer units from a bare integer.
+
+use alloy::primitives::U256;
+use bloom_proto::format_units;
+use std::time::Duration;
+
+/// Live balance/nonce reads change with the chain head but are expensive enough
+/// to cache briefly during agent bursts and mounted filesystem probes.
+pub(crate) const LIVE_BALANCE_TTL: Duration = Duration::from_secs(5);
+
+/// ERC-20 metadata is effectively static for normal tokens. Keep this separate
+/// from live balance TTLs so display leaves can refresh balances without
+/// repeatedly calling `symbol()` and `decimals()`.
+pub(crate) const TOKEN_METADATA_TTL: Duration = Duration::from_secs(7 * 86_400);
+
+/// `"<formatted> <symbol>\n"` for the `balance` leaf.
+pub(crate) fn display_line(raw: U256, decimals: u8, symbol: &str) -> Vec<u8> {
+    format!("{} {}\n", format_units(raw, decimals), symbol).into_bytes()
+}
+
+/// `"<raw>\n"` for the `balance.raw` leaf.
+pub(crate) fn raw_line(raw: U256) -> Vec<u8> {
+    format!("{raw}\n").into_bytes()
+}
+
+/// Pretty JSON facts for the `balance.json` leaf. `asset` is `"native"` or
+/// `"erc20"`; `token_address` is included only for tokens.
+pub(crate) fn balance_json(
+    chain: &str,
+    asset: &str,
+    token_address: Option<&str>,
+    symbol: &str,
+    decimals: u8,
+    raw: U256,
+) -> Vec<u8> {
+    let formatted = format_units(raw, decimals);
+    let mut obj = serde_json::json!({
+        "chain": chain,
+        "asset": asset,
+        "symbol": symbol,
+        "decimals": decimals,
+        "raw": raw.to_string(),
+        "formatted": formatted,
+        "display": format!("{formatted} {symbol}"),
+    });
+    if let Some(addr) = token_address {
+        obj["address"] = serde_json::Value::String(addr.to_string());
+    }
+    let mut v = serde_json::to_vec_pretty(&obj).expect("balance json serializes");
+    v.push(b'\n');
+    v
+}

--- a/crates/bloom-vfs/src/handlers/chains.rs
+++ b/crates/bloom-vfs/src/handlers/chains.rs
@@ -7,11 +7,12 @@
 //! - `chains/<chain>/head/timestamp`
 //! - `chains/<chain>/head/full.json`
 //! - `chains/<chain>/blocks/<n>/full.json`
-//! - `chains/<chain>/addresses/<addr>/balance` (wei, decimal)
-//! - `chains/<chain>/addresses/<addr>/balance.eth`
+//! - `chains/<chain>/addresses/<addr>/balance` (display, e.g. "1.5 POL")
+//! - `chains/<chain>/addresses/<addr>/balance.raw` (integer base units)
+//! - `chains/<chain>/addresses/<addr>/balance.json` (structured facts)
 //! - `chains/<chain>/addresses/<addr>/nonce`
 //! - `chains/<chain>/addresses/<addr>/code` (hex bytecode)
-//! - `chains/<chain>/addresses/<addr>/tokens/<token>/{balance,balance.raw,balance.formatted,symbol,decimals}`
+//! - `chains/<chain>/addresses/<addr>/tokens/<token>/{balance,balance.raw,balance.json,symbol,decimals}`
 //! - `chains/<chain>/tx/<hash>/{receipt.json,status,block_number,gas_used,logs.json,full.json,error.json}`
 //! - `chains/<chain>/gas/current.json`
 //!
@@ -35,14 +36,14 @@
 //!   address or `not a proxy\n` when the slot is empty.
 
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 
 use bloom_chain::{ChainClient, ChainRegistry};
 use bloom_ens::{EnsClient, EnsError};
 use bloom_etherscan::{AddressHistorySource, ContractMetadataSource, EtherscanClient};
-use bloom_proto::{Backend, BackendsConfig, checksum_address, format_units};
+use bloom_proto::{Backend, BackendsConfig, checksum_address};
 use bloom_revert::{DecodeContext, DecodedRevert, DecoderChain};
 use parking_lot::Mutex as PlMutex;
 
@@ -84,6 +85,8 @@ pub struct ChainsHandler {
     pending: Arc<PendingBodies>,
     /// Process-wide cache of ERC-165 NFT kind detection.
     nft_cache: Arc<NftKindCache>,
+    /// Longer-lived ERC-20 metadata cache used by display/JSON balance leaves.
+    token_metadata_cache: Arc<PlMutex<std::collections::HashMap<TokenMetadataKey, TokenMetadata>>>,
     /// Tiered revert decoder chain, shared across requests. `None` is a
     /// degenerate config: `error.json` will return an empty marker.
     revert_decoder: Arc<DecoderChain>,
@@ -99,6 +102,19 @@ pub struct ChainsHandler {
         Arc<std::collections::BTreeMap<String, Arc<super::chains_mempool::MempoolHandler>>>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct TokenMetadataKey {
+    chain_id: u64,
+    token: alloy::primitives::Address,
+}
+
+#[derive(Clone, Debug)]
+struct TokenMetadata {
+    decimals: u8,
+    symbol: String,
+    expires_at: Instant,
+}
+
 impl ChainsHandler {
     pub fn new(registry: ChainRegistry) -> Self {
         Self {
@@ -111,6 +127,7 @@ impl ChainsHandler {
             live_state: Arc::new(LiveTailState::new()),
             pending: Arc::new(PendingBodies::new()),
             nft_cache: Arc::new(NftKindCache::new()),
+            token_metadata_cache: Arc::new(PlMutex::new(std::collections::HashMap::new())),
             revert_decoder: Arc::new(DecoderChain::new()),
             revert_cache: Arc::new(PlMutex::new(std::collections::HashMap::new())),
             mempool_handlers: Arc::new(std::collections::BTreeMap::new()),
@@ -177,6 +194,42 @@ impl ChainsHandler {
         self.registry
             .get(name)
             .ok_or_else(|| HandlerError::not_found(format!("chain '{}'", name)))
+    }
+
+    async fn token_metadata(
+        &self,
+        client: &ChainClient,
+        token: alloy::primitives::Address,
+    ) -> Result<(u8, String), HandlerError> {
+        let key = TokenMetadataKey {
+            chain_id: client.spec().chain_id,
+            token,
+        };
+        if let Some(meta) = self.token_metadata_cache.lock().get(&key)
+            && meta.expires_at > Instant::now()
+        {
+            return Ok((meta.decimals, meta.symbol.clone()));
+        }
+
+        let decimals = client
+            .erc20_decimals(token)
+            .await
+            .map_err(err_be)?
+            .unwrap_or(18);
+        let symbol = client
+            .erc20_symbol(token)
+            .await
+            .map_err(err_be)?
+            .unwrap_or_else(|| "?".into());
+        self.token_metadata_cache.lock().insert(
+            key,
+            TokenMetadata {
+                decimals,
+                symbol: symbol.clone(),
+                expires_at: Instant::now() + super::balances::TOKEN_METADATA_TTL,
+            },
+        );
+        Ok((decimals, symbol))
     }
 
     /// Resolve the contract-metadata source. Returns `NotFound` with an
@@ -423,8 +476,8 @@ fn err_be(e: impl std::fmt::Display) -> HandlerError {
 /// flagged so we only emit them when an etherscan client is configured.
 const ADDRESS_FILES_CORE: &[&str] = &[
     "balance",
-    "balance.eth",
     "balance.raw",
+    "balance.json",
     "nonce",
     "code",
     "is_contract",
@@ -450,7 +503,7 @@ const TX_FILES: &[&str] = &[
 const TOKEN_FILES: &[&str] = &[
     "balance",
     "balance.raw",
-    "balance.formatted",
+    "balance.json",
     "symbol",
     "decimals",
 ];
@@ -681,18 +734,28 @@ impl ChainsHandler {
                 let addr = parse_addr(&segs[2])?;
                 let spec = client.spec();
                 match segs[3].as_str() {
-                    "balance" | "balance.raw" => {
+                    "balance" => {
                         let bal = client.balance(addr).await.map_err(err_be)?;
-                        Ok(format!("{}\n", bal).into_bytes())
+                        Ok(super::balances::display_line(
+                            bal,
+                            spec.native_decimals,
+                            &spec.native_symbol,
+                        ))
                     }
-                    "balance.eth" => {
+                    "balance.raw" => {
                         let bal = client.balance(addr).await.map_err(err_be)?;
-                        Ok(format!(
-                            "{} {}\n",
-                            format_units(bal, spec.native_decimals),
-                            spec.native_symbol
-                        )
-                        .into_bytes())
+                        Ok(super::balances::raw_line(bal))
+                    }
+                    "balance.json" => {
+                        let bal = client.balance(addr).await.map_err(err_be)?;
+                        Ok(super::balances::balance_json(
+                            chain,
+                            "native",
+                            None,
+                            &spec.native_symbol,
+                            spec.native_decimals,
+                            bal,
+                        ))
                     }
                     "nonce" => {
                         let n = client.nonce(addr).await.map_err(err_be)?;
@@ -738,43 +801,45 @@ impl ChainsHandler {
                 let holder = parse_addr(&segs[2])?;
                 let token = parse_addr(&segs[4])?;
                 match segs[5].as_str() {
-                    "balance" | "balance.raw" => {
+                    "balance" => {
                         let bal = client
                             .erc20_balance(token, holder)
                             .await
                             .map_err(err_be)?
                             .ok_or_else(|| HandlerError::backend("erc20 balanceOf reverted"))?;
-                        Ok(format!("{}\n", bal).into_bytes())
+                        let (dec, sym) = self.token_metadata(&client, token).await?;
+                        Ok(super::balances::display_line(bal, dec, &sym))
                     }
-                    "balance.formatted" => {
+                    "balance.raw" => {
                         let bal = client
                             .erc20_balance(token, holder)
                             .await
                             .map_err(err_be)?
                             .ok_or_else(|| HandlerError::backend("erc20 balanceOf reverted"))?;
-                        let dec = client
-                            .erc20_decimals(token)
+                        Ok(super::balances::raw_line(bal))
+                    }
+                    "balance.json" => {
+                        let bal = client
+                            .erc20_balance(token, holder)
                             .await
                             .map_err(err_be)?
-                            .unwrap_or(18);
-                        let sym = client.erc20_symbol(token).await.map_err(err_be)?;
-                        Ok(format!(
-                            "{} {}\n",
-                            format_units(bal, dec),
-                            sym.unwrap_or_else(|| "?".into())
-                        )
-                        .into_bytes())
+                            .ok_or_else(|| HandlerError::backend("erc20 balanceOf reverted"))?;
+                        let (dec, sym) = self.token_metadata(&client, token).await?;
+                        Ok(super::balances::balance_json(
+                            chain,
+                            "erc20",
+                            Some(&checksum_address(&token)),
+                            &sym,
+                            dec,
+                            bal,
+                        ))
                     }
                     "symbol" => {
-                        let sym = client.erc20_symbol(token).await.map_err(err_be)?;
-                        Ok(format!("{}\n", sym.unwrap_or_default()).into_bytes())
+                        let (_, sym) = self.token_metadata(&client, token).await?;
+                        Ok(format!("{sym}\n").into_bytes())
                     }
                     "decimals" => {
-                        let dec = client
-                            .erc20_decimals(token)
-                            .await
-                            .map_err(err_be)?
-                            .unwrap_or(18);
+                        let (dec, _) = self.token_metadata(&client, token).await?;
                         Ok(format!("{}\n", dec).into_bytes())
                     }
                     _ => Err(HandlerError::NotAFile(path.to_string_path())),
@@ -1008,18 +1073,28 @@ impl ChainsHandler {
                 let spec = client.spec().clone();
                 let session = client.open_session_at(block_number).await.map_err(err_be)?;
                 match segs[3].as_str() {
-                    "balance" | "balance.raw" => {
+                    "balance" => {
                         let bal = session.balance(addr).await.map_err(err_be)?;
-                        Ok(format!("{}\n", bal).into_bytes())
+                        Ok(super::balances::display_line(
+                            bal,
+                            spec.native_decimals,
+                            &spec.native_symbol,
+                        ))
                     }
-                    "balance.eth" => {
+                    "balance.raw" => {
                         let bal = session.balance(addr).await.map_err(err_be)?;
-                        Ok(format!(
-                            "{} {}\n",
-                            format_units(bal, spec.native_decimals),
-                            spec.native_symbol
-                        )
-                        .into_bytes())
+                        Ok(super::balances::raw_line(bal))
+                    }
+                    "balance.json" => {
+                        let bal = session.balance(addr).await.map_err(err_be)?;
+                        Ok(super::balances::balance_json(
+                            chain,
+                            "native",
+                            None,
+                            &spec.native_symbol,
+                            spec.native_decimals,
+                            bal,
+                        ))
                     }
                     "nonce" => {
                         let n = session.nonce(addr).await.map_err(err_be)?;
@@ -1175,8 +1250,8 @@ impl ChainsHandler {
             // chain head. Etherscan-backed history is rate-limited so
             // we cache it longer.
             "addresses" => match segs.get(3).map(|s| s.as_str()) {
-                Some("balance" | "balance.eth" | "balance.raw" | "nonce") => {
-                    Some(Duration::from_secs(5))
+                Some("balance" | "balance.raw" | "balance.json" | "nonce") => {
+                    Some(super::balances::LIVE_BALANCE_TTL)
                 }
                 Some("code" | "is_contract") => Some(Duration::from_secs(86_400)),
                 Some("txs" | "internal_txs" | "erc20_txs" | "erc721_txs") => {
@@ -1198,6 +1273,13 @@ impl ChainsHandler {
                     (_, Some("owner" | "balance" | "is_owner" | "approved")) => {
                         Some(Duration::from_secs(5))
                     }
+                    _ => None,
+                },
+                Some("tokens") => match segs.get(5).map(|s| s.as_str()) {
+                    Some("balance" | "balance.raw" | "balance.json") => {
+                        Some(super::balances::LIVE_BALANCE_TTL)
+                    }
+                    Some("symbol" | "decimals") => Some(super::balances::TOKEN_METADATA_TTL),
                     _ => None,
                 },
                 _ => None,
@@ -2663,6 +2745,73 @@ mod tests {
         ))
         .unwrap();
         assert_eq!(h.cache_ttl(&p), Some(Duration::from_secs(3600)));
+    }
+
+    #[tokio::test]
+    async fn balance_cache_ttls_cover_native_and_token_balance_leaves() {
+        let h = ChainsHandler::new(anvil_registry());
+        let chain = h.registry.list_names()[0].clone();
+        for leaf in ["balance", "balance.raw", "balance.json", "nonce"] {
+            let p = VfsPath::parse(&format!("/{chain}/addresses/{HOLDER_ADDR}/{leaf}")).unwrap();
+            assert_eq!(
+                h.cache_ttl(&p),
+                Some(super::super::balances::LIVE_BALANCE_TTL),
+                "native leaf {leaf}"
+            );
+        }
+        for leaf in ["balance", "balance.raw", "balance.json"] {
+            let p = VfsPath::parse(&format!(
+                "/{chain}/addresses/{HOLDER_ADDR}/tokens/{NFT_CONTRACT}/{leaf}"
+            ))
+            .unwrap();
+            assert_eq!(
+                h.cache_ttl(&p),
+                Some(super::super::balances::LIVE_BALANCE_TTL),
+                "token leaf {leaf}"
+            );
+        }
+        for leaf in ["symbol", "decimals"] {
+            let p = VfsPath::parse(&format!(
+                "/{chain}/addresses/{HOLDER_ADDR}/tokens/{NFT_CONTRACT}/{leaf}"
+            ))
+            .unwrap();
+            assert_eq!(
+                h.cache_ttl(&p),
+                Some(super::super::balances::TOKEN_METADATA_TTL),
+                "token metadata leaf {leaf}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn balance_native_display_and_json_are_self_describing() {
+        let mut responses = std::collections::HashMap::new();
+        responses.insert(
+            "eth_getBalance".to_string(),
+            serde_json::Value::String("0xde0b6b3a7640000".into()),
+        );
+        let rpc = spawn_rpc(31338, responses);
+        let h = ChainsHandler::new(registry_for_rpc(rpc, 31338));
+        let balance = h
+            .read(&VfsPath::parse(&format!("/test/addresses/{HOLDER_ADDR}/balance")).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(std::str::from_utf8(&balance).unwrap(), "1 ETH\n");
+
+        let raw = h
+            .read(&VfsPath::parse(&format!("/test/addresses/{HOLDER_ADDR}/balance.raw")).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(std::str::from_utf8(&raw).unwrap(), "1000000000000000000\n");
+
+        let json = h
+            .read(&VfsPath::parse(&format!("/test/addresses/{HOLDER_ADDR}/balance.json")).unwrap())
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&json).unwrap();
+        assert_eq!(json["symbol"], "ETH");
+        assert_eq!(json["raw"], "1000000000000000000");
+        assert_eq!(json["display"], "1 ETH");
     }
 
     // ---- methods/ enumeration + EIP-1967 proxy resolution ----------------

--- a/crates/bloom-vfs/src/handlers/mod.rs
+++ b/crates/bloom-vfs/src/handlers/mod.rs
@@ -1,4 +1,5 @@
 pub mod addressbook;
+mod balances;
 pub mod chains;
 pub mod chains_contracts;
 mod chains_history;

--- a/crates/bloom-vfs/src/handlers/polymarket.rs
+++ b/crates/bloom-vfs/src/handlers/polymarket.rs
@@ -11,7 +11,7 @@ use alloy::primitives::{Address, U256};
 use async_trait::async_trait;
 use bloom_chain::ChainClient;
 use bloom_keystore::{Keystore, KeystoreError};
-use bloom_polymarket::eip712::PUSD;
+use bloom_polymarket::eip712::{PUSD, PUSD_DECIMALS};
 use bloom_polymarket::onboard::OnEvent;
 use bloom_polymarket::order::{self, OrderType};
 use bloom_polymarket::order_store::{OrderDraft, render_plan_md};
@@ -34,7 +34,13 @@ pub const MARKETS_LIST_LIMIT: u32 = 20;
 const MARKET_FILES: [&str; 3] = ["market.json", "book.json", "prices.json"];
 const POSITION_FILES: [&str; 3] = ["positions.json", "trades.json", "activity.json"];
 const ONBOARD_RO_FILES: [&str; 3] = ["status.json", "plan.md", "approvals.json"];
-const ACCOUNT_FILES: [&str; 2] = ["portfolio.json", "orders.json"];
+const ACCOUNT_FILES: [&str; 5] = [
+    "portfolio.json",
+    "orders.json",
+    "status.json",
+    "buying_power.json",
+    "funding_options.json",
+];
 const FUND_FILES: [&str; 3] = ["plan.md", "request.json", "status.json"];
 const DRAFT_FILES: [&str; 5] = [
     "plan.md",
@@ -1192,16 +1198,16 @@ impl PolymarketHandler {
     ) -> Result<Vec<u8>, HandlerError> {
         let ob = self.onboarding_or_not_found(path)?;
         let owner = self.wallet_address(wallet)?;
-        let creds = ob.creds.load(wallet).map_err(err_be)?.ok_or_else(|| {
-            HandlerError::invalid(format!(
-                "wallet '{wallet}' is not onboarded (no CLOB credentials); \
-                     write polymarket/onboard/{wallet}/begin first"
-            ))
-        })?;
         match file {
             // Sectioned by source so provenance is unambiguous: what the CLOB
             // believes vs. what the chain holds vs. where onboarding stands.
             "portfolio.json" => {
+                let creds = ob.creds.load(wallet).map_err(err_be)?.ok_or_else(|| {
+                    HandlerError::invalid(format!(
+                        "wallet '{wallet}' is not onboarded (no CLOB credentials); \
+                         write polymarket/onboard/{wallet}/begin first"
+                    ))
+                })?;
                 let st = ob.onboarder.status(wallet, owner).map_err(err_be)?;
                 let deposit: Address = st.deposit_wallet.parse().map_err(|_| {
                     HandlerError::backend("corrupt deposit_wallet in onboarding state")
@@ -1232,9 +1238,119 @@ impl PolymarketHandler {
                 }))
             }
             "orders.json" => {
+                let creds = ob.creds.load(wallet).map_err(err_be)?.ok_or_else(|| {
+                    HandlerError::invalid(format!(
+                        "wallet '{wallet}' is not onboarded (no CLOB credentials); \
+                         write polymarket/onboard/{wallet}/begin first"
+                    ))
+                })?;
                 let orders = self.clob.open_orders(&creds, owner).await.map_err(err_be)?;
                 pretty(&orders)
             }
+            // Polymarket *trading* state only. Owner native balance is NOT here;
+            // it is a chain fact at wallets/<w>/chains/<chain>/balance.json.
+            "status.json" => {
+                use bloom_polymarket::onboard::Stage;
+                let st = ob.onboarder.status(wallet, owner).map_err(err_be)?;
+                let deposit: Address = st.deposit_wallet.parse().map_err(|_| {
+                    HandlerError::backend("corrupt deposit_wallet in onboarding state")
+                })?;
+                let pusd = ob
+                    .chain
+                    .erc20_balance(PUSD, deposit)
+                    .await
+                    .map_err(err_be)?;
+                let tradeable = matches!(st.stage, Stage::Sync) && st.creds_present;
+                let approvals_granted = matches!(st.stage, Stage::Creds | Stage::Sync);
+                let next_required_action = if tradeable {
+                    serde_json::Value::Null
+                } else {
+                    serde_json::Value::String(format!(
+                        "continue onboarding (stage: {})",
+                        st.stage.as_str()
+                    ))
+                };
+                let fmt = bloom_proto::format_units(pusd, PUSD_DECIMALS);
+                pretty(&serde_json::json!({
+                    "wallet": wallet,
+                    "owner_address": bloom_proto::checksum_address(&owner),
+                    "deposit_wallet": st.deposit_wallet,
+                    "deposit_wallet_source": st.deposit_wallet_source,
+                    "mode": "deposit_wallet",
+                    "tradeable": tradeable,
+                    "onboarding_stage": st.stage.as_str(),
+                    "chain_id": st.chain_id,
+                    "approvals_granted": approvals_granted,
+                    "approve_tx_id": st.approve_tx_id,
+                    "balances": {
+                        "deposit_pusd": {
+                            "symbol": "pUSD",
+                            "raw": pusd.to_string(),
+                            "formatted": fmt,
+                            "display": format!("{fmt} pUSD"),
+                        }
+                    },
+                    "next_required_action": next_required_action,
+                }))
+            }
+            "buying_power.json" => {
+                let creds = ob.creds.load(wallet).map_err(err_be)?.ok_or_else(|| {
+                    HandlerError::invalid(format!(
+                        "wallet '{wallet}' is not onboarded (no CLOB credentials); \
+                         write polymarket/onboard/{wallet}/begin first"
+                    ))
+                })?;
+                use bloom_polymarket::onboard::Stage;
+                let st = ob.onboarder.status(wallet, owner).map_err(err_be)?;
+                let deposit: Address = st.deposit_wallet.parse().map_err(|_| {
+                    HandlerError::backend("corrupt deposit_wallet in onboarding state")
+                })?;
+                let clob_ba = self
+                    .clob
+                    .balance_allowance(&creds, owner, "COLLATERAL", 3)
+                    .await
+                    .map_err(err_be)?;
+                let pusd = ob
+                    .chain
+                    .erc20_balance(PUSD, deposit)
+                    .await
+                    .map_err(err_be)?;
+                let tradeable = matches!(st.stage, Stage::Sync) && st.creds_present;
+                let fmt = bloom_proto::format_units(pusd, PUSD_DECIMALS);
+                pretty(&serde_json::json!({
+                    "wallet": wallet,
+                    "spendable": {
+                        "asset": "pUSD",
+                        "raw": pusd.to_string(),
+                        "formatted": fmt,
+                        "source": "deposit_wallet",
+                        "clob_balance_allowance": clob_ba,
+                    },
+                    "native_funding_capacity_ref":
+                        format!("wallets/{wallet}/chains/polygon/balance.json"),
+                    "can_trade_now": tradeable && pusd > U256::ZERO,
+                    "funding_needed": pusd == U256::ZERO,
+                    "notes": [
+                        "Order size must be based on spendable pUSD, not owner native balance.",
+                        "Native funding capacity is not embedded here; read native_funding_capacity_ref."
+                    ],
+                }))
+            }
+            "funding_options.json" => pretty(&serde_json::json!({
+                "wallet": wallet,
+                "target_asset": "pUSD",
+                "options": [{
+                    "from": "native",
+                    "supported": true,
+                    "review_required": true,
+                    "notes": "Use Bloom Polymarket funding (`bloom polymarket fund` / `onboard --target-pusd`); do not call external DEX APIs directly."
+                }],
+                "limits": {
+                    "policy_caps_apply": true,
+                    "requires_quote": true,
+                    "native_value_caps_are_quantity_caps": true
+                }
+            })),
             _ => Err(HandlerError::NotAFile(path.to_string_path())),
         }
     }
@@ -1279,7 +1395,7 @@ impl PolymarketHandler {
             deposit_wallet_source: st.deposit_wallet_source,
             deposit_wallet_fundable: st.deposit_wallet_fundable,
             current_pusd_raw: pusd.to_string(),
-            current_pusd: bloom_proto::units::format_units(pusd, 6),
+            current_pusd: bloom_proto::units::format_units(pusd, PUSD_DECIMALS),
             target_pusd: req.target_pusd,
             max_spend: req.max_spend,
             from_token: req.from_token.unwrap_or_else(|| "native".to_string()),
@@ -2188,6 +2304,38 @@ mod tests {
             .unwrap();
         let ov: serde_json::Value = serde_json::from_slice(&orders).unwrap();
         assert_eq!(ov[0]["id"], "order-1");
+    }
+
+    #[tokio::test]
+    async fn account_status_and_funding_options_do_not_need_creds() {
+        let (addr, _s) = spawn_scripted(vec![]).await;
+        let f = onboard_fixture(addr, true).await;
+
+        let status = f
+            .handler
+            .read(&p("/account/alice/status.json"))
+            .await
+            .unwrap();
+        let status: serde_json::Value = serde_json::from_slice(&status).unwrap();
+        assert_eq!(status["wallet"], "alice");
+        assert_eq!(status["tradeable"], false);
+        assert_eq!(status["onboarding_stage"], "derive");
+        assert_eq!(status["balances"]["deposit_pusd"]["display"], "25 pUSD");
+
+        let funding = f
+            .handler
+            .read(&p("/account/alice/funding_options.json"))
+            .await
+            .unwrap();
+        let funding: serde_json::Value = serde_json::from_slice(&funding).unwrap();
+        assert_eq!(funding["target_asset"], "pUSD");
+
+        let err = f
+            .handler
+            .read(&p("/account/alice/buying_power.json"))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("not onboarded"), "{err}");
     }
 
     #[tokio::test]

--- a/crates/bloom-vfs/src/handlers/wallets.rs
+++ b/crates/bloom-vfs/src/handlers/wallets.rs
@@ -11,7 +11,7 @@
 //! - `wallets/<wallet>/public_key`                                  — secp256k1 pubkey hex
 //! - `wallets/<wallet>/kind`                                        — local/watch
 //! - `wallets/<wallet>/policy.toml`                                 — read+write policy
-//! - `wallets/<wallet>/chains/<chain>/balance(.eth|.raw)`           — native balance
+//! - `wallets/<wallet>/chains/<chain>/{balance,balance.raw,balance.json}` — native balance
 //! - `wallets/<wallet>/chains/<chain>/nonce`
 //! - `wallets/<wallet>/chains/<chain>/outbox/new.tx`                — write to stage
 //! - `wallets/<wallet>/chains/<chain>/outbox/pending/<id>/<file>`   — read staged
@@ -25,7 +25,7 @@ use alloy::signers::SignerSync;
 use async_trait::async_trait;
 use bloom_chain::ChainRegistry;
 use bloom_keystore::Keystore;
-use bloom_proto::{AddressBook, HomeWritePermit, RawIntent, format_units};
+use bloom_proto::{AddressBook, HomeWritePermit, RawIntent};
 use bloom_tx::{
     intent_parser,
     outbox::OutboxState,
@@ -193,6 +193,22 @@ impl Handler for WalletsHandler {
             );
         }
         r
+    }
+
+    fn cache_ttl(&self, path: &VfsPath) -> Option<std::time::Duration> {
+        let segs = path.segments();
+        match segs {
+            [_, s, _, leaf]
+                if s == "chains"
+                    && matches!(
+                        leaf.as_str(),
+                        "balance" | "balance.raw" | "balance.json" | "nonce"
+                    ) =>
+            {
+                Some(super::balances::LIVE_BALANCE_TTL)
+            }
+            _ => None,
+        }
     }
 
     /// Defense-in-depth gate against the mount layer rendering at
@@ -373,7 +389,7 @@ impl WalletsHandler {
             .ok_or_else(|| HandlerError::not_found(format!("chain '{}'", chain)))?;
         match rest {
             [] => Ok(Entry::dir(chain)),
-            [s] if s == "balance" || s == "balance.eth" || s == "balance.raw" || s == "nonce" => {
+            [s] if s == "balance" || s == "balance.raw" || s == "balance.json" || s == "nonce" => {
                 Ok(Entry::file(s))
             }
             [s] if s == "pending_external.jsonl" || s == "nonce_conflicts.json" => {
@@ -498,19 +514,30 @@ impl WalletsHandler {
             .get(chain)
             .ok_or_else(|| HandlerError::not_found(format!("chain '{}'", chain)))?;
         match rest {
-            [s] if s == "balance" || s == "balance.raw" => {
-                let bal = client.balance(info.address).await.map_err(err_be)?;
-                Ok(format!("{}\n", bal).into_bytes())
-            }
-            [s] if s == "balance.eth" => {
+            [s] if s == "balance" => {
                 let bal = client.balance(info.address).await.map_err(err_be)?;
                 let spec = client.spec();
-                Ok(format!(
-                    "{} {}\n",
-                    format_units(bal, spec.native_decimals),
-                    spec.native_symbol
-                )
-                .into_bytes())
+                Ok(super::balances::display_line(
+                    bal,
+                    spec.native_decimals,
+                    &spec.native_symbol,
+                ))
+            }
+            [s] if s == "balance.raw" => {
+                let bal = client.balance(info.address).await.map_err(err_be)?;
+                Ok(super::balances::raw_line(bal))
+            }
+            [s] if s == "balance.json" => {
+                let bal = client.balance(info.address).await.map_err(err_be)?;
+                let spec = client.spec();
+                Ok(super::balances::balance_json(
+                    chain,
+                    "native",
+                    None,
+                    &spec.native_symbol,
+                    spec.native_decimals,
+                    bal,
+                ))
             }
             [s] if s == "nonce" => {
                 let n = client.nonce(info.address).await.map_err(err_be)?;
@@ -644,8 +671,8 @@ impl WalletsHandler {
         match rest {
             [] => Ok(vec![
                 Entry::file("balance"),
-                Entry::file("balance.eth"),
                 Entry::file("balance.raw"),
+                Entry::file("balance.json"),
                 Entry::file("nonce"),
                 Entry::file("pending_external.jsonl"),
                 Entry::file("nonce_conflicts.json"),
@@ -1129,6 +1156,21 @@ mod tests {
             wallet_addr: info.address,
             sign_dir,
         }
+    }
+
+    #[tokio::test]
+    async fn balance_cache_ttl_covers_wallet_native_balance_leaves() {
+        let f = make_handler_with_chain(true);
+        for leaf in ["balance", "balance.raw", "balance.json", "nonce"] {
+            let p = VfsPath::parse(&format!("/alice/chains/anvil/{leaf}")).unwrap();
+            assert_eq!(
+                f.handler.cache_ttl(&p),
+                Some(super::super::balances::LIVE_BALANCE_TTL),
+                "leaf {leaf}"
+            );
+        }
+        let outbox = VfsPath::parse("/alice/chains/anvil/outbox").unwrap();
+        assert_eq!(f.handler.cache_ttl(&outbox), None);
     }
 
     /// Write a synthetic staged tx directly into the outbox so the tests

--- a/crates/bloom/Cargo.toml
+++ b/crates/bloom/Cargo.toml
@@ -54,6 +54,7 @@ shellexpand.workspace = true
 hex.workspace = true
 alloy.workspace = true
 base64.workspace = true
+qrcode.workspace = true
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/crates/bloom/src/commands/qr.rs
+++ b/crates/bloom/src/commands/qr.rs
@@ -1,0 +1,34 @@
+//! Terminal QR helpers for wallet deposit addresses.
+
+use qrcode::QrCode;
+use qrcode::render::svg;
+use qrcode::render::unicode;
+
+/// Render `data` as a terminal QR code (Unicode half-blocks), or `None` if the
+/// payload is too large to encode. Callers should always print the raw payload
+/// too, so a `None` here is non-fatal.
+pub fn render_qr(data: &str) -> Option<String> {
+    let code = QrCode::new(data.as_bytes()).ok()?;
+    Some(code.render::<unicode::Dense1x2>().quiet_zone(true).build())
+}
+
+/// Render `data` as a standalone SVG QR document (scannable image file), or
+/// `None` if the payload is too large to encode.
+pub fn render_qr_svg(data: &str) -> Option<String> {
+    let code = QrCode::new(data.as_bytes()).ok()?;
+    Some(
+        code.render::<svg::Color>()
+            .min_dimensions(256, 256)
+            .quiet_zone(true)
+            .build(),
+    )
+}
+
+/// Print the deposit QR + plain address block for a single address.
+pub fn print_deposit(address: &str) {
+    println!("deposit address (same EOA on every EVM chain; send only on supported chains):");
+    if let Some(qr) = render_qr(address) {
+        println!("\n{qr}");
+    }
+    println!("  {address}\n");
+}

--- a/crates/bloom/src/main.rs
+++ b/crates/bloom/src/main.rs
@@ -12,6 +12,7 @@ mod commands {
     pub mod chain;
     pub mod pipe;
     pub mod polymarket;
+    pub mod qr;
 }
 
 use std::path::{Path, PathBuf};
@@ -191,7 +192,7 @@ enum Cmd {
     /// Manage wasm petals: install, run, list, name.
     #[command(subcommand)]
     Petals(PetalsCmd),
-    /// Polymarket: onboard a wallet.
+    /// Polymarket venue workflows.
     #[command(subcommand)]
     Polymarket(PolymarketCmd),
     /// Initialise ~/.bloom with default config + dirs.
@@ -513,6 +514,17 @@ enum WalletCmd {
     },
     /// List configured wallets.
     List,
+    /// Print a wallet's deposit address. Default output is the bare checksummed
+    /// address (one line, scriptable); `--qr` adds a scannable QR block above it,
+    /// and `--qr-out <path>` writes a scannable SVG of the address to a file.
+    Address {
+        name: String,
+        #[arg(long)]
+        qr: bool,
+        /// Write a scannable SVG QR of the deposit address to this path.
+        #[arg(long, value_name = "PATH")]
+        qr_out: Option<PathBuf>,
+    },
     /// Unlock a wallet for the lifetime of the process.
     /// For passkey wallets the passphrase is not needed — a browser
     /// ceremony is opened instead.
@@ -721,8 +733,9 @@ async fn run(cli: Cli) -> Result<()> {
             println!("home: {}", d.home.root().display());
             println!("config: {}", d.home.config_path().display());
             println!("chains: {:?}", d.chains.list_names());
-            println!("next: mkdir -p ~/bloom && bloom serve --mount ~/bloom");
-            println!("then: ls ~/bloom && cat ~/bloom/docs/README.md");
+            println!("next: bloom wallet new main --passkey");
+            println!("then: bloom wallet address main --qr");
+            println!("mount: mkdir -p ~/bloom && bloom serve --mount ~/bloom");
             println!("fallback: bloom vfs cat /docs/README.md");
             println!("agent setup: https://bloom.directory/SKILL.md");
             Ok(())
@@ -738,7 +751,12 @@ async fn run(cli: Cli) -> Result<()> {
                 d.config.block_mainnet_broadcast
             );
             println!("try: bloom vfs ls /");
-            println!("wallet: bloom wallet new alice --passphrase <passphrase>");
+            if d.keystore.list()?.is_empty() {
+                println!("no wallets yet — create one with bloom wallet new main --passkey");
+            } else {
+                println!("deposit: bloom wallet address <wallet> --qr");
+                println!("agent workflow: browse the mounted VFS or use bloom vfs cat/ls/write");
+            }
             Ok(())
         }
         Cmd::Vfs(VfsCmd::Cat { path }) => {
@@ -957,6 +975,10 @@ async fn run(cli: Cli) -> Result<()> {
             if let Some(ref key) = info.recovery_key {
                 acknowledge_recovery_key(&info.name, key);
             }
+            // Show the deposit QR + address right away — a fresh wallet's first
+            // need is to receive funds.
+            println!("\n── deposit ──");
+            commands::qr::print_deposit(&bloom_proto::checksum_address(&info.address));
             Ok(())
         }
         Cmd::Wallet(WalletCmd::Import {
@@ -991,6 +1013,26 @@ async fn run(cli: Cli) -> Result<()> {
                 };
                 println!("{}\t{}\t{}", info.name, info.address, kind);
             }
+            Ok(())
+        }
+        Cmd::Wallet(WalletCmd::Address { name, qr, qr_out }) => {
+            let d = Daemon::from_home(home).context("build daemon")?;
+            let info = d.keystore.info(&name)?;
+            let address = bloom_proto::checksum_address(&info.address);
+            if let Some(path) = qr_out {
+                match commands::qr::render_qr_svg(&address) {
+                    Some(svg) => {
+                        std::fs::write(&path, svg)
+                            .with_context(|| format!("write QR SVG to {}", path.display()))?;
+                        eprintln!("wrote deposit QR SVG: {}", path.display());
+                    }
+                    None => anyhow::bail!("address too large to encode as a QR code"),
+                }
+            }
+            if qr && let Some(code) = commands::qr::render_qr(&address) {
+                println!("{code}");
+            }
+            println!("{address}");
             Ok(())
         }
         Cmd::Wallet(WalletCmd::Unlock { name, passphrase }) => {

--- a/crates/bloom/tests/cli.rs
+++ b/crates/bloom/tests/cli.rs
@@ -376,6 +376,89 @@ fn wallet_new_via_env_passphrase() {
     );
 }
 
+#[test]
+fn status_on_empty_keystore_points_to_wallet_creation() {
+    let home = fresh_home();
+    let assert = bloom_cmd(home.path()).args(["status"]).assert().success();
+    let out = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        out.contains("no wallets yet"),
+        "empty status should say no wallet exists:\n{out}"
+    );
+    assert!(
+        out.contains("bloom wallet new main --passkey"),
+        "status should point at the explicit wallet command:\n{out}"
+    );
+}
+
+/// `wallet address <name>` prints the bare checksummed address; adding `--qr`
+/// prepends a scannable QR block while keeping the address line.
+#[test]
+fn wallet_address_with_and_without_qr() {
+    let home = fresh_home();
+    bloom_cmd(home.path())
+        .args(["wallet", "new", "alice", "--passphrase", "addr-smoke-pass"])
+        .assert()
+        .success();
+
+    let plain = bloom_cmd(home.path())
+        .args(["wallet", "address", "alice"])
+        .assert()
+        .success();
+    let plain_out = String::from_utf8(plain.get_output().stdout.clone()).unwrap();
+    let addr = plain_out.trim();
+    assert!(
+        addr.starts_with("0x") && addr.len() == 42,
+        "plain output should be a bare address, got: {plain_out:?}"
+    );
+
+    let qr = bloom_cmd(home.path())
+        .args(["wallet", "address", "alice", "--qr"])
+        .assert()
+        .success();
+    let qr_out = String::from_utf8(qr.get_output().stdout.clone()).unwrap();
+    assert!(
+        qr_out.contains(addr),
+        "--qr output must still include the address:\n{qr_out}"
+    );
+    assert!(
+        qr_out.lines().count() > plain_out.lines().count(),
+        "--qr should add a QR block above the address:\n{qr_out}"
+    );
+}
+
+/// `wallet address <name> --qr-out <path>` writes a scannable SVG QR file and
+/// still prints the address; the SVG is a real `<svg>` document.
+#[test]
+fn wallet_address_qr_out_writes_svg() {
+    let home = fresh_home();
+    bloom_cmd(home.path())
+        .args(["wallet", "new", "alice", "--passphrase", "qr-out-pass"])
+        .assert()
+        .success();
+    let svg_path = home.path().join("deposit.svg");
+    let out = bloom_cmd(home.path())
+        .args([
+            "wallet",
+            "address",
+            "alice",
+            "--qr-out",
+            svg_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    // The bare address still goes to stdout (scriptable).
+    let stdout = String::from_utf8(out.get_output().stdout.clone()).unwrap();
+    assert!(stdout.trim().starts_with("0x"), "stdout: {stdout:?}");
+    // The SVG file exists and is a real SVG document.
+    let svg = std::fs::read_to_string(&svg_path).expect("qr svg written");
+    assert!(
+        svg.contains("<svg") && svg.contains("</svg>"),
+        "expected an SVG document, got: {}",
+        &svg[..svg.len().min(80)]
+    );
+}
+
 /// Spin up an in-process `IpcServer` bound to the home's default socket
 /// path, then invoke the CLI so its `vfs` subcommand routes through IPC.
 /// The CLI's local-vs-IPC selection keys solely off `socket.exists()`, so

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -50,7 +50,7 @@ Default TTLs (handler overrides):
 | chains | `chains/<c>/head/*` | 1s |
 | chains | `chains/<c>/gas/*` | 2s |
 | chains | `chains/<c>/tx/<hash>/*` | 60s |
-| chains | `chains/<c>/addresses/<a>/{balance,balance.eth,balance.raw,nonce}` | 5s |
+| chains | `chains/<c>/addresses/<a>/{balance,balance.raw,balance.json,nonce}` | 5s |
 | chains | `chains/<c>/addresses/<a>/{code,is_contract}` | 1 day |
 | chains | `chains/<c>/addresses/<a>/{txs,internal_txs,erc20_txs,erc721_txs}` | 30s |
 | chains | `chains/<c>/contracts/<a>/{source,abi}` | 7 days |
@@ -68,11 +68,11 @@ data or rely on their own internal caches, e.g. the etherscan client).
 | Surface | VFS path(s) | Status | Implementation / Tests |
 |---|---|---|---|
 | Chains: head/safe/finalized, gas, fee history, eth_call, receipts, tx lookups, logs | `chains/<chain>/...` | shipped | `crates/bloom-vfs/src/handlers/chains.rs` + `chains_history.rs` |
-| ERC-20 reads (balance / symbol / decimals) | `chains/<chain>/addresses/<a>/tokens/<token>/{balance,balance.raw,balance.formatted,symbol,decimals}` | shipped | `chains.rs` + `crates/bloom-chain/src/lib.rs::ChainClient::erc20_*` |
+| ERC-20 reads (balance / symbol / decimals) | `chains/<chain>/addresses/<a>/tokens/<token>/{balance,balance.raw,balance.json,symbol,decimals}` | shipped | `chains.rs` + `crates/bloom-chain/src/lib.rs::ChainClient::erc20_*` |
 | Tx lookups | `chains/<chain>/tx/<hash>/{receipt.json,status,block_number,gas_used,logs.json,full.json}` | shipped | `chains.rs` (eth_getTransactionByHash + receipt) |
 | Etherscan history (txs, internal, ERC-20, ERC-721, source, abi) | `chains/<chain>/addresses/<a>/{txs,internal_txs,erc20_txs,erc721_txs}` and `chains/<chain>/contracts/<a>/{source,abi}` | shipped | `chains_history.rs` + `crates/bloom-etherscan/src/lib.rs` (TTL cache in `cache.rs`) |
 | Wallets: VFS-driven creation (local / import / watch) | `wallets/new` (writable) | shipped | `wallets.rs::write_new_wallet` + `parse_new_wallet_spec` |
-| Wallets: metadata, balance, nonce, policy round-trip | `wallets/<w>/{address,public_key,kind,policy.toml,chains/<c>/{balance,balance.eth,balance.raw,nonce}}` | shipped | `wallets.rs`; covered by outbox tests + `acceptance.sh` |
+| Wallets: metadata, balance, nonce, policy round-trip | `wallets/<w>/{address,public_key,kind,policy.toml,chains/<c>/{balance,balance.raw,balance.json,nonce}}` | shipped | `wallets.rs`; covered by outbox tests + `acceptance.sh` |
 | Wallets: outbox stage / confirm | `wallets/<w>/chains/<c>/outbox/{new.tx,pending/<id>/{plan.md,policy_check.json,confirm},sent/<id>/*,failed/<id>/*}` | shipped | `wallets.rs::write_outbox` → `crates/bloom-tx/src/tx_engine.rs`. Intents: `send` (native + ERC-20), `approve`, `call`, `raw`, plus NFT writes — `nft_transfer` (auto-detects ERC-721 vs ERC-1155, optional `safe`/`amount`/`data`), `nft_approve` (per-token, ERC-721 only), `nft_approve_all` (`setApprovalForAll`, policy-warned). |
 | Wallets: sign — EIP-191 + raw hash + EIP-712 | `wallets/<w>/sign/{message,hash,typed_data}` (+ `.sig`) | shipped | `wallets.rs::write_sign` |
 | DeFi (Enso intents, route quoting, stage-confirm) | `defi/intents/<wallet>/{new,<sess>/{intent.txt,route.json,plan.md,tx.json,simulation.json,confirm}}` | shipped | `crates/bloom-vfs/src/handlers/defi.rs` + `crates/bloom-defi/src/lib.rs` |

--- a/docs/examples-domain/01-chains.md
+++ b/docs/examples-domain/01-chains.md
@@ -52,15 +52,16 @@ cat /bloom/chains/ethereum/head/full.json | jq '.header.baseFeePerGas'
 
 ## Addresses (core, RPC-only)
 
-`addresses/<addr>/` lists `balance`, `balance.eth`, `balance.raw`,
+`addresses/<addr>/` lists `balance`, `balance.raw`, `balance.json`,
 `nonce`, `code`, `is_contract`, plus `tokens/` and `nfts/` subdirs. ENS
 reverse and the Etherscan history files only appear when the matching
 backend is wired (see further below).
 
 ```sh
 # vitalik.eth
-cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/balance       # wei (decimal)
-cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/balance.eth   # "1.234567 ETH"
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/balance       # "1.234567 ETH" (display, with symbol)
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/balance.raw   # wei (integer base units)
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/balance.json  # { symbol, decimals, raw, formatted, display }
 cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/nonce
 cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/code          # 0x for EOA
 cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/is_contract   # true / false
@@ -87,14 +88,14 @@ allowance is **not** exposed at this address-scoped path; use
 
 ```sh
 ls /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/
-# → balance, balance.raw, balance.formatted, symbol, decimals
+# → balance, balance.raw, balance.json, symbol, decimals
 
-cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/balance.formatted   # "1234.56 USDC"
+cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/balance   # "1234.56 USDC" (display, with symbol)
 cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/symbol            # → WETH
 cat /bloom/chains/ethereum/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0x6B175474E89094C44Da98b954EedeAC495271d0f/decimals          # → 18
 
 # Same shape on Base (USDC on Base):
-cat /bloom/chains/base/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913/balance.formatted
+cat /bloom/chains/base/addresses/0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045/tokens/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913/balance
 
 # Allowance: read it via the token's allowance() method.
 echo '{"args":["0xd8dA6BF26964aF9D7eeD9e03E53415D37aA96045","0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D"]}' \

--- a/docs/examples-domain/03-wallets-simulate-watch.md
+++ b/docs/examples-domain/03-wallets-simulate-watch.md
@@ -62,9 +62,9 @@ cat /bloom/wallets/alice/kind             # local | watch
 cat /bloom/wallets/alice/policy.toml      # current policy
 
 # Per-chain native balance + nonce.
-cat /bloom/wallets/alice/chains/base/balance       # raw wei
-cat /bloom/wallets/alice/chains/base/balance.eth   # human "0.123 ETH"
-cat /bloom/wallets/alice/chains/base/balance.raw   # same as balance
+cat /bloom/wallets/alice/chains/base/balance       # human "0.123 ETH" (display, with symbol)
+cat /bloom/wallets/alice/chains/base/balance.raw   # raw wei (integer base units)
+cat /bloom/wallets/alice/chains/base/balance.json  # { symbol, decimals, raw, formatted, display }
 cat /bloom/wallets/alice/chains/base/nonce
 ```
 
@@ -73,12 +73,12 @@ out-of-band and the daemon picks it up on the next `info` call.
 
 ERC-20 reads are not under `wallets/` — they live under the
 chain-rooted reader at
-`chains/<c>/addresses/<addr>/tokens/<token>/{balance,balance.formatted,balance.raw,symbol,decimals}`.
+`chains/<c>/addresses/<addr>/tokens/<token>/{balance,balance.raw,balance.json,symbol,decimals}`.
 For example, alice's USDC balance on Base:
 
 ```sh
 ALICE=$(cat /bloom/wallets/alice/address)
-cat /bloom/chains/base/addresses/$ALICE/tokens/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913/balance.formatted
+cat /bloom/chains/base/addresses/$ALICE/tokens/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913/balance
 ```
 
 ### Signing

--- a/docs/plans/2026-06-13-enso-simulation-verification.md
+++ b/docs/plans/2026-06-13-enso-simulation-verification.md
@@ -43,6 +43,25 @@ WP0 probed `https://quoter.api.enso.build` on 2026-06-14:
   `RouteResponse::calldata_contains_receiver(addr)` as a consistency check, not
   a malicious-Enso defense.
 
+Polymarket funding probe on 2026-06-17:
+
+- Enso does route Polygon native → pUSD (`PUSD =
+  0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB`) today. A live Bloom dry-run for
+  `--target-pusd 6 --max-spend 90 --from-token native` returned an Enso router
+  route via `bitget` to the resolved Polymarket deposit wallet.
+- The observed route was roughly `79.0367 POL -> >= 6.121186 pUSD`. Given POL at
+  about `$0.077` at probe time, this was not obviously a bad route; agents
+  confused by old MATIC price intuition may overestimate the native balance's
+  USD value.
+- The route still produced quote-only warnings: minimum output was the Enso quote
+  floor, not simulation-verified, and receiver/min-output verification remains
+  incomplete until this plan lands.
+- EVM policy denied the staged tx because the route attached about `79` native
+  units while the wallet cap was `max_value_eth = 0.1`. This is a native-token
+  quantity cap, not a USD cap. Do not solve that by broadening caps inside this
+  verification work; surface the quantity clearly and require normal policy
+  review.
+
 Autonomous cross-chain DeFi remains denied until both the calldata receiver
 consistency check and live destination settlement proof hold. Same-chain routes
 may use the calldata consistency check once min-output simulation policy exists.
@@ -189,6 +208,9 @@ decoder.
 - receiver must be the authoritative deposit wallet/funding address;
 - target pUSD amount must be proven by simulated output or settlement;
 - quote-only funding is denied for autonomous mode.
+- dry-run/review artifacts must say whether the route is merely quote-backed or
+  simulation-verified, and must include the native input quantity separately from
+  any optional USD estimate.
 
 Direct pUSD owner-to-deposit transfers are simple ERC-20 transfers and can use
 decoded standard calldata plus normal TxEngine policy.
@@ -203,6 +225,8 @@ decoded standard calldata plus normal TxEngine policy.
 - Policy denies below-floor output.
 - Policy denies unverified receiver for autonomous VFS.
 - Foreground quote-only path requires explicit signed policy opt-in.
+- Polymarket native→pUSD route fixtures preserve output token, receiver, native
+  value, protocols, and quote-only warning state.
 - VFS `confirm` refreshes validation immediately before staging.
 - Cross-chain dependent action refuses until live settlement proof exists.
 

--- a/docs/plans/2026-06-16-wallet-agenda-entanglement-scan.md
+++ b/docs/plans/2026-06-16-wallet-agenda-entanglement-scan.md
@@ -1,0 +1,258 @@
+# Wallet Agenda + Entanglement Scan
+
+**Status:** Design. Phase 0 scoped; not yet built. Updated after removal of
+top-level `bloom onboard`: the agenda is now VFS-first, with CLI rendering only
+as a convenience.
+**Date:** 2026-06-16.
+
+## 1. Motivation
+
+bloom is an agent-guided wallet: the user opens their agent, the agent drives
+bloom. For that loop to be useful the agent needs **situational awareness** at
+session start — *what do I hold, what am I entangled with, what's at risk, what's
+time-sensitive, what did I recently do* — not just a balance readout.
+
+Today the only "what needs attention" surface is `bloom polymarket obligations`
+(Polymarket-only, CLI-only). There is no cross-protocol view, and no
+lending/staking/LP awareness anywhere in the VFS (audited: only Polymarket's
+`redeemable` flag exists).
+
+The agenda must not become a new setup dashboard. It is an agent-readable VFS
+summary of live wallet context, with an optional CLI renderer for humans.
+
+## 2. Approaches considered
+
+- **Per-protocol adapters** (a hand-written Aave reader, Lido reader, …):
+  endless and brittle; does not scale to the long tail of protocols. Rejected as
+  the primary mechanism.
+- **Persistent trace store with time-series snapshots + a learned-interpretation
+  cache:** rejected after red-teaming. It is a cache of derived state over a
+  source of truth (the chain), and is sync-fragile in ways that are dangerous for
+  a wallet:
+  - a stored risk number (e.g. health factor) is stale the instant it is
+    written; acting on it is the catastrophic case;
+  - `abi_hash`-keyed interpretation breaks on proxy upgrades (proxy ABI stable,
+    implementation changed underneath);
+  - a wrong persisted interpretation looks authoritative and compounds silently;
+  - incremental discovery cursors break on reorgs / indexer lag;
+  - multi-writer (daemon + one-shot CLI) coherence, and a third local ledger
+    (after the audit log and Polymarket receipts) that can disagree with both.
+  The most elaborate parts of that design were also the most fragile — a smell.
+
+- **Chosen — live-first, nearly stateless.** bloom is the always-live
+  grounding/verification layer; the **agent** is the memory/interpretation layer,
+  and its guesses are always re-verified against bloom's live reads. This deletes
+  the "agenda said safe, chain said liquidated" bug class, is far less code, and
+  ships on primitives bloom already has.
+
+## 3. Design principles
+
+1. **Live-first where it matters.** The agenda is computed on demand per read.
+   Risk-bearing facts such as balances, pending outbox state, and current
+   Polymarket position state are read live. Historical provenance may come from
+   bounded/cached indexer feeds, but the output must label that coverage
+   honestly.
+2. **bloom grounds, the agent interprets.** bloom surfaces decoded history,
+   entangled contracts (with ABI when verified), and live view-reads. Semantic
+   risk ("this is an Aave loan, HF 1.05, near liquidation") is the agent's job.
+   bloom computes **no** per-protocol risk in Phase 0.
+3. **Honest coverage is non-negotiable.** Every agenda declares what it scanned
+   and what it cannot see. A false "nothing urgent" is the one outcome worse than
+   silence.
+4. **Persist nothing in Phase 0.** No trace store, no snapshots, no learned
+   interpretations. Interpretation/labels live in the agent's own cross-session
+   memory, re-verified against live reads each session.
+5. **Degrade, never hang or lie.** Each network-touching section is time-boxed
+   and degrades to an explicit `unavailable` note surfaced in `coverage`, never
+   silently dropped.
+
+## 4. Architecture
+
+One read triggers three on-demand steps:
+
+### 4.1 Entanglement scan
+For `(wallet_address, chain)`, pull bounded recent account history and reduce it
+to the distinct set of counterparties the wallet has recently interacted with:
+- contracts the wallet has called (`txlist`, `txlistinternal`);
+- tokens held / transferred (`tokentx`, `tokennfttx`).
+
+Reduction rules:
+- normalize addresses to lowercase; dedup; drop the wallet's own address.
+- classify each as `token` (appears in token-transfer feeds) / `contract`
+  (called, has code / verified ABI) / `eoa` (called, no code).
+- carry `first_seen_block`, `last_seen_block`, `interaction_count`, and a few
+  representative `tx_refs` as provenance.
+- bound the scan (configurable lookback window / max records) so it stays cheap
+  and RPC-resilient; record the bound in `coverage`.
+
+This is a **recently observed entanglement scan**, not proof of all open
+positions. Long-lived lending/staking/LP exposure can be missed if the opening
+transaction is outside the scan window. The agenda must say that plainly.
+
+Reuse the chains handler's existing `AddressHistorySource` (Etherscan-backed,
+cached) rather than calling Etherscan directly — consistent caching + one code
+path.
+
+### 4.2 Grounding
+For each entanglement: set `abi_available` from `contracts/<addr>/abi`. Optionally
+perform **cheap, generic** live view-reads where the read is standard and safe
+(e.g. ERC-20 `balanceOf(wallet)`) via `contracts/<addr>/methods/<name>.read`.
+Protocol-specific view-reads (e.g. `getUserAccountData`) are **not** auto-called
+in Phase 0 — the agent requests them once it has interpreted the contract.
+
+### 4.3 Aggregation
+Combine:
+- **"What I did"** — tail of the hash-chained audit log + Polymarket receipts.
+- **"What I hold"** — live native balance facts from the canonical native
+  balance VFS paths (`balance.json`; legacy balance paths only as a temporary
+  fallback).
+- **"What I recently touched"** — the observed entanglement set + grounding.
+- **The one interpreted protocol** — Polymarket obligations (reuse existing
+  data once refactored out of the current CLI renderer: open positions,
+  `redeemable`, next exit action).
+Rank by severity, attach provenance + next-action, emit the coverage block.
+
+## 5. Surface
+
+- **VFS (primary, machine-readable):** `wallets/<w>/agenda.json`.
+- **CLI (human + agent convenience):** `bloom wallet agenda <name>`, mirroring
+  the VFS JSON without becoming a separate source of truth.
+
+No top-level `onboard` integration. First-run wallet setup remains explicit
+wallet/VFS workflow; agenda is session awareness after a wallet exists.
+
+## 6. Data model (`agenda.json`)
+
+```json
+{
+  "wallet": "main",
+  "address": "0x..",
+  "generated_at_ms": 0,
+  "chains_scanned": ["polygon"],
+  "balances": [
+    { "chain": "polygon", "asset": "native", "symbol": "POL",
+      "decimals": 18, "raw": "95084027568306020633",
+      "formatted": "95.084027568306020633",
+      "display": "95.084027568306020633 POL",
+      "source": "wallets/main/chains/polygon/balance.json" }
+  ],
+  "did": [
+    { "ts_ms": 0, "kind": "tx.broadcast", "summary": "…", "ref": "audit:…" }
+  ],
+  "entanglements": [
+    { "address": "0x..", "chain": "polygon", "kind": "contract",
+      "symbol": null, "first_seen_block": 0, "last_seen_block": 0,
+      "interaction_count": 3, "tx_refs": ["0x.."],
+      "abi_available": true, "interpreted": false }
+  ],
+  "items": [
+    { "id": "outbox:…", "severity": "high", "kind": "pending_tx",
+      "summary": "1 staged tx awaiting confirm",
+      "condition": null, "evidence": ["outbox:…"],
+      "next_action": {
+        "kind": "confirm_staged_tx",
+        "surface": "vfs",
+        "review_path": "wallets/main/chains/polygon/outbox/pending/<id>/plan.md",
+        "write_path": "wallets/main/chains/polygon/outbox/pending/<id>/confirm",
+        "requires_unlock": true
+      },
+      "coverage_note": null }
+  ],
+  "coverage": {
+    "sources": ["audit", "etherscan-history", "polymarket"],
+    "chains_scanned": ["polygon"],
+    "scan_window": "last 5000 blocks / 100 records",
+    "uninterpreted": ["0x.. (no adapter; agent should interpret)"],
+    "unavailable": ["etherscan-history@arbitrum: timed out"],
+    "not_covered": [
+      "lending/staking/LP risk interpretation = agent's job",
+      "unverified contracts (no ABI)",
+      "positions opened by third parties may be missed",
+      "old positions may be missed when the opening interaction is outside the scan window"
+    ]
+  }
+}
+```
+
+Severity model (Phase 0, no interpretation required):
+- `high` — pending/staged outbox tx awaiting confirm; a Polymarket position the
+  existing logic flags as redeemable/needs-exit.
+- `medium` — open Polymarket positions with no immediate action.
+- `info` — one item per **uninterpreted observed entanglement**, inviting the
+  agent to study it (`"summary": "you recently interacted with 0x… on polygon; I
+  have not interpreted it"`).
+
+bloom never fabricates a risk item (e.g. "near liquidation") in Phase 0 — that
+requires interpretation it does not have. Such items appear only after the agent
+interprets and acts.
+
+## 7. Reuse map (do not rebuild)
+
+| Need | Existing primitive |
+|---|---|
+| account history | `bloom-etherscan` `txlist`/`txlistinternal`/`tokentx`/`tokennfttx` + on-disk TTL cache; chains handler `AddressHistorySource` |
+| ABI availability / decode | chains handler `contracts/<addr>/abi`, `AbiCache` |
+| live view-reads | chains handler `contracts/<addr>/methods/<name>.read` |
+| live native balances | `wallets/<w>/chains/<c>/balance.json`; current balance paths as fallback |
+| "what I did" | `bloom-proto::AuditLog::tail` + Polymarket receipts |
+| interpreted protocol slice | refactored data-returning Polymarket obligations helper + `OnboardStore` |
+| human rendering | `bloom wallet agenda <name>` CLI renderer over `agenda.json` |
+
+## 8. Non-goals / deferred (named, not buried)
+
+- Persistent trace store, time-series snapshots, learned-interpretation cache.
+- Per-protocol risk math (health factors, APRs, LP valuations).
+- An incremental **entanglement index** with a saved block cursor — a *future*
+  optimization that must **fail safe** (stale list → re-read live). Earns its
+  place only when scan cost proves it.
+- MCP transport for the agenda (separate, larger piece; the path to robust
+  agent consumption, but out of scope here).
+- Global portfolio rollup (`wallets/<w>/balances.json`) beyond the native
+  balance facts needed for agenda context.
+
+## 9. Phase-0 implementation outline (separate go-ahead)
+
+1. Refactor Polymarket obligations into a data-returning helper. The current
+   CLI function prints human text; agenda must consume structured position and
+   next-action facts, not parse stdout.
+2. `crates/bloom-vfs/src/handlers/agenda.rs` — entanglement scan + aggregation,
+   sibling to the existing `chains_history` module; pure async functions taking
+   the history source + audit log + native balance reader + polymarket data;
+   time-boxed per section.
+3. Wire `wallets/<w>/agenda.json` into `crates/bloom-vfs/src/handlers/wallets.rs`
+   (read-only; likely `is_read_side_effecting = true` since the scan hits
+   Etherscan).
+4. `bloom wallet agenda <name>` subcommand in `crates/bloom/src/main.rs`,
+   rendering the VFS JSON for humans.
+
+## 10. Verification (when built)
+
+- `cargo test -p bloom-vfs` + `cargo test -p bloom`.
+- Unit (offline, deterministic via `bloom-test-util::mocks` mock
+  `AddressHistorySource`):
+  - empty wallet → honest coverage, zero fabricated items, exit 0;
+  - mock history of N contracts → N deduped entanglements, each with
+    `abi_available` set; an uninterpreted entanglement yields exactly one `info`
+    item, never a risk item.
+  - bounded history output says "recently observed" and includes scan window /
+    missed-old-position caveat in coverage.
+  - native Polygon balance facts use the chain's native symbol, not ETH.
+  - `next_action` is structured VFS/action metadata, not a CLI command string.
+- CLI smoke (assert_cmd, hermetic `BLOOM_HOME`, pattern from
+  `crates/bloom/tests/cli.rs`): `bloom wallet agenda main` prints the coverage
+  block and invents no risk.
+- Manual: `bloom wallet agenda <w>` against a funded testnet wallet → real
+  entanglements + honest coverage.
+
+## 11. Future phases
+
+- **P1 — entanglement index + cursor** (fail-safe optimization) if scan cost
+  hurts.
+- **P2 — global portfolio rollup:** add `wallets/<w>/balances.json` only after
+  native balance JSON is stable and there is a clear need for multi-chain
+  portfolio sizing.
+- **P3 — agent-memory interpretation loop:** the agent labels a contract once
+  (in its own memory), bloom re-verifies the label against live reads each
+  session; bloom never stores the label as authoritative.
+- **P4 — MCP transport** so agents consume the agenda as a typed resource/tool
+  rather than scraping the CLI.

--- a/docs/plans/2026-06-17-next-priorities-mcp-first.md
+++ b/docs/plans/2026-06-17-next-priorities-mcp-first.md
@@ -1,0 +1,93 @@
+# Next Priorities: MCP Interface First
+
+**Status:** Recommendation. Prioritization after a design/review session.
+**Date:** 2026-06-17.
+
+## Context
+
+bloom is an agent-guided EVM wallet: the user opens their agent, the agent drives
+bloom to read state and move funds within policy. This doc records *what to build
+next* and why, after a session that produced more analysis than code. It is a
+prioritization decision, not an implementation spec.
+
+## Framing: three layers of "guiding an agent"
+
+Don't conflate these — work on the one that's actually the bottleneck.
+
+1. **Orientation** — *what bloom is, the rules.* `AGENTS.md` + the session-start
+   hook. **Done.** More prose does not make an agent more capable.
+2. **Interface** — *the agent's hands.* Today: CLI/VFS text-scraping. Robust
+   version: an **MCP server** over the `Vfs` router. **Missing. This is the
+   bottleneck.**
+3. **Situation** — *what you hold, what's at risk, what you did.* The wallet
+   agenda / entanglement scan (`2026-06-16-wallet-agenda-entanglement-scan.md`).
+   Sits *on top of* the interface; deferred (below).
+
+## Recommendation: read-only MCP server next
+
+Build a minimal, **read-only** MCP server (`bloom-mcp`) over the existing `Vfs`
+router, speaking MCP over stdio.
+
+Why this, over the alternatives:
+- **Highest leverage on the product thesis.** "Agent uses bloom" today means
+  scraping CLI text — works for a strong model, fragile otherwise. MCP gives
+  agents *typed tools* instead. It is the one piece `DIRECTION.md` named as step
+  one that was never built.
+- **Bounded, shippable, not a research project.** v0 is read tools only — chain
+  state, balances, `simulate`, prices — wrapping the same router the daemon's
+  `IpcServer` already wraps (the JSON-RPC-over-transport template to mirror). No
+  signing path, no policy surface, no money risk in v0.
+- **Unblocks everything downstream.** The agenda and any future surface are
+  better consumed through a typed contract than scraped. Build the contract
+  first; the agenda gets better for free once agents consume MCP.
+
+### v0 scope
+- New `bloom-mcp` transport mirroring `bloom-daemon/src/ipc.rs` (`IpcServer`),
+  wrapping `crates/bloom-vfs` `Vfs`.
+- Expose **read tools** onto existing VFS paths: chain reads, balances,
+  `simulate`, prices.
+- Stdio transport so any MCP client (Claude Desktop, Cursor, Inspector) connects
+  with no SDK.
+- No write tools in v0.
+
+## Sequencing
+
+1. **Now (~minutes):** land the deposit-QR + `wallet address` change as its own
+   small PR; clear the working tree. (Pending a green `cargo build` +
+   `cargo test -p bloom`.)
+2. **Next (the real build):** read-only `bloom-mcp` over the Vfs router.
+3. **Then:** guarded **write** tools (DeFi intent + wallet outbox), routed
+   through the existing `bloom-tx` policy / outbox / audit path — *and* harden
+   the audit log alongside them (below). Exposing write tools is the forcing
+   function for the audit work.
+
+## Deferred — and why (named, not buried)
+
+- **Wallet agenda / entanglement scan.** Good design (keep the doc), but building
+  ahead of demand: for today's Polymarket-centric usage, `polymarket obligations`
+  already covers the one protocol in use, and the scan's payoff (cross-protocol
+  risk) needs multi-protocol positions that aren't in evidence yet. It also sits
+  on top of the interface. **Trigger to revisit:** evidence that real users hold
+  positions across protocols and get burned by not being reminded.
+
+## Supporting assessments (from this session)
+
+- **Trust model is decent.** Value-moving actions route through
+  `evaluate_action_authorization` (`bloom-proto/src/policy.rs`): a layered,
+  fail-closed authorization state machine (deny is absolute; reviewed-hash path;
+  `under_policy` autonomy bounded by verified calldata + USD budget). Credit it.
+- **Audit log is the weak spot, and it's where money-safety lives.** It is
+  hash-chained and verifiable, but (a) **fail-open** — append errors are dropped
+  and the action proceeds; (b) integrity is scoped to *error*, not a local
+  adversary (no external anchor); (c) it logs path + sha, **not the authorization
+  decision** (autonomous vs reviewed, subject hash, USD debit). For an autonomous
+  money-mover, value-moving actions should fail **closed** on audit and record
+  the decision. Do this with the MCP write-tools phase.
+- **Interface fragility is the bottleneck**, which is why MCP leads.
+
+## Risk / open question
+
+The real safety surface appears when MCP exposes **write** tools. Those must go
+through the existing outbox/policy/audit path with no shortcut — and that is the
+moment to make the audit log fail-closed and decision-recording. v0 stays
+read-only precisely to keep that surface out of the first, fast shippable slice.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -14,12 +14,17 @@ ignored `docs/.scratch/`.
   min-output and settlement remain before unattended use.
 - `2026-06-13-policy-browser-editor.md` — separate validated policy editor;
   fuzzy search belongs there, not as a separate active plan.
+- `2026-06-16-wallet-agenda-entanglement-scan.md` — live-first wallet agenda
+  and cross-protocol entanglement scan design; Phase 0 not yet built.
+- `2026-06-17-next-priorities-mcp-first.md` — prioritization note for building
+  a read-only MCP interface before larger agent-facing surfaces.
 
 ## Removed From Active Set
 
 Live-run notes and superseded drafts for passkey review pages, Polymarket
-funding/auth UX, VFS exit UX, agent-friendly IPC, and broad policy autonomy are
-implemented, stale, or covered by the active plans above.
+funding/auth UX, VFS exit UX, agent-friendly IPC, deposit QR export, native
+balance display, Polymarket account workflow clarity, and broad policy autonomy
+are implemented, stale, or covered by the active plans above.
 
 ## Older Open Work
 

--- a/docs/polymarket-integration.md
+++ b/docs/polymarket-integration.md
@@ -44,8 +44,8 @@ instruction to trade.
 - Passkey/WebAuthn proves user presence, not transaction content. Bloom opens a
   local browser review page and prints a matching review hash; this is a local
   consistency check, not a hardware trusted display.
-- Scoped run capabilities are the next auth milestone; see
-  `docs/plans/2026-06-13-scoped-agent-run-capabilities-roadmap.md`.
+- Scoped run capabilities are the next auth milestone and remain tracked in the
+  active plan queue.
 
 ## Funding And Approvals
 

--- a/tests/docker/lib.sh
+++ b/tests/docker/lib.sh
@@ -326,8 +326,8 @@ read_chain_head_breadcrumb() {
 read_wallet_balance_breadcrumb() {
     local mnt=$1 chain=$2 wallet=$3 address=$4
 
-    echo '::group::wallet eth balance' >&2
-    BAL_ETH=$(cat "$mnt/chains/$chain/addresses/$address/balance.eth" | tr -d '\n')
-    log "$wallet ($address) ETH balance: $BAL_ETH"
+    echo '::group::wallet native balance' >&2
+    BAL_NATIVE=$(cat "$mnt/chains/$chain/addresses/$address/balance" | tr -d '\n')
+    log "$wallet ($address) native balance: $BAL_NATIVE"
     echo '::endgroup::' >&2
 }

--- a/tests/docker/test_enso_aave.sh
+++ b/tests/docker/test_enso_aave.sh
@@ -135,9 +135,9 @@ read_wallet_balance_breadcrumb "$MNT" "$CHAIN" "$WALLET" "$DEST1"
 # mode anvil_setBalance guarantees 10 ETH; in live mode the wallet
 # must already hold > swap+gas. We use awk for the comparison because
 # `[[ ... -lt ... ]]` is integer-only and the balance is decimal.
-[[ -n "$BAL_ETH" && "$BAL_ETH" != "0" ]] || fail "$WALLET ETH balance is 0"
-if ! awk -v b="$BAL_ETH" -v s="$SWAP_AMOUNT_ETH" 'BEGIN { exit !(b+0 > s+0) }'; then
-    fail "$WALLET ETH balance ($BAL_ETH) is not greater than swap amount ($SWAP_AMOUNT_ETH); top up before retrying"
+[[ -n "$BAL_NATIVE" && "$BAL_NATIVE" != "0" ]] || fail "$WALLET native balance is 0"
+if ! awk -v b="$BAL_NATIVE" -v s="$SWAP_AMOUNT_ETH" 'BEGIN { exit !(b+0 > s+0) }'; then
+    fail "$WALLET native balance ($BAL_NATIVE) is not greater than swap amount ($SWAP_AMOUNT_ETH); top up before retrying"
 fi
 
 # ---------- post the intent through the mount ----------

--- a/tests/docker/test_fork_mount.sh
+++ b/tests/docker/test_fork_mount.sh
@@ -59,7 +59,7 @@ wait_for_mount "$SENTINEL" "$DAEMON_PID" "$LOGFILE" 90
 read_chain_head_breadcrumb "$MNT" "$CHAIN"
 read_wallet_balance_breadcrumb "$MNT" "$CHAIN" "$WALLET" "$DEST1"
 
-[[ -n "$BAL_ETH" && "$BAL_ETH" != "0" ]] || fail "$WALLET ETH balance is 0 after anvil_setBalance"
+[[ -n "$BAL_NATIVE" && "$BAL_NATIVE" != "0" ]] || fail "$WALLET native balance is 0 after anvil_setBalance"
 
 # ---------- 1. stage + confirm a native-ETH send via the outbox ----------
 OUTBOX="$MNT/wallets/$WALLET/chains/$CHAIN/outbox"


### PR DESCRIPTION
## Summary

Changes relative to `origin/master`: makes agent-facing wallet reads self-describing, adds a deposit-QR export, adds read-only Polymarket account surfaces, fixes a mount render-cache stale read, and clears small clippy/test hygiene. **33 files, +1199/-160.** The branch is squashed to one commit.

No repo-root agent-guide files or per-harness agent hooks are included. Runtime agent guidance remains the vendored VFS guidance served as `/AGENTS.md` and `/CLAUDE.md`; contributor-facing repo-root guidance is deferred for a separate design pass.

## Balance API — breaking

`crates/bloom-vfs/src/handlers/{balances.rs, chains.rs, wallets.rs, mod.rs}`

- `balance` now returns a human display with symbol, e.g. `23739.58 POL`.
- `balance.raw` is the integer base-unit value.
- `balance.json` carries structured facts: `chain`, `asset`, `symbol`, `decimals`, `raw`, `formatted`, `display`.
- ERC-20 `tokens/<token>/` follows the same display/raw/json convention.
- `balance.eth` and `balance.formatted` are removed.
- Live balance/nonce leaves share a short 5s TTL; ERC-20 `symbol`/`decimals` use a separate longer metadata cache so display reads do not repeatedly call token metadata.

## Deposit QR

`crates/bloom/src/commands/qr.rs`, `crates/bloom/src/main.rs`, `Cargo.toml`, `crates/bloom/Cargo.toml`

- `bloom wallet address <wallet> --qr-out <path>` writes a scannable SVG.
- Terminal `--qr` behavior is unchanged.

## Polymarket Account Surfaces

`crates/bloom-vfs/src/handlers/polymarket.rs`, `crates/bloom-polymarket/src/{eip712.rs,order_store.rs}`

- Adds read-only `polymarket/account/<wallet>/{status,buying_power,funding_options}.json`.
- `status.json` and `funding_options.json` are readable before CLOB credentials exist, so agents can inspect onboarding/pre-trade state instead of getting a contradictory “not onboarded” error.
- `buying_power.json` keeps order sizing tied to deposit-wallet pUSD, not owner native balance.
- pUSD display formatting uses a named protocol constant (`PUSD_DECIMALS`) instead of an inline magic number.
- Order-draft `plan.md` now states `value_moved`, `order_posted`, and `persistent_staged_action` explicitly. This is output-only; execution behavior is unchanged.

## Mount Render-Cache Fix

`crates/bloom-mount/src/adapter.rs`

- Invalidates the mount render cache after successful writes, so write-then-read cannot return pre-write bytes.
- Includes regression coverage and related mount listing/dedup fixes.

## CI / Test Hygiene

- `crates/bloom-revert/src/heimdall.rs` and `crates/bloom-daemon/examples/mount_demo.rs`: collapse nested `if let` into let-chains for clippy `-D warnings`.
- `crates/bloom-mempool/tests/it_alchemy_smoke.rs`: mark the live Alchemy smoke test ignored so default local/CI test runs stay hermetic.
- The acceptance workflow disk-space cleanup is deliberately not included.

## Docs & Tests

- Balance-shape docs updated: `README.md`, `QUICKSTART.md`, `EXAMPLES.md`, `docs/AUDIT.md`, `docs/examples-domain/*`, `crates/bloom-vfs/src/docs/README.md`, `docs/polymarket-integration.md`.
- Tests cover balance display/raw/json semantics, token/wallet balance TTLs, QR SVG export, Polymarket pre-creds account status/funding options, and mount render-cache invalidation.
- Design notes under `docs/plans/` track remaining active work.

## Validation

Latest local validation after the final changes:
- `cargo fmt --all`
- `cargo test -p bloom-vfs balance` — 5 passed
- `cargo test -p bloom-vfs account_status_and_funding_options_do_not_need_creds` — 1 passed
- `cargo clippy -p bloom-vfs --all-targets --all-features -- -D warnings`

Earlier red-team pass on this branch also ran the full `bloom-vfs` suite: 322 passed, 1 ignored.
