### PR TITLE
[codex] route intent CLIs through daemon IPC

### DIFF
--- a/crates/bloom-mount/src/adapter.rs
+++ b/crates/bloom-mount/src/adapter.rs
@@ -25,7 +25,7 @@ use bytes::Bytes;
 use embednfs::{
     AccessMask, Attrs, CommitSupport, CreateKind, CreateRequest, CreateResult, DirEntry, DirPage,
     FileSystem, FsError, FsResult, FsStats, ObjectType, ReadResult, RequestContext, SetAttrs,
-    Timestamp, WriteResult, WriteStability,
+    Symlinks, Timestamp, WriteResult, WriteStability,
 };
 use futures::FutureExt;
 use futures::future::{BoxFuture, Shared};
@@ -243,6 +243,14 @@ fn entry_to_attrs(path: &VfsPath, e: &Entry, size: u64) -> Attrs {
         EntryKind::File => ObjectType::File,
         EntryKind::Symlink => ObjectType::Symlink,
     };
+    let size = if e.kind == EntryKind::Symlink && size == 0 {
+        e.link_target
+            .as_ref()
+            .map(|target| target.len() as u64)
+            .unwrap_or(0)
+    } else {
+        size
+    };
     let mut a = Attrs::new(ot, fileid_for(path));
     a.size = size;
     a.space_used = size;
@@ -251,7 +259,7 @@ fn entry_to_attrs(path: &VfsPath, e: &Entry, size: u64) -> Attrs {
     a.mtime = ts;
     a.atime = ts;
     a.ctime = ts;
-    if e.kind == EntryKind::File {
+    if matches!(e.kind, EntryKind::File | EntryKind::Symlink) {
         a.change = file_change_now();
     }
     a
@@ -1190,6 +1198,36 @@ impl FileSystem for BloomFs {
         // flushes the per-handle write buffer.
         Some(self)
     }
+
+    fn symlinks(&self) -> Option<&dyn Symlinks<BloomHandle>> {
+        Some(self)
+    }
+}
+
+#[async_trait]
+impl Symlinks<BloomHandle> for BloomFs {
+    async fn create_symlink(
+        &self,
+        _ctx: &RequestContext,
+        _parent: &BloomHandle,
+        _name: &str,
+        _target: &str,
+        _attrs: &SetAttrs,
+    ) -> FsResult<CreateResult<BloomHandle>> {
+        Err(FsError::Unsupported)
+    }
+
+    async fn readlink(&self, _ctx: &RequestContext, handle: &BloomHandle) -> FsResult<String> {
+        let path = match handle {
+            BloomHandle::Root => return Err(FsError::InvalidInput),
+            BloomHandle::Path { path, .. } => path,
+        };
+        let entry = self.vfs.lookup(path).await.map_err(map_err)?;
+        match entry.kind {
+            EntryKind::Symlink => entry.link_target.ok_or(FsError::InvalidInput),
+            _ => Err(FsError::InvalidInput),
+        }
+    }
 }
 
 #[async_trait]
@@ -1232,6 +1270,7 @@ mod tests {
             }
             match p.first() {
                 Some("hello") => Ok(Entry::file("hello")),
+                Some("latest") => Ok(Entry::symlink("latest", "pending/req-1")),
                 _ => Err(HandlerError::NotFound(p.to_string_path())),
             }
         }
