### PR TITLE
feat: payments improved

### DIFF
--- a/crates/bloom-paid-http/src/lib.rs
+++ b/crates/bloom-paid-http/src/lib.rs
@@ -437,6 +437,24 @@ pub fn parse_payment_amount_usd(asset: Option<&str>, amount: Option<&str>) -> Op
     parse_money(raw)
 }
 
+pub fn selected_requirement_amount_usd(
+    challenge: &NormalizedChallenge,
+    requirement: &PaymentRequirement,
+) -> Option<f64> {
+    parse_payment_amount_usd(requirement.asset.as_deref(), requirement.amount.as_deref())
+        .or(challenge.amount_usd)
+}
+
+pub fn usd_to_atomic_units(asset: Option<&str>, usd: f64) -> Option<u128> {
+    if !usd.is_finite() || usd < 0.0 {
+        return None;
+    }
+    if asset.is_some_and(is_known_six_decimal_usd_asset) {
+        return Some((usd * 1_000_000.0).floor() as u128);
+    }
+    Some(usd.floor() as u128)
+}
+
 fn is_known_six_decimal_usd_asset(asset: &str) -> bool {
     matches!(
         asset.to_ascii_lowercase().as_str(),
@@ -446,6 +464,37 @@ fn is_known_six_decimal_usd_asset(asset: &str) -> bool {
             | "0x20c000000000000000000000b9537d11c60e8b50"
             // USD0 on Tempo.
             | "0x779ded0c9e1022225f8e0630b35a9b54be713736"
+    )
+}
+
+pub fn normalize_paid_http_network(network: &str) -> String {
+    let raw = network.trim().to_ascii_lowercase();
+    match raw.as_str() {
+        "base" | "8453" | "eip155:8453" => "eip155:8453".into(),
+        "tempo" | "42431" | "eip155:42431" => "eip155:42431".into(),
+        other if other.starts_with("eip155:") => other.into(),
+        other if other.chars().all(|c| c.is_ascii_digit()) => format!("eip155:{other}"),
+        other => other.into(),
+    }
+}
+
+pub fn networks_equivalent(a: &str, b: &str) -> bool {
+    normalize_paid_http_network(a) == normalize_paid_http_network(b)
+}
+
+pub fn is_sensitive_paid_http_header(name: &str) -> bool {
+    matches!(
+        name.to_ascii_lowercase().as_str(),
+        "authorization"
+            | "proxy-authorization"
+            | "x-payment"
+            | "payment-signature"
+            | "payment-receipt"
+            | "set-cookie"
+            | "cookie"
+            | "x-api-key"
+            | "api-key"
+            | "apikey"
     )
 }
 
@@ -543,10 +592,12 @@ pub fn evaluate_payment_policy(policy: &Policy, input: PolicyEvalInput<'_>) -> V
         }
     }
     if let Some(network) = network {
-        if contains_ci(&payments.networks.deny, network) {
+        if contains_network(&payments.networks.deny, network) {
             out.push(deny("payments.networks.deny", format!("{network} denied")));
         }
-        if !payments.networks.allow.is_empty() && !contains_ci(&payments.networks.allow, network) {
+        if !payments.networks.allow.is_empty()
+            && !contains_network(&payments.networks.allow, network)
+        {
             out.push(deny(
                 "payments.networks.allow",
                 format!("{network} not allowed"),
@@ -701,6 +752,11 @@ fn deny(rule: &str, detail: impl Into<String>) -> PolicyCheck {
 fn contains_ci(set: &std::collections::BTreeSet<String>, needle: &str) -> bool {
     set.iter().any(|v| v.eq_ignore_ascii_case(needle))
 }
+fn contains_network(set: &std::collections::BTreeSet<String>, needle: &str) -> bool {
+    let normalized = normalize_paid_http_network(needle);
+    set.iter()
+        .any(|v| v.eq_ignore_ascii_case(needle) || normalize_paid_http_network(v) == normalized)
+}
 fn min_cap<const N: usize>(values: [Option<f64>; N]) -> Option<f64> {
     values.into_iter().flatten().reduce(f64::min)
 }
@@ -743,7 +799,7 @@ pub fn select_payment_requirement(
                 asset: req.asset.as_deref(),
                 network: req.network.as_deref(),
                 intent: &challenge.intent,
-                amount_usd: challenge.amount_usd,
+                amount_usd: selected_requirement_amount_usd(challenge, req),
                 request_max_amount_usd: None,
                 spent_24h_usd: 0.0,
             },
@@ -818,6 +874,10 @@ pub fn headers_to_string_map(headers: &HeaderMap) -> BTreeMap<String, String> {
 
 #[cfg(test)]
 mod tests {
+    use super::{
+        PaymentRequirement, networks_equivalent, selected_requirement_amount_usd,
+        usd_to_atomic_units,
+    };
     use super::{normalize_challenge, parse_payment_amount_usd};
     use reqwest::header::{HeaderMap, HeaderValue};
     use url::Url;
@@ -857,5 +917,35 @@ mod tests {
         assert_eq!(challenge.protocol, "x402");
         assert_eq!(challenge.amount.as_deref(), Some("10000"));
         assert_eq!(challenge.amount_usd, Some(0.01));
+    }
+
+    #[test]
+    fn selected_requirement_cost_wins_over_low_merchant_usd() {
+        let mut challenge = normalize_challenge(
+            &reqwest::header::HeaderMap::new(),
+            br#"{"x402Version":1,"amountUsd":0.01,"accepts":[{"network":"base","asset":"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913","maxAmountRequired":"5000000"}]}"#,
+            &url::Url::parse("https://merchant.test/pay").unwrap(),
+        );
+        challenge.amount_usd = Some(0.01);
+        let req = PaymentRequirement {
+            scheme: None,
+            network: Some("base".into()),
+            asset: Some("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913".into()),
+            amount: Some("5000000".into()),
+            pay_to: None,
+            resource: None,
+            raw: serde_json::json!({}),
+        };
+        assert_eq!(selected_requirement_amount_usd(&challenge, &req), Some(5.0));
+    }
+
+    #[test]
+    fn shared_network_and_atomic_amount_helpers_cover_x402_and_mpp() {
+        assert!(networks_equivalent("base", "eip155:8453"));
+        assert!(networks_equivalent("tempo", "eip155:42431"));
+        assert_eq!(
+            usd_to_atomic_units(Some("0x20C000000000000000000000b9537d11c60E8b50"), 5.0),
+            Some(5_000_000)
+        );
     }
 }

--- a/crates/bloom-paid-mpp/src/lib.rs
+++ b/crates/bloom-paid-mpp/src/lib.rs
@@ -4,17 +4,17 @@ use async_trait::async_trait;
 use bloom_keystore::{Keystore, KeystoreError, WalletKind};
 use bloom_paid_http::{
     EmptyPaidHttpChainRpcResolver, NormalizedChallenge, PaidHttpChainRpcResolver, ParsedRequest,
+    usd_to_atomic_units,
 };
 use bloom_proto::Policy;
 use mpp::client::{PaymentProvider, TempoProvider, TempoSessionProvider};
-use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use serde_json::json;
 use std::sync::Arc;
 
 #[async_trait]
 pub trait PaymentBackend: Send + Sync {
     fn name(&self) -> &'static str;
-    async fn confirm(
+    async fn prepare(
         &self,
         challenge: &NormalizedChallenge,
         request: &ParsedRequest,
@@ -73,10 +73,8 @@ impl RealMppBackend {
 
 pub struct PaymentExecution {
     pub credential_metadata: serde_json::Value,
-    pub receipt_raw: serde_json::Value,
-    pub response_status: u16,
-    pub response_headers: HeaderMap,
-    pub response_body: Vec<u8>,
+    pub header_name: &'static str,
+    pub header_value: String,
 }
 
 #[async_trait]
@@ -85,7 +83,7 @@ impl PaymentBackend for RealMppBackend {
         "mpp_tempo"
     }
 
-    async fn confirm(
+    async fn prepare(
         &self,
         challenge: &NormalizedChallenge,
         request: &ParsedRequest,
@@ -93,6 +91,7 @@ impl PaymentBackend for RealMppBackend {
         policy: &Policy,
         _request_id: &str,
     ) -> Result<PaymentExecution, String> {
+        let _ = request;
         if challenge.protocol != "mpp" || challenge.network.as_deref() != Some("tempo") {
             return Err(
                 "only Tempo MPP challenges can be confirmed by the real MPP backend".to_string(),
@@ -125,7 +124,7 @@ impl PaymentBackend for RealMppBackend {
                     .payments
                     .sessions
                     .max_deposit_usd
-                    .and_then(f64_to_u128_amount)
+                    .and_then(|usd| usd_to_atomic_units(challenge.asset.as_deref(), usd))
                 {
                     provider = provider.with_max_deposit(max);
                 }
@@ -141,14 +140,6 @@ impl PaymentBackend for RealMppBackend {
         let authorization_sha256 = bloom_tools::sha256_hex(authorization.as_bytes());
         let credential_value = serde_json::to_value(&credential)
             .map_err(|e| format!("serialize MPP credential metadata: {e}"))?;
-        let retry = retry_paid_request(&self.client, request, &authorization).await?;
-        let receipt_raw = retry
-            .headers
-            .get("payment-receipt")
-            .and_then(|h| h.to_str().ok())
-            .and_then(|h| mpp::parse_receipt(h).ok())
-            .and_then(|r| serde_json::to_value(r).ok())
-            .unwrap_or_else(|| json!({}));
         Ok(PaymentExecution {
             credential_metadata: json!({
                 "redacted": true,
@@ -167,10 +158,8 @@ impl PaymentBackend for RealMppBackend {
                 "chain_id": chain_id,
                 "rpc_url_configured": true
             }),
-            receipt_raw,
-            response_status: retry.status,
-            response_headers: retry.headers,
-            response_body: retry.body,
+            header_name: "Authorization",
+            header_value: authorization,
         })
     }
 }
@@ -190,120 +179,4 @@ fn parse_stored_mpp_challenge(
         .ok_or_else(|| {
             "stored challenge is missing a parseable Tempo MPP WWW-Authenticate header".to_string()
         })
-}
-
-fn f64_to_u128_amount(v: f64) -> Option<u128> {
-    if v.is_finite() && v >= 0.0 {
-        Some(v.floor() as u128)
-    } else {
-        None
-    }
-}
-
-pub struct RetryResponse {
-    pub status: u16,
-    pub headers: HeaderMap,
-    pub body: Vec<u8>,
-}
-
-async fn retry_paid_request(
-    client: &reqwest::Client,
-    request: &ParsedRequest,
-    authorization: &str,
-) -> Result<RetryResponse, String> {
-    let mut req = client.request(
-        request.method.parse().unwrap_or(reqwest::Method::GET),
-        request.url.clone(),
-    );
-    for (k, v) in &request.headers {
-        if is_sensitive_retry_header(k) {
-            continue;
-        }
-        let name =
-            HeaderName::from_bytes(k.as_bytes()).map_err(|e| format!("invalid header {k}: {e}"))?;
-        let val = HeaderValue::from_str(v).map_err(|e| format!("invalid header {k}: {e}"))?;
-        req = req.header(name, val);
-    }
-    req = req.header(reqwest::header::AUTHORIZATION, authorization);
-    if let Some(body) = &request.body {
-        req = req.body(body.clone());
-    }
-    let response = req
-        .send()
-        .await
-        .map_err(|e| format!("paid HTTP retry failed: {e}"))?;
-    let status = response.status().as_u16();
-    let headers = response.headers().clone();
-    let body = response
-        .bytes()
-        .await
-        .map_err(|e| format!("read paid HTTP retry response: {e}"))?
-        .to_vec();
-    Ok(RetryResponse {
-        status,
-        headers,
-        body,
-    })
-}
-
-fn is_sensitive_retry_header(name: &str) -> bool {
-    matches!(
-        name.to_ascii_lowercase().as_str(),
-        "authorization"
-            | "proxy-authorization"
-            | "x-payment"
-            | "payment-signature"
-            | "x-api-key"
-            | "api-key"
-            | "apikey"
-    )
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::collections::BTreeMap;
-    use std::io::{Read, Write};
-    use std::net::TcpListener;
-    use std::sync::mpsc;
-
-    #[tokio::test]
-    async fn paid_retry_replaces_probe_authorization_header() {
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let addr = listener.local_addr().unwrap();
-        let (tx, rx) = mpsc::channel();
-        std::thread::spawn(move || {
-            let (mut stream, _) = listener.accept().unwrap();
-            let mut buf = [0u8; 4096];
-            let n = stream.read(&mut buf).unwrap();
-            let raw = String::from_utf8_lossy(&buf[..n]).to_string();
-            tx.send(raw).unwrap();
-            stream
-                .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 2\r\nconnection: close\r\n\r\n{}")
-                .unwrap();
-        });
-
-        let mut headers = BTreeMap::new();
-        headers.insert("authorization".to_string(), "Payment".to_string());
-        headers.insert("content-type".to_string(), "application/json".to_string());
-        let request = ParsedRequest {
-            method: "POST".to_string(),
-            url: format!("http://{addr}/paid").parse().unwrap(),
-            wallet: Some("gavin".to_string()),
-            max_amount_usd: None,
-            headers,
-            body: Some(r#"{"ok":true}"#.to_string()),
-        };
-
-        let response =
-            retry_paid_request(&reqwest::Client::new(), &request, "Payment signed").await;
-        assert_eq!(response.unwrap().status, 200);
-
-        let raw = rx.recv().unwrap();
-        let auth_lines: Vec<_> = raw
-            .lines()
-            .filter(|line| line.to_ascii_lowercase().starts_with("authorization:"))
-            .collect();
-        assert_eq!(auth_lines, vec!["authorization: Payment signed"]);
-    }
 }

--- a/crates/bloom-paid-x402/src/lib.rs
+++ b/crates/bloom-paid-x402/src/lib.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use bloom_keystore::{Keystore, KeystoreError, WalletKind};
 use bloom_paid_http::{
     NormalizedChallenge, PaidHttpChainRpcResolver, ParsedRequest, PaymentRequirement,
+    networks_equivalent,
 };
 use serde_json::json;
 use x402_chain_eip155::{V1Eip155ExactClient, V2Eip155ExactClient};
@@ -67,7 +68,7 @@ impl X402PaymentSigner for KeystoreX402PaymentSigner {
         })?;
         if let Some(network) = ctx.requirement.network.as_deref() {
             let candidate_network = candidate.chain_id.to_string();
-            if candidate_network != network {
+            if !networks_equivalent(&candidate_network, network) {
                 return Err(format!(
                     "x402 selected network {candidate_network}, expected staged network {network}"
                 ));

--- a/crates/bloom-vfs/src/handlers/requests.rs
+++ b/crates/bloom-vfs/src/handlers/requests.rs
@@ -117,7 +117,7 @@ impl RequestsHandler {
                 return Ok((state.to_string(), raw));
             }
         }
-        Err(HandlerError::NotFound(raw.into()))
+        Err(HandlerError::NotFound(raw))
     }
 
     fn req_dir(&self, state: &str, id: &str) -> PathBuf {
@@ -917,9 +917,7 @@ async fn confirm_with_backend(
         requests_root.join("latest"),
         format!("{final_state}/{id}\n"),
     )?;
-    Ok(ConfirmResult {
-        final_state: final_state.into(),
-    })
+    Ok(ConfirmResult { final_state })
 }
 
 fn parsed_request_from_dir(dir: &Path) -> Result<ParsedRequest, HandlerError> {

--- a/crates/bloom-vfs/src/handlers/requests.rs
+++ b/crates/bloom-vfs/src/handlers/requests.rs
@@ -12,7 +12,8 @@ use bloom_paid_http::{
     EmptyPaidHttpChainRpcResolver, NormalizedChallenge, PaidHttpChainRpcResolver, ParsedRequest,
     PaymentRequirement, PolicyCheck, PolicyEvalInput, evaluate_payment_policy,
     evaluate_session_policy, headers_to_string_map, json_number, normalize_challenge,
-    paid_http_intent_label, parse_money, parse_request, select_payment_requirement, trim_money,
+    paid_http_intent_label, parse_money, parse_payment_amount_usd, parse_request,
+    select_payment_requirement, trim_money,
 };
 use bloom_paid_mpp::{PaymentBackend, RealMppBackend};
 use bloom_paid_x402::{KeystoreX402PaymentSigner, X402PaymentSigner, X402SignContext};
@@ -346,7 +347,12 @@ impl RequestsHandler {
             total += receipt
                 .get("amount_usd")
                 .and_then(json_number)
-                .or_else(|| receipt.get("amount").and_then(json_number))
+                .or_else(|| {
+                    parse_payment_amount_usd(
+                        receipt.get("currency").and_then(|v| v.as_str()),
+                        receipt.get("amount").and_then(|v| v.as_str()),
+                    )
+                })
                 .unwrap_or(0.0);
         }
         Ok(total)
@@ -1302,6 +1308,30 @@ mod tests {
         assert!(consume_request_confirm_approved(&pending, "alice", "y").is_err());
         assert!(consume_request_confirm_approved(&pending, "alice", "confirm").is_ok());
         assert!(consume_request_confirm_approved(&pending, "alice", "confirm").is_err());
+    }
+
+    #[test]
+    fn spent_usd_history_converts_mpp_base_units_like_x402() {
+        let f = fixture(Some("alice"));
+        let sent = f.handler.requests_root().join("sent/req_mpp_paid");
+        fs::create_dir_all(&sent).unwrap();
+        write_json(
+            sent.join("receipt.json"),
+            &json!({
+                "request_id": "req_mpp_paid",
+                "wallet": "alice",
+                "merchant": "api.nansen.ai",
+                "amount": "10000",
+                "currency": "0x20C000000000000000000000b9537d11c60E8b50",
+                "network": "tempo",
+                "protocol": "mpp",
+                "intent": "charge"
+            }),
+        )
+        .unwrap();
+
+        let spent = f.handler.sum_paid_usd_last_24h("alice").unwrap();
+        assert!((spent - 0.01).abs() < f64::EPSILON, "{spent}");
     }
 
     async fn mock_server(

--- a/crates/bloom-vfs/src/handlers/requests.rs
+++ b/crates/bloom-vfs/src/handlers/requests.rs
@@ -11,9 +11,9 @@ use bloom_keystore::Keystore;
 use bloom_paid_http::{
     EmptyPaidHttpChainRpcResolver, NormalizedChallenge, PaidHttpChainRpcResolver, ParsedRequest,
     PaymentRequirement, PolicyCheck, PolicyEvalInput, evaluate_payment_policy,
-    evaluate_session_policy, headers_to_string_map, json_number, normalize_challenge,
+    evaluate_session_policy, is_sensitive_paid_http_header, json_number, normalize_challenge,
     paid_http_intent_label, parse_money, parse_payment_amount_usd, parse_request,
-    select_payment_requirement, trim_money,
+    select_payment_requirement, selected_requirement_amount_usd, trim_money,
 };
 use bloom_paid_mpp::{PaymentBackend, RealMppBackend};
 use bloom_paid_x402::{KeystoreX402PaymentSigner, X402PaymentSigner, X402SignContext};
@@ -22,6 +22,7 @@ use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 use url::Url;
 
@@ -106,13 +107,14 @@ impl RequestsHandler {
     }
 
     fn resolve_ref(&self, raw: &str) -> Result<(String, String), HandlerError> {
+        let raw = safe_fs_component(raw, "request id")?;
         if raw == "latest" {
             return self.read_latest();
         }
         for state in ["pending", "sent", "failed"] {
-            let path = self.requests_root().join(state).join(raw);
+            let path = self.requests_root().join(state).join(&raw);
             if path.exists() {
-                return Ok((state.to_string(), raw.to_string()));
+                return Ok((state.to_string(), raw));
             }
         }
         Err(HandlerError::NotFound(raw.into()))
@@ -142,6 +144,9 @@ impl RequestsHandler {
             request.url.clone(),
         );
         for (k, v) in &request.headers {
+            if is_sensitive_request_header(k) && !is_mpp_probe_marker_header(k, v) {
+                continue;
+            }
             let name = HeaderName::from_bytes(k.as_bytes())
                 .map_err(|e| HandlerError::invalid(format!("invalid header {k}: {e}")))?;
             let val = HeaderValue::from_str(v)
@@ -167,14 +172,27 @@ impl RequestsHandler {
             let challenge = normalize_challenge(&headers, &body, &request.url);
             let policy = self.wallet_policy(&wallet)?;
             let spent_24h_usd = self.sum_paid_usd_last_24h(&wallet)?;
+            let policy_requirement = select_payment_requirement(&challenge, &policy, &host)
+                .or_else(|| challenge.accepts.first().cloned())
+                .unwrap_or_else(|| PaymentRequirement {
+                    scheme: None,
+                    network: challenge.network.clone(),
+                    asset: challenge.asset.clone(),
+                    amount: challenge.amount.clone(),
+                    pay_to: None,
+                    resource: None,
+                    raw: json!({}),
+                });
+            let policy_amount_usd =
+                selected_requirement_amount_usd(&challenge, &policy_requirement);
             let mut checks = evaluate_payment_policy(
                 &policy,
                 PolicyEvalInput {
                     host: &host,
-                    asset: challenge.asset.as_deref(),
-                    network: challenge.network.as_deref(),
+                    asset: policy_requirement.asset.as_deref(),
+                    network: policy_requirement.network.as_deref(),
                     intent: &challenge.intent,
-                    amount_usd: challenge.amount_usd,
+                    amount_usd: policy_amount_usd,
                     request_max_amount_usd: request.max_amount_usd,
                     spent_24h_usd,
                 },
@@ -196,7 +214,7 @@ impl RequestsHandler {
             checks.extend(evaluate_session_policy(&policy, &challenge, already_spent));
             let dir = self.req_dir("pending", &id);
             fs::create_dir_all(dir.join("response"))?;
-            write_request_artifacts(&dir, &request, &wallet, "pending")?;
+            write_request_artifacts(&dir, &request, &wallet, "pending", dry_run)?;
             fs::write(dir.join("status"), b"pending\n")?;
             fs::write(dir.join("challenge.raw"), &body)?;
             write_json(dir.join("challenge.json"), &challenge)?;
@@ -212,14 +230,14 @@ impl RequestsHandler {
             )?;
             write_json(
                 dir.join("audit.json"),
-                &json!({"request_id": id, "event": "staged", "reads_spent": false}),
+                &json!({"request_id": id, "event": "staged", "reads_spent": false, "dry_run": dry_run}),
             )?;
             self.write_latest("pending", &id)?;
             Ok(id)
         } else {
             let dir = self.req_dir("sent", &id);
             fs::create_dir_all(dir.join("response"))?;
-            write_request_artifacts(&dir, &request, &wallet, "sent")?;
+            write_request_artifacts(&dir, &request, &wallet, "sent", dry_run)?;
             fs::write(dir.join("status"), b"sent\n")?;
             fs::write(
                 dir.join("plan.md"),
@@ -228,7 +246,7 @@ impl RequestsHandler {
             fs::write(dir.join("response/status"), format!("{status}\n"))?;
             write_json(
                 dir.join("response/headers.json"),
-                &headers_to_json(&headers),
+                &public_headers_to_json(&headers),
             )?;
             fs::write(dir.join("response/body"), &body)?;
             let sha = bloom_tools::sha256_hex(&body);
@@ -367,7 +385,7 @@ impl RequestsHandler {
     ) -> Result<(), HandlerError> {
         let dir = self.req_dir("failed", id);
         fs::create_dir_all(dir.join("response"))?;
-        write_request_artifacts(&dir, request, wallet, "failed")?;
+        write_request_artifacts(&dir, request, wallet, "failed", false)?;
         fs::write(dir.join("status"), b"failed\n")?;
         fs::write(dir.join("error.txt"), format!("{error}\n"))?;
         write_json(
@@ -385,36 +403,21 @@ impl RequestsHandler {
             return Err(HandlerError::NotFound(format!("/requests/pending/{id}")));
         }
         let request_json: serde_json::Value = read_json(pending.join("request.toml"))?;
-        let request = ParsedRequest {
-            method: request_json
-                .get("method")
-                .and_then(|v| v.as_str())
-                .unwrap_or("GET")
-                .to_string(),
-            url: Url::parse(
-                request_json
-                    .get("url")
-                    .and_then(|v| v.as_str())
-                    .ok_or_else(|| HandlerError::backend("request.toml missing url"))?,
-            )
-            .map_err(|e| HandlerError::backend(format!("stored request url: {e}")))?,
-            wallet: request_json
-                .get("wallet")
-                .and_then(|v| v.as_str())
-                .map(str::to_string),
-            max_amount_usd: request_json.get("max_amount_usd").and_then(|v| v.as_f64()),
-            headers: serde_json::from_value(
-                request_json
-                    .get("headers")
-                    .cloned()
-                    .unwrap_or_else(|| json!({})),
-            )
-            .map_err(|e| HandlerError::backend(format!("stored request headers: {e}")))?,
-            body: request_json
-                .get("body")
-                .and_then(|v| v.as_str())
-                .map(str::to_string),
-        };
+        if request_json
+            .get("dry_run")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+        {
+            return Err(HandlerError::invalid(
+                "dry-run paid requests cannot be confirmed; stage a fresh request with /requests/new",
+            ));
+        }
+        if pending.join("private/credential_minted.json").exists() {
+            return Err(HandlerError::invalid(
+                "this pending request already minted a payment credential; cancel and stage a fresh request instead of re-confirming",
+            ));
+        }
+        let request = parsed_request_from_dir(&pending)?;
         let wallet = request
             .wallet
             .as_deref()
@@ -453,7 +456,18 @@ impl RequestsHandler {
                     asset: challenge.asset.as_deref(),
                     network: challenge.network.as_deref(),
                     intent: &challenge.intent,
-                    amount_usd: challenge.amount_usd,
+                    amount_usd: selected_requirement_amount_usd(
+                        &challenge,
+                        &PaymentRequirement {
+                            scheme: None,
+                            network: challenge.network.clone(),
+                            asset: challenge.asset.clone(),
+                            amount: challenge.amount.clone(),
+                            pay_to: None,
+                            resource: None,
+                            raw: json!({}),
+                        },
+                    ),
                     request_max_amount_usd: request.max_amount_usd,
                     spent_24h_usd: self.sum_paid_usd_last_24h(&wallet)?,
                 },
@@ -496,6 +510,7 @@ impl RequestsHandler {
         challenge.network = requirement.network.clone();
         challenge.asset = requirement.asset.clone();
         challenge.amount = requirement.amount.clone();
+        let amount_usd = selected_requirement_amount_usd(&challenge, &requirement);
         let checks = evaluate_payment_policy(
             &policy,
             PolicyEvalInput {
@@ -503,7 +518,7 @@ impl RequestsHandler {
                 asset: challenge.asset.as_deref(),
                 network: challenge.network.as_deref(),
                 intent: &challenge.intent,
-                amount_usd: challenge.amount_usd,
+                amount_usd,
                 request_max_amount_usd: request.max_amount_usd,
                 spent_24h_usd: self.sum_paid_usd_last_24h(&wallet)?,
             },
@@ -531,95 +546,47 @@ impl RequestsHandler {
             .await
             .map_err(HandlerError::backend)?;
 
-        let mut retry = self.client.request(
-            request.method.parse().unwrap_or(reqwest::Method::GET),
-            request.url.clone(),
-        );
-        for (k, v) in &request.headers {
-            if is_sensitive_request_header(k) {
-                continue;
-            }
-            let name = HeaderName::from_bytes(k.as_bytes())
-                .map_err(|e| HandlerError::invalid(format!("invalid header {k}: {e}")))?;
-            let val = HeaderValue::from_str(v)
-                .map_err(|e| HandlerError::invalid(format!("invalid header {k}: {e}")))?;
-            retry = retry.header(name, val);
-        }
-        retry = retry.header(credential.header_name, credential.header_value.clone());
-        if let Some(body) = &request.body {
-            retry = retry.body(body.clone());
-        }
-        let response = retry
-            .send()
-            .await
-            .map_err(|e| HandlerError::backend(format!("paid HTTP retry failed: {e}")))?;
-        let status = response.status().as_u16();
-        let response_headers = response.headers().clone();
-        let response_body = response
-            .bytes()
-            .await
-            .map_err(|e| HandlerError::backend(format!("read paid HTTP response: {e}")))?
-            .to_vec();
-        let sha = bloom_tools::sha256_hex(&response_body);
-        write_json(
-            pending.join("credential.json"),
-            &json!({
-                "redacted": true,
-                "protocol": challenge.protocol,
-                "intent": challenge.intent,
-                "scheme": requirement.scheme,
-                "network": requirement.network,
-                "asset": requirement.asset,
-                "pay_to": requirement.pay_to,
-                "charge_id": challenge.charge_id,
-                "session_id": challenge.session_id,
-                "material": "not_stored",
-                "header_name": credential.header_name,
-                "secret_material_in_vfs": false,
-                "public": credential.public_metadata,
-            }),
+        let credential_metadata = json!({
+            "redacted": true,
+            "protocol": challenge.protocol,
+            "intent": challenge.intent,
+            "scheme": requirement.scheme,
+            "network": requirement.network,
+            "asset": requirement.asset,
+            "pay_to": requirement.pay_to,
+            "charge_id": challenge.charge_id,
+            "session_id": challenge.session_id,
+            "material": "not_stored",
+            "header_name": credential.header_name,
+            "secret_material_in_vfs": false,
+            "public": credential.public_metadata,
+        });
+        write_minted_marker(&pending, id, &credential_metadata)?;
+        let retry = retry_paid_request(
+            &self.client,
+            &request,
+            credential.header_name,
+            &credential.header_value,
+        )
+        .await;
+        finalize_paid_retry(
+            &self.requests_root(),
+            &pending,
+            id,
+            &wallet,
+            &host,
+            &challenge,
+            &requirement,
+            amount_usd,
+            credential_metadata,
+            retry,
         )?;
-        fs::write(pending.join("response/status"), format!("{status}\n"))?;
-        write_json(
-            pending.join("response/headers.json"),
-            &headers_to_json(&response_headers),
-        )?;
-        fs::write(pending.join("response/body"), &response_body)?;
-        fs::write(pending.join("response/body.sha256"), format!("{sha}\n"))?;
-        write_json(
-            pending.join("receipt.json"),
-            &json!({
-                "request_id": id,
-                "wallet": wallet,
-                "merchant": host,
-                "amount": requirement.amount,
-                "currency": requirement.asset,
-                "network": requirement.network,
-                "protocol": challenge.protocol,
-                "intent": challenge.intent,
-                "scheme": requirement.scheme,
-                "charge_id": challenge.charge_id,
-                "session_id": challenge.session_id,
-                "amount_usd": challenge.amount_usd,
-                "response_status": status,
-                "credential_redacted": true,
-            }),
-        )?;
-        write_json(
-            pending.join("audit.json"),
-            &json!({"request_id": id, "event": "confirmed_and_retried", "reads_spent": false, "credential_redacted": true}),
-        )?;
-        let target_state = if status < 400 { "sent" } else { "failed" };
-        if target_state == "sent" && challenge.intent == "session" {
-            update_session_state(&self.requests_root(), &challenge, id, &wallet)?;
-        }
-        fs::write(pending.join("status"), format!("{target_state}\n"))?;
-        let target = self.req_dir(target_state, id);
-        if target.exists() {
-            fs::remove_dir_all(&target)?;
-        }
-        fs::rename(&pending, &target)?;
-        self.write_latest(target_state, id)?;
+        let final_state = if self.req_dir("sent", id).exists() {
+            "sent"
+        } else {
+            "failed"
+        };
+        self.write_latest(final_state, id)?;
         Ok(())
     }
 }
@@ -671,6 +638,7 @@ fn consume_request_confirm_approved(
 #[async_trait]
 impl Handler for RequestsHandler {
     async fn lookup(&self, path: &VfsPath) -> Result<Entry, HandlerError> {
+        validate_vfs_segments(path)?;
         let segs = path.segments();
         match segs {
             [] => Ok(Entry::dir("requests")),
@@ -714,6 +682,7 @@ impl Handler for RequestsHandler {
     }
 
     async fn list(&self, path: &VfsPath) -> Result<Vec<Entry>, HandlerError> {
+        validate_vfs_segments(path)?;
         self.ensure_layout()?;
         let segs = path.segments();
         match segs {
@@ -746,6 +715,7 @@ impl Handler for RequestsHandler {
     }
 
     async fn read(&self, path: &VfsPath) -> Result<Vec<u8>, HandlerError> {
+        validate_vfs_segments(path)?;
         let segs = path.segments();
         match segs {
             [one] if one == "latest" => {
@@ -786,6 +756,7 @@ impl Handler for RequestsHandler {
     }
 
     async fn write(&self, path: &VfsPath, data: &[u8]) -> Result<(), HandlerError> {
+        validate_vfs_segments(path)?;
         let segs = path.segments();
         match segs {
             [one] if one == "new" || one == "new.dry-run" => {
@@ -880,7 +851,21 @@ async fn confirm_with_backend(
     }
     let challenge: NormalizedChallenge = read_json(pending.join("challenge.json"))?;
     let request_value: serde_json::Value = read_json(pending.join("request.toml"))?;
-    let request = parsed_request_from_artifact(&request_value)?;
+    if request_value
+        .get("dry_run")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        return Err(HandlerError::invalid(
+            "dry-run paid requests cannot be confirmed; stage a fresh request with /requests/new",
+        ));
+    }
+    if pending.join("private/credential_minted.json").exists() {
+        return Err(HandlerError::invalid(
+            "this pending request already minted a payment credential; cancel and stage a fresh request instead of re-confirming",
+        ));
+    }
+    let request = parsed_request_from_dir(&pending)?;
     let wallet = request_value
         .get("wallet")
         .and_then(|v| v.as_str())
@@ -895,71 +880,39 @@ async fn confirm_with_backend(
         }
     };
     let execution = backend
-        .confirm(&challenge, &request, &wallet, policy, id)
+        .prepare(&challenge, &request, &wallet, policy, id)
         .await
         .map_err(HandlerError::backend)?;
-    let succeeded = execution.response_status < 400;
-    let final_state = if succeeded { "sent" } else { "failed" };
-    fs::create_dir_all(pending.join("response"))?;
-    write_json(
-        pending.join("credential.json"),
-        &execution.credential_metadata,
+    write_minted_marker(&pending, id, &execution.credential_metadata)?;
+    let retry = retry_paid_request(
+        &reqwest::Client::new(),
+        &request,
+        execution.header_name,
+        &execution.header_value,
+    )
+    .await;
+    let requirement = PaymentRequirement {
+        scheme: None,
+        network: challenge.network.clone(),
+        asset: challenge.asset.clone(),
+        amount: challenge.amount.clone(),
+        pay_to: None,
+        resource: None,
+        raw: json!({}),
+    };
+    let amount_usd = selected_requirement_amount_usd(&challenge, &requirement);
+    let final_state = finalize_paid_retry(
+        &requests_root,
+        &pending,
+        id,
+        &wallet,
+        &challenge.merchant,
+        &challenge,
+        &requirement,
+        amount_usd,
+        execution.credential_metadata,
+        retry,
     )?;
-    fs::write(
-        pending.join("response/status"),
-        format!("{}\n", execution.response_status),
-    )?;
-    fs::write(pending.join("response/body"), &execution.response_body)?;
-    write_json(
-        pending.join("response/headers.json"),
-        &headers_to_json(&execution.response_headers),
-    )?;
-    let sha = bloom_tools::sha256_hex(&execution.response_body);
-    fs::write(pending.join("response/body.sha256"), format!("{sha}\n"))?;
-    write_json(
-        pending.join("receipt.json"),
-        &json!({
-            "request_id": id,
-            "wallet": request_json_field(&pending, "wallet"),
-            "merchant": challenge.merchant,
-            "amount": challenge.amount,
-            "currency": challenge.asset,
-            "network": challenge.network,
-            "protocol": challenge.protocol,
-            "intent": challenge.intent,
-            "tx_hash": null,
-            "session_id": challenge.session_id,
-            "response_sha256": sha,
-            "mock_backend": false,
-            "raw": execution.receipt_raw
-        }),
-    )?;
-    write_json(
-        pending.join("audit.json"),
-        &json!({
-            "request_id": id,
-            "event": "confirmed_and_retried",
-            "backend": backend.name(),
-            "response_status": execution.response_status,
-            "paid_retry_succeeded": succeeded,
-            "reads_spent": false,
-            "secret_material_in_vfs": false
-        }),
-    )?;
-    if succeeded && challenge.intent == "session" {
-        let wallet = request_json_field(&pending, "wallet")
-            .as_str()
-            .unwrap_or("unknown")
-            .to_string();
-        update_session_state(&requests_root, &challenge, id, &wallet)?;
-    }
-    fs::write(pending.join("status"), format!("{final_state}\n"))?;
-    fs::create_dir_all(requests_root.join(final_state))?;
-    let dest = requests_root.join(final_state).join(id);
-    if dest.exists() {
-        fs::remove_dir_all(&dest)?;
-    }
-    fs::rename(&pending, &dest)?;
     fs::write(
         requests_root.join("latest"),
         format!("{final_state}/{id}\n"),
@@ -967,6 +920,16 @@ async fn confirm_with_backend(
     Ok(ConfirmResult {
         final_state: final_state.into(),
     })
+}
+
+fn parsed_request_from_dir(dir: &Path) -> Result<ParsedRequest, HandlerError> {
+    let mut request =
+        parsed_request_from_artifact(&read_json::<serde_json::Value>(dir.join("request.toml"))?)?;
+    let private_body = dir.join("private/request_body");
+    if private_body.exists() {
+        request.body = Some(fs::read_to_string(private_body)?);
+    }
+    Ok(request)
 }
 
 fn parsed_request_from_artifact(v: &serde_json::Value) -> Result<ParsedRequest, HandlerError> {
@@ -996,13 +959,6 @@ fn parsed_request_from_artifact(v: &serde_json::Value) -> Result<ParsedRequest, 
 fn backend_policy_for_wallet(root: &Path, wallet: &str) -> Result<Policy, HandlerError> {
     let raw = fs::read_to_string(root.join("keystore").join(wallet).join("policy.toml"))?;
     toml::from_str(&raw).map_err(|e| HandlerError::backend(e.to_string()))
-}
-
-fn request_json_field(dir: &Path, field: &str) -> serde_json::Value {
-    read_json::<serde_json::Value>(dir.join("request.toml"))
-        .ok()
-        .and_then(|v| v.get(field).cloned())
-        .unwrap_or(serde_json::Value::Null)
 }
 
 /// Records a redacted, append-only voucher trail after a session-intent paid
@@ -1134,7 +1090,19 @@ fn write_request_artifacts(
     req: &ParsedRequest,
     wallet: &str,
     state: &str,
+    dry_run: bool,
 ) -> Result<(), HandlerError> {
+    fs::create_dir_all(dir.join("private"))?;
+    let (body_redacted, body_len, body_sha256) = if let Some(body) = &req.body {
+        fs::write(dir.join("private/request_body"), body)?;
+        (
+            true,
+            Some(body.len()),
+            Some(bloom_tools::sha256_hex(body.as_bytes())),
+        )
+    } else {
+        (false, None, None)
+    };
     write_json(
         dir.join("request.toml"),
         &json!({
@@ -1143,7 +1111,11 @@ fn write_request_artifacts(
             "wallet": wallet,
             "max_amount_usd": req.max_amount_usd,
             "headers": redacted_headers(&req.headers),
-            "body": req.body,
+            "body": if body_redacted { serde_json::Value::String("redacted".into()) } else { serde_json::Value::Null },
+            "body_redacted": body_redacted,
+            "body_len": body_len,
+            "body_sha256": body_sha256,
+            "dry_run": dry_run,
             "state": state
         }),
     )?;
@@ -1156,17 +1128,193 @@ fn write_request_artifacts(
         };
         http.push_str(&format!("{k}: {value}\n"));
     }
-    if let Some(body) = &req.body {
+    if req.body.is_some() {
         http.push('\n');
-        http.push_str(body);
+        http.push_str("[request body redacted; see body_sha256 in request.toml]");
         http.push('\n');
     }
     fs::write(dir.join("request.http"), http)?;
     Ok(())
 }
 
-fn headers_to_json(headers: &HeaderMap) -> serde_json::Value {
-    json!(headers_to_string_map(headers))
+#[derive(Debug)]
+struct PaidRetryResponse {
+    status: u16,
+    headers: HeaderMap,
+    body: Vec<u8>,
+}
+
+async fn retry_paid_request(
+    client: &reqwest::Client,
+    request: &ParsedRequest,
+    payment_header_name: &str,
+    payment_header_value: &str,
+) -> Result<PaidRetryResponse, HandlerError> {
+    let mut retry = client.request(
+        request.method.parse().unwrap_or(reqwest::Method::GET),
+        request.url.clone(),
+    );
+    for (k, v) in &request.headers {
+        if is_sensitive_request_header(k) {
+            continue;
+        }
+        let name = HeaderName::from_bytes(k.as_bytes())
+            .map_err(|e| HandlerError::invalid(format!("invalid header {k}: {e}")))?;
+        let val = HeaderValue::from_str(v)
+            .map_err(|e| HandlerError::invalid(format!("invalid header {k}: {e}")))?;
+        retry = retry.header(name, val);
+    }
+    let name = HeaderName::from_bytes(payment_header_name.as_bytes()).map_err(|e| {
+        HandlerError::backend(format!("invalid paid HTTP credential header name: {e}"))
+    })?;
+    let value = HeaderValue::from_str(payment_header_value).map_err(|e| {
+        HandlerError::backend(format!("invalid paid HTTP credential header value: {e}"))
+    })?;
+    retry = retry.header(name, value);
+    if let Some(body) = &request.body {
+        retry = retry.body(body.clone());
+    }
+    let response = retry
+        .send()
+        .await
+        .map_err(|e| HandlerError::backend(format!("paid HTTP retry failed: {e}")))?;
+    let status = response.status().as_u16();
+    let headers = response.headers().clone();
+    let body = response
+        .bytes()
+        .await
+        .map_err(|e| HandlerError::backend(format!("read paid HTTP response: {e}")))?
+        .to_vec();
+    Ok(PaidRetryResponse {
+        status,
+        headers,
+        body,
+    })
+}
+
+fn write_minted_marker(
+    pending: &Path,
+    id: &str,
+    credential_metadata: &serde_json::Value,
+) -> Result<(), HandlerError> {
+    fs::create_dir_all(pending.join("private"))?;
+    write_json(pending.join("credential.json"), credential_metadata)?;
+    write_json(
+        pending.join("private/credential_minted.json"),
+        &json!({
+            "request_id": id,
+            "credential_redacted": true,
+            "secret_material_in_vfs": false
+        }),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn finalize_paid_retry(
+    requests_root: &Path,
+    pending: &Path,
+    id: &str,
+    wallet: &str,
+    merchant: &str,
+    challenge: &NormalizedChallenge,
+    requirement: &PaymentRequirement,
+    amount_usd: Option<f64>,
+    credential_metadata: serde_json::Value,
+    retry: Result<PaidRetryResponse, HandlerError>,
+) -> Result<String, HandlerError> {
+    fs::create_dir_all(pending.join("response"))?;
+    write_json(pending.join("credential.json"), &credential_metadata)?;
+    let (status, response_headers, response_body, retry_error) = match retry {
+        Ok(response) => (response.status, response.headers, response.body, None),
+        Err(err) => (
+            599,
+            HeaderMap::new(),
+            format!("{err}\n").into_bytes(),
+            Some(err.to_string()),
+        ),
+    };
+    fs::write(pending.join("response/status"), format!("{status}\n"))?;
+    write_json(
+        pending.join("response/headers.json"),
+        &public_headers_to_json(&response_headers),
+    )?;
+    fs::write(pending.join("response/body"), &response_body)?;
+    let sha = bloom_tools::sha256_hex(&response_body);
+    fs::write(pending.join("response/body.sha256"), format!("{sha}\n"))?;
+    if let Some(error) = &retry_error {
+        fs::write(pending.join("error.txt"), format!("{error}\n"))?;
+    }
+    let receipt_raw = response_headers
+        .get("payment-receipt")
+        .and_then(|h| h.to_str().ok())
+        .and_then(|h| mpp::parse_receipt(h).ok())
+        .and_then(|r| serde_json::to_value(r).ok())
+        .unwrap_or_else(|| json!({}));
+    write_json(
+        pending.join("receipt.json"),
+        &json!({
+            "request_id": id,
+            "wallet": wallet,
+            "merchant": merchant,
+            "amount": requirement.amount,
+            "currency": requirement.asset,
+            "network": requirement.network,
+            "protocol": challenge.protocol,
+            "intent": challenge.intent,
+            "scheme": requirement.scheme,
+            "charge_id": challenge.charge_id,
+            "session_id": challenge.session_id,
+            "amount_usd": amount_usd,
+            "response_status": status,
+            "response_sha256": sha,
+            "credential_redacted": true,
+            "raw": receipt_raw,
+        }),
+    )?;
+    let succeeded = status < 400 && retry_error.is_none();
+    write_json(
+        pending.join("audit.json"),
+        &json!({
+            "request_id": id,
+            "event": "confirmed_and_retried",
+            "response_status": status,
+            "paid_retry_succeeded": succeeded,
+            "retry_error": retry_error,
+            "reads_spent": false,
+            "credential_redacted": true,
+            "secret_material_in_vfs": false
+        }),
+    )?;
+    let final_state = if succeeded { "sent" } else { "failed" };
+    if succeeded && challenge.intent == "session" {
+        update_session_state(requests_root, challenge, id, wallet)?;
+    }
+    fs::write(pending.join("status"), format!("{final_state}\n"))?;
+    fs::create_dir_all(requests_root.join(final_state))?;
+    let dest = requests_root
+        .join(final_state)
+        .join(safe_fs_component(id, "request id")?);
+    if dest.exists() {
+        return Err(HandlerError::backend(format!(
+            "request destination already exists for id {id}"
+        )));
+    }
+    fs::rename(pending, &dest)?;
+    Ok(final_state.into())
+}
+
+fn public_headers_to_json(headers: &HeaderMap) -> serde_json::Value {
+    let mut map = std::collections::BTreeMap::new();
+    for (name, value) in headers {
+        let key = name.as_str().to_ascii_lowercase();
+        let rendered = if is_sensitive_response_header(&key) {
+            "redacted".to_string()
+        } else {
+            value.to_str().unwrap_or("<non-utf8>").to_string()
+        };
+        map.insert(key, rendered);
+    }
+    json!(map)
 }
 
 fn redacted_headers(headers: &std::collections::BTreeMap<String, String>) -> serde_json::Value {
@@ -1188,32 +1336,45 @@ fn redacted_headers(headers: &std::collections::BTreeMap<String, String>) -> ser
 }
 
 fn is_sensitive_request_header(name: &str) -> bool {
-    matches!(
-        name.to_ascii_lowercase().as_str(),
-        "authorization"
-            | "proxy-authorization"
-            | "x-payment"
-            | "payment-signature"
-            | "x-api-key"
-            | "api-key"
-            | "apikey"
-    )
+    is_sensitive_paid_http_header(name)
+}
+
+fn is_mpp_probe_marker_header(name: &str, value: &str) -> bool {
+    name.eq_ignore_ascii_case("authorization") && value.trim().eq_ignore_ascii_case("Payment")
+}
+
+fn is_sensitive_response_header(name: &str) -> bool {
+    is_sensitive_paid_http_header(name)
+        || matches!(
+            name.to_ascii_lowercase().as_str(),
+            "www-authenticate" | "payment-required"
+        )
 }
 
 fn session_dir_name(raw: &str) -> Result<String, HandlerError> {
+    safe_fs_component(raw, "paid request session id")
+}
+
+fn safe_fs_component(raw: &str, label: &str) -> Result<String, HandlerError> {
     let name = raw.trim();
     if name.is_empty()
         || name == "."
         || name == ".."
         || name.contains('/')
         || name.contains('\\')
+        || name.contains('\0')
         || Path::new(name).is_absolute()
     {
-        return Err(HandlerError::invalid(format!(
-            "invalid paid request session id '{raw}'"
-        )));
+        return Err(HandlerError::invalid(format!("invalid {label} '{raw}'")));
     }
     Ok(name.to_string())
+}
+
+fn validate_vfs_segments(path: &VfsPath) -> Result<(), HandlerError> {
+    for segment in path.segments() {
+        safe_fs_component(segment, "VFS path segment")?;
+    }
+    Ok(())
 }
 
 fn write_json(path: impl AsRef<Path>, v: &impl Serialize) -> Result<(), HandlerError> {
@@ -1245,6 +1406,9 @@ fn list_entries(path: PathBuf) -> Result<Vec<Entry>, HandlerError> {
     for e in fs::read_dir(path)? {
         let e = e?;
         let name = e.file_name().to_string_lossy().to_string();
+        if name == "private" {
+            continue;
+        }
         let ty = e.file_type()?;
         out.push(if ty.is_dir() {
             Entry::dir(&name)
@@ -1258,11 +1422,13 @@ fn list_entries(path: PathBuf) -> Result<Vec<Entry>, HandlerError> {
     Ok(out)
 }
 fn new_request_id() -> String {
+    static REQUEST_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
     let ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis();
-    format!("req_{ms}")
+    let n = REQUEST_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("req_{ms}_{n}")
 }
 
 #[cfg(test)]
@@ -1270,6 +1436,7 @@ mod tests {
     use super::*;
     use crate::path::VfsPath;
     use bloom_paid_mpp::PaymentExecution;
+    use bloom_paid_x402::X402PaymentCredential;
     use mpp::client::{PaymentProvider, TempoProvider};
     use std::collections::BTreeMap;
     use std::sync::{
@@ -1282,6 +1449,25 @@ mod tests {
     struct Fixture {
         _tmp: tempfile::TempDir,
         handler: RequestsHandler,
+    }
+
+    struct StaticX402Signer {
+        calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl X402PaymentSigner for StaticX402Signer {
+        async fn sign_x402_payment(
+            &self,
+            _ctx: &X402SignContext<'_>,
+        ) -> Result<X402PaymentCredential, String> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(X402PaymentCredential {
+                header_name: "X-Payment",
+                header_value: "signed-x402".into(),
+                public_metadata: json!({"test": true}),
+            })
+        }
     }
 
     fn fixture(default_wallet: Option<&str>) -> Fixture {
@@ -1374,6 +1560,178 @@ mod tests {
         (format!("http://{addr}/resource"), count)
     }
 
+    async fn capture_server(
+        status: u16,
+        body: &'static [u8],
+    ) -> (String, tokio::sync::oneshot::Receiver<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 8192];
+            let n = socket.read(&mut buf).await.unwrap();
+            let _ = tx.send(String::from_utf8_lossy(&buf[..n]).to_string());
+            let response = format!(
+                "HTTP/1.1 {status} OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                body.len()
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+            socket.write_all(body).await.unwrap();
+        });
+        (format!("http://{addr}/resource"), rx)
+    }
+
+    #[test]
+    fn request_ids_include_collision_disambiguator() {
+        let id = new_request_id();
+        assert!(id.starts_with("req_"));
+        assert!(id.rsplit_once('_').is_some(), "{id}");
+    }
+
+    #[tokio::test]
+    async fn dry_run_paid_request_cannot_be_confirmed() {
+        let f = fixture(Some("alice"));
+        let body = br#"{"accepts":[{"network":"base","asset":"USDC","maxAmountRequired":"1000"}]}"#;
+        let (url, _hits) = mock_server(402, &[("x-payment-required", "1")], body).await;
+        let id = f
+            .handler
+            .create_request(format!("GET {url}").as_bytes(), true)
+            .await
+            .unwrap();
+
+        let err = f
+            .handler
+            .write(
+                &VfsPath::parse(&format!("/pending/{id}/confirm")).unwrap(),
+                b"confirm",
+            )
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("dry-run"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn unpaid_probe_strips_sensitive_payment_headers() {
+        let f = fixture(Some("alice"));
+        let (url, raw_rx) = capture_server(200, b"ok").await;
+        f.handler
+            .create_request(
+                format!(
+                    "GET {url}\nauthorization: Payment\nproxy-authorization: Bearer secret\nx-payment: old\npayment-signature: old\nx-api-key: key\naccept: application/json"
+                )
+                .as_bytes(),
+                false,
+            )
+            .await
+            .unwrap();
+
+        let raw = raw_rx.await.unwrap().to_ascii_lowercase();
+        assert!(raw.contains("authorization: payment"), "{raw}");
+        assert!(!raw.contains("proxy-authorization:"), "{raw}");
+        assert!(!raw.contains("x-payment:"), "{raw}");
+        assert!(!raw.contains("payment-signature:"), "{raw}");
+        assert!(!raw.contains("x-api-key:"), "{raw}");
+        assert!(raw.contains("accept: application/json"), "{raw}");
+    }
+
+    #[tokio::test]
+    async fn public_response_headers_are_redacted() {
+        let f = fixture(Some("alice"));
+        let (url, _hits) = mock_server(
+            200,
+            &[
+                ("set-cookie", "sid=secret"),
+                ("payment-receipt", "secret-receipt"),
+                ("content-type", "application/json"),
+            ],
+            b"{}",
+        )
+        .await;
+        let id = f
+            .handler
+            .create_request(format!("GET {url}").as_bytes(), false)
+            .await
+            .unwrap();
+        let headers: serde_json::Value = serde_json::from_slice(
+            &f.handler
+                .read(&VfsPath::parse(&format!("/sent/{id}/response/headers.json")).unwrap())
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(headers["set-cookie"], "redacted");
+        assert_eq!(headers["payment-receipt"], "redacted");
+        assert_eq!(headers["content-type"], "application/json");
+    }
+
+    #[tokio::test]
+    async fn decoded_unsafe_vfs_segments_are_rejected() {
+        let f = fixture(Some("alice"));
+        let path = VfsPath::root().join("pending").join("bad/seg");
+        let err = f.handler.read(&path).await.unwrap_err();
+        assert!(err.to_string().contains("invalid"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn x402_retry_failure_moves_failed_and_does_not_resign() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let f = fixture(Some("alice"));
+        let mut policy = Policy::default();
+        policy.payments.enabled = true;
+        policy.payments.require_plan = true;
+        f.handler
+            .keystore
+            .write_policy("alice", toml::to_string_pretty(&policy).unwrap().as_bytes())
+            .unwrap();
+        let handler = f.handler.with_x402_signer(Arc::new(StaticX402Signer {
+            calls: calls.clone(),
+        }));
+        let pending = handler.requests_root().join("pending/req_retry_fail");
+        fs::create_dir_all(&pending).unwrap();
+        let challenge = normalize_challenge(
+            &HeaderMap::new(),
+            br#"{"x402Version":1,"accepts":[{"network":"base","asset":"USDC","maxAmountRequired":"1000"}]}"#,
+            &Url::parse("http://127.0.0.1:9/pay").unwrap(),
+        );
+        write_json(pending.join("challenge.json"), &challenge).unwrap();
+        write_json(
+            pending.join("payment_method.json"),
+            &challenge.payment_method(),
+        )
+        .unwrap();
+        let empty_checks: Vec<PolicyCheck> = vec![];
+        write_json(pending.join("policy_check.json"), &empty_checks).unwrap();
+        write_json(
+            pending.join("request.toml"),
+            &json!({"method":"GET","url":"http://127.0.0.1:9/pay","wallet":"alice","headers":{},"dry_run":false}),
+        )
+        .unwrap();
+        fs::write(pending.join("status"), "pending\n").unwrap();
+
+        persist_request_confirm_approved(
+            handler.root.as_path(),
+            "req_retry_fail",
+            "alice",
+            "confirm",
+        )
+        .unwrap();
+        handler.confirm("req_retry_fail", b"confirm").await.unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(
+            handler
+                .requests_root()
+                .join("failed/req_retry_fail")
+                .exists()
+        );
+        let err = handler
+            .confirm("req_retry_fail", b"confirm")
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("pending"), "{err}");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
     #[test]
     fn parses_one_line_toml_and_http_message_forms() {
         let req =
@@ -1427,16 +1785,18 @@ inline = '{"prompt":"hi"}'
 "#,
         )
         .unwrap();
-        write_request_artifacts(dir.path(), &req, "research", "pending").unwrap();
+        write_request_artifacts(dir.path(), &req, "research", "pending", false).unwrap();
 
         let stored: serde_json::Value = read_json(dir.path().join("request.toml")).unwrap();
-        assert_eq!(stored["body"], r#"{"prompt":"hi"}"#);
-        let reloaded = parsed_request_from_artifact(&stored).unwrap();
+        assert_eq!(stored["body"], "redacted");
+        assert_eq!(stored["body_redacted"], true);
+        let reloaded = parsed_request_from_dir(dir.path()).unwrap();
         assert_eq!(reloaded.body.as_deref(), Some(r#"{"prompt":"hi"}"#));
 
         let http = fs::read_to_string(dir.path().join("request.http")).unwrap();
         assert!(http.contains("content-type: application/json\n\n"));
-        assert!(http.ends_with("{\"prompt\":\"hi\"}\n"));
+        assert!(!http.contains("{\"prompt\":\"hi\"}"));
+        assert!(http.contains("request body redacted"));
     }
 
     #[test]
@@ -1446,7 +1806,7 @@ inline = '{"prompt":"hi"}'
             "GET https://api.example.com/data\nauthorization: Bearer secret\nx-api-key: key-123\naccept: application/json",
         )
         .unwrap();
-        write_request_artifacts(dir.path(), &req, "research", "pending").unwrap();
+        write_request_artifacts(dir.path(), &req, "research", "pending", false).unwrap();
 
         let stored: serde_json::Value = read_json(dir.path().join("request.toml")).unwrap();
         assert_eq!(stored["headers"]["authorization"], "redacted");
@@ -1825,7 +2185,7 @@ inline = '{"prompt":"hi"}'
             "mpp_tempo_test_double"
         }
 
-        async fn confirm(
+        async fn prepare(
             &self,
             challenge: &NormalizedChallenge,
             _request: &ParsedRequest,
@@ -1843,10 +2203,8 @@ inline = '{"prompt":"hi"}'
                     "raw_authorization_stored": false,
                     "raw_signed_payload_stored": false
                 }),
-                receipt_raw: json!({"backend": self.name()}),
-                response_status: 200,
-                response_headers: HeaderMap::new(),
-                response_body: b"paid response\n".to_vec(),
+                header_name: "Authorization",
+                header_value: "Payment test".into(),
             })
         }
     }
@@ -1856,10 +2214,16 @@ inline = '{"prompt":"hi"}'
         let dir = tempfile::tempdir().unwrap();
         let pending = dir.path().join("requests/pending/req_1");
         fs::create_dir_all(&pending).unwrap();
+        let (url, _hits) = mock_server(
+            200,
+            &[("payment-receipt", r#"{"status":"success"}"#)],
+            b"paid response\n",
+        )
+        .await;
         let challenge = normalize_challenge(
             &HeaderMap::new(),
             br#"{"protocol":"tempo-mpp","type":"Session","network":"tempo","asset":"pathUSD","session":{"id":"sess_1","voucherAmount":"0.10","voucherAmountUsd":0.10,"depositAmount":"1.00","depositAmountUsd":1.00}}"#,
-            &Url::parse("https://mpp.test/data").unwrap(),
+            &Url::parse(&url).unwrap(),
         );
         write_json(pending.join("challenge.json"), &challenge).unwrap();
         let payment = challenge.payment_method();
@@ -1868,7 +2232,7 @@ inline = '{"prompt":"hi"}'
         write_json(pending.join("policy_check.json"), &empty_checks).unwrap();
         write_json(
             pending.join("request.toml"),
-            &json!({"method":"GET","url":"https://mpp.test/data","wallet":"alice","headers":{}}),
+            &json!({"method":"GET","url":url,"wallet":"alice","headers":{}}),
         )
         .unwrap();
         fs::write(pending.join("request.http"), "GET https://mpp.test/data\n").unwrap();
@@ -1898,7 +2262,6 @@ inline = '{"prompt":"hi"}'
         let receipt: serde_json::Value =
             read_json(dir.path().join("requests/sent/req_1/receipt.json")).unwrap();
         assert_eq!(receipt["session_id"], "sess_1");
-        assert_eq!(receipt["mock_backend"], false);
         let audit: serde_json::Value =
             read_json(dir.path().join("requests/sent/req_1/audit.json")).unwrap();
         assert_eq!(audit["paid_retry_succeeded"], true);
@@ -1971,7 +2334,7 @@ inline = '{"prompt":"hi"}'
             "mpp_tempo_test_double_failing"
         }
 
-        async fn confirm(
+        async fn prepare(
             &self,
             challenge: &NormalizedChallenge,
             _request: &ParsedRequest,
@@ -1989,10 +2352,8 @@ inline = '{"prompt":"hi"}'
                     "raw_authorization_stored": false,
                     "raw_signed_payload_stored": false
                 }),
-                receipt_raw: json!({"backend": self.name()}),
-                response_status: 500,
-                response_headers: HeaderMap::new(),
-                response_body: b"merchant error\n".to_vec(),
+                header_name: "Authorization",
+                header_value: "Payment test".into(),
             })
         }
     }
@@ -2002,10 +2363,11 @@ inline = '{"prompt":"hi"}'
         let dir = tempfile::tempdir().unwrap();
         let pending = dir.path().join("requests/pending/req_fail");
         fs::create_dir_all(&pending).unwrap();
+        let (url, _hits) = mock_server(500, &[], b"merchant error\n").await;
         let challenge = normalize_challenge(
             &HeaderMap::new(),
             br#"{"protocol":"tempo-mpp","type":"Session","network":"tempo","asset":"pathUSD","session":{"id":"sess_fail","voucherAmount":"0.10","voucherAmountUsd":0.10,"depositAmount":"1.00","depositAmountUsd":1.00}}"#,
-            &Url::parse("https://mpp.test/data").unwrap(),
+            &Url::parse(&url).unwrap(),
         );
         write_json(pending.join("challenge.json"), &challenge).unwrap();
         write_json(
@@ -2017,7 +2379,7 @@ inline = '{"prompt":"hi"}'
         write_json(pending.join("policy_check.json"), &empty_checks).unwrap();
         write_json(
             pending.join("request.toml"),
-            &json!({"method":"GET","url":"https://mpp.test/data","wallet":"alice","headers":{}}),
+            &json!({"method":"GET","url":url,"wallet":"alice","headers":{}}),
         )
         .unwrap();
         fs::write(pending.join("request.http"), "GET https://mpp.test/data\n").unwrap();
@@ -2060,7 +2422,6 @@ inline = '{"prompt":"hi"}'
 
         let receipt: serde_json::Value = read_json(failed.join("receipt.json")).unwrap();
         assert_eq!(receipt["session_id"], "sess_fail");
-        assert_eq!(receipt["mock_backend"], false);
         let audit: serde_json::Value = read_json(failed.join("audit.json")).unwrap();
         assert_eq!(audit["paid_retry_succeeded"], false);
         assert_eq!(audit["response_status"], 500);
@@ -2106,7 +2467,7 @@ inline = '{"prompt":"hi"}'
         let request = parse_request("GET https://merchant.test/pay wallet=alice").unwrap();
 
         let msg = match backend
-            .confirm(
+            .prepare(
                 &challenge,
                 &request,
                 "alice",
@@ -2153,7 +2514,7 @@ inline = '{"prompt":"hi"}'
         let request = parse_request("GET https://merchant.test/pay wallet=passkey_alice").unwrap();
 
         let msg = match backend
-            .confirm(
+            .prepare(
                 &challenge,
                 &request,
                 "passkey_alice",

--- a/crates/bloom/src/main.rs
+++ b/crates/bloom/src/main.rs
@@ -552,8 +552,11 @@ enum RequestCmd {
         /// staged request.
         #[arg(long)]
         wallet: Option<String>,
-        /// Passphrase for a local/imported paying wallet (passkey wallets prompt).
+        /// Alias for `--wallet`, kept for parity with `bloom vfs write`.
         #[arg(long)]
+        unlock_wallet: Option<String>,
+        /// Passphrase for a local/imported paying wallet (passkey wallets prompt).
+        #[arg(long, env = "BLOOM_PASSPHRASE")]
         passphrase: Option<String>,
     },
     /// Print response body for an id or `latest`.
@@ -1376,6 +1379,15 @@ async fn run(cli: Cli) -> Result<()> {
                         &intent.intent_hash(),
                     )?;
                 }
+                if let Some(id) = request_confirm_id(d.home.root(), &p) {
+                    let confirm_value = String::from_utf8_lossy(&body).trim().to_ascii_lowercase();
+                    bloom_vfs::handlers::requests::persist_request_confirm_approved(
+                        d.home.root(),
+                        &id,
+                        &wallet,
+                        &confirm_value,
+                    )?;
+                }
                 d.vfs.write(&p, &body).await.context("vfs write")?;
 
                 // If this is a polymarket `begin` write, the handler spawned a background
@@ -1474,21 +1486,21 @@ async fn run(cli: Cli) -> Result<()> {
             id,
             text,
             wallet,
+            unlock_wallet,
             passphrase,
         }) => {
             let path = format!("/requests/{id}/confirm");
             let p = VfsPath::parse(&path)?;
             let body = text.into_bytes();
-            // Confirming a paid request signs payment credentials, so it must go
-            // through the wallet-signer ceremony — resolve the paying wallet
-            // (from --wallet or the staged request) and route via write_unlocked.
             let client = IpcClient::new(&client_endpoint.socket);
+            let wallet = unlock_wallet.or(wallet);
             let wallet = match wallet {
                 Some(w) => Some(w),
                 None => read_request_wallet(&client, &client_endpoint, &home, &id).await?,
             };
-            let wallet = wallet
-                .context("could not determine paying wallet for this request; pass --wallet")?;
+            let wallet = wallet.context(
+                "could not determine paying wallet for this request; pass --wallet or --unlock-wallet",
+            )?;
             let ipc_res = try_ipc(
                 &client,
                 &client_endpoint,
@@ -1506,7 +1518,6 @@ async fn run(cli: Cli) -> Result<()> {
                 debug!(endpoint = %client_endpoint.display, "cli.request.confirm.via_ipc");
                 return Ok(());
             }
-            // No daemon: fall back to an in-process unlock + write.
             debug!("cli.request.confirm.via_inproc: no daemon socket present");
             let (_home_permit, d) = build_write_daemon(home)?;
             let info = d.keystore.info(&wallet)?;
@@ -1533,6 +1544,12 @@ async fn run(cli: Cli) -> Result<()> {
                         .unlock(&wallet, passphrase.as_deref().unwrap_or(""))?;
                 }
             }
+            bloom_vfs::handlers::requests::persist_request_confirm_approved(
+                d.home.root(),
+                &id,
+                &wallet,
+                &String::from_utf8_lossy(&body).trim().to_ascii_lowercase(),
+            )?;
             d.vfs.write(&p, &body).await.context("request confirm")?;
             Ok(())
         }
@@ -2962,6 +2979,30 @@ fn is_policy_session_new(wallet: &str, path: &VfsPath) -> bool {
     )
 }
 
+fn request_confirm_id(home: &std::path::Path, path: &VfsPath) -> Option<String> {
+    match path.segments() {
+        [root, reference, action] if root == "requests" && action == "confirm" => {
+            if reference == "latest" {
+                latest_pending_request_id(home)
+            } else {
+                Some(reference.to_string())
+            }
+        }
+        [root, state, id, action]
+            if root == "requests" && state == "pending" && action == "confirm" =>
+        {
+            Some(id.to_string())
+        }
+        _ => None,
+    }
+}
+
+fn latest_pending_request_id(home: &std::path::Path) -> Option<String> {
+    let latest = std::fs::read_to_string(home.join("requests").join("latest")).ok()?;
+    let (state, id) = latest.trim().split_once('/')?;
+    (state == "pending").then(|| id.to_string())
+}
+
 fn is_outbox_confirm_write(wallet: &str, path: &VfsPath) -> bool {
     matches!(
         path.segments(),
@@ -3038,10 +3079,17 @@ fn request_body_with_wallet(mut request: String, wallet: Option<&str>) -> String
     let Some(wallet) = wallet else {
         return request;
     };
-    if request.trim_start().starts_with("url") || request.trim_start().starts_with("method") {
-        request.push('\n');
-        request.push_str(&format!("wallet = \"{wallet}\""));
-        return request;
+    if let Ok(mut value) = request.parse::<toml::Value>()
+        && value.get("url").is_some()
+        && let Some(table) = value.as_table_mut()
+    {
+        table.insert("wallet".into(), toml::Value::String(wallet.to_string()));
+        return toml::to_string_pretty(&value).unwrap_or_else(|_| {
+            let mut fallback = request.clone();
+            fallback.push('\n');
+            fallback.push_str(&format!("wallet = \"{wallet}\""));
+            fallback
+        });
     }
     let Some(first_newline) = request.find('\n') else {
         request.push(' ');
@@ -3798,6 +3846,30 @@ mod tests {
         assert_eq!(
             output,
             "GET https://api.example.com/data max_amount_usd=0.05 wallet=gavin"
+        );
+    }
+
+    #[test]
+    fn request_wallet_injection_preserves_valid_toml_shape() {
+        let output = request_body_with_wallet(
+            r#"# comment before keys
+max_amount_usd = "0.05"
+url = "https://api.example.com/data"
+method = "POST"
+
+[headers]
+content-type = "application/json"
+"#
+            .to_string(),
+            Some("gavin"),
+        );
+        let parsed: toml::Value = output.parse().unwrap();
+        assert_eq!(parsed["wallet"].as_str(), Some("gavin"));
+        assert_eq!(parsed["url"].as_str(), Some("https://api.example.com/data"));
+        assert_eq!(parsed["method"].as_str(), Some("POST"));
+        assert_eq!(
+            parsed["headers"]["content-type"].as_str(),
+            Some("application/json")
         );
     }
 }


### PR DESCRIPTION
Supersedes PR #47.

## Summary
- preserve the paid HTTP payment work from the payments branch lineage
- fix MPP spend history accounting so historical base-unit amounts use the same USD conversion path as x402 challenge normalization
- add a regression test for Tempo MPP receipts where `amount: "10000"` should count as `$0.01`, not `$10000`

## Validation
- `cargo +nightly test -p bloom-vfs spent_usd_history_converts_mpp_base_units_like_x402 -- --nocapture`
- `cargo +nightly test -p bloom-vfs mpp_confirm_rechecks_current_policy -- --nocapture`