### PR TITLE
[codex] fix paid request merge blockers

### DIFF
--- a/crates/bloom-paid-x402/src/lib.rs
+++ b/crates/bloom-paid-x402/src/lib.rs
@@ -1,5 +1,6 @@
 //! x402 protocol adapter for Bloom paid HTTP requests.
 
+use alloy::primitives::U256;
 use async_trait::async_trait;
 use bloom_keystore::{Keystore, KeystoreError, WalletKind};
 use bloom_paid_http::{
@@ -63,33 +64,10 @@ impl X402PaymentSigner for KeystoreX402PaymentSigner {
             .info(ctx.wallet)
             .map_err(|e| format!("x402 signer wallet metadata unavailable: {e}"))?;
         let payment_required = parse_payment_required(ctx.challenge)?;
-        let candidate = select_candidate(&payment_required, signer).ok_or_else(|| {
-            "x402 upstream signer found no matching EIP-155 exact payment option".to_string()
-        })?;
-        if let Some(network) = ctx.requirement.network.as_deref() {
-            let candidate_network = candidate.chain_id.to_string();
-            if !networks_equivalent(&candidate_network, network) {
-                return Err(format!(
-                    "x402 selected network {candidate_network}, expected staged network {network}"
-                ));
-            }
-        }
-        if let Some(asset) = ctx.requirement.asset.as_deref()
-            && !candidate.asset.eq_ignore_ascii_case(asset)
-        {
-            return Err(format!(
-                "x402 selected asset {}, expected staged asset {asset}",
-                candidate.asset
-            ));
-        }
-        if let Some(pay_to) = ctx.requirement.pay_to.as_deref()
-            && !candidate.pay_to.eq_ignore_ascii_case(pay_to)
-        {
-            return Err(format!(
-                "x402 selected pay_to {}, expected staged pay_to {pay_to}",
-                candidate.pay_to
-            ));
-        }
+        let candidate =
+            select_candidate(&payment_required, signer, ctx.requirement)?.ok_or_else(|| {
+                "x402 upstream signer found no matching selected payment option".to_string()
+            })?;
         let header_value = candidate
             .sign()
             .await
@@ -148,10 +126,52 @@ fn parse_payment_required(
 fn select_candidate(
     payment_required: &proto::PaymentRequired,
     signer: std::sync::Arc<alloy::signers::local::PrivateKeySigner>,
-) -> Option<x402_types::scheme::client::PaymentCandidate> {
+    requirement: &PaymentRequirement,
+) -> Result<Option<x402_types::scheme::client::PaymentCandidate>, String> {
     let mut candidates = V2Eip155ExactClient::new(signer.clone()).accept(payment_required);
     candidates.extend(V1Eip155ExactClient::new(signer).accept(payment_required));
-    candidates.into_iter().next()
+    for candidate in candidates {
+        if candidate_matches_requirement(&candidate, requirement)? {
+            return Ok(Some(candidate));
+        }
+    }
+    Ok(None)
+}
+
+fn candidate_matches_requirement(
+    candidate: &x402_types::scheme::client::PaymentCandidate,
+    requirement: &PaymentRequirement,
+) -> Result<bool, String> {
+    if let Some(scheme) = requirement.scheme.as_deref()
+        && !candidate.scheme.eq_ignore_ascii_case(scheme)
+    {
+        return Ok(false);
+    }
+    if let Some(network) = requirement.network.as_deref() {
+        let candidate_network = candidate.chain_id.to_string();
+        if !networks_equivalent(&candidate_network, network) {
+            return Ok(false);
+        }
+    }
+    if let Some(asset) = requirement.asset.as_deref()
+        && !candidate.asset.eq_ignore_ascii_case(asset)
+    {
+        return Ok(false);
+    }
+    if let Some(pay_to) = requirement.pay_to.as_deref()
+        && !candidate.pay_to.eq_ignore_ascii_case(pay_to)
+    {
+        return Ok(false);
+    }
+    if let Some(amount) = requirement.amount.as_deref() {
+        let expected = amount
+            .parse::<U256>()
+            .map_err(|e| format!("selected x402 requirement amount is not a valid integer: {e}"))?;
+        if candidate.amount != expected {
+            return Ok(false);
+        }
+    }
+    Ok(true)
 }
 
 fn eip155_chain_id_u64(chain_id: &x402_types::chain::ChainId) -> Option<u64> {
@@ -184,10 +204,35 @@ fn x402_keystore_signer_error(wallet: &str, keystore: &Keystore, err: KeystoreEr
 
 #[cfg(test)]
 mod tests {
-    use super::parse_payment_required;
+    use super::{candidate_matches_requirement, parse_payment_required};
+    use alloy::primitives::U256;
+    use async_trait::async_trait;
     use bloom_paid_http::normalize_challenge;
     use reqwest::header::{HeaderMap, HeaderValue};
     use url::Url;
+    use x402_types::chain::ChainId;
+    use x402_types::scheme::client::{PaymentCandidate, PaymentCandidateSigner, X402Error};
+
+    struct DummyPaymentSigner;
+
+    #[async_trait]
+    impl PaymentCandidateSigner for DummyPaymentSigner {
+        async fn sign_payment(&self) -> Result<String, X402Error> {
+            Ok("signed".into())
+        }
+    }
+
+    fn candidate(amount: u64) -> PaymentCandidate {
+        PaymentCandidate {
+            chain_id: "eip155:8453".parse::<ChainId>().unwrap(),
+            asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913".into(),
+            amount: U256::from(amount),
+            scheme: "exact".into(),
+            x402_version: 1,
+            pay_to: "0x93053f1e7A5eFEDa532Fe69CbbE43cBEc3A0F13f".into(),
+            signer: Box::new(DummyPaymentSigner),
+        }
+    }
 
     #[test]
     fn parses_nansen_v2_payment_required_header() {
@@ -210,5 +255,21 @@ mod tests {
             }
             _ => panic!("expected v2 payment required"),
         }
+    }
+
+    #[test]
+    fn candidate_match_requires_selected_atomic_amount() {
+        let requirement = bloom_paid_http::PaymentRequirement {
+            scheme: Some("exact".into()),
+            network: Some("base".into()),
+            asset: Some("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913".into()),
+            amount: Some("10000".into()),
+            pay_to: Some("0x93053f1e7A5eFEDa532Fe69CbbE43cBEc3A0F13f".into()),
+            resource: None,
+            raw: serde_json::json!({}),
+        };
+
+        assert!(candidate_matches_requirement(&candidate(10_000), &requirement).unwrap());
+        assert!(!candidate_matches_requirement(&candidate(5_000_000), &requirement).unwrap());
     }
 }

--- a/crates/bloom-vfs/src/handlers/requests.rs
+++ b/crates/bloom-vfs/src/handlers/requests.rs
@@ -329,49 +329,51 @@ impl RequestsHandler {
             .as_secs()
             .saturating_sub(24 * 60 * 60);
         let mut total = 0.0;
-        let sent_root = self.requests_root().join("sent");
-        if !sent_root.exists() {
-            return Ok(total);
-        }
-        for entry in fs::read_dir(sent_root)? {
-            let entry = entry?;
-            if !entry.file_type()?.is_dir() {
+        for state in ["sent", "failed"] {
+            let root = self.requests_root().join(state);
+            if !root.exists() {
                 continue;
             }
-            let dir = entry.path();
-            let modified = entry
-                .metadata()?
-                .modified()
-                .ok()
-                .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
-                .map(|d| d.as_secs())
-                .unwrap_or(0);
-            if modified < since {
-                continue;
+            for entry in fs::read_dir(root)? {
+                let entry = entry?;
+                if !entry.file_type()?.is_dir() {
+                    continue;
+                }
+                let dir = entry.path();
+                let modified = entry
+                    .metadata()?
+                    .modified()
+                    .ok()
+                    .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0);
+                if modified < since {
+                    continue;
+                }
+                let Ok(receipt) = read_json::<serde_json::Value>(dir.join("receipt.json")) else {
+                    continue;
+                };
+                if receipt.get("wallet").and_then(|v| v.as_str()) != Some(wallet) {
+                    continue;
+                }
+                let protocol = receipt
+                    .get("protocol")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("free");
+                if protocol == "free" {
+                    continue;
+                }
+                total += receipt
+                    .get("amount_usd")
+                    .and_then(json_number)
+                    .or_else(|| {
+                        parse_payment_amount_usd(
+                            receipt.get("currency").and_then(|v| v.as_str()),
+                            receipt.get("amount").and_then(|v| v.as_str()),
+                        )
+                    })
+                    .unwrap_or(0.0);
             }
-            let Ok(receipt) = read_json::<serde_json::Value>(dir.join("receipt.json")) else {
-                continue;
-            };
-            if receipt.get("wallet").and_then(|v| v.as_str()) != Some(wallet) {
-                continue;
-            }
-            let protocol = receipt
-                .get("protocol")
-                .and_then(|v| v.as_str())
-                .unwrap_or("free");
-            if protocol == "free" {
-                continue;
-            }
-            total += receipt
-                .get("amount_usd")
-                .and_then(json_number)
-                .or_else(|| {
-                    parse_payment_amount_usd(
-                        receipt.get("currency").and_then(|v| v.as_str()),
-                        receipt.get("amount").and_then(|v| v.as_str()),
-                    )
-                })
-                .unwrap_or(0.0);
         }
         Ok(total)
     }
@@ -426,6 +428,7 @@ impl RequestsHandler {
         consume_request_confirm_approved(&pending, &wallet, &value)?;
         let host = request.url.host_str().unwrap_or("unknown").to_string();
         let mut challenge: NormalizedChallenge = read_json(pending.join("challenge.json"))?;
+        validate_session_state_target(&challenge, id)?;
         let policy = self.wallet_policy(&wallet)?;
         let sentinel = policy.override_sentinel().to_ascii_lowercase();
         if !matches!(value.as_str(), "y" | "yes" | "confirm") && value != sentinel.as_str() {
@@ -597,7 +600,8 @@ pub fn persist_request_confirm_approved(
     wallet: &str,
     confirm_value: &str,
 ) -> Result<(), HandlerError> {
-    let dir = root.join("requests").join("pending").join(id);
+    let id = safe_fs_component(id, "request id")?;
+    let dir = root.join("requests").join("pending").join(&id);
     fs::write(
         dir.join(CONFIRM_APPROVAL_FILE),
         serde_json::to_vec_pretty(&json!({
@@ -850,6 +854,7 @@ async fn confirm_with_backend(
         )));
     }
     let challenge: NormalizedChallenge = read_json(pending.join("challenge.json"))?;
+    validate_session_state_target(&challenge, id)?;
     let request_value: serde_json::Value = read_json(pending.join("request.toml"))?;
     if request_value
         .get("dry_run")
@@ -1037,6 +1042,21 @@ control files are limitation stubs pending a real mpp-rs Tempo provider.\n",
         .append(true)
         .open(dir.join("vouchers.jsonl"))?;
     file.write_all(&line)?;
+    Ok(())
+}
+
+fn validate_session_state_target(
+    challenge: &NormalizedChallenge,
+    request_id: &str,
+) -> Result<(), HandlerError> {
+    if challenge.intent == "session" {
+        let session_id = challenge
+            .session_id
+            .as_deref()
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("session_{request_id}"));
+        session_dir_name(&session_id)?;
+    }
     Ok(())
 }
 
@@ -1495,6 +1515,19 @@ mod tests {
     }
 
     #[test]
+    fn request_confirm_approval_rejects_unsafe_request_ids() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pending = tmp.path().join("requests").join("pending").join("req_1");
+        std::fs::create_dir_all(&pending).unwrap();
+
+        let err =
+            persist_request_confirm_approved(tmp.path(), "../pending/req_1", "alice", "confirm")
+                .unwrap_err();
+        assert!(err.to_string().contains("invalid request id"), "{err}");
+        assert!(!pending.join(CONFIRM_APPROVAL_FILE).exists());
+    }
+
+    #[test]
     fn spent_usd_history_converts_mpp_base_units_like_x402() {
         let f = fixture(Some("alice"));
         let sent = f.handler.requests_root().join("sent/req_mpp_paid");
@@ -1516,6 +1549,33 @@ mod tests {
 
         let spent = f.handler.sum_paid_usd_last_24h("alice").unwrap();
         assert!((spent - 0.01).abs() < f64::EPSILON, "{spent}");
+    }
+
+    #[test]
+    fn spent_usd_history_counts_paid_failed_retries() {
+        let f = fixture(Some("alice"));
+        let failed = f.handler.requests_root().join("failed/req_paid_failed");
+        fs::create_dir_all(&failed).unwrap();
+        write_json(
+            failed.join("receipt.json"),
+            &json!({
+                "request_id": "req_paid_failed",
+                "wallet": "alice",
+                "merchant": "api.example.test",
+                "amount_usd": 0.25,
+                "currency": "USDC",
+                "network": "base",
+                "protocol": "x402",
+                "intent": "charge",
+                "response_status": 500,
+                "credential_redacted": true,
+                "raw": {"status": "success"}
+            }),
+        )
+        .unwrap();
+
+        let spent = f.handler.sum_paid_usd_last_24h("alice").unwrap();
+        assert!((spent - 0.25).abs() < f64::EPSILON, "{spent}");
     }
 
     async fn mock_server(
@@ -2303,6 +2363,41 @@ inline = '{"prompt":"hi"}'
         .await
         .unwrap_err();
         assert!(err.to_string().contains("hard payment policy denial"));
+    }
+
+    #[tokio::test]
+    async fn mpp_confirm_rejects_unsafe_session_id_before_minting() {
+        let dir = tempfile::tempdir().unwrap();
+        let pending = dir.path().join("requests/pending/req_escape");
+        fs::create_dir_all(&pending).unwrap();
+        let challenge = normalize_challenge(
+            &HeaderMap::new(),
+            br#"{"protocol":"tempo-mpp","type":"Session","network":"tempo","asset":"pathUSD","session":{"id":"../escape","voucherAmount":"0.10","voucherAmountUsd":0.10,"depositAmount":"1.00","depositAmountUsd":1.00}}"#,
+            &Url::parse("https://mpp.test/data").unwrap(),
+        );
+        write_json(pending.join("challenge.json"), &challenge).unwrap();
+        let empty_checks: Vec<PolicyCheck> = vec![];
+        write_json(pending.join("policy_check.json"), &empty_checks).unwrap();
+        write_json(
+            pending.join("request.toml"),
+            &json!({"method":"GET","url":"https://mpp.test/data","wallet":"alice","headers":{}}),
+        )
+        .unwrap();
+        fs::write(pending.join("status"), "pending\n").unwrap();
+
+        let err = confirm_with_backend(
+            dir.path(),
+            "req_escape",
+            b"confirm",
+            &StaticMppTestBackend,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("invalid paid request session id"));
+        assert!(!pending.join("private/credential_minted.json").exists());
     }
 
     #[test]

--- a/crates/bloom/src/main.rs
+++ b/crates/bloom/src/main.rs
@@ -1544,9 +1544,11 @@ async fn run(cli: Cli) -> Result<()> {
                         .unlock(&wallet, passphrase.as_deref().unwrap_or(""))?;
                 }
             }
+            let approval_id = request_confirm_id(d.home.root(), &p)
+                .context("request confirm path does not target a pending paid request")?;
             bloom_vfs::handlers::requests::persist_request_confirm_approved(
                 d.home.root(),
-                &id,
+                &approval_id,
                 &wallet,
                 &String::from_utf8_lossy(&body).trim().to_ascii_lowercase(),
             )?;


### PR DESCRIPTION
## Summary

Fixes four paid-request blockers found after PR #51 merged.

1. x402 could sign a different accepted option than the one policy approved. The signer now filters upstream payment candidates against the selected requirement, including scheme, normalized network, asset, pay_to, and exact atomic amount before signing.

2. Charged failed paid retries were invisible to daily spend caps because spend history only scanned `sent`. Spend accounting now scans both `sent` and paid `failed` receipts, so settled/charged failures still count toward wallet caps.

3. Unsafe merchant-controlled MPP session IDs could strand a request after credential minting and retry. Session state targets are now validated before credentials are minted, preventing unrecoverable pending requests with `credential_minted` markers.

4. The no-daemon `bloom request confirm` fallback could persist approval using a raw request id. Approval persistence now rejects unsafe request ids, and the CLI fallback derives the approval id from the normalized pending request path.

## Validation

- `cargo +nightly check -p bloom-paid-x402 -p bloom-vfs -p bloom`
- `cargo +nightly test -p bloom-paid-x402 -- --nocapture`
- `cargo +nightly test -p bloom-vfs request_confirm_approval -- --nocapture`
- `cargo +nightly test -p bloom-vfs spent_usd_history -- --nocapture`
- `cargo +nightly test -p bloom-vfs mpp_confirm_rejects_unsafe_session_id_before_minting -- --nocapture`