@@ -1240,7 +1279,10 @@ mod tests {
         }
         async fn list(&self, p: &VfsPath) -> Result<Vec<Entry>, HandlerError> {
             if p.is_root() {
-                Ok(vec![Entry::file("hello")])
+                Ok(vec![
+                    Entry::file("hello"),
+                    Entry::symlink("latest", "pending/req-1"),
+                ])
             } else {
                 Err(HandlerError::NotADir(p.to_string_path()))
             }
@@ -1389,6 +1431,24 @@ mod tests {
         let r = fs.read(&ctx, &hello, 0, 1024).await.unwrap();
         assert_eq!(&r.data[..], b"world\n");
         assert!(r.eof);
+    }
+
+    #[tokio::test]
+    async fn readlink_returns_vfs_symlink_target() {
+        let vfs = Vfs::builder()
+            .mount("echo", Arc::new(StaticHandler))
+            .build();
+        let fs = BloomFs::new(vfs);
+        let ctx = fake_ctx();
+        let echo = fs.lookup(&ctx, &BloomHandle::Root, "echo").await.unwrap();
+        let latest = fs.lookup(&ctx, &echo, "latest").await.unwrap();
+        let attrs = fs.getattr(&ctx, &latest).await.unwrap();
+        assert_eq!(attrs.object_type, ObjectType::Symlink);
+        assert_eq!(attrs.size, "pending/req-1".len() as u64);
+
+        let symlinks = fs.symlinks().expect("BloomFs must advertise READLINK");
+        let target = symlinks.readlink(&ctx, &latest).await.unwrap();
+        assert_eq!(target, "pending/req-1");
     }
 
     #[tokio::test]

--- a/crates/bloom/src/main.rs
+++ b/crates/bloom/src/main.rs
@@ -1450,17 +1450,32 @@ async fn run(cli: Cli) -> Result<()> {
             wallet,
             dry_run,
         }) => {
-            let (_home_permit, d) = build_write_daemon(home)?;
             let body = request_body_with_wallet(request, wallet.as_deref());
+            let path = if dry_run {
+                "/requests/new.dry-run"
+            } else {
+                "/requests/new"
+            };
+            let client = IpcClient::new(&client_endpoint.socket);
+            let ipc_res = try_ipc(
+                &client,
+                &client_endpoint,
+                "write",
+                serde_json::json!({ "path": path, "bytes_b64": B64.encode(body.as_bytes()) }),
+            )
+            .await
+            .with_context(|| format!("ipc request new via {}", client_endpoint.display))?;
+            if ipc_res.is_some() {
+                debug!(endpoint = %client_endpoint.display, "cli.request.new.via_ipc");
+                if dry_run {
+                    println!("dry_run: true (unpaid probe/staging only; no spend/signing)");
+                }
+                return Ok(());
+            }
+            debug!("cli.request.new.via_inproc: no daemon socket present");
+            let (_home_permit, d) = build_write_daemon(home)?;
             d.vfs
-                .write(
-                    &VfsPath::parse(if dry_run {
-                        "/requests/new.dry-run"
-                    } else {
-                        "/requests/new"
-                    })?,
-                    body.as_bytes(),
-                )
+                .write(&VfsPath::parse(path)?, body.as_bytes())
                 .await
                 .context("request new")?;
             let latest = d
@@ -1913,7 +1928,6 @@ async fn run(cli: Cli) -> Result<()> {
             chain,
             intent,
         }) => {
-            let (home_permit, d) = build_write_daemon(home)?;
             let body = match intent {
                 Some(s) => s,
                 None => {
@@ -1922,6 +1936,22 @@ async fn run(cli: Cli) -> Result<()> {
                     buf
                 }
             };
+            let path = format!("/wallets/{wallet}/chains/{chain}/outbox/new.tx");
+            let client = IpcClient::new(&client_endpoint.socket);
+            let ipc_res = try_ipc(
+                &client,
+                &client_endpoint,
+                "write",
+                serde_json::json!({ "path": path, "bytes_b64": B64.encode(body.as_bytes()) }),
+            )
+            .await
+            .with_context(|| format!("ipc wallet stage via {}", client_endpoint.display))?;
+            if ipc_res.is_some() {
+                debug!(endpoint = %client_endpoint.display, "cli.wallet.stage.via_ipc");
+                return Ok(());
+            }
+            debug!("cli.wallet.stage.via_inproc: no daemon socket present");
+            let (home_permit, d) = build_write_daemon(home)?;
             let parsed = bloom_tx::intent_parser::parse(&body).context("parse intent")?;
             let info = d.keystore.info(&wallet)?;
             let client = d
@@ -1950,6 +1980,28 @@ async fn run(cli: Cli) -> Result<()> {
             passphrase,
             text,
         }) => {
+            let path = format!("/wallets/{wallet}/chains/{chain}/outbox/pending/{id}/confirm");
+            let body = text.into_bytes();
+            let client = IpcClient::new(&client_endpoint.socket);
+            let ipc_res = try_ipc(
+                &client,
+                &client_endpoint,
+                "write_unlocked",
+                serde_json::json!({
+                    "path": path,
+                    "bytes_b64": B64.encode(&body),
+                    "wallet": &wallet,
+                    "passphrase": passphrase.as_deref(),
+                }),
+            )
+            .await
+            .with_context(|| format!("ipc wallet confirm via {}", client_endpoint.display))?;
+            if ipc_res.is_some() {
+                debug!(endpoint = %client_endpoint.display, "cli.wallet.confirm.via_ipc");
+                return Ok(());
+            }
+            debug!("cli.wallet.confirm.via_inproc: no daemon socket present");
+            let text = String::from_utf8(body).expect("wallet confirm text originated as UTF-8");
             let (home_permit, d) = build_write_daemon(home)?;
             let info = d.keystore.info(&wallet)?;
             let mut reviewed_intent_hash: Option<String> = None;

--- a/crates/bloom/tests/cli.rs
+++ b/crates/bloom/tests/cli.rs
@@ -12,12 +12,14 @@ use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::path::Path;
 use std::sync::{
-    Arc,
+    Arc, Mutex,
     atomic::{AtomicUsize, Ordering},
 };
 use std::time::Duration;
 
 use assert_cmd::Command;
+use async_trait::async_trait;
+use bloom_vfs::{Entry, Handler, HandlerError, VfsPath};
 use predicates::prelude::*;
 use tempfile::TempDir;
 
@@ -43,6 +45,99 @@ fn write_passphrase_file(home: &Path, passphrase: &str) -> String {
     let path = home.join(".passphrase");
     std::fs::write(&path, passphrase).expect("write passphrase file");
     path.to_string_lossy().into_owned()
+}
+
+#[derive(Default)]
+struct RecordingWriteHandler {
+    writes: Mutex<Vec<(String, Vec<u8>)>>,
+}
+
+impl RecordingWriteHandler {
+    fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    fn writes(&self) -> Vec<(String, Vec<u8>)> {
+        self.writes.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl Handler for RecordingWriteHandler {
+    async fn lookup(&self, p: &VfsPath) -> Result<Entry, HandlerError> {
+        if p.is_root() {
+            return Ok(Entry::dir(""));
+        }
+        Ok(Entry::writable_file(
+            p.segments().last().map(String::as_str).unwrap_or("write"),
+        ))
+    }
+
+    async fn list(&self, p: &VfsPath) -> Result<Vec<Entry>, HandlerError> {
+        if p.is_root() {
+            Ok(vec![])
+        } else {
+            Err(HandlerError::NotADir(p.to_string_path()))
+        }
+    }
+
+    async fn write(&self, p: &VfsPath, data: &[u8]) -> Result<(), HandlerError> {
+        self.writes
+            .lock()
+            .unwrap()
+            .push((p.to_string_path(), data.to_vec()));
+        Ok(())
+    }
+}
+
+fn spawn_ipc_server(
+    home: &Path,
+    vfs: bloom_vfs::Vfs,
+) -> (bloom_daemon::ipc::IpcServer, std::thread::JoinHandle<()>) {
+    use bloom_daemon::ipc::{IpcServer, default_socket_path};
+
+    let socket = default_socket_path(home);
+    std::fs::create_dir_all(socket.parent().unwrap()).unwrap();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio runtime");
+    let server = IpcServer::new(vfs, "ipc-test-version", vec!["ipc-chain".into()]);
+    let server_for_thread = server.clone();
+    let socket_for_thread = socket.clone();
+    let server_thread = std::thread::spawn(move || {
+        rt.block_on(async move {
+            server_for_thread
+                .serve(&socket_for_thread)
+                .await
+                .expect("ipc serve");
+        });
+    });
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while !socket.exists() {
+        if std::time::Instant::now() >= deadline {
+            panic!("ipc server never created socket at {}", socket.display());
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    (server, server_thread)
+}
+
+fn stop_ipc_server(
+    server: bloom_daemon::ipc::IpcServer,
+    server_thread: std::thread::JoinHandle<()>,
+) {
+    server.trigger_shutdown();
+    let join_deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while !server_thread.is_finished() {
+        if std::time::Instant::now() >= join_deadline {
+            panic!("ipc server thread did not exit after shutdown");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    server_thread.join().expect("ipc server thread panicked");
 }
 
 fn http_fixture(
@@ -368,6 +463,84 @@ fn chain_ls_validators_does_not_take_home_write_lock() {
         .args(["chain", "ls-validators"])
         .assert()
         .failure()
+        .stderr(predicate::str::contains("already open for writing").not());
+}
+
+#[test]
+fn request_new_routes_via_ipc_when_home_write_lock_is_live() {
+    use bloom_vfs::Vfs;
+
+    let home = fresh_home();
+    let _permit = bloom_proto::HomeWritePermit::acquire(&bloom_proto::HomeDir::at(home.path()))
+        .expect("hold home write permit");
+    let requests = RecordingWriteHandler::new();
+    let vfs = Vfs::builder().mount("requests", requests.clone()).build();
+    let (server, server_thread) = spawn_ipc_server(home.path(), vfs);
+
+    bloom_cmd(home.path())
+        .args([
+            "request",
+            "new",
+            "--dry-run",
+            "--wallet",
+            "alice",
+            "GET https://example.com",
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("already open for writing").not())
+        .stdout(predicate::str::contains("dry_run: true"));
+
+    stop_ipc_server(server, server_thread);
+    let writes = requests.writes();
+    assert_eq!(writes.len(), 1, "writes={writes:?}");
+    assert_eq!(writes[0].0, "/new.dry-run");
+    assert_eq!(
+        String::from_utf8_lossy(&writes[0].1),
+        "GET https://example.com wallet=alice"
+    );
+}
+
+#[test]
+fn wallet_stage_routes_via_ipc_when_home_write_lock_is_live() {
+    use bloom_vfs::Vfs;
+
+    let home = fresh_home();
+    let _permit = bloom_proto::HomeWritePermit::acquire(&bloom_proto::HomeDir::at(home.path()))
+        .expect("hold home write permit");
+    let wallets = RecordingWriteHandler::new();
+    let vfs = Vfs::builder().mount("wallets", wallets.clone()).build();
+    let (server, server_thread) = spawn_ipc_server(home.path(), vfs);
+    let intent = "send 0.001 eth to 0x0000000000000000000000000000000000000000 on anvil";
+
+    bloom_cmd(home.path())
+        .args(["wallet", "stage", "alice", "anvil", "--intent", intent])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("already open for writing").not());
+
+    stop_ipc_server(server, server_thread);
+    let writes = wallets.writes();
+    assert_eq!(writes.len(), 1, "writes={writes:?}");
+    assert_eq!(writes[0].0, "/alice/chains/anvil/outbox/new.tx");
+    assert_eq!(String::from_utf8_lossy(&writes[0].1), intent);
+}
+
+#[test]
+fn wallet_stage_without_daemon_uses_in_process_parser() {
+    let home = fresh_home();
+    bloom_cmd(home.path())
+        .args([
+            "wallet",
+            "stage",
+            "alice",
+            "anvil",
+            "--intent",
+            "not an intent",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("parse intent"))
         .stderr(predicate::str::contains("already open for writing").not());
 }
 

--- a/tests/docker/test.sh
+++ b/tests/docker/test.sh
@@ -27,6 +27,9 @@ source "$SCRIPT_DIR/lib.sh"
 HOME_DIR=/tmp/bloom-home
 
 prepare_home_dir "$HOME_DIR"
+mkdir -p "$HOME_DIR/requests/pending/req-symlink"
+printf '%s\n' 'pending/req-symlink' > "$HOME_DIR/requests/latest"
+printf '%s\n' 'mount latest plan' > "$HOME_DIR/requests/pending/req-symlink/plan.md"
 build_mount_demo
 # No wallet, no chain config — this test is mount-surface only.
 start_mount_demo "$MNT" "$HOME_DIR" "$PIDFILE" "$LOGFILE"
@@ -57,6 +60,28 @@ echo "::endgroup::"
 echo "::group::cat $MNT/tools/keccak/abc"
 if ! cat "$MNT/tools/keccak/abc"; then
     echo "FAIL: tools/keccak/abc unreadable" >&2
+    fail_count=1
+fi
+echo "::endgroup::"
+
+# Regression for VFS symlinks over NFS. `/requests/latest` is exposed
+# by the VFS as a dynamic symlink (latest -> pending/<id>). The CLI path
+# worked because RequestsHandler special-cases `latest` during `read`,
+# but the kernel mount follows the advertised symlink and therefore
+# requires the NFS adapter to implement READLINK.
+echo "::group::read $MNT/requests/latest"
+if ! latest_target=$(readlink "$MNT/requests/latest"); then
+    echo "FAIL: requests/latest readlink failed" >&2
+    fail_count=1
+elif [ "$latest_target" != "pending/req-symlink" ]; then
+    echo "FAIL: requests/latest target [$latest_target]" >&2
+    fail_count=1
+fi
+if ! latest_plan=$(cat "$MNT/requests/latest/plan.md"); then
+    echo "FAIL: requests/latest/plan.md unreadable" >&2
+    fail_count=1
+elif [ "$latest_plan" != "mount latest plan" ]; then
+    echo "FAIL: requests/latest/plan.md content [$latest_plan]" >&2
     fail_count=1
 fi
 echo "::endgroup::"


### PR DESCRIPTION
## Summary
- route `bloom request new` through daemon IPC `write` before falling back in-process
- route `bloom wallet stage` through daemon IPC `write` to the outbox staging path
- mirror `request confirm` for `wallet confirm` by trying IPC `write_unlocked` first
- add CLI regressions for home-write-lock scenarios and no-daemon fallback

## Root Cause
`request new` and `wallet stage` opened the Bloom home directly with `build_write_daemon`, so they failed while `bloom serve` held the write lock. These commands can use the same VFS write surfaces that mounted/NFS workflows use. Staging uses plain `write` because `/requests/new*` and `/wallets/<wallet>/chains/<chain>/outbox/new.tx` are non-signer write paths; signing/broadcast remains on `write_unlocked`.

## Validation
- `cargo test -p bloom routes_via_ipc_when_home_write_lock_is_live`
- `cargo test -p bloom wallet_stage_without_daemon_uses_in_process_parser`
- `cargo test -p bloom -p bloom-daemon`
- `cargo clippy --all-targets`