### PR TITLE
Implement Layer B auth hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2295,6 +2295,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "bloom-auth"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "blake3",
+ "bloom-auth-api",
+ "bloom-prices",
+ "rusqlite",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "bloom-auth-api"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "blake3",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "bloom-chain"
 version = "0.1.0"
 dependencies = [
@@ -2412,6 +2439,8 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "blake3",
+ "bloom-auth",
+ "bloom-auth-api",
  "bloom-chain",
  "bloom-chain-node",
  "bloom-chain-types",
@@ -2565,9 +2594,11 @@ dependencies = [
  "alloy 2.0.5",
  "anyhow",
  "argon2",
+ "async-trait",
  "axum",
  "base64 0.22.1",
  "blake3",
+ "bloom-auth-api",
  "bloom-chain-types",
  "bloom-proto",
  "chacha20poly1305",
@@ -2580,6 +2611,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -2922,6 +2954,7 @@ dependencies = [
  "alloy 2.0.5",
  "anyhow",
  "blake3",
+ "bloom-auth-api",
  "dirs 5.0.1",
  "fs2",
  "hex",
@@ -3067,7 +3100,9 @@ dependencies = [
  "alloy 2.0.5",
  "anyhow",
  "async-trait",
+ "base64 0.22.1",
  "blake3",
+ "bloom-auth-api",
  "bloom-chain",
  "bloom-keystore",
  "bloom-mempool",
@@ -3076,6 +3111,7 @@ dependencies = [
  "bloom-tools",
  "hex",
  "parking_lot 0.12.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "tempfile",
@@ -3104,6 +3140,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
+ "blake3",
+ "bloom-auth-api",
  "bloom-chain",
  "bloom-chain-types",
  "bloom-defi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 members = [
   "crates/bloom",
   "crates/bloom-daemon",
+  "crates/bloom-auth-api",
+  "crates/bloom-auth",
   "crates/bloom-vfs",
   "crates/bloom-paid-mpp",
   "crates/bloom-paid-x402",
@@ -145,6 +147,8 @@ bloom-prices   = { path = "crates/bloom-prices" }
 bloom-revert   = { path = "crates/bloom-revert" }
 bloom-petals   = { path = "crates/bloom-petals" }
 bloom-daemon   = { path = "crates/bloom-daemon" }
+bloom-auth-api = { path = "crates/bloom-auth-api" }
+bloom-auth     = { path = "crates/bloom-auth" }
 bloom-chain-types = { path = "crates/bloom-chain-types" }
 bloom-chain-state = { path = "crates/bloom-chain-state" }
 bloom-chain-node = { path = "crates/bloom-chain-node" }

--- a/crates/bloom-auth-api/Cargo.toml
+++ b/crates/bloom-auth-api/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "bloom-auth-api"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+async-trait.workspace = true
+base64.workspace = true
+blake3.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true

--- a/crates/bloom-auth-api/src/lib.rs
+++ b/crates/bloom-auth-api/src/lib.rs
@@ -1,0 +1,978 @@
+//! Shared authorization API for Bloom Layer B.
+//!
+//! This crate intentionally contains only stable data types and traits. The
+//! concrete store, verifier, and signer integrations live outside the VFS-facing
+//! crates so NFS/petal surfaces do not pull in the whole authorization TCB.
+
+use async_trait::async_trait;
+use base64::Engine as _;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+pub const APPROVAL_SCHEMA_V1: &str = "bloom.approval.v1";
+pub const CANONICAL_ENVELOPE_SCHEMA_V1: &str = "bloom.canonical_envelope.v1";
+pub const INTENT_HASH_DOMAIN: &[u8] = b"bloom.intent.v1";
+pub const APPROVAL_CHALLENGE_DOMAIN: &[u8] = b"bloom.approval.v1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AssuranceLevel {
+    Convenience,
+    Hardened,
+}
+
+impl Default for AssuranceLevel {
+    fn default() -> Self {
+        Self::Convenience
+    }
+}
+
+impl AssuranceLevel {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Convenience => "convenience",
+            Self::Hardened => "hardened",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SignerKind {
+    Password,
+    PasskeyBrowser,
+    PasskeyCtap,
+    Test,
+}
+
+impl SignerKind {
+    pub fn satisfies(self, assurance: AssuranceLevel) -> bool {
+        match assurance {
+            AssuranceLevel::Convenience => {
+                matches!(
+                    self,
+                    SignerKind::Password | SignerKind::PasskeyBrowser | SignerKind::PasskeyCtap
+                )
+            }
+            AssuranceLevel::Hardened => {
+                matches!(self, SignerKind::PasskeyBrowser | SignerKind::PasskeyCtap)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CanonicalIntentHeader {
+    pub schema: String,
+    pub wallet: String,
+    pub surface: String,
+    pub entry_id: String,
+    pub executor_id: String,
+    pub network: String,
+    pub account: String,
+    pub action_kind: String,
+    pub value_movement: bool,
+    pub authority_change: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CanonicalEnvelope {
+    pub schema: String,
+    pub header: CanonicalIntentHeader,
+    pub subject_kind: String,
+    pub subject_schema: String,
+    pub subject_bytes_b64: String,
+}
+
+impl CanonicalEnvelope {
+    pub fn new(
+        header: CanonicalIntentHeader,
+        subject_kind: impl Into<String>,
+        subject_schema: impl Into<String>,
+        subject_bytes: Vec<u8>,
+    ) -> Self {
+        Self {
+            schema: CANONICAL_ENVELOPE_SCHEMA_V1.to_string(),
+            header,
+            subject_kind: subject_kind.into(),
+            subject_schema: subject_schema.into(),
+            subject_bytes_b64: base64::engine::general_purpose::STANDARD.encode(subject_bytes),
+        }
+    }
+
+    pub fn canonical_bytes(&self) -> Result<Vec<u8>, AuthApiError> {
+        serde_json::to_vec(self).map_err(AuthApiError::Json)
+    }
+
+    pub fn intent_hash(&self) -> Result<String, AuthApiError> {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(INTENT_HASH_DOMAIN);
+        hasher.update(&self.canonical_bytes()?);
+        Ok(hasher.finalize().to_hex().to_string())
+    }
+}
+
+pub trait CanonicalSubject {
+    fn subject_kind(&self) -> &'static str;
+    fn subject_schema(&self) -> &'static str;
+    fn validate(&self) -> Result<(), AuthApiError>;
+    fn canonical_subject_bytes(&self) -> Result<Vec<u8>, AuthApiError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Approval {
+    pub schema: String,
+    pub wallet: String,
+    pub surface: String,
+    pub entry_id: String,
+    pub intent_hash: String,
+    pub executor_id: String,
+    pub network: String,
+    pub assurance: AssuranceLevel,
+    pub server_nonce: String,
+    pub caps: ApprovalCaps,
+    pub expiry_ms: u64,
+    pub signer_kind: SignerKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub review_session_id: Option<String>,
+    pub signature: ApprovalSignature,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UnsignedApproval {
+    pub schema: String,
+    pub wallet: String,
+    pub surface: String,
+    pub entry_id: String,
+    pub intent_hash: String,
+    pub executor_id: String,
+    pub network: String,
+    pub assurance: AssuranceLevel,
+    pub server_nonce: String,
+    pub caps: ApprovalCaps,
+    pub expiry_ms: u64,
+    pub signer_kind: SignerKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub review_session_id: Option<String>,
+}
+
+impl Approval {
+    pub fn unsigned_payload(&self) -> UnsignedApproval {
+        UnsignedApproval {
+            schema: self.schema.clone(),
+            wallet: self.wallet.clone(),
+            surface: self.surface.clone(),
+            entry_id: self.entry_id.clone(),
+            intent_hash: self.intent_hash.clone(),
+            executor_id: self.executor_id.clone(),
+            network: self.network.clone(),
+            assurance: self.assurance,
+            server_nonce: self.server_nonce.clone(),
+            caps: self.caps.clone(),
+            expiry_ms: self.expiry_ms,
+            signer_kind: self.signer_kind.clone(),
+            credential_id: self.credential_id.clone(),
+            review_session_id: self.review_session_id.clone(),
+        }
+    }
+
+    pub fn validate_against_sealed(
+        &self,
+        sealed: &SealedIntentRecord,
+        now_ms: u64,
+    ) -> Result<(), AuthApiError> {
+        if self.schema != APPROVAL_SCHEMA_V1 {
+            return Err(AuthApiError::Denied(format!(
+                "unsupported approval schema {}",
+                self.schema
+            )));
+        }
+        if now_ms >= self.expiry_ms {
+            return Err(AuthApiError::Denied("approval expired".into()));
+        }
+        if !self.signer_kind.satisfies(self.assurance) {
+            return Err(AuthApiError::Denied(format!(
+                "signer {:?} does not satisfy {:?} assurance",
+                self.signer_kind, self.assurance
+            )));
+        }
+        self.signature
+            .validate_for_unsigned(&self.unsigned_payload())?;
+        if self.intent_hash != sealed.intent_hash {
+            return Err(AuthApiError::Denied("intent_hash mismatch".into()));
+        }
+        let header = &sealed.envelope.header;
+        let checks = [
+            ("wallet", self.wallet.as_str(), header.wallet.as_str()),
+            ("surface", self.surface.as_str(), header.surface.as_str()),
+            ("entry_id", self.entry_id.as_str(), header.entry_id.as_str()),
+            (
+                "executor_id",
+                self.executor_id.as_str(),
+                header.executor_id.as_str(),
+            ),
+            ("network", self.network.as_str(), header.network.as_str()),
+        ];
+        for (field, approval, sealed) in checks {
+            if approval != sealed {
+                return Err(AuthApiError::Denied(format!("{field} mismatch")));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl UnsignedApproval {
+    pub fn canonical_bytes(&self) -> Result<Vec<u8>, AuthApiError> {
+        serde_json::to_vec(self).map_err(AuthApiError::Json)
+    }
+
+    pub fn challenge_hash(&self) -> Result<[u8; 32], AuthApiError> {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(APPROVAL_CHALLENGE_DOMAIN);
+        hasher.update(&self.canonical_bytes()?);
+        Ok(*hasher.finalize().as_bytes())
+    }
+
+    pub fn challenge_hash_hex(&self) -> Result<String, AuthApiError> {
+        Ok(hex_lower(&self.challenge_hash()?))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ApprovalCaps {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_usd_micro: Option<i128>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_ttl_secs: Option<u64>,
+    #[serde(default)]
+    pub destinations: Vec<String>,
+    #[serde(default)]
+    pub extra: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ApprovalSignature {
+    PasswordMac { mac_hex: String },
+    WebAuthnAssertion(WebAuthnAssertionRecord),
+    Test { sig_hex: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WebAuthnAssertionRecord {
+    pub credential_id: String,
+    pub authenticator_data_b64: String,
+    pub client_data_json_b64: String,
+    pub signature_b64: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_handle_b64: Option<String>,
+}
+
+impl ApprovalSignature {
+    pub fn validate_for_unsigned(&self, unsigned: &UnsignedApproval) -> Result<(), AuthApiError> {
+        match self {
+            ApprovalSignature::WebAuthnAssertion(assertion) => {
+                assertion.validate_challenge(unsigned)
+            }
+            ApprovalSignature::PasswordMac { .. } | ApprovalSignature::Test { .. } => Ok(()),
+        }
+    }
+}
+
+impl WebAuthnAssertionRecord {
+    pub fn client_data_json(&self) -> Result<serde_json::Value, AuthApiError> {
+        let bytes = decode_b64_any(&self.client_data_json_b64)?;
+        serde_json::from_slice(&bytes).map_err(AuthApiError::Json)
+    }
+
+    pub fn client_challenge(&self) -> Result<String, AuthApiError> {
+        self.client_data_json()?
+            .get("challenge")
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+            .ok_or_else(|| AuthApiError::Denied("WebAuthn clientDataJSON missing challenge".into()))
+    }
+
+    pub fn validate_challenge(&self, unsigned: &UnsignedApproval) -> Result<(), AuthApiError> {
+        let expected =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(unsigned.challenge_hash()?);
+        let got = self.client_challenge()?;
+        if got != expected {
+            return Err(AuthApiError::Denied(
+                "WebAuthn assertion challenge does not match approval payload".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StandingAuthorityGrant {
+    pub grant_id: String,
+    pub wallet: String,
+    pub assurance: AssuranceLevel,
+    pub signer_kind: SignerKind,
+    pub policy_digest: String,
+    pub caps: ApprovalCaps,
+    pub issued_ms: u64,
+    pub expiry_ms: u64,
+    pub revoked_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ApprovalCredentialRecord {
+    pub wallet: String,
+    pub credential_id: String,
+    pub signer_kind: SignerKind,
+    pub assurance: AssuranceLevel,
+    pub public_key_json: serde_json::Value,
+    pub registered_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revoked_ms: Option<u64>,
+}
+
+impl ApprovalCredentialRecord {
+    pub fn validate(&self) -> Result<(), AuthApiError> {
+        if self.wallet.trim().is_empty() {
+            return Err(AuthApiError::Denied("credential wallet is empty".into()));
+        }
+        if self.credential_id.trim().is_empty() {
+            return Err(AuthApiError::Denied("credential_id is empty".into()));
+        }
+        if !self.signer_kind.satisfies(self.assurance) {
+            return Err(AuthApiError::Denied(format!(
+                "credential signer {:?} does not satisfy {:?} assurance",
+                self.signer_kind, self.assurance
+            )));
+        }
+        if matches!(self.assurance, AssuranceLevel::Hardened)
+            && !matches!(
+                self.signer_kind,
+                SignerKind::PasskeyBrowser | SignerKind::PasskeyCtap
+            )
+        {
+            return Err(AuthApiError::Denied(
+                "hardened credentials require WebAuthn/FIDO2 signer kind".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl StandingAuthorityGrant {
+    pub fn is_active_at(&self, now_ms: u64) -> bool {
+        self.revoked_ms.is_none() && now_ms < self.expiry_ms
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ValuationQuote {
+    pub asset_id: String,
+    pub amount_base_units: String,
+    pub usd_micro: i128,
+    pub source: String,
+    pub quote_timestamp_ms: u64,
+    pub fetched_at_ms: u64,
+    pub max_age_ms: u64,
+    pub confidence_ppm: Option<u32>,
+    pub stablecoin_assumption: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthEntryState {
+    Staged,
+    Challenged,
+    Approved,
+    Submitting,
+    Submitted,
+    Settled,
+    Failed,
+    Unknown,
+}
+
+impl AuthEntryState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Staged => "staged",
+            Self::Challenged => "challenged",
+            Self::Approved => "approved",
+            Self::Submitting => "submitting",
+            Self::Submitted => "submitted",
+            Self::Settled => "settled",
+            Self::Failed => "failed",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NonceState {
+    Unused,
+    Consumed,
+}
+
+impl NonceState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Unused => "unused",
+            Self::Consumed => "consumed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthEntryRecord {
+    pub surface: String,
+    pub entry_id: String,
+    pub state: AuthEntryState,
+    pub intent_hash: String,
+    pub assurance: AssuranceLevel,
+    pub nonce: Option<String>,
+    pub nonce_state: NonceState,
+    pub reservation_id: Option<String>,
+    pub updated_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChallengeRecord {
+    pub surface: String,
+    pub entry_id: String,
+    pub intent_hash: String,
+    pub server_nonce: String,
+    pub assurance: AssuranceLevel,
+    pub expiry_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReviewSessionRecord {
+    pub review_session_id: String,
+    pub surface: String,
+    pub entry_id: String,
+    pub intent_hash: String,
+    pub assurance: AssuranceLevel,
+    pub expires_ms: u64,
+    pub consumed_ms: Option<u64>,
+    pub created_ms: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReservationState {
+    Active,
+    Committed,
+    Released,
+    Failed,
+    Unknown,
+}
+
+impl ReservationState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Committed => "committed",
+            Self::Released => "released",
+            Self::Failed => "failed",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReservationRecord {
+    pub reservation_id: String,
+    pub wallet: String,
+    pub venue: String,
+    pub amount_micro_usd: i128,
+    pub state: ReservationState,
+    pub created_ms: u64,
+    pub updated_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ValuationPolicy {
+    pub volatile_max_age_ms: u64,
+    pub stablecoin_max_age_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_confidence_ppm: Option<u32>,
+    #[serde(default)]
+    pub stablecoin_asset_allowlist: Vec<String>,
+}
+
+impl Default for ValuationPolicy {
+    fn default() -> Self {
+        Self {
+            volatile_max_age_ms: 30_000,
+            stablecoin_max_age_ms: 120_000,
+            min_confidence_ppm: None,
+            stablecoin_asset_allowlist: Vec::new(),
+        }
+    }
+}
+
+impl ValuationPolicy {
+    pub fn max_age_for(&self, quote: &ValuationQuote) -> u64 {
+        let policy_age = if quote.stablecoin_assumption {
+            self.stablecoin_max_age_ms
+        } else {
+            self.volatile_max_age_ms
+        };
+        quote.max_age_ms.min(policy_age)
+    }
+
+    pub fn stablecoin_allowed(&self, asset_id: &str) -> bool {
+        self.stablecoin_asset_allowlist
+            .iter()
+            .any(|allowed| allowed.eq_ignore_ascii_case(asset_id))
+    }
+}
+
+impl ValuationQuote {
+    pub fn is_fresh_at(&self, now_ms: u64) -> bool {
+        now_ms.saturating_sub(self.fetched_at_ms) <= self.max_age_ms
+    }
+
+    pub fn validate_for_authorization(
+        &self,
+        policy: &ValuationPolicy,
+        now_ms: u64,
+    ) -> Result<(), AuthApiError> {
+        if self.asset_id.trim().is_empty() {
+            return Err(AuthApiError::Denied("valuation asset_id is empty".into()));
+        }
+        if self.amount_base_units.trim().is_empty() {
+            return Err(AuthApiError::Denied(
+                "valuation amount_base_units is empty".into(),
+            ));
+        }
+        if self.source.trim().is_empty() {
+            return Err(AuthApiError::Denied("valuation source is empty".into()));
+        }
+        if self.usd_micro < 0 {
+            return Err(AuthApiError::Denied("valuation is negative".into()));
+        }
+        if self.quote_timestamp_ms == 0 {
+            return Err(AuthApiError::Denied(
+                "valuation quote timestamp is missing".into(),
+            ));
+        }
+        if self.fetched_at_ms == 0 {
+            return Err(AuthApiError::Denied(
+                "valuation fetched timestamp is missing".into(),
+            ));
+        }
+        let max_age_ms = policy.max_age_for(self);
+        if now_ms.saturating_sub(self.fetched_at_ms) > max_age_ms {
+            return Err(AuthApiError::Denied(format!(
+                "valuation quote is stale: age_ms={} max_age_ms={}",
+                now_ms.saturating_sub(self.fetched_at_ms),
+                max_age_ms
+            )));
+        }
+        if let Some(min_confidence) = policy.min_confidence_ppm {
+            match self.confidence_ppm {
+                Some(confidence) if confidence >= min_confidence => {}
+                Some(confidence) => {
+                    return Err(AuthApiError::Denied(format!(
+                        "valuation confidence {confidence}ppm below required {min_confidence}ppm"
+                    )));
+                }
+                None => {
+                    return Err(AuthApiError::Denied(
+                        "valuation confidence is missing".into(),
+                    ));
+                }
+            }
+        }
+        if self.stablecoin_assumption && !policy.stablecoin_allowed(&self.asset_id) {
+            return Err(AuthApiError::Denied(format!(
+                "stablecoin shortcut is not allowed for {}",
+                self.asset_id
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+pub trait PriceOracle: Send + Sync {
+    async fn quote_usd(
+        &self,
+        asset_id: &str,
+        amount_base_units: &str,
+        now_ms: u64,
+    ) -> Result<ValuationQuote, AuthApiError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SealedIntentRecord {
+    pub intent_hash: String,
+    pub envelope: CanonicalEnvelope,
+    pub sealed_at_ms: u64,
+}
+
+#[async_trait]
+pub trait AuthStoreView: Send + Sync {
+    async fn sealed_intent(&self, intent_hash: &str) -> Result<SealedIntentRecord, AuthApiError>;
+}
+
+#[async_trait]
+pub trait AuthStoreWriter: Send + Sync {
+    async fn stage_entry(
+        &self,
+        envelope: CanonicalEnvelope,
+        assurance: AssuranceLevel,
+        now_ms: u64,
+    ) -> Result<AuthEntryRecord, AuthApiError>;
+
+    async fn issue_challenge(
+        &self,
+        surface: &str,
+        entry_id: &str,
+        server_nonce: &str,
+        expiry_ms: u64,
+        now_ms: u64,
+    ) -> Result<ChallengeRecord, AuthApiError>;
+
+    async fn issue_review_session(
+        &self,
+        review_session_id: &str,
+        surface: &str,
+        entry_id: &str,
+        expires_ms: u64,
+        now_ms: u64,
+    ) -> Result<ReviewSessionRecord, AuthApiError>;
+}
+
+#[async_trait]
+pub trait ApprovalSignatureVerifier: Send + Sync {
+    async fn verify_signature(
+        &self,
+        unsigned: &UnsignedApproval,
+        signature: &ApprovalSignature,
+        now_ms: u64,
+    ) -> Result<(), AuthApiError>;
+}
+
+#[async_trait]
+pub trait ApprovalVerifier: Send + Sync {
+    async fn verify_and_consume(&self, approval: Approval, now_ms: u64)
+    -> Result<(), AuthApiError>;
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum AuthApiError {
+    #[error("json: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("invalid canonical subject: {0}")]
+    InvalidSubject(String),
+    #[error("invalid assurance transition: {0}")]
+    InvalidAssuranceTransition(String),
+    #[error("authorization denied: {0}")]
+    Denied(String),
+    #[error("not found: {0}")]
+    NotFound(String),
+    #[error("store: {0}")]
+    Store(String),
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    out
+}
+
+fn decode_b64_any(value: &str) -> Result<Vec<u8>, AuthApiError> {
+    base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(value)
+        .or_else(|_| base64::engine::general_purpose::URL_SAFE.decode(value))
+        .or_else(|_| base64::engine::general_purpose::STANDARD.decode(value))
+        .map_err(|e| AuthApiError::Denied(format!("invalid base64 field: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn header() -> CanonicalIntentHeader {
+        CanonicalIntentHeader {
+            schema: "bloom.intent_header.v1".into(),
+            wallet: "my-wallet".into(),
+            surface: "requests".into(),
+            entry_id: "req_1".into(),
+            executor_id: "paid-http".into(),
+            network: "base".into(),
+            account: "default".into(),
+            action_kind: "x402_payment".into(),
+            value_movement: true,
+            authority_change: false,
+        }
+    }
+
+    #[test]
+    fn intent_hash_is_full_256_bit_hex_and_changes_with_subject_kind() {
+        let a = CanonicalEnvelope::new(
+            header(),
+            "paid_http",
+            "paid_http.v1",
+            br#"{"a":1}"#.to_vec(),
+        );
+        let b = CanonicalEnvelope::new(header(), "defi", "paid_http.v1", br#"{"a":1}"#.to_vec());
+        let ah = a.intent_hash().unwrap();
+        let bh = b.intent_hash().unwrap();
+        assert_eq!(ah.len(), 64);
+        assert_ne!(ah, bh);
+    }
+
+    #[test]
+    fn approval_challenge_commits_to_assurance() {
+        let mut a = UnsignedApproval {
+            schema: APPROVAL_SCHEMA_V1.into(),
+            wallet: "my-wallet".into(),
+            surface: "outbox".into(),
+            entry_id: "abc".into(),
+            intent_hash: "0".repeat(64),
+            executor_id: "evm".into(),
+            network: "base".into(),
+            assurance: AssuranceLevel::Convenience,
+            server_nonce: "nonce".into(),
+            caps: ApprovalCaps::default(),
+            expiry_ms: 42,
+            signer_kind: SignerKind::Password,
+            credential_id: None,
+            review_session_id: None,
+        };
+        let c1 = a.challenge_hash_hex().unwrap();
+        a.assurance = AssuranceLevel::Hardened;
+        a.signer_kind = SignerKind::PasskeyCtap;
+        let c2 = a.challenge_hash_hex().unwrap();
+        assert_ne!(c1, c2);
+    }
+
+    fn unsigned_approval() -> UnsignedApproval {
+        UnsignedApproval {
+            schema: APPROVAL_SCHEMA_V1.into(),
+            wallet: "my-wallet".into(),
+            surface: "outbox".into(),
+            entry_id: "abc".into(),
+            intent_hash: "0".repeat(64),
+            executor_id: "evm".into(),
+            network: "base".into(),
+            assurance: AssuranceLevel::Hardened,
+            server_nonce: "nonce".into(),
+            caps: ApprovalCaps::default(),
+            expiry_ms: 42,
+            signer_kind: SignerKind::PasskeyBrowser,
+            credential_id: Some("cred-1".into()),
+            review_session_id: Some("review-1".into()),
+        }
+    }
+
+    fn webauthn_assertion_for(unsigned: &UnsignedApproval) -> WebAuthnAssertionRecord {
+        let challenge = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(unsigned.challenge_hash().unwrap());
+        let client_data_json = serde_json::json!({
+            "type": "webauthn.get",
+            "challenge": challenge,
+            "origin": "http://localhost:18734",
+        });
+        WebAuthnAssertionRecord {
+            credential_id: "cred-1".into(),
+            authenticator_data_b64: "AA".into(),
+            client_data_json_b64: base64::engine::general_purpose::URL_SAFE_NO_PAD
+                .encode(serde_json::to_vec(&client_data_json).unwrap()),
+            signature_b64: "AA".into(),
+            user_handle_b64: None,
+        }
+    }
+
+    #[test]
+    fn webauthn_assertion_challenge_binds_to_unsigned_approval_payload() {
+        let unsigned = unsigned_approval();
+        ApprovalSignature::WebAuthnAssertion(webauthn_assertion_for(&unsigned))
+            .validate_for_unsigned(&unsigned)
+            .unwrap();
+
+        let mut substituted = unsigned.clone();
+        substituted.entry_id = "other".into();
+        let err = ApprovalSignature::WebAuthnAssertion(webauthn_assertion_for(&unsigned))
+            .validate_for_unsigned(&substituted)
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("challenge does not match"),
+            "{err}"
+        );
+    }
+
+    fn approval_for(
+        sealed: &SealedIntentRecord,
+        assurance: AssuranceLevel,
+        signer_kind: SignerKind,
+    ) -> Approval {
+        Approval {
+            schema: APPROVAL_SCHEMA_V1.into(),
+            wallet: sealed.envelope.header.wallet.clone(),
+            surface: sealed.envelope.header.surface.clone(),
+            entry_id: sealed.envelope.header.entry_id.clone(),
+            intent_hash: sealed.intent_hash.clone(),
+            executor_id: sealed.envelope.header.executor_id.clone(),
+            network: sealed.envelope.header.network.clone(),
+            assurance,
+            server_nonce: "nonce".into(),
+            caps: ApprovalCaps::default(),
+            expiry_ms: 200,
+            signer_kind,
+            credential_id: None,
+            review_session_id: None,
+            signature: ApprovalSignature::Test {
+                sig_hex: "00".into(),
+            },
+        }
+    }
+
+    #[test]
+    fn approval_validation_binds_to_sealed_header_and_assurance() {
+        let env = CanonicalEnvelope::new(header(), "paid_http", "paid_http.v1", b"{}".to_vec());
+        let sealed = SealedIntentRecord {
+            intent_hash: env.intent_hash().unwrap(),
+            envelope: env,
+            sealed_at_ms: 1,
+        };
+        approval_for(&sealed, AssuranceLevel::Convenience, SignerKind::Password)
+            .validate_against_sealed(&sealed, 100)
+            .unwrap();
+
+        let err = approval_for(&sealed, AssuranceLevel::Hardened, SignerKind::Password)
+            .validate_against_sealed(&sealed, 100)
+            .unwrap_err();
+        assert!(err.to_string().contains("does not satisfy"), "{err}");
+
+        let mut wrong = approval_for(&sealed, AssuranceLevel::Convenience, SignerKind::Password);
+        wrong.network = "wrong".into();
+        let err = wrong.validate_against_sealed(&sealed, 100).unwrap_err();
+        assert!(err.to_string().contains("network mismatch"), "{err}");
+    }
+
+    #[test]
+    fn approval_validation_rejects_expired_approval() {
+        let env = CanonicalEnvelope::new(header(), "paid_http", "paid_http.v1", b"{}".to_vec());
+        let sealed = SealedIntentRecord {
+            intent_hash: env.intent_hash().unwrap(),
+            envelope: env,
+            sealed_at_ms: 1,
+        };
+        let err = approval_for(&sealed, AssuranceLevel::Convenience, SignerKind::Password)
+            .validate_against_sealed(&sealed, 200)
+            .unwrap_err();
+        assert!(err.to_string().contains("expired"), "{err}");
+    }
+
+    #[test]
+    fn signer_kind_enforces_assurance_levels() {
+        assert!(SignerKind::Password.satisfies(AssuranceLevel::Convenience));
+        assert!(!SignerKind::Password.satisfies(AssuranceLevel::Hardened));
+        assert!(SignerKind::PasskeyBrowser.satisfies(AssuranceLevel::Hardened));
+        assert!(!SignerKind::Test.satisfies(AssuranceLevel::Convenience));
+    }
+
+    #[test]
+    fn approval_credential_record_rejects_hardened_software_signers() {
+        let mut record = ApprovalCredentialRecord {
+            wallet: "my-wallet".into(),
+            credential_id: "cred-1".into(),
+            signer_kind: SignerKind::PasskeyBrowser,
+            assurance: AssuranceLevel::Hardened,
+            public_key_json: serde_json::json!({"kty":"placeholder"}),
+            registered_ms: 100,
+            revoked_ms: None,
+        };
+        record.validate().unwrap();
+
+        record.signer_kind = SignerKind::Password;
+        let err = record.validate().unwrap_err();
+        assert!(err.to_string().contains("does not satisfy"), "{err}");
+
+        record.signer_kind = SignerKind::Test;
+        let err = record.validate().unwrap_err();
+        assert!(err.to_string().contains("does not satisfy"), "{err}");
+    }
+
+    fn valuation_quote() -> ValuationQuote {
+        ValuationQuote {
+            asset_id: "ethereum:0x0000000000000000000000000000000000000001".into(),
+            amount_base_units: "1000000000000000000".into(),
+            usd_micro: 1_000_000,
+            source: "test-oracle".into(),
+            quote_timestamp_ms: 1_000,
+            fetched_at_ms: 1_000,
+            max_age_ms: 30_000,
+            confidence_ppm: Some(990_000),
+            stablecoin_assumption: false,
+        }
+    }
+
+    #[test]
+    fn valuation_validation_fails_closed_for_stale_or_low_confidence_quotes() {
+        let policy = ValuationPolicy {
+            min_confidence_ppm: Some(950_000),
+            ..ValuationPolicy::default()
+        };
+        assert!(
+            valuation_quote()
+                .validate_for_authorization(&policy, 20_000)
+                .is_ok()
+        );
+
+        let stale = valuation_quote();
+        let err = stale
+            .validate_for_authorization(&policy, 40_001)
+            .unwrap_err();
+        assert!(err.to_string().contains("stale"), "{err}");
+
+        let mut low_confidence = valuation_quote();
+        low_confidence.confidence_ppm = Some(900_000);
+        let err = low_confidence
+            .validate_for_authorization(&policy, 20_000)
+            .unwrap_err();
+        assert!(err.to_string().contains("below required"), "{err}");
+
+        let mut missing_confidence = valuation_quote();
+        missing_confidence.confidence_ppm = None;
+        let err = missing_confidence
+            .validate_for_authorization(&policy, 20_000)
+            .unwrap_err();
+        assert!(err.to_string().contains("missing"), "{err}");
+    }
+
+    #[test]
+    fn stablecoin_shortcut_requires_explicit_asset_allowlist() {
+        let mut quote = valuation_quote();
+        quote.asset_id = "base:0x1234".into();
+        quote.stablecoin_assumption = true;
+        quote.max_age_ms = 120_000;
+        let policy = ValuationPolicy {
+            stablecoin_asset_allowlist: vec!["base:0xabcd".into()],
+            ..ValuationPolicy::default()
+        };
+        let err = quote
+            .validate_for_authorization(&policy, 60_000)
+            .unwrap_err();
+        assert!(err.to_string().contains("stablecoin shortcut"), "{err}");
+
+        let policy = ValuationPolicy {
+            stablecoin_asset_allowlist: vec!["base:0x1234".into()],
+            ..ValuationPolicy::default()
+        };
+        assert!(quote.validate_for_authorization(&policy, 60_000).is_ok());
+    }
+}

--- a/crates/bloom-auth/Cargo.toml
+++ b/crates/bloom-auth/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "bloom-auth"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+async-trait.workspace = true
+blake3.workspace = true
+bloom-auth-api.workspace = true
+bloom-prices.workspace = true
+rusqlite.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/bloom-auth/src/lib.rs
+++ b/crates/bloom-auth/src/lib.rs
@@ -1,0 +1,1758 @@
+//! Concrete Layer B authorization store and verifier.
+//!
+//! The daemon wires [`AuthStore`] and [`StoreApprovalVerifier`] into the VFS
+//! handlers, TX engine, and IPC server at startup. VFS-facing crates depend
+//! only on `bloom-auth-api`; this crate stays daemon-side so NFS/petal
+//! surfaces never pull in the authorization TCB.
+
+use async_trait::async_trait;
+use bloom_auth_api::{
+    Approval, ApprovalCredentialRecord, ApprovalSignature, ApprovalSignatureVerifier,
+    ApprovalVerifier, AssuranceLevel, AuthApiError, AuthEntryRecord, AuthEntryState, AuthStoreView,
+    AuthStoreWriter, CanonicalEnvelope, ChallengeRecord, NonceState, PriceOracle,
+    ReservationRecord, ReservationState, ReviewSessionRecord, SealedIntentRecord, SignerKind,
+    UnsignedApproval, ValuationPolicy, ValuationQuote,
+};
+use bloom_prices::{CoinId, PricesClient};
+use rusqlite::{Connection, OptionalExtension, params};
+use std::path::Path;
+use std::sync::Mutex;
+
+#[derive(Debug, thiserror::Error)]
+pub enum AuthStoreError {
+    #[error("sqlite: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("json: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("auth api: {0}")]
+    Api(#[from] AuthApiError),
+    #[error("invalid database pragma {name}: expected {expected}, got {actual}")]
+    InvalidPragma {
+        name: &'static str,
+        expected: &'static str,
+        actual: String,
+    },
+    #[error("invalid state value {0}")]
+    InvalidState(String),
+    #[error("invalid assurance value {0}")]
+    InvalidAssurance(String),
+    #[error("invalid reservation state value {0}")]
+    InvalidReservationState(String),
+    #[error("invalid integer value {field}: {value}")]
+    InvalidInteger { field: &'static str, value: String },
+    #[error("authorization denied: {0}")]
+    Denied(String),
+}
+
+impl From<AuthStoreError> for AuthApiError {
+    fn from(value: AuthStoreError) -> Self {
+        AuthApiError::Store(value.to_string())
+    }
+}
+
+pub struct AuthStore {
+    conn: Connection,
+}
+
+pub struct StoreApprovalVerifier<S> {
+    store: Mutex<AuthStore>,
+    signature_verifier: S,
+}
+
+/// Fail-closed placeholder for runtime wiring before production approval
+/// signature verification is installed.
+///
+/// This is deliberately not a test signer. If a migrated production path is
+/// connected to it, approval verification fails instead of creating a soft
+/// authorization bypass while the WebAuthn/CTAP verifier is still being built.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RejectingApprovalSignatureVerifier;
+
+#[derive(Debug, Clone)]
+pub struct BloomPricesOracle {
+    client: PricesClient,
+    source: String,
+}
+
+impl BloomPricesOracle {
+    pub fn new(client: PricesClient) -> Self {
+        Self {
+            client,
+            source: "bloom-prices:defillama".into(),
+        }
+    }
+
+    pub fn with_source(mut self, source: impl Into<String>) -> Self {
+        self.source = source.into();
+        self
+    }
+}
+
+impl<S> StoreApprovalVerifier<S> {
+    pub fn new(store: AuthStore, signature_verifier: S) -> Self {
+        Self {
+            store: Mutex::new(store),
+            signature_verifier,
+        }
+    }
+}
+
+#[async_trait]
+impl ApprovalSignatureVerifier for RejectingApprovalSignatureVerifier {
+    async fn verify_signature(
+        &self,
+        _unsigned: &UnsignedApproval,
+        _signature: &ApprovalSignature,
+        _now_ms: u64,
+    ) -> Result<(), AuthApiError> {
+        Err(AuthApiError::Denied(
+            "production approval signature verifier is not installed".into(),
+        ))
+    }
+}
+
+impl AuthStore {
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, AuthStoreError> {
+        if let Some(parent) = path.as_ref().parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let conn = Connection::open(path)?;
+        Self::configure_connection(&conn)?;
+        Self::migrate(&conn)?;
+        Ok(Self { conn })
+    }
+
+    pub fn open_in_memory_for_tests() -> Result<Self, AuthStoreError> {
+        let conn = Connection::open_in_memory()?;
+        Self::configure_connection(&conn)?;
+        Self::migrate(&conn)?;
+        Ok(Self { conn })
+    }
+
+    fn configure_connection(conn: &Connection) -> Result<(), AuthStoreError> {
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+        conn.pragma_update(None, "foreign_keys", "ON")?;
+        conn.pragma_update(None, "synchronous", "FULL")?;
+        let synchronous: i64 = conn.query_row("PRAGMA synchronous", [], |row| row.get(0))?;
+        if synchronous != 2 {
+            return Err(AuthStoreError::InvalidPragma {
+                name: "synchronous",
+                expected: "FULL",
+                actual: synchronous.to_string(),
+            });
+        }
+        let foreign_keys: i64 = conn.query_row("PRAGMA foreign_keys", [], |row| row.get(0))?;
+        if foreign_keys != 1 {
+            return Err(AuthStoreError::InvalidPragma {
+                name: "foreign_keys",
+                expected: "ON",
+                actual: foreign_keys.to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    fn migrate(conn: &Connection) -> Result<(), AuthStoreError> {
+        conn.execute_batch(
+            r#"
+            CREATE TABLE IF NOT EXISTS sealed_intents (
+                intent_hash TEXT PRIMARY KEY NOT NULL,
+                envelope_json TEXT NOT NULL,
+                sealed_at_ms INTEGER NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS auth_entries (
+                surface TEXT NOT NULL,
+                entry_id TEXT NOT NULL,
+                state TEXT NOT NULL,
+                intent_hash TEXT NOT NULL REFERENCES sealed_intents(intent_hash),
+                assurance TEXT NOT NULL,
+                nonce TEXT,
+                nonce_state TEXT NOT NULL DEFAULT 'unused',
+                reservation_id TEXT,
+                updated_ms INTEGER NOT NULL,
+                PRIMARY KEY(surface, entry_id)
+            );
+
+            CREATE TABLE IF NOT EXISTS approvals (
+                surface TEXT NOT NULL,
+                entry_id TEXT NOT NULL,
+                nonce TEXT NOT NULL,
+                approval_json TEXT NOT NULL,
+                signer_kind TEXT NOT NULL,
+                assurance TEXT NOT NULL,
+                expiry_ms INTEGER NOT NULL,
+                consumed_ms INTEGER,
+                PRIMARY KEY(surface, entry_id, nonce)
+            );
+
+            CREATE TABLE IF NOT EXISTS review_sessions (
+                review_session_id TEXT PRIMARY KEY NOT NULL,
+                surface TEXT NOT NULL,
+                entry_id TEXT NOT NULL,
+                intent_hash TEXT NOT NULL REFERENCES sealed_intents(intent_hash),
+                assurance TEXT NOT NULL,
+                expires_ms INTEGER NOT NULL,
+                consumed_ms INTEGER,
+                created_ms INTEGER NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS approval_credentials (
+                wallet TEXT NOT NULL,
+                credential_id TEXT NOT NULL,
+                signer_kind TEXT NOT NULL,
+                assurance TEXT NOT NULL,
+                public_key_json TEXT NOT NULL,
+                registered_ms INTEGER NOT NULL,
+                revoked_ms INTEGER,
+                PRIMARY KEY(wallet, credential_id)
+            );
+
+            CREATE TABLE IF NOT EXISTS reservations (
+                reservation_id TEXT PRIMARY KEY NOT NULL,
+                wallet TEXT NOT NULL,
+                venue TEXT NOT NULL,
+                amount_micro_usd TEXT NOT NULL,
+                state TEXT NOT NULL,
+                created_ms INTEGER NOT NULL,
+                updated_ms INTEGER NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS valuation_snapshots (
+                reservation_id TEXT PRIMARY KEY NOT NULL REFERENCES reservations(reservation_id),
+                valuation_json TEXT NOT NULL,
+                created_ms INTEGER NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS audit (
+                seq INTEGER PRIMARY KEY AUTOINCREMENT,
+                prev_digest TEXT NOT NULL,
+                digest TEXT NOT NULL,
+                event TEXT NOT NULL,
+                record_json TEXT NOT NULL,
+                created_ms INTEGER NOT NULL
+            );
+            "#,
+        )?;
+        Ok(())
+    }
+
+    pub fn insert_sealed_intent(
+        &mut self,
+        envelope: &CanonicalEnvelope,
+        sealed_at_ms: u64,
+    ) -> Result<String, AuthStoreError> {
+        let intent_hash = envelope.intent_hash().map_err(AuthStoreError::from_api)?;
+        let envelope_json = serde_json::to_string(envelope)?;
+        let tx = self.conn.transaction()?;
+        tx.execute(
+            "INSERT OR IGNORE INTO sealed_intents(intent_hash, envelope_json, sealed_at_ms)
+             VALUES (?1, ?2, ?3)",
+            params![intent_hash, envelope_json, sealed_at_ms as i64],
+        )?;
+        tx.commit()?;
+        Ok(intent_hash)
+    }
+
+    pub fn stage_entry(
+        &mut self,
+        envelope: &CanonicalEnvelope,
+        assurance: AssuranceLevel,
+        now_ms: u64,
+    ) -> Result<AuthEntryRecord, AuthStoreError> {
+        let intent_hash = envelope.intent_hash().map_err(AuthStoreError::from_api)?;
+        let envelope_json = serde_json::to_string(envelope)?;
+        let tx = self.conn.transaction()?;
+        tx.execute(
+            "INSERT OR IGNORE INTO sealed_intents(intent_hash, envelope_json, sealed_at_ms)
+             VALUES (?1, ?2, ?3)",
+            params![intent_hash, envelope_json, now_ms as i64],
+        )?;
+        tx.execute(
+            "INSERT OR IGNORE INTO auth_entries(
+                surface, entry_id, state, intent_hash, assurance, nonce, nonce_state,
+                reservation_id, updated_ms
+             )
+             VALUES (?1, ?2, ?3, ?4, ?5, NULL, ?6, NULL, ?7)
+            ",
+            params![
+                envelope.header.surface,
+                envelope.header.entry_id,
+                AuthEntryState::Staged.as_str(),
+                intent_hash,
+                assurance.as_str(),
+                NonceState::Unused.as_str(),
+                now_ms as i64,
+            ],
+        )?;
+        tx.commit()?;
+        let entry = self
+            .auth_entry(&envelope.header.surface, &envelope.header.entry_id)?
+            .ok_or_else(|| AuthStoreError::Denied("staged entry was not persisted".into()))?;
+        if entry.intent_hash != intent_hash || entry.assurance != assurance {
+            return Err(AuthStoreError::Denied(
+                "auth entry already exists for different intent or assurance".into(),
+            ));
+        }
+        Ok(entry)
+    }
+
+    pub fn issue_challenge(
+        &mut self,
+        surface: &str,
+        entry_id: &str,
+        server_nonce: &str,
+        expiry_ms: u64,
+        now_ms: u64,
+    ) -> Result<ChallengeRecord, AuthStoreError> {
+        let tx = self.conn.transaction()?;
+        let (intent_hash, assurance): (String, String) = tx
+            .query_row(
+                "SELECT intent_hash, assurance FROM auth_entries
+                 WHERE surface = ?1 AND entry_id = ?2 AND nonce_state = 'unused'",
+                params![surface, entry_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()?
+            .ok_or_else(|| AuthStoreError::Denied("entry is not challengeable".into()))?;
+        tx.execute(
+            "UPDATE auth_entries
+             SET state = ?3, nonce = ?4, nonce_state = ?5, updated_ms = ?6
+             WHERE surface = ?1 AND entry_id = ?2 AND nonce_state = 'unused'",
+            params![
+                surface,
+                entry_id,
+                AuthEntryState::Challenged.as_str(),
+                server_nonce,
+                NonceState::Unused.as_str(),
+                now_ms as i64,
+            ],
+        )?;
+        tx.commit()?;
+        Ok(ChallengeRecord {
+            surface: surface.to_string(),
+            entry_id: entry_id.to_string(),
+            intent_hash,
+            server_nonce: server_nonce.to_string(),
+            assurance: parse_assurance(&assurance)?,
+            expiry_ms,
+        })
+    }
+
+    pub fn issue_review_session(
+        &mut self,
+        review_session_id: &str,
+        surface: &str,
+        entry_id: &str,
+        expires_ms: u64,
+        now_ms: u64,
+    ) -> Result<ReviewSessionRecord, AuthStoreError> {
+        let tx = self.conn.transaction()?;
+        let (intent_hash, assurance): (String, String) = tx
+            .query_row(
+                "SELECT intent_hash, assurance FROM auth_entries
+                 WHERE surface = ?1 AND entry_id = ?2",
+                params![surface, entry_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()?
+            .ok_or_else(|| AuthStoreError::Denied("entry not found".into()))?;
+        tx.execute(
+            "INSERT INTO review_sessions(
+                review_session_id, surface, entry_id, intent_hash, assurance, expires_ms,
+                consumed_ms, created_ms
+             )
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL, ?7)",
+            params![
+                review_session_id,
+                surface,
+                entry_id,
+                intent_hash,
+                assurance,
+                expires_ms as i64,
+                now_ms as i64,
+            ],
+        )?;
+        tx.commit()?;
+        self.review_session(review_session_id)?
+            .ok_or_else(|| AuthStoreError::Denied("review session was not persisted".into()))
+    }
+
+    pub fn review_session(
+        &self,
+        review_session_id: &str,
+    ) -> Result<Option<ReviewSessionRecord>, AuthStoreError> {
+        self.conn
+            .query_row(
+                "SELECT surface, entry_id, intent_hash, assurance, expires_ms, consumed_ms, created_ms
+                 FROM review_sessions WHERE review_session_id = ?1",
+                params![review_session_id],
+                |row| {
+                    let surface: String = row.get(0)?;
+                    let entry_id: String = row.get(1)?;
+                    let intent_hash: String = row.get(2)?;
+                    let assurance: String = row.get(3)?;
+                    let expires_ms: i64 = row.get(4)?;
+                    let consumed_ms: Option<i64> = row.get(5)?;
+                    let created_ms: i64 = row.get(6)?;
+                    Ok((
+                        surface,
+                        entry_id,
+                        intent_hash,
+                        assurance,
+                        expires_ms,
+                        consumed_ms,
+                        created_ms,
+                    ))
+                },
+            )
+            .optional()?
+            .map(
+                |(surface, entry_id, intent_hash, assurance, expires_ms, consumed_ms, created_ms)| {
+                    Ok(ReviewSessionRecord {
+                        review_session_id: review_session_id.to_string(),
+                        surface,
+                        entry_id,
+                        intent_hash,
+                        assurance: parse_assurance(&assurance)?,
+                        expires_ms: expires_ms as u64,
+                        consumed_ms: consumed_ms.map(|v| v as u64),
+                        created_ms: created_ms as u64,
+                    })
+                },
+            )
+            .transpose()
+    }
+
+    pub fn register_approval_credential(
+        &mut self,
+        record: &ApprovalCredentialRecord,
+    ) -> Result<(), AuthStoreError> {
+        record.validate().map_err(AuthStoreError::from_api)?;
+        let public_key_json = serde_json::to_string(&record.public_key_json)?;
+        self.conn.execute(
+            "INSERT INTO approval_credentials(
+                wallet, credential_id, signer_kind, assurance, public_key_json,
+                registered_ms, revoked_ms
+             )
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                record.wallet,
+                record.credential_id,
+                signer_kind_str(record.signer_kind),
+                record.assurance.as_str(),
+                public_key_json,
+                record.registered_ms as i64,
+                record.revoked_ms.map(|v| v as i64),
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn approval_credential(
+        &self,
+        wallet: &str,
+        credential_id: &str,
+    ) -> Result<Option<ApprovalCredentialRecord>, AuthStoreError> {
+        self.conn
+            .query_row(
+                "SELECT signer_kind, assurance, public_key_json, registered_ms, revoked_ms
+                 FROM approval_credentials WHERE wallet = ?1 AND credential_id = ?2",
+                params![wallet, credential_id],
+                |row| {
+                    let signer_kind: String = row.get(0)?;
+                    let assurance: String = row.get(1)?;
+                    let public_key_json: String = row.get(2)?;
+                    let registered_ms: i64 = row.get(3)?;
+                    let revoked_ms: Option<i64> = row.get(4)?;
+                    Ok((
+                        signer_kind,
+                        assurance,
+                        public_key_json,
+                        registered_ms,
+                        revoked_ms,
+                    ))
+                },
+            )
+            .optional()?
+            .map(
+                |(signer_kind, assurance, public_key_json, registered_ms, revoked_ms)| {
+                    let record = ApprovalCredentialRecord {
+                        wallet: wallet.to_string(),
+                        credential_id: credential_id.to_string(),
+                        signer_kind: parse_signer_kind(&signer_kind)?,
+                        assurance: parse_assurance(&assurance)?,
+                        public_key_json: serde_json::from_str(&public_key_json)?,
+                        registered_ms: registered_ms as u64,
+                        revoked_ms: revoked_ms.map(|v| v as u64),
+                    };
+                    record.validate().map_err(AuthStoreError::from_api)?;
+                    Ok(record)
+                },
+            )
+            .transpose()
+    }
+
+    pub fn revoke_approval_credential(
+        &mut self,
+        wallet: &str,
+        credential_id: &str,
+        revoked_ms: u64,
+    ) -> Result<(), AuthStoreError> {
+        let rows = self.conn.execute(
+            "UPDATE approval_credentials
+             SET revoked_ms = ?3
+             WHERE wallet = ?1 AND credential_id = ?2 AND revoked_ms IS NULL",
+            params![wallet, credential_id, revoked_ms as i64],
+        )?;
+        if rows == 0 {
+            return Err(AuthStoreError::Denied(
+                "approval credential not found or already revoked".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn auth_entry(
+        &self,
+        surface: &str,
+        entry_id: &str,
+    ) -> Result<Option<AuthEntryRecord>, AuthStoreError> {
+        self.conn
+            .query_row(
+                "SELECT state, intent_hash, assurance, nonce, nonce_state, reservation_id, updated_ms
+                 FROM auth_entries WHERE surface = ?1 AND entry_id = ?2",
+                params![surface, entry_id],
+                |row| {
+                    let state: String = row.get(0)?;
+                    let intent_hash: String = row.get(1)?;
+                    let assurance: String = row.get(2)?;
+                    let nonce: Option<String> = row.get(3)?;
+                    let nonce_state: String = row.get(4)?;
+                    let reservation_id: Option<String> = row.get(5)?;
+                    let updated_ms: i64 = row.get(6)?;
+                    Ok((
+                        state,
+                        intent_hash,
+                        assurance,
+                        nonce,
+                        nonce_state,
+                        reservation_id,
+                        updated_ms,
+                    ))
+                },
+            )
+            .optional()?
+            .map(
+                |(state, intent_hash, assurance, nonce, nonce_state, reservation_id, updated_ms)| {
+                    Ok(AuthEntryRecord {
+                        surface: surface.to_string(),
+                        entry_id: entry_id.to_string(),
+                        state: parse_entry_state(&state)?,
+                        intent_hash,
+                        assurance: parse_assurance(&assurance)?,
+                        nonce,
+                        nonce_state: parse_nonce_state(&nonce_state)?,
+                        reservation_id,
+                        updated_ms: updated_ms as u64,
+                    })
+                },
+            )
+            .transpose()
+    }
+
+    pub fn consume_verified_approval_transactionally(
+        &mut self,
+        approval: &Approval,
+        now_ms: u64,
+    ) -> Result<(), AuthStoreError> {
+        let tx = self.conn.transaction()?;
+        let (entry_intent_hash, entry_assurance, entry_nonce, nonce_state): (
+            String,
+            String,
+            Option<String>,
+            String,
+        ) = tx
+            .query_row(
+                "SELECT intent_hash, assurance, nonce, nonce_state FROM auth_entries
+                 WHERE surface = ?1 AND entry_id = ?2",
+                params![approval.surface, approval.entry_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .optional()?
+            .ok_or_else(|| AuthStoreError::Denied("entry not found".into()))?;
+        if entry_intent_hash != approval.intent_hash {
+            return Err(AuthStoreError::Denied("entry intent_hash mismatch".into()));
+        }
+        if parse_assurance(&entry_assurance)? != approval.assurance {
+            return Err(AuthStoreError::Denied("entry assurance mismatch".into()));
+        }
+        if entry_nonce.as_deref() != Some(approval.server_nonce.as_str()) {
+            return Err(AuthStoreError::Denied("server_nonce mismatch".into()));
+        }
+        if parse_nonce_state(&nonce_state)? != NonceState::Unused {
+            return Err(AuthStoreError::Denied(
+                "server_nonce already consumed".into(),
+            ));
+        }
+        let (envelope_json, sealed_at_ms): (String, i64) = tx.query_row(
+            "SELECT envelope_json, sealed_at_ms FROM sealed_intents WHERE intent_hash = ?1",
+            params![approval.intent_hash],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        let envelope: CanonicalEnvelope = serde_json::from_str(&envelope_json)?;
+        approval
+            .validate_against_sealed(
+                &SealedIntentRecord {
+                    intent_hash: approval.intent_hash.clone(),
+                    envelope,
+                    sealed_at_ms: sealed_at_ms as u64,
+                },
+                now_ms,
+            )
+            .map_err(AuthStoreError::from_api)?;
+        if approval.assurance == AssuranceLevel::Hardened {
+            let review_session_id = approval.review_session_id.as_deref().ok_or_else(|| {
+                AuthStoreError::Denied("hardened approval requires a review_session_id".into())
+            })?;
+            let (
+                session_surface,
+                session_entry_id,
+                session_intent_hash,
+                session_assurance,
+                session_expires_ms,
+                session_consumed_ms,
+            ): (String, String, String, String, i64, Option<i64>) = tx
+                .query_row(
+                    "SELECT surface, entry_id, intent_hash, assurance, expires_ms, consumed_ms
+                     FROM review_sessions WHERE review_session_id = ?1",
+                    params![review_session_id],
+                    |row| {
+                        Ok((
+                            row.get(0)?,
+                            row.get(1)?,
+                            row.get(2)?,
+                            row.get(3)?,
+                            row.get(4)?,
+                            row.get(5)?,
+                        ))
+                    },
+                )
+                .optional()?
+                .ok_or_else(|| AuthStoreError::Denied("review session not found".into()))?;
+            if session_surface != approval.surface
+                || session_entry_id != approval.entry_id
+                || session_intent_hash != approval.intent_hash
+                || parse_assurance(&session_assurance)? != approval.assurance
+            {
+                return Err(AuthStoreError::Denied(
+                    "review session does not match approval".into(),
+                ));
+            }
+            if session_consumed_ms.is_some() {
+                return Err(AuthStoreError::Denied(
+                    "review session already consumed".into(),
+                ));
+            }
+            if now_ms >= session_expires_ms as u64 {
+                return Err(AuthStoreError::Denied("review session expired".into()));
+            }
+            tx.execute(
+                "UPDATE review_sessions SET consumed_ms = ?2
+                 WHERE review_session_id = ?1 AND consumed_ms IS NULL",
+                params![review_session_id, now_ms as i64],
+            )?;
+            if tx.changes() != 1 {
+                return Err(AuthStoreError::Denied(
+                    "review session was not consumed".into(),
+                ));
+            }
+        }
+        let approval_json = serde_json::to_string(approval)?;
+        tx.execute(
+            "INSERT INTO approvals(
+                surface, entry_id, nonce, approval_json, signer_kind, assurance, expiry_ms,
+                consumed_ms
+             )
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+             ON CONFLICT(surface, entry_id, nonce) DO UPDATE SET
+                approval_json = excluded.approval_json,
+                signer_kind = excluded.signer_kind,
+                assurance = excluded.assurance,
+                expiry_ms = excluded.expiry_ms,
+                consumed_ms = excluded.consumed_ms",
+            params![
+                approval.surface,
+                approval.entry_id,
+                approval.server_nonce,
+                approval_json,
+                signer_kind_str(approval.signer_kind),
+                approval.assurance.as_str(),
+                approval.expiry_ms as i64,
+                now_ms as i64,
+            ],
+        )?;
+        tx.execute(
+            "UPDATE auth_entries
+             SET state = ?3, nonce_state = ?4, updated_ms = ?5
+             WHERE surface = ?1 AND entry_id = ?2 AND nonce = ?6 AND nonce_state = 'unused'",
+            params![
+                approval.surface,
+                approval.entry_id,
+                AuthEntryState::Approved.as_str(),
+                NonceState::Consumed.as_str(),
+                now_ms as i64,
+                approval.server_nonce,
+            ],
+        )?;
+        if tx.changes() != 1 {
+            return Err(AuthStoreError::Denied("approval was not consumed".into()));
+        }
+        let audit_record = serde_json::json!({
+            "surface": approval.surface,
+            "entry_id": approval.entry_id,
+            "intent_hash": approval.intent_hash,
+            "nonce": approval.server_nonce,
+        })
+        .to_string();
+        let prev_digest: String = tx
+            .query_row(
+                "SELECT digest FROM audit ORDER BY seq DESC LIMIT 1",
+                [],
+                |row| row.get(0),
+            )
+            .optional()?
+            .unwrap_or_else(|| "0".repeat(64));
+        let digest = audit_digest(&prev_digest, "approval_consumed", &audit_record, now_ms);
+        tx.execute(
+            "INSERT INTO audit(prev_digest, digest, event, record_json, created_ms)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                prev_digest,
+                digest,
+                "approval_consumed",
+                audit_record,
+                now_ms as i64,
+            ],
+        )?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub fn create_reservation(
+        &mut self,
+        reservation_id: &str,
+        wallet: &str,
+        venue: &str,
+        amount_micro_usd: i128,
+        now_ms: u64,
+    ) -> Result<ReservationRecord, AuthStoreError> {
+        let tx = self.conn.transaction()?;
+        tx.execute(
+            "INSERT INTO reservations(
+                reservation_id, wallet, venue, amount_micro_usd, state, created_ms, updated_ms
+             )
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                reservation_id,
+                wallet,
+                venue,
+                amount_micro_usd.to_string(),
+                ReservationState::Active.as_str(),
+                now_ms as i64,
+                now_ms as i64,
+            ],
+        )?;
+        tx.commit()?;
+        self.reservation(reservation_id)?
+            .ok_or_else(|| AuthStoreError::Denied("reservation was not persisted".into()))
+    }
+
+    pub fn create_reservation_with_valuation(
+        &mut self,
+        reservation_id: &str,
+        wallet: &str,
+        venue: &str,
+        valuation: &ValuationQuote,
+        policy: &ValuationPolicy,
+        now_ms: u64,
+    ) -> Result<ReservationRecord, AuthStoreError> {
+        valuation.validate_for_authorization(policy, now_ms)?;
+        let tx = self.conn.transaction()?;
+        tx.execute(
+            "INSERT INTO reservations(
+                reservation_id, wallet, venue, amount_micro_usd, state, created_ms, updated_ms
+             )
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                reservation_id,
+                wallet,
+                venue,
+                valuation.usd_micro.to_string(),
+                ReservationState::Active.as_str(),
+                now_ms as i64,
+                now_ms as i64,
+            ],
+        )?;
+        tx.execute(
+            "INSERT INTO valuation_snapshots(reservation_id, valuation_json, created_ms)
+             VALUES (?1, ?2, ?3)",
+            params![
+                reservation_id,
+                serde_json::to_string(valuation)?,
+                now_ms as i64,
+            ],
+        )?;
+        tx.commit()?;
+        self.reservation(reservation_id)?
+            .ok_or_else(|| AuthStoreError::Denied("reservation was not persisted".into()))
+    }
+
+    pub fn transition_reservation(
+        &mut self,
+        reservation_id: &str,
+        from: ReservationState,
+        to: ReservationState,
+        now_ms: u64,
+    ) -> Result<ReservationRecord, AuthStoreError> {
+        let tx = self.conn.transaction()?;
+        tx.execute(
+            "UPDATE reservations SET state = ?2, updated_ms = ?3
+             WHERE reservation_id = ?1 AND state = ?4",
+            params![reservation_id, to.as_str(), now_ms as i64, from.as_str()],
+        )?;
+        if tx.changes() != 1 {
+            return Err(AuthStoreError::Denied(
+                "reservation transition was not applied".into(),
+            ));
+        }
+        tx.commit()?;
+        self.reservation(reservation_id)?
+            .ok_or_else(|| AuthStoreError::Denied("reservation disappeared".into()))
+    }
+
+    pub fn reservation(
+        &self,
+        reservation_id: &str,
+    ) -> Result<Option<ReservationRecord>, AuthStoreError> {
+        self.conn
+            .query_row(
+                "SELECT wallet, venue, amount_micro_usd, state, created_ms, updated_ms
+                 FROM reservations WHERE reservation_id = ?1",
+                params![reservation_id],
+                |row| {
+                    let wallet: String = row.get(0)?;
+                    let venue: String = row.get(1)?;
+                    let amount_micro_usd: String = row.get(2)?;
+                    let state: String = row.get(3)?;
+                    let created_ms: i64 = row.get(4)?;
+                    let updated_ms: i64 = row.get(5)?;
+                    Ok((
+                        wallet,
+                        venue,
+                        amount_micro_usd,
+                        state,
+                        created_ms,
+                        updated_ms,
+                    ))
+                },
+            )
+            .optional()?
+            .map(
+                |(wallet, venue, amount_micro_usd, state, created_ms, updated_ms)| {
+                    Ok(ReservationRecord {
+                        reservation_id: reservation_id.to_string(),
+                        wallet,
+                        venue,
+                        amount_micro_usd: parse_i128("amount_micro_usd", &amount_micro_usd)?,
+                        state: parse_reservation_state(&state)?,
+                        created_ms: created_ms as u64,
+                        updated_ms: updated_ms as u64,
+                    })
+                },
+            )
+            .transpose()
+    }
+
+    pub fn valuation_snapshot(
+        &self,
+        reservation_id: &str,
+    ) -> Result<Option<ValuationQuote>, AuthStoreError> {
+        self.conn
+            .query_row(
+                "SELECT valuation_json FROM valuation_snapshots WHERE reservation_id = ?1",
+                params![reservation_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?
+            .map(|json| Ok(serde_json::from_str(&json)?))
+            .transpose()
+    }
+
+    pub fn active_reservation_total(
+        &self,
+        wallet: &str,
+        venue: Option<&str>,
+    ) -> Result<i128, AuthStoreError> {
+        let mut total = 0i128;
+        if let Some(venue) = venue {
+            let mut stmt = self.conn.prepare(
+                "SELECT amount_micro_usd FROM reservations
+                 WHERE wallet = ?1 AND venue = ?2 AND state = 'active'",
+            )?;
+            let mut rows = stmt.query(params![wallet, venue])?;
+            while let Some(row) = rows.next()? {
+                let amount: String = row.get(0)?;
+                total += parse_i128("amount_micro_usd", &amount)?;
+            }
+        } else {
+            let mut stmt = self.conn.prepare(
+                "SELECT amount_micro_usd FROM reservations
+                 WHERE wallet = ?1 AND state = 'active'",
+            )?;
+            let mut rows = stmt.query(params![wallet])?;
+            while let Some(row) = rows.next()? {
+                let amount: String = row.get(0)?;
+                total += parse_i128("amount_micro_usd", &amount)?;
+            }
+        }
+        Ok(total)
+    }
+
+    pub fn sealed_intent(
+        &self,
+        intent_hash: &str,
+    ) -> Result<Option<SealedIntentRecord>, AuthStoreError> {
+        self.conn
+            .query_row(
+                "SELECT envelope_json, sealed_at_ms FROM sealed_intents WHERE intent_hash = ?1",
+                params![intent_hash],
+                |row| {
+                    let envelope_json: String = row.get(0)?;
+                    let sealed_at_ms: i64 = row.get(1)?;
+                    Ok((envelope_json, sealed_at_ms))
+                },
+            )
+            .optional()?
+            .map(|(envelope_json, sealed_at_ms)| {
+                let envelope: CanonicalEnvelope = serde_json::from_str(&envelope_json)?;
+                Ok(SealedIntentRecord {
+                    intent_hash: intent_hash.to_string(),
+                    envelope,
+                    sealed_at_ms: sealed_at_ms as u64,
+                })
+            })
+            .transpose()
+    }
+
+    pub fn pragma_string(&self, name: &str) -> Result<String, AuthStoreError> {
+        let sql = format!("PRAGMA {name}");
+        Ok(self.conn.query_row(&sql, [], |row| row.get(0))?)
+    }
+
+    pub fn pragma_i64(&self, name: &str) -> Result<i64, AuthStoreError> {
+        let sql = format!("PRAGMA {name}");
+        Ok(self.conn.query_row(&sql, [], |row| row.get(0))?)
+    }
+}
+
+#[async_trait]
+impl<S> ApprovalVerifier for StoreApprovalVerifier<S>
+where
+    S: ApprovalSignatureVerifier + Send + Sync,
+{
+    async fn verify_and_consume(
+        &self,
+        approval: Approval,
+        now_ms: u64,
+    ) -> Result<(), AuthApiError> {
+        let unsigned = approval.unsigned_payload();
+        self.signature_verifier
+            .verify_signature(&unsigned, &approval.signature, now_ms)
+            .await?;
+        let mut store = self
+            .store
+            .lock()
+            .map_err(|_| AuthApiError::Store("auth store mutex poisoned".into()))?;
+        store.consume_verified_approval_transactionally(&approval, now_ms)?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<S> AuthStoreView for StoreApprovalVerifier<S>
+where
+    S: Send + Sync,
+{
+    async fn sealed_intent(&self, intent_hash: &str) -> Result<SealedIntentRecord, AuthApiError> {
+        let store = self
+            .store
+            .lock()
+            .map_err(|_| AuthApiError::Store("auth store mutex poisoned".into()))?;
+        store
+            .sealed_intent(intent_hash)?
+            .ok_or_else(|| AuthApiError::NotFound(format!("sealed intent {intent_hash}")))
+    }
+}
+
+#[async_trait]
+impl<S> AuthStoreWriter for StoreApprovalVerifier<S>
+where
+    S: Send + Sync,
+{
+    async fn stage_entry(
+        &self,
+        envelope: CanonicalEnvelope,
+        assurance: AssuranceLevel,
+        now_ms: u64,
+    ) -> Result<AuthEntryRecord, AuthApiError> {
+        let mut store = self
+            .store
+            .lock()
+            .map_err(|_| AuthApiError::Store("auth store mutex poisoned".into()))?;
+        Ok(store.stage_entry(&envelope, assurance, now_ms)?)
+    }
+
+    async fn issue_challenge(
+        &self,
+        surface: &str,
+        entry_id: &str,
+        server_nonce: &str,
+        expiry_ms: u64,
+        now_ms: u64,
+    ) -> Result<ChallengeRecord, AuthApiError> {
+        let mut store = self
+            .store
+            .lock()
+            .map_err(|_| AuthApiError::Store("auth store mutex poisoned".into()))?;
+        Ok(store.issue_challenge(surface, entry_id, server_nonce, expiry_ms, now_ms)?)
+    }
+
+    async fn issue_review_session(
+        &self,
+        review_session_id: &str,
+        surface: &str,
+        entry_id: &str,
+        expires_ms: u64,
+        now_ms: u64,
+    ) -> Result<ReviewSessionRecord, AuthApiError> {
+        let mut store = self
+            .store
+            .lock()
+            .map_err(|_| AuthApiError::Store("auth store mutex poisoned".into()))?;
+        Ok(store.issue_review_session(review_session_id, surface, entry_id, expires_ms, now_ms)?)
+    }
+}
+
+#[async_trait]
+impl PriceOracle for BloomPricesOracle {
+    async fn quote_usd(
+        &self,
+        asset_id: &str,
+        amount_base_units: &str,
+        now_ms: u64,
+    ) -> Result<ValuationQuote, AuthApiError> {
+        let coin = parse_coin_id(asset_id)?;
+        let quote = self
+            .client
+            .current(coin)
+            .await
+            .map_err(|err| AuthApiError::Denied(format!("price oracle unavailable: {err}")))?;
+        let decimals = quote
+            .decimals
+            .ok_or_else(|| AuthApiError::Denied("price quote decimals missing".into()))?;
+        if quote.timestamp == 0 {
+            return Err(AuthApiError::Denied("price quote timestamp missing".into()));
+        }
+        let usd_micro = amount_to_usd_micro(amount_base_units, decimals, quote.price)
+            .map_err(AuthApiError::Denied)?;
+        let confidence_ppm = match quote.confidence {
+            Some(confidence) if confidence.is_finite() && confidence >= 0.0 => {
+                Some((confidence.min(1.0) * 1_000_000.0).round() as u32)
+            }
+            Some(_) => {
+                return Err(AuthApiError::Denied(
+                    "price quote confidence is invalid".into(),
+                ));
+            }
+            None => None,
+        };
+        Ok(ValuationQuote {
+            asset_id: asset_id.to_string(),
+            amount_base_units: amount_base_units.to_string(),
+            usd_micro,
+            source: self.source.clone(),
+            quote_timestamp_ms: quote.timestamp.saturating_mul(1_000),
+            fetched_at_ms: now_ms,
+            max_age_ms: self.client.ttl().as_millis().try_into().unwrap_or(u64::MAX),
+            confidence_ppm,
+            stablecoin_assumption: false,
+        })
+    }
+}
+
+fn parse_coin_id(asset_id: &str) -> Result<CoinId, AuthApiError> {
+    if asset_id.contains(':') {
+        CoinId::parse(asset_id)
+            .map_err(|err| AuthApiError::Denied(format!("invalid price asset id: {err}")))
+    } else {
+        Ok(CoinId::Symbol(asset_id.to_string()))
+    }
+}
+
+fn amount_to_usd_micro(
+    amount_base_units: &str,
+    decimals: u8,
+    price_usd: f64,
+) -> Result<i128, String> {
+    if !price_usd.is_finite() || price_usd < 0.0 {
+        return Err("price quote is invalid".into());
+    }
+    let amount = amount_base_units
+        .parse::<u128>()
+        .map_err(|_| "amount_base_units is invalid".to_string())?;
+    let scale = 10f64.powi(decimals as i32);
+    if !scale.is_finite() || scale <= 0.0 {
+        return Err("asset decimals are invalid".into());
+    }
+    let usd_micro = (amount as f64 / scale) * price_usd * 1_000_000.0;
+    if !usd_micro.is_finite() || usd_micro < 0.0 || usd_micro > i128::MAX as f64 {
+        return Err("computed USD value is invalid".into());
+    }
+    Ok(usd_micro.round() as i128)
+}
+
+fn parse_entry_state(value: &str) -> Result<AuthEntryState, AuthStoreError> {
+    match value {
+        "staged" => Ok(AuthEntryState::Staged),
+        "challenged" => Ok(AuthEntryState::Challenged),
+        "approved" => Ok(AuthEntryState::Approved),
+        "submitting" => Ok(AuthEntryState::Submitting),
+        "submitted" => Ok(AuthEntryState::Submitted),
+        "settled" => Ok(AuthEntryState::Settled),
+        "failed" => Ok(AuthEntryState::Failed),
+        "unknown" => Ok(AuthEntryState::Unknown),
+        other => Err(AuthStoreError::InvalidState(other.to_string())),
+    }
+}
+
+fn parse_nonce_state(value: &str) -> Result<NonceState, AuthStoreError> {
+    match value {
+        "unused" => Ok(NonceState::Unused),
+        "consumed" => Ok(NonceState::Consumed),
+        other => Err(AuthStoreError::InvalidState(other.to_string())),
+    }
+}
+
+fn parse_assurance(value: &str) -> Result<AssuranceLevel, AuthStoreError> {
+    match value {
+        "convenience" => Ok(AssuranceLevel::Convenience),
+        "hardened" => Ok(AssuranceLevel::Hardened),
+        other => Err(AuthStoreError::InvalidAssurance(other.to_string())),
+    }
+}
+
+fn parse_reservation_state(value: &str) -> Result<ReservationState, AuthStoreError> {
+    match value {
+        "active" => Ok(ReservationState::Active),
+        "committed" => Ok(ReservationState::Committed),
+        "released" => Ok(ReservationState::Released),
+        "failed" => Ok(ReservationState::Failed),
+        "unknown" => Ok(ReservationState::Unknown),
+        other => Err(AuthStoreError::InvalidReservationState(other.to_string())),
+    }
+}
+
+fn parse_i128(field: &'static str, value: &str) -> Result<i128, AuthStoreError> {
+    value
+        .parse::<i128>()
+        .map_err(|_| AuthStoreError::InvalidInteger {
+            field,
+            value: value.to_string(),
+        })
+}
+
+fn signer_kind_str(value: bloom_auth_api::SignerKind) -> &'static str {
+    match value {
+        bloom_auth_api::SignerKind::Password => "password",
+        bloom_auth_api::SignerKind::PasskeyBrowser => "passkey_browser",
+        bloom_auth_api::SignerKind::PasskeyCtap => "passkey_ctap",
+        bloom_auth_api::SignerKind::Test => "test",
+    }
+}
+
+fn parse_signer_kind(value: &str) -> Result<SignerKind, AuthStoreError> {
+    match value {
+        "password" => Ok(SignerKind::Password),
+        "passkey_browser" => Ok(SignerKind::PasskeyBrowser),
+        "passkey_ctap" => Ok(SignerKind::PasskeyCtap),
+        "test" => Ok(SignerKind::Test),
+        other => Err(AuthStoreError::Denied(format!(
+            "invalid signer_kind {other}"
+        ))),
+    }
+}
+
+fn audit_digest(prev_digest: &str, event: &str, record_json: &str, created_ms: u64) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"bloom.auth.audit.v1");
+    hasher.update(prev_digest.as_bytes());
+    hasher.update(event.as_bytes());
+    hasher.update(record_json.as_bytes());
+    hasher.update(&created_ms.to_be_bytes());
+    hasher.finalize().to_hex().to_string()
+}
+
+impl AuthStoreError {
+    fn from_api(err: AuthApiError) -> Self {
+        Self::Api(err)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bloom_auth_api::{
+        APPROVAL_SCHEMA_V1, ApprovalCaps, ApprovalSignature, CanonicalEnvelope,
+        CanonicalIntentHeader, SignerKind,
+    };
+
+    fn envelope() -> CanonicalEnvelope {
+        CanonicalEnvelope::new(
+            CanonicalIntentHeader {
+                schema: "bloom.intent_header.v1".into(),
+                wallet: "my-wallet".into(),
+                surface: "requests".into(),
+                entry_id: "req_1".into(),
+                executor_id: "paid-http".into(),
+                network: "base".into(),
+                account: "default".into(),
+                action_kind: "x402_payment".into(),
+                value_movement: true,
+                authority_change: false,
+            },
+            "paid_http",
+            "paid_http.v1",
+            br#"{"amount":"1.00"}"#.to_vec(),
+        )
+    }
+
+    fn approval_for(entry: &AuthEntryRecord, sealed: &SealedIntentRecord) -> Approval {
+        Approval {
+            schema: APPROVAL_SCHEMA_V1.into(),
+            wallet: sealed.envelope.header.wallet.clone(),
+            surface: entry.surface.clone(),
+            entry_id: entry.entry_id.clone(),
+            intent_hash: entry.intent_hash.clone(),
+            executor_id: sealed.envelope.header.executor_id.clone(),
+            network: sealed.envelope.header.network.clone(),
+            assurance: entry.assurance,
+            server_nonce: entry.nonce.clone().unwrap(),
+            caps: ApprovalCaps::default(),
+            expiry_ms: 500,
+            signer_kind: SignerKind::Password,
+            credential_id: None,
+            review_session_id: None,
+            signature: ApprovalSignature::PasswordMac {
+                mac_hex: "test-only".into(),
+            },
+        }
+    }
+
+    #[test]
+    fn production_pragmas_are_strict() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = AuthStore::open(dir.path().join("auth.sqlite")).unwrap();
+        assert_eq!(store.pragma_i64("synchronous").unwrap(), 2);
+        assert_eq!(store.pragma_i64("foreign_keys").unwrap(), 1);
+        assert_eq!(
+            store.pragma_string("journal_mode").unwrap().to_lowercase(),
+            "wal"
+        );
+    }
+
+    #[test]
+    fn sealed_intent_round_trip_uses_hash_key() {
+        let mut store = AuthStore::open_in_memory_for_tests().unwrap();
+        let env = envelope();
+        let hash = store.insert_sealed_intent(&env, 123).unwrap();
+        assert_eq!(hash.len(), 64);
+        let got = store.sealed_intent(&hash).unwrap().unwrap();
+        assert_eq!(got.intent_hash, hash);
+        assert_eq!(got.envelope, env);
+        assert_eq!(got.sealed_at_ms, 123);
+    }
+
+    #[test]
+    fn stage_and_issue_challenge_tracks_nonce() {
+        let mut store = AuthStore::open_in_memory_for_tests().unwrap();
+        let env = envelope();
+        let staged = store
+            .stage_entry(&env, AssuranceLevel::Convenience, 100)
+            .unwrap();
+        assert_eq!(staged.state, AuthEntryState::Staged);
+        assert_eq!(staged.nonce_state, NonceState::Unused);
+        assert_eq!(staged.nonce, None);
+
+        let challenge = store
+            .issue_challenge("requests", "req_1", "nonce-1", 220, 101)
+            .unwrap();
+        assert_eq!(challenge.intent_hash, staged.intent_hash);
+        assert_eq!(challenge.server_nonce, "nonce-1");
+        assert_eq!(challenge.assurance, AssuranceLevel::Convenience);
+
+        let entry = store.auth_entry("requests", "req_1").unwrap().unwrap();
+        assert_eq!(entry.state, AuthEntryState::Challenged);
+        assert_eq!(entry.nonce.as_deref(), Some("nonce-1"));
+        assert_eq!(entry.nonce_state, NonceState::Unused);
+    }
+
+    #[test]
+    fn stage_entry_is_idempotent_for_same_entry_and_rejects_collisions() {
+        let mut store = AuthStore::open_in_memory_for_tests().unwrap();
+        let env = envelope();
+        let first = store
+            .stage_entry(&env, AssuranceLevel::Convenience, 100)
+            .unwrap();
+        let second = store
+            .stage_entry(&env, AssuranceLevel::Convenience, 101)
+            .unwrap();
+        assert_eq!(second.intent_hash, first.intent_hash);
+        assert_eq!(second.updated_ms, first.updated_ms);
+        assert!(
+            store
+                .stage_entry(&env, AssuranceLevel::Hardened, 102)
+                .is_err()
+        );
+        let changed = CanonicalEnvelope::new(
+            env.header.clone(),
+            env.subject_kind.clone(),
+            env.subject_schema.clone(),
+            br#"{"amount":"2"}"#.to_vec(),
+        );
+        assert!(
+            store
+                .stage_entry(&changed, AssuranceLevel::Convenience, 103)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn consume_approval_burns_nonce_and_replay_fails() {
+        let mut store = AuthStore::open_in_memory_for_tests().unwrap();
+        let env = envelope();
+        store
+            .stage_entry(&env, AssuranceLevel::Convenience, 100)
+            .unwrap();
+        store
+            .issue_challenge("requests", "req_1", "nonce-1", 220, 101)
+            .unwrap();
+        let entry = store.auth_entry("requests", "req_1").unwrap().unwrap();
+        let sealed = store.sealed_intent(&entry.intent_hash).unwrap().unwrap();
+        let approval = approval_for(&entry, &sealed);
+
+        store
+            .consume_verified_approval_transactionally(&approval, 150)
+            .unwrap();
+        let consumed = store.auth_entry("requests", "req_1").unwrap().unwrap();
+        assert_eq!(consumed.state, AuthEntryState::Approved);
+        assert_eq!(consumed.nonce_state, NonceState::Consumed);
+
+        let replay = store.consume_verified_approval_transactionally(&approval, 151);
+        assert!(replay.is_err());
+
+        let (prev_digest, digest): (String, String) = store
+            .conn
+            .query_row(
+                "SELECT prev_digest, digest FROM audit WHERE event = 'approval_consumed'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(prev_digest, "0".repeat(64));
+        assert_eq!(digest.len(), 64);
+        assert_ne!(digest, "0".repeat(64));
+    }
+
+    #[test]
+    fn consumed_nonce_survives_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth.sqlite");
+        let approval = {
+            let mut store = AuthStore::open(&path).unwrap();
+            let env = envelope();
+            store
+                .stage_entry(&env, AssuranceLevel::Convenience, 100)
+                .unwrap();
+            store
+                .issue_challenge("requests", "req_1", "nonce-1", 220, 101)
+                .unwrap();
+            let entry = store.auth_entry("requests", "req_1").unwrap().unwrap();
+            let sealed = store.sealed_intent(&entry.intent_hash).unwrap().unwrap();
+            let approval = approval_for(&entry, &sealed);
+            store
+                .consume_verified_approval_transactionally(&approval, 150)
+                .unwrap();
+            approval
+        };
+
+        let mut reopened = AuthStore::open(&path).unwrap();
+        let entry = reopened.auth_entry("requests", "req_1").unwrap().unwrap();
+        assert_eq!(entry.nonce_state, NonceState::Consumed);
+        assert!(
+            reopened
+                .consume_verified_approval_transactionally(&approval, 151)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn mismatched_approval_does_not_burn_nonce() {
+        let mut store = AuthStore::open_in_memory_for_tests().unwrap();
+        let env = envelope();
+        store
+            .stage_entry(&env, AssuranceLevel::Convenience, 100)
+            .unwrap();
+        store
+            .issue_challenge("requests", "req_1", "nonce-1", 220, 101)
+            .unwrap();
+        let entry = store.auth_entry("requests", "req_1").unwrap().unwrap();
+        let sealed = store.sealed_intent(&entry.intent_hash).unwrap().unwrap();
+        let mut approval = approval_for(&entry, &sealed);
+        approval.intent_hash = "f".repeat(64);
+
+        assert!(
+            store
+                .consume_verified_approval_transactionally(&approval, 150)
+                .is_err()
+        );
+        let still_unused = store.auth_entry("requests", "req_1").unwrap().unwrap();
+        assert_eq!(still_unused.nonce_state, NonceState::Unused);
+    }
+
+    #[tokio::test]
+    async fn rejecting_signature_verifier_fails_before_nonce_burn() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth.sqlite");
+        let mut store = AuthStore::open(&path).unwrap();
+        let env = envelope();
+        store
+            .stage_entry(&env, AssuranceLevel::Convenience, 100)
+            .unwrap();
+        store
+            .issue_challenge("requests", "req_1", "nonce-1", 220, 101)
+            .unwrap();
+        let entry = store.auth_entry("requests", "req_1").unwrap().unwrap();
+        let sealed = store.sealed_intent(&entry.intent_hash).unwrap().unwrap();
+        let approval = approval_for(&entry, &sealed);
+        let verifier = StoreApprovalVerifier::new(store, RejectingApprovalSignatureVerifier);
+
+        let err = verifier
+            .verify_and_consume(approval, 150)
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("signature verifier is not installed"),
+            "{err}"
+        );
+
+        drop(verifier);
+        let reopened = AuthStore::open(&path).unwrap();
+        let entry = reopened.auth_entry("requests", "req_1").unwrap().unwrap();
+        assert_eq!(entry.nonce_state, NonceState::Unused);
+    }
+
+    #[tokio::test]
+    async fn store_writer_trait_stages_and_issues_challenge() {
+        let verifier = StoreApprovalVerifier::new(
+            AuthStore::open_in_memory_for_tests().unwrap(),
+            RejectingApprovalSignatureVerifier,
+        );
+        let env = envelope();
+        let staged =
+            AuthStoreWriter::stage_entry(&verifier, env.clone(), AssuranceLevel::Hardened, 100)
+                .await
+                .unwrap();
+        assert_eq!(staged.surface, "requests");
+        assert_eq!(staged.entry_id, "req_1");
+        assert_eq!(staged.assurance, AssuranceLevel::Hardened);
+
+        let challenge =
+            AuthStoreWriter::issue_challenge(&verifier, "requests", "req_1", "nonce-1", 250, 101)
+                .await
+                .unwrap();
+        assert_eq!(challenge.server_nonce, "nonce-1");
+        assert_eq!(challenge.assurance, AssuranceLevel::Hardened);
+
+        let duplicate = AuthStoreWriter::stage_entry(&verifier, env, AssuranceLevel::Hardened, 102)
+            .await
+            .unwrap();
+        assert_eq!(duplicate.intent_hash, staged.intent_hash);
+        assert_eq!(duplicate.state, AuthEntryState::Challenged);
+        assert_eq!(duplicate.nonce.as_deref(), Some("nonce-1"));
+    }
+
+    #[test]
+    fn approval_credentials_persist_and_revoke() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth.sqlite");
+        {
+            let mut store = AuthStore::open(&path).unwrap();
+            store
+                .register_approval_credential(&ApprovalCredentialRecord {
+                    wallet: "my-wallet".into(),
+                    credential_id: "cred-1".into(),
+                    signer_kind: SignerKind::PasskeyBrowser,
+                    assurance: AssuranceLevel::Hardened,
+                    public_key_json: serde_json::json!({"credential":"placeholder"}),
+                    registered_ms: 100,
+                    revoked_ms: None,
+                })
+                .unwrap();
+            let stored = store
+                .approval_credential("my-wallet", "cred-1")
+                .unwrap()
+                .unwrap();
+            assert_eq!(stored.assurance, AssuranceLevel::Hardened);
+            assert_eq!(stored.signer_kind, SignerKind::PasskeyBrowser);
+            assert_eq!(stored.revoked_ms, None);
+            store
+                .revoke_approval_credential("my-wallet", "cred-1", 200)
+                .unwrap();
+        }
+
+        let reopened = AuthStore::open(&path).unwrap();
+        let stored = reopened
+            .approval_credential("my-wallet", "cred-1")
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored.revoked_ms, Some(200));
+    }
+
+    #[test]
+    fn approval_credentials_reject_password_hardened_registration() {
+        let mut store = AuthStore::open_in_memory_for_tests().unwrap();
+        let err = store
+            .register_approval_credential(&ApprovalCredentialRecord {
+                wallet: "my-wallet".into(),
+                credential_id: "cred-1".into(),
+                signer_kind: SignerKind::Password,
+                assurance: AssuranceLevel::Hardened,
+                public_key_json: serde_json::json!({"credential":"placeholder"}),
+                registered_ms: 100,
+                revoked_ms: None,
+            })
+            .unwrap_err();
+        assert!(err.to_string().contains("does not satisfy"), "{err}");
+        assert!(
+            store
+                .approval_credential("my-wallet", "cred-1")
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn hardened_approval_requires_matching_review_session() {
+        let mut store = AuthStore::open_in_memory_for_tests().unwrap();
+        let env = envelope();
+        store
+            .stage_entry(&env, AssuranceLevel::Hardened, 100)
+            .unwrap();
+        store
+            .issue_challenge("requests", "req_1", "nonce-1", 220, 101)
+            .unwrap();
+        let entry = store.auth_entry("requests", "req_1").unwrap().unwrap();
+        let sealed = store.sealed_intent(&entry.intent_hash).unwrap().unwrap();
+        let mut approval = approval_for(&entry, &sealed);
+        approval.signer_kind = SignerKind::PasskeyCtap;
+
+        let err = store
+            .consume_verified_approval_transactionally(&approval, 150)
+            .unwrap_err();
+        assert!(err.to_string().contains("review_session_id"), "{err}");
+        let still_unused = store.auth_entry("requests", "req_1").unwrap().unwrap();
+        assert_eq!(still_unused.nonce_state, NonceState::Unused);
+    }
+
+    #[test]
+    fn hardened_approval_consumes_matching_review_session() {
+        let mut store = AuthStore::open_in_memory_for_tests().unwrap();
+        let env = envelope();
+        store
+            .stage_entry(&env, AssuranceLevel::Hardened, 100)
+            .unwrap();
+        store
+            .issue_challenge("requests", "req_1", "nonce-1", 220, 101)
+            .unwrap();
+        let session = store
+            .issue_review_session("review-1", "requests", "req_1", 220, 102)
+            .unwrap();
+        assert_eq!(session.consumed_ms, None);
+
+        let entry = store.auth_entry("requests", "req_1").unwrap().unwrap();
+        let sealed = store.sealed_intent(&entry.intent_hash).unwrap().unwrap();
+        let mut approval = approval_for(&entry, &sealed);
+        approval.signer_kind = SignerKind::PasskeyCtap;
+        approval.review_session_id = Some("review-1".into());
+
+        store
+            .consume_verified_approval_transactionally(&approval, 150)
+            .unwrap();
+        let consumed_entry = store.auth_entry("requests", "req_1").unwrap().unwrap();
+        assert_eq!(consumed_entry.nonce_state, NonceState::Consumed);
+        let consumed_session = store.review_session("review-1").unwrap().unwrap();
+        assert_eq!(consumed_session.consumed_ms, Some(150));
+
+        let replay = store.consume_verified_approval_transactionally(&approval, 151);
+        assert!(replay.is_err());
+    }
+
+    #[test]
+    fn reservation_totals_count_only_active_rows() {
+        let mut store = AuthStore::open_in_memory_for_tests().unwrap();
+        store
+            .create_reservation("res_1", "my-wallet", "requests", 10, 100)
+            .unwrap();
+        store
+            .create_reservation("res_2", "my-wallet", "hyperliquid", 20, 101)
+            .unwrap();
+        store
+            .create_reservation("res_3", "other-wallet", "requests", 30, 102)
+            .unwrap();
+        assert_eq!(
+            store.active_reservation_total("my-wallet", None).unwrap(),
+            30
+        );
+        assert_eq!(
+            store
+                .active_reservation_total("my-wallet", Some("requests"))
+                .unwrap(),
+            10
+        );
+
+        let committed = store
+            .transition_reservation(
+                "res_1",
+                ReservationState::Active,
+                ReservationState::Committed,
+                110,
+            )
+            .unwrap();
+        assert_eq!(committed.state, ReservationState::Committed);
+        assert_eq!(committed.updated_ms, 110);
+        assert_eq!(
+            store.active_reservation_total("my-wallet", None).unwrap(),
+            20
+        );
+    }
+
+    #[test]
+    fn reservation_state_survives_restart_and_duplicate_ids_fail() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth.sqlite");
+        {
+            let mut store = AuthStore::open(&path).unwrap();
+            store
+                .create_reservation("res_1", "my-wallet", "requests", 10, 100)
+                .unwrap();
+            assert!(
+                store
+                    .create_reservation("res_1", "my-wallet", "requests", 10, 101)
+                    .is_err()
+            );
+            store
+                .transition_reservation(
+                    "res_1",
+                    ReservationState::Active,
+                    ReservationState::Released,
+                    110,
+                )
+                .unwrap();
+        }
+
+        let store = AuthStore::open(&path).unwrap();
+        let reservation = store.reservation("res_1").unwrap().unwrap();
+        assert_eq!(reservation.state, ReservationState::Released);
+        assert_eq!(
+            store.active_reservation_total("my-wallet", None).unwrap(),
+            0
+        );
+    }
+
+    fn valuation_quote() -> ValuationQuote {
+        ValuationQuote {
+            asset_id: "base:0x0000000000000000000000000000000000000001".into(),
+            amount_base_units: "1000000".into(),
+            usd_micro: 1_250_000,
+            source: "test-oracle".into(),
+            quote_timestamp_ms: 1_000,
+            fetched_at_ms: 1_000,
+            max_age_ms: 30_000,
+            confidence_ppm: Some(990_000),
+            stablecoin_assumption: false,
+        }
+    }
+
+    #[test]
+    fn reservation_with_valuation_persists_snapshot_and_uses_quote_amount() {
+        let mut store = AuthStore::open_in_memory_for_tests().unwrap();
+        let policy = ValuationPolicy {
+            min_confidence_ppm: Some(950_000),
+            ..ValuationPolicy::default()
+        };
+        let quote = valuation_quote();
+        let reservation = store
+            .create_reservation_with_valuation(
+                "res_quote",
+                "my-wallet",
+                "requests",
+                &quote,
+                &policy,
+                10_000,
+            )
+            .unwrap();
+        assert_eq!(reservation.amount_micro_usd, quote.usd_micro);
+        assert_eq!(
+            store.active_reservation_total("my-wallet", None).unwrap(),
+            quote.usd_micro
+        );
+        let snapshot = store.valuation_snapshot("res_quote").unwrap().unwrap();
+        assert_eq!(snapshot, quote);
+    }
+
+    #[test]
+    fn stale_valuation_rejects_reservation_without_writing_rows() {
+        let mut store = AuthStore::open_in_memory_for_tests().unwrap();
+        let policy = ValuationPolicy::default();
+        let quote = valuation_quote();
+        let err = store
+            .create_reservation_with_valuation(
+                "res_stale",
+                "my-wallet",
+                "requests",
+                &quote,
+                &policy,
+                40_001,
+            )
+            .unwrap_err();
+        assert!(err.to_string().contains("stale"), "{err}");
+        assert!(store.reservation("res_stale").unwrap().is_none());
+        assert!(store.valuation_snapshot("res_stale").unwrap().is_none());
+    }
+
+    #[test]
+    fn price_adapter_amount_conversion_is_fail_closed() {
+        assert_eq!(amount_to_usd_micro("1000000", 6, 1.25).unwrap(), 1_250_000);
+        assert_eq!(
+            amount_to_usd_micro("1500000000000000000", 18, 2.0).unwrap(),
+            3_000_000
+        );
+        assert!(amount_to_usd_micro("not-a-number", 6, 1.0).is_err());
+        assert!(amount_to_usd_micro("1000000", 6, f64::NAN).is_err());
+        assert!(amount_to_usd_micro("1000000", 6, -1.0).is_err());
+    }
+}

--- a/crates/bloom-daemon/Cargo.toml
+++ b/crates/bloom-daemon/Cargo.toml
@@ -20,6 +20,8 @@ mount = ["bloom-mount/mount"]
 bytecode-decompile = ["bloom-revert/bytecode-decompile"]
 
 [dependencies]
+bloom-auth-api.workspace = true
+bloom-auth.workspace = true
 bloom-proto.workspace = true
 bloom-paid-http.workspace = true
 bloom-keystore.workspace = true

--- a/crates/bloom-daemon/src/ipc.rs
+++ b/crates/bloom-daemon/src/ipc.rs
@@ -27,10 +27,13 @@ use std::sync::Arc;
 
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as B64;
+use bloom_auth_api::{
+    APPROVAL_SCHEMA_V1, Approval, ApprovalCaps, ChallengeRecord, SignerKind, UnsignedApproval,
+};
 use bloom_keystore::{Keystore, WalletKind};
 use bloom_petals::{Capability, PetalError, PetalRunner, RunOptions, VfsHost};
 use bloom_proto::{CeremonyIntent, CeremonyIntentKind};
-use bloom_vfs::{Entry, EntryKind, Handler, HandlerError, Vfs, VfsPath};
+use bloom_vfs::{AuthServices, Entry, EntryKind, Handler, HandlerError, Vfs, VfsPath};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeSet;
@@ -122,6 +125,7 @@ pub struct IpcServer {
     pub chains: Vec<String>,
     keystore: Option<Keystore>,
     petals: Option<PetalRunner>,
+    auth_services: AuthServices,
     /// Pre-wrapped `Arc<Vfs>` for building [`VfsHost`] per `petals.run`.
     /// We keep it next to the bare `vfs` clone so the existing handler
     /// surface stays untouched.
@@ -138,6 +142,7 @@ impl IpcServer {
             chains,
             keystore: None,
             petals: None,
+            auth_services: AuthServices::default(),
             vfs_arc,
             shutdown: Arc::new(Notify::new()),
         }
@@ -155,6 +160,11 @@ impl IpcServer {
     /// `-32601 method not found`.
     pub fn with_petals(mut self, runner: PetalRunner) -> Self {
         self.petals = Some(runner);
+        self
+    }
+
+    pub fn with_auth_services(mut self, auth_services: AuthServices) -> Self {
+        self.auth_services = auth_services;
         self
     }
 
@@ -363,6 +373,7 @@ impl IpcServer {
         let info = keystore
             .info(wallet)
             .map_err(|e: bloom_keystore::KeystoreError| HandlerError::backend(e.to_string()))?;
+        let mut layer_b_approval_written = false;
         match info.kind {
             WalletKind::PasskeyGated => {
                 // A daemon may have a signer cached from a previous ceremony.
@@ -400,7 +411,28 @@ impl IpcServer {
                     })?;
                 if let Some(policy) = edited_policy {
                     bytes = policy.into_bytes();
-                } else if is_outbox_confirm_write(wallet, &path) {
+                } else {
+                    layer_b_approval_written = self
+                        .maybe_sign_layer_b_approval(
+                            keystore,
+                            wallet,
+                            &path,
+                            &bytes,
+                            Some(write_unlocked_intent(
+                                wallet,
+                                &path,
+                                &bytes,
+                                Some(bloom_proto::checksum_address(&info.address)),
+                                keystore.root().parent().map(|home| home.join("outbox")),
+                                keystore.raw_policy(wallet).ok().map(|(p, _)| p).as_deref(),
+                            )),
+                        )
+                        .await?;
+                }
+                if !self.auth_services.is_wired()
+                    && !layer_b_approval_written
+                    && is_outbox_confirm_write(wallet, &path)
+                {
                     if let Some(home) = keystore.root().parent() {
                         persist_outbox_review_approved(
                             wallet,
@@ -415,9 +447,20 @@ impl IpcServer {
                     );
                 }
             }
-            _ => keystore
-                .unlock(wallet, passphrase.unwrap_or(""))
-                .map_err(|e: bloom_keystore::KeystoreError| HandlerError::backend(e.to_string()))?,
+            _ => {
+                keystore.unlock(wallet, passphrase.unwrap_or("")).map_err(
+                    |e: bloom_keystore::KeystoreError| HandlerError::backend(e.to_string()),
+                )?;
+                if self.auth_services.is_wired()
+                    && let Some((challenge_path, _approval_path)) =
+                        layer_b_approval_paths(keystore, wallet, &path, &bytes)
+                    && challenge_path.exists()
+                {
+                    return Err(HandlerError::Unsupported(
+                        "fresh Layer B approval requires a passkey wallet; local password wallets can only auto-confirm actions that remain in policy".into(),
+                    ));
+                }
+            }
         }
         // For a policy-session mint, persist the one-time reviewed-intent approval
         // marker the VFS mint handler requires. The passkey branch bound this exact
@@ -425,6 +468,8 @@ impl IpcServer {
         // proof. Either way a real ceremony happened, so the marker is authorized.
         if is_policy_session_new(wallet, &path)
             && let Some(home) = keystore.root().parent()
+            && !layer_b_approval_written
+            && !self.auth_services.is_wired()
         {
             let intent =
                 bloom_proto::policy_session_mint_intent(wallet, &path.to_string_path(), &bytes);
@@ -440,6 +485,8 @@ impl IpcServer {
         // reuse a cached signer without passing through write_unlocked.
         if let Some(home) = keystore.root().parent()
             && let Some(id) = request_confirm_id(home, &path)
+            && !layer_b_approval_written
+            && !self.auth_services.is_wired()
         {
             let confirm_value = String::from_utf8_lossy(&bytes).trim().to_ascii_lowercase();
             bloom_vfs::handlers::requests::persist_request_confirm_approved(
@@ -450,6 +497,96 @@ impl IpcServer {
             )?;
         }
         self.vfs.write(&path, &bytes).await
+    }
+
+    async fn maybe_sign_layer_b_approval(
+        &self,
+        keystore: &Keystore,
+        wallet: &str,
+        path: &VfsPath,
+        bytes: &[u8],
+        intent: Option<CeremonyIntent>,
+    ) -> Result<bool, HandlerError> {
+        let Some((challenge_path, approval_path)) =
+            layer_b_approval_paths(keystore, wallet, path, bytes)
+        else {
+            return Ok(false);
+        };
+        if !challenge_path.exists() {
+            return Ok(false);
+        }
+        let challenge_body = std::fs::read(&challenge_path)?;
+        let challenge: ChallengeRecord = serde_json::from_slice(&challenge_body)
+            .map_err(|e| HandlerError::backend(format!("read approval challenge: {e}")))?;
+        let sealed = self
+            .auth_services
+            .require_store()?
+            .sealed_intent(&challenge.intent_hash)
+            .await
+            .map_err(|e| HandlerError::backend(format!("read sealed intent: {e}")))?;
+        let review_session_id = if challenge.assurance == bloom_auth_api::AssuranceLevel::Hardened {
+            let review_session_id = hardened_review_session_id(&challenge);
+            self.auth_services
+                .require_writer()?
+                .issue_review_session(
+                    &review_session_id,
+                    &challenge.surface,
+                    &challenge.entry_id,
+                    challenge.expiry_ms,
+                    ipc_now_ms(),
+                )
+                .await
+                .map_err(|e| HandlerError::backend(format!("issue review session: {e}")))?;
+            Some(review_session_id)
+        } else {
+            None
+        };
+        let unsigned = UnsignedApproval {
+            schema: APPROVAL_SCHEMA_V1.into(),
+            wallet: wallet.to_string(),
+            surface: challenge.surface.clone(),
+            entry_id: challenge.entry_id.clone(),
+            intent_hash: challenge.intent_hash.clone(),
+            executor_id: sealed.envelope.header.executor_id.clone(),
+            network: sealed.envelope.header.network.clone(),
+            assurance: challenge.assurance,
+            server_nonce: challenge.server_nonce.clone(),
+            caps: ApprovalCaps::default(),
+            expiry_ms: challenge.expiry_ms,
+            signer_kind: SignerKind::PasskeyBrowser,
+            credential_id: None,
+            review_session_id,
+        };
+        let signature = keystore
+            .sign_approval_with_passkey(wallet, &unsigned, intent)
+            .await
+            .map_err(|e| HandlerError::backend(format!("sign Layer B approval: {e}")))?;
+        let approval = Approval {
+            schema: unsigned.schema,
+            wallet: unsigned.wallet,
+            surface: unsigned.surface,
+            entry_id: unsigned.entry_id,
+            intent_hash: unsigned.intent_hash,
+            executor_id: unsigned.executor_id,
+            network: unsigned.network,
+            assurance: unsigned.assurance,
+            server_nonce: unsigned.server_nonce,
+            caps: unsigned.caps,
+            expiry_ms: unsigned.expiry_ms,
+            signer_kind: unsigned.signer_kind,
+            credential_id: unsigned.credential_id,
+            review_session_id: unsigned.review_session_id,
+            signature,
+        };
+        if let Some(parent) = approval_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(
+            approval_path,
+            serde_json::to_vec_pretty(&approval)
+                .map_err(|e| HandlerError::backend(format!("encode approval: {e}")))?,
+        )?;
+        Ok(true)
     }
 
     async fn do_wallet_sign_policy(&self, params: &Value) -> Result<(), HandlerError> {
@@ -831,6 +968,68 @@ fn is_outbox_confirm_write(wallet: &str, path: &VfsPath) -> bool {
     )
 }
 
+fn layer_b_approval_paths(
+    keystore: &Keystore,
+    wallet: &str,
+    path: &VfsPath,
+    bytes: &[u8],
+) -> Option<(PathBuf, PathBuf)> {
+    let home = keystore.root().parent()?;
+    if let Some(id) = request_confirm_id(home, path) {
+        let dir = home.join("requests").join("pending").join(id);
+        return Some((
+            dir.join("approval_challenge.json"),
+            dir.join("approval.json"),
+        ));
+    }
+    if let Some(dir) = outbox_confirm_dir(wallet, path, &home.join("outbox")) {
+        return Some((
+            dir.join("approval_challenge.json"),
+            dir.join("approval.json"),
+        ));
+    }
+    if is_policy_session_new(wallet, path) {
+        let entry_id = policy_session_entry_id(wallet, bytes);
+        let dir = keystore
+            .root()
+            .join(wallet)
+            .join("policy-session")
+            .join(entry_id);
+        return Some((
+            dir.join("approval_challenge.json"),
+            dir.join("approval.json"),
+        ));
+    }
+    if let Some(dir) = polymarket_onboard_dir(home, wallet, path) {
+        return Some((
+            dir.join("approval_challenge.json"),
+            dir.join("approval.json"),
+        ));
+    }
+    if let Some(dir) = hyperliquid_usd_send_dir(home, wallet, path) {
+        return Some((
+            dir.join("approval_challenge.json"),
+            dir.join("approval.json"),
+        ));
+    }
+    if let Some(dir) = hyperliquid_agent_session_dir(home, wallet, path, bytes) {
+        return Some((
+            dir.join("approval_challenge.json"),
+            dir.join("approval.json"),
+        ));
+    }
+    None
+}
+
+fn policy_session_entry_id(wallet: &str, data: &[u8]) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"bloom.policy_session.entry.v1");
+    hasher.update(wallet.as_bytes());
+    hasher.update(&[0]);
+    hasher.update(data);
+    format!("ps-{}", hasher.finalize().to_hex())
+}
+
 fn outbox_confirm_dir(wallet: &str, path: &VfsPath, outbox_root: &Path) -> Option<PathBuf> {
     let [root, w, chains, chain, outbox, pending, id, confirm] = path.segments() else {
         return None;
@@ -852,6 +1051,93 @@ fn outbox_confirm_dir(wallet: &str, path: &VfsPath, outbox_root: &Path) -> Optio
     } else {
         None
     }
+}
+
+fn polymarket_onboard_dir(home: &Path, wallet: &str, path: &VfsPath) -> Option<PathBuf> {
+    let [root, action, w, leaf] = path.segments() else {
+        return None;
+    };
+    if root == "polymarket" && action == "onboard" && w == wallet && leaf == "begin" {
+        Some(home.join("polymarket").join(safe_layer_b_segment(wallet)?))
+    } else {
+        None
+    }
+}
+
+fn hyperliquid_usd_send_dir(home: &Path, wallet: &str, path: &VfsPath) -> Option<PathBuf> {
+    let [root, network, branch, w, leaf] = path.segments() else {
+        return None;
+    };
+    if root == "hyperliquid" && branch == "exchange" && w == wallet && leaf == "send_asset.json" {
+        Some(
+            home.join("hyperliquid")
+                .join("exchange")
+                .join(safe_layer_b_segment(network)?)
+                .join(safe_layer_b_segment(wallet)?),
+        )
+    } else {
+        None
+    }
+}
+
+fn hyperliquid_agent_session_dir(
+    home: &Path,
+    wallet: &str,
+    path: &VfsPath,
+    bytes: &[u8],
+) -> Option<PathBuf> {
+    let [root, network, branch, w, leaf] = path.segments() else {
+        return None;
+    };
+    if !(root == "hyperliquid" && branch == "agent_sessions" && w == wallet && leaf == "new.json") {
+        return None;
+    }
+    let body: Value = serde_json::from_slice(bytes).ok()?;
+    let session_id = body.get("id")?.as_str()?;
+    Some(
+        home.join("hyperliquid")
+            .join("agent_sessions")
+            .join(safe_layer_b_segment(network)?)
+            .join(safe_layer_b_segment(wallet)?)
+            .join(safe_layer_b_segment(session_id)?),
+    )
+}
+
+fn safe_layer_b_segment(raw: &str) -> Option<String> {
+    if raw.is_empty()
+        || raw == "."
+        || raw == ".."
+        || raw.len() > 128
+        || !raw
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.'))
+    {
+        return None;
+    }
+    Some(raw.to_string())
+}
+
+fn hardened_review_session_id(challenge: &ChallengeRecord) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"bloom.review_session.v1");
+    hasher.update(challenge.surface.as_bytes());
+    hasher.update(&[0]);
+    hasher.update(challenge.entry_id.as_bytes());
+    hasher.update(&[0]);
+    hasher.update(challenge.intent_hash.as_bytes());
+    hasher.update(&[0]);
+    hasher.update(challenge.server_nonce.as_bytes());
+    format!("review-{}", hasher.finalize().to_hex())
+}
+
+fn ipc_now_ms() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
 }
 
 fn persist_outbox_review_intent(

--- a/crates/bloom-daemon/src/lib.rs
+++ b/crates/bloom-daemon/src/lib.rs
@@ -13,6 +13,7 @@ mod price_oracle;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use bloom_auth::{AuthStore, StoreApprovalVerifier};
 use bloom_chain::{ChainClient, ChainRegistry};
 use bloom_chain_node::rpc::{RpcChainAdapter, RpcClient};
 use bloom_chain_types::ssz::Encode;
@@ -22,7 +23,7 @@ use bloom_defi::EnsoClient;
 use bloom_ens::EnsClient;
 use bloom_etherscan::EtherscanClient;
 use bloom_hyperliquid::{HyperliquidClient, HyperliquidNetwork};
-use bloom_keystore::Keystore;
+use bloom_keystore::{Keystore, KeystoreApprovalSignatureVerifier};
 use bloom_paid_http::PaidHttpChainRpcResolver;
 use bloom_petals::{NameRegistry, PetalRunner, PetalStore, PetalVm, PetalsHandler};
 use bloom_polymarket::{ClobClient, CredentialStore, DataClient, GammaClient, GeoblockClient};
@@ -43,7 +44,7 @@ use bloom_vfs::handlers::{
     ToolsHandler, WalletsHandler, WatchHandler,
 };
 use bloom_vfs::tx_handler::PtbSubmitter;
-use bloom_vfs::{HandlerError, PathCache, Vfs};
+use bloom_vfs::{AuthServices, HandlerError, PathCache, Vfs};
 use bloom_watch::{WatchExecutor, WatchRegistry};
 use thiserror::Error;
 use tokio::sync::watch;
@@ -82,6 +83,7 @@ pub struct Daemon {
     pub home_write_permit: Option<Arc<HomeWritePermit>>,
     pub address_book: Arc<AddressBook>,
     pub audit: Arc<AuditLog>,
+    pub auth_services: AuthServices,
     pub vfs: Vfs,
     pub petals: PetalRunner,
     pub watch_registry: Arc<WatchRegistry>,
@@ -277,6 +279,18 @@ impl Daemon {
         let audit =
             AuditLog::open(home.audit_path()).map_err(|e| DaemonError::Audit(e.to_string()))?;
         let audit_arc = Arc::new(audit.clone());
+        let auth_store = AuthStore::open(home.root().join("auth").join("auth.sqlite"))
+            .map_err(|e| DaemonError::Audit(format!("auth store: {e}")))?;
+        let auth_verifier = Arc::new(StoreApprovalVerifier::new(
+            auth_store,
+            KeystoreApprovalSignatureVerifier::new(keystore.clone()),
+        ));
+        tx_engine = tx_engine.with_auth_services(auth_verifier.clone(), auth_verifier.clone());
+        let auth_services = AuthServices::new(
+            Some(auth_verifier.clone()),
+            Some(auth_verifier.clone()),
+            Some(auth_verifier),
+        );
         let path_cache = Arc::new(PathCache::new());
 
         let watch_registry = Arc::new(
@@ -490,6 +504,7 @@ impl Daemon {
             debug!("daemon.hyperliquid_mounted");
             let handler = Arc::new(
                 HyperliquidHandler::new(mainnet, testnet, keystore.clone())
+                    .with_auth_services(auth_services.clone())
                     .with_store_root(home.root().join("hyperliquid")),
             );
             handler.clone().start_monitoring();
@@ -513,6 +528,7 @@ impl Daemon {
                         tx_engine.clone(),
                         address_book.clone(),
                     )
+                    .with_auth_services(auth_services.clone())
                     .with_home_write_permit_opt(home_write_permit.clone())
                     .with_mempool_indexes(mempool_indexes.clone())
                     .with_polymarket_root(home.polymarket_dir())
@@ -528,6 +544,7 @@ impl Daemon {
                         keystore.clone(),
                         config.default_wallet.clone(),
                     )
+                    .with_auth_services(auth_services.clone())
                     .with_paid_http_rpc_resolver(paid_http_rpc_resolver.clone()),
                 ) as _,
             )
@@ -618,6 +635,7 @@ impl Daemon {
                         tx_engine.clone(),
                         address_book_arc.clone(),
                     )
+                    .with_auth_services(auth_services.clone())
                     .with_home_write_permit_opt(home_write_permit.clone())
                     .with_default_chain(config.default_chain.clone())
                     .with_store_root(home.root().join("defi"))
@@ -658,6 +676,7 @@ impl Daemon {
             }
 
             let mut handler = PolymarketHandler::new(gamma, data, clob.clone(), keystore.clone())
+                .with_auth_services(auth_services.clone())
                 .with_order_store(bloom_polymarket::OrderStore::new(home.polymarket_dir()))
                 .with_fund_store(home.polymarket_dir())
                 .with_builder_key_store(bloom_polymarket::BuilderCredentialStore::new(
@@ -701,6 +720,7 @@ impl Daemon {
                                     None => GeoblockClient::new(),
                                 }
                             }),
+                            auth_dir: state_dir.clone(),
                             creds: CredentialStore::new(&state_dir),
                             chain,
                         })
@@ -1043,6 +1063,7 @@ impl Daemon {
             home_write_permit,
             address_book: address_book_arc,
             audit: audit_arc,
+            auth_services,
             vfs,
             petals,
             watch_registry,

--- a/crates/bloom-keystore/Cargo.toml
+++ b/crates/bloom-keystore/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 description = "Encrypted local keystore for bloom"
 
 [dependencies]
+bloom-auth-api.workspace = true
 bloom-chain-types.workspace = true
 bloom-proto.workspace = true
 serde.workspace = true
@@ -27,6 +28,7 @@ ml-dsa.workspace = true
 ed25519-dalek.workspace = true
 
 tokio.workspace = true
+async-trait.workspace = true
 webauthn-rs.workspace = true
 open.workspace = true
 axum.workspace = true
@@ -35,3 +37,4 @@ url.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 reqwest.workspace = true
+sha2.workspace = true

--- a/crates/bloom-keystore/src/lib.rs
+++ b/crates/bloom-keystore/src/lib.rs
@@ -49,6 +49,9 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use zeroize::{Zeroize, Zeroizing};
 
+use bloom_auth_api::{
+    ApprovalSignature, ApprovalSignatureVerifier, AuthApiError, UnsignedApproval,
+};
 use bloom_proto::{Policy, checksum_address};
 
 // ── errors ────────────────────────────────────────────────────────────────────
@@ -928,6 +931,36 @@ impl Keystore {
             policy: default_policy,
             recovery_key: None,
         })
+    }
+}
+
+#[derive(Clone)]
+pub struct KeystoreApprovalSignatureVerifier {
+    keystore: Keystore,
+}
+
+impl KeystoreApprovalSignatureVerifier {
+    pub fn new(keystore: Keystore) -> Self {
+        Self { keystore }
+    }
+}
+
+#[async_trait::async_trait]
+impl ApprovalSignatureVerifier for KeystoreApprovalSignatureVerifier {
+    async fn verify_signature(
+        &self,
+        unsigned: &UnsignedApproval,
+        signature: &ApprovalSignature,
+        _now_ms: u64,
+    ) -> Result<(), AuthApiError> {
+        match self
+            .keystore
+            .verify_approval_signature_with_passkey(unsigned, signature)
+            .await
+        {
+            Ok(()) => Ok(()),
+            Err(e) => Err(AuthApiError::Denied(e.to_string())),
+        }
     }
 }
 

--- a/crates/bloom-keystore/src/passkey.rs
+++ b/crates/bloom-keystore/src/passkey.rs
@@ -38,6 +38,9 @@ use rand::RngCore;
 use url::Url;
 use webauthn_rs::prelude::*;
 
+use bloom_auth_api::{
+    ApprovalSignature, AssuranceLevel, SignerKind, UnsignedApproval, WebAuthnAssertionRecord,
+};
 use bloom_proto::CeremonyIntent;
 
 // ── constants ────────────────────────────────────────────────────────────────
@@ -145,6 +148,90 @@ fn inject_prf_into_challenge_json(
         }
     }
     v
+}
+
+fn patch_request_challenge_json(
+    challenge_json: &str,
+    challenge: &[u8; 32],
+    require_uv: bool,
+) -> Result<String, String> {
+    let challenge_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(challenge);
+    let mut v: serde_json::Value =
+        serde_json::from_str(challenge_json).map_err(|e| e.to_string())?;
+    let Some(pk) = v.get_mut("publicKey").and_then(|v| v.as_object_mut()) else {
+        return Err("challenge JSON missing publicKey object".into());
+    };
+    pk.insert("challenge".into(), serde_json::Value::String(challenge_b64));
+    if require_uv {
+        pk.insert(
+            "userVerification".into(),
+            serde_json::Value::String("required".into()),
+        );
+    }
+    serde_json::to_string(&v).map_err(|e| e.to_string())
+}
+
+/// Layer-B assurance gate on the WebAuthn UV flag: `Hardened` approvals need a
+/// user-verified assertion (PIN/biometric), never a presence-only tap.
+///
+/// webauthn-rs's `Passkey` API currently also enforces UV (its
+/// `start_passkey_authentication` hardcodes `UserVerificationPolicy::Required`),
+/// but that is an implementation detail of the dependency. This gate makes the
+/// hardened-requires-UV invariant explicit in bloom so it survives library
+/// upgrades or a future decision to relax convenience-level ceremonies.
+fn require_user_verification_for_assurance(
+    assurance: AssuranceLevel,
+    user_verified: bool,
+) -> Result<(), String> {
+    if assurance == AssuranceLevel::Hardened && !user_verified {
+        return Err(
+            "hardened approval requires a user-verified WebAuthn assertion \
+             (UV flag not set; presence-only is not sufficient)"
+                .into(),
+        );
+    }
+    Ok(())
+}
+
+fn patch_passkey_authentication_challenge(
+    state: PasskeyAuthentication,
+    challenge: &[u8; 32],
+) -> Result<PasskeyAuthentication, String> {
+    let challenge_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(challenge);
+    let mut v = serde_json::to_value(state).map_err(|e| e.to_string())?;
+    let Some(ast) = v.get_mut("ast").and_then(|v| v.as_object_mut()) else {
+        return Err("passkey authentication state missing ast object".into());
+    };
+    ast.insert("challenge".into(), serde_json::Value::String(challenge_b64));
+    serde_json::from_value(v).map_err(|e| e.to_string())
+}
+
+fn b64_field(value: &impl serde::Serialize, field: &'static str) -> Result<String, String> {
+    serde_json::to_value(value)
+        .map_err(|e| format!("{field}: {e}"))?
+        .as_str()
+        .map(str::to_string)
+        .ok_or_else(|| format!("{field}: expected base64 string"))
+}
+
+fn webauthn_assertion_record(
+    credential: &PublicKeyCredential,
+) -> Result<WebAuthnAssertionRecord, String> {
+    Ok(WebAuthnAssertionRecord {
+        credential_id: credential.id.clone(),
+        authenticator_data_b64: b64_field(
+            &credential.response.authenticator_data,
+            "authenticatorData",
+        )?,
+        client_data_json_b64: b64_field(&credential.response.client_data_json, "clientDataJSON")?,
+        signature_b64: b64_field(&credential.response.signature, "signature")?,
+        user_handle_b64: credential
+            .response
+            .user_handle
+            .as_ref()
+            .map(|v| b64_field(v, "userHandle"))
+            .transpose()?,
+    })
 }
 
 /// Bind a local TCP listener on `127.0.0.1:{port}`. `ctx` is used in error
@@ -333,21 +420,34 @@ pub(crate) async fn register_ceremony(
 /// If `prf_salt` is `None` (legacy/non-PRF path), no PRF extension is
 /// injected and the second element of the return tuple is `None`.
 ///
-/// Returns `(AuthenticationResult, Option<prf_output>, Option<edited_policy>)`.
+pub(crate) struct AuthCeremonyResult {
+    auth_result: AuthenticationResult,
+    prf_output: Option<[u8; 32]>,
+    edited_policy: Option<String>,
+    credential: PublicKeyCredential,
+}
+
+/// Returns a verified authentication ceremony result.
 /// The caller must update the credential counter if `auth_result.needs_update()`.
 pub(crate) async fn auth_ceremony(
     credential: &Passkey,
     prf_salt: Option<&[u8; 32]>,
     intent: Option<CeremonyIntent>,
     editable_policy: Option<String>,
-) -> Result<(AuthenticationResult, Option<[u8; 32]>, Option<String>), String> {
+    challenge_override: Option<[u8; 32]>,
+    require_uv: bool,
+) -> Result<AuthCeremonyResult, String> {
     let webauthn = build_webauthn()?;
 
-    let (rcr, auth_state) = webauthn
+    let (rcr, mut auth_state) = webauthn
         .start_passkey_authentication(std::slice::from_ref(credential))
         .map_err(|e| format!("start_passkey_authentication: {e}"))?;
 
     let mut challenge_json = serde_json::to_string(&rcr).map_err(|e| e.to_string())?;
+    if let Some(challenge) = challenge_override {
+        challenge_json = patch_request_challenge_json(&challenge_json, &challenge, require_uv)?;
+        auth_state = patch_passkey_authentication_challenge(auth_state, &challenge)?;
+    }
 
     // Inject PRF extension if a salt is provided.
     if let Some(salt) = prf_salt {
@@ -423,7 +523,12 @@ pub(crate) async fn auth_ceremony(
 
     let prf_output = state.prf_output.lock().take();
     let edited_policy = state.editable_policy.lock().take();
-    Ok((auth_result, prf_output, edited_policy))
+    Ok(AuthCeremonyResult {
+        auth_result,
+        prf_output,
+        edited_policy,
+        credential: pkc,
+    })
 }
 
 // ── axum apps ─────────────────────────────────────────────────────────────────
@@ -1348,6 +1453,10 @@ fn unique_rebind_backup_dir(root: &std::path::Path, name: &str) -> std::path::Pa
 // ── impl Keystore — passkey operations ───────────────────────────────────────
 
 impl super::Keystore {
+    fn from_auth_api(err: bloom_auth_api::AuthApiError) -> KeystoreError {
+        KeystoreError::PasskeyCredential(err.to_string())
+    }
+
     /// Inner: write wallet files and run the registration ceremony.
     /// Called by `create_passkey` and `import_passkey`.
     pub(super) async fn import_passkey_inner(
@@ -1544,23 +1653,30 @@ impl super::Keystore {
 
         // Authentication ceremony — injects the PRF salt into the challenge.
         // Returns (auth_result, Some(prf_output)).
-        let (auth_result, prf_output_opt, edited_policy) =
-            auth_ceremony(&credential, Some(&prf_salt), intent, editable_policy)
-                .await
-                .map_err(KeystoreError::PasskeyCeremony)?;
+        let ceremony = auth_ceremony(
+            &credential,
+            Some(&prf_salt),
+            intent,
+            editable_policy,
+            None,
+            false,
+        )
+        .await
+        .map_err(KeystoreError::PasskeyCeremony)?;
 
         // Persist updated counter if the authenticator incremented it. This
         // happens before the decrypt below; if decryption later fails the
         // monotonic counter is harmlessly bumped (no security impact — it only
         // ever moves forward) while the unlock still returns an error.
-        if auth_result.needs_update() {
-            credential.update_credential(&auth_result);
+        if ceremony.auth_result.needs_update() {
+            credential.update_credential(&ceremony.auth_result);
             let updated_json = serde_json::to_string(&credential)
                 .map_err(|e| KeystoreError::Malformed(format!("passkey re-serialise: {e}")))?;
             write_atomic(&dir.join("passkey.json"), updated_json.as_bytes())?;
         }
 
-        let mut prf_output = prf_output_opt
+        let mut prf_output = ceremony
+            .prf_output
             .ok_or_else(|| KeystoreError::PasskeyCeremony(PRF_NOT_SUPPORTED_MSG.into()))?;
 
         let enc_blob =
@@ -1584,7 +1700,146 @@ impl super::Keystore {
             .write()
             .insert(name.to_string(), Arc::new(signer));
         tracing::debug!(wallet = name, "keystore.passkey_unlocked");
-        Ok(edited_policy)
+        Ok(ceremony.edited_policy)
+    }
+
+    /// Run a passkey ceremony whose WebAuthn challenge is the Layer-B approval
+    /// payload hash, returning the verified assertion as an approval signature.
+    ///
+    /// This does not decrypt or cache the wallet signing key. It proves user
+    /// presence/verification for the approval payload itself, so the resulting
+    /// assertion can authorize out-of-policy or authority-changing actions
+    /// without making the wallet key resident in daemon memory.
+    pub async fn sign_approval_with_passkey(
+        &self,
+        name: &str,
+        unsigned: &UnsignedApproval,
+        intent: Option<bloom_proto::CeremonyIntent>,
+    ) -> Result<ApprovalSignature, KeystoreError> {
+        Self::validate_name(name)?;
+        let dir = self.wallet_path(name);
+        if !dir.exists() {
+            return Err(KeystoreError::NotFound(name.into()));
+        }
+        let kind_str = read_trim(&dir.join("kind"))?;
+        if kind_str != "passkey" {
+            return Err(KeystoreError::PasskeyCredential(format!(
+                "approval signing requires a passkey wallet (wallet '{name}' is '{kind_str}')"
+            )));
+        }
+        if unsigned.wallet != name {
+            return Err(KeystoreError::PasskeyCredential(format!(
+                "approval wallet '{}' does not match passkey wallet '{name}'",
+                unsigned.wallet
+            )));
+        }
+        if !matches!(
+            unsigned.signer_kind,
+            SignerKind::PasskeyBrowser | SignerKind::PasskeyCtap
+        ) {
+            return Err(KeystoreError::PasskeyCredential(format!(
+                "approval signer_kind {:?} is not a passkey signer",
+                unsigned.signer_kind
+            )));
+        }
+
+        let passkey_json = std::fs::read_to_string(dir.join("passkey.json")).map_err(|source| {
+            KeystoreError::Io {
+                path: dir.join("passkey.json"),
+                source,
+            }
+        })?;
+        let mut credential: Passkey = serde_json::from_str(&passkey_json)
+            .map_err(|e| KeystoreError::PasskeyCredential(e.to_string()))?;
+        let challenge = unsigned.challenge_hash().map_err(Self::from_auth_api)?;
+        let require_uv = unsigned.assurance == AssuranceLevel::Hardened;
+        let ceremony = auth_ceremony(&credential, None, intent, None, Some(challenge), require_uv)
+            .await
+            .map_err(KeystoreError::PasskeyCeremony)?;
+
+        if ceremony.auth_result.needs_update() {
+            credential.update_credential(&ceremony.auth_result);
+            let updated_json = serde_json::to_string(&credential)
+                .map_err(|e| KeystoreError::Malformed(format!("passkey re-serialise: {e}")))?;
+            write_atomic(&dir.join("passkey.json"), updated_json.as_bytes())?;
+        }
+
+        require_user_verification_for_assurance(
+            unsigned.assurance,
+            ceremony.auth_result.user_verified(),
+        )
+        .map_err(KeystoreError::PasskeyCredential)?;
+
+        let assertion = webauthn_assertion_record(&ceremony.credential)
+            .map_err(KeystoreError::PasskeyCredential)?;
+        ApprovalSignature::WebAuthnAssertion(assertion.clone())
+            .validate_for_unsigned(unsigned)
+            .map_err(Self::from_auth_api)?;
+        Ok(ApprovalSignature::WebAuthnAssertion(assertion))
+    }
+
+    pub async fn verify_approval_signature_with_passkey(
+        &self,
+        unsigned: &UnsignedApproval,
+        signature: &ApprovalSignature,
+    ) -> Result<(), KeystoreError> {
+        signature
+            .validate_for_unsigned(unsigned)
+            .map_err(Self::from_auth_api)?;
+        let ApprovalSignature::WebAuthnAssertion(assertion) = signature else {
+            return Err(KeystoreError::PasskeyCredential(
+                "approval signature is not a WebAuthn assertion".into(),
+            ));
+        };
+        Self::validate_name(&unsigned.wallet)?;
+        let dir = self.wallet_path(&unsigned.wallet);
+        let passkey_json = std::fs::read_to_string(dir.join("passkey.json")).map_err(|source| {
+            KeystoreError::Io {
+                path: dir.join("passkey.json"),
+                source,
+            }
+        })?;
+        let mut credential: Passkey = serde_json::from_str(&passkey_json)
+            .map_err(|e| KeystoreError::PasskeyCredential(e.to_string()))?;
+        let webauthn = build_webauthn().map_err(KeystoreError::PasskeyCredential)?;
+        let (_rcr, auth_state) = webauthn
+            .start_passkey_authentication(std::slice::from_ref(&credential))
+            .map_err(|e| {
+                KeystoreError::PasskeyCredential(format!("start_passkey_authentication: {e}"))
+            })?;
+        let challenge = unsigned.challenge_hash().map_err(Self::from_auth_api)?;
+        let auth_state = patch_passkey_authentication_challenge(auth_state, &challenge)
+            .map_err(KeystoreError::PasskeyCredential)?;
+        let mut response = serde_json::json!({
+            "authenticatorData": assertion.authenticator_data_b64,
+            "clientDataJSON": assertion.client_data_json_b64,
+            "signature": assertion.signature_b64,
+        });
+        if let Some(user_handle) = &assertion.user_handle_b64 {
+            response["userHandle"] = serde_json::Value::String(user_handle.clone());
+        }
+        let pkc_value = serde_json::json!({
+            "id": assertion.credential_id,
+            "rawId": assertion.credential_id,
+            "type": "public-key",
+            "response": response,
+        });
+        let pkc: PublicKeyCredential = serde_json::from_value(pkc_value)
+            .map_err(|e| KeystoreError::PasskeyCredential(e.to_string()))?;
+        let auth_result = webauthn
+            .finish_passkey_authentication(&pkc, &auth_state)
+            .map_err(|e| {
+                KeystoreError::PasskeyCredential(format!("finish_passkey_authentication: {e}"))
+            })?;
+        require_user_verification_for_assurance(unsigned.assurance, auth_result.user_verified())
+            .map_err(KeystoreError::PasskeyCredential)?;
+        if auth_result.needs_update() {
+            credential.update_credential(&auth_result);
+            let updated_json = serde_json::to_string(&credential)
+                .map_err(|e| KeystoreError::Malformed(format!("passkey re-serialise: {e}")))?;
+            write_atomic(&dir.join("passkey.json"), updated_json.as_bytes())?;
+        }
+        Ok(())
     }
 
     /// Re-bind a PRF-based passkey wallet to a new passkey credential.
@@ -1818,6 +2073,52 @@ mod ceremony_gate_tests {
 
     fn client() -> reqwest::Client {
         reqwest::Client::new()
+    }
+
+    #[test]
+    fn approval_challenge_patch_updates_request_json() {
+        let challenge = [7u8; 32];
+        let challenge_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(challenge);
+        let patched = patch_request_challenge_json(
+            r#"{"publicKey":{"challenge":"AAAA","timeout":60000}}"#,
+            &challenge,
+            false,
+        )
+        .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&patched).unwrap();
+        assert_eq!(
+            v["publicKey"]["challenge"].as_str(),
+            Some(challenge_b64.as_str())
+        );
+        assert!(v["publicKey"].get("userVerification").is_none());
+    }
+
+    #[test]
+    fn approval_challenge_patch_requires_uv_for_hardened() {
+        let challenge = [7u8; 32];
+        let patched = patch_request_challenge_json(
+            r#"{"publicKey":{"challenge":"AAAA","timeout":60000}}"#,
+            &challenge,
+            true,
+        )
+        .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&patched).unwrap();
+        assert_eq!(
+            v["publicKey"]["userVerification"].as_str(),
+            Some("required")
+        );
+    }
+
+    #[test]
+    fn hardened_assurance_requires_user_verified_flag() {
+        assert!(require_user_verification_for_assurance(AssuranceLevel::Hardened, true).is_ok());
+        assert!(
+            require_user_verification_for_assurance(AssuranceLevel::Convenience, false).is_ok()
+        );
+        assert!(require_user_verification_for_assurance(AssuranceLevel::Convenience, true).is_ok());
+        let err =
+            require_user_verification_for_assurance(AssuranceLevel::Hardened, false).unwrap_err();
+        assert!(err.contains("user-verified"), "{err}");
     }
 
     /// The core safety invariant: no WebAuthn challenge is served before the
@@ -2104,5 +2405,203 @@ mod ceremony_gate_tests {
         // and review state is unchanged
         assert!(!*state.reviewed.lock());
         state.shutdown.notify_one();
+    }
+}
+
+/// End-to-end UV enforcement tests using a software Ed25519 WebAuthn
+/// credential registered *without* UV (`user_verified: false`, policy
+/// `preferred`). They pin the invariant that a presence-only assertion never
+/// authorizes an approval: today webauthn-rs's hardcoded Required policy
+/// rejects it first, and `require_user_verification_for_assurance` keeps the
+/// hardened guarantee even if that library default ever changes.
+#[cfg(test)]
+mod approval_uv_tests {
+    use super::*;
+    use bloom_auth_api::{APPROVAL_SCHEMA_V1, ApprovalCaps};
+    use ed25519_dalek::Signer as _;
+    use sha2::{Digest, Sha256};
+
+    const UP: u8 = 0x01;
+    const UV: u8 = 0x04;
+
+    fn unsigned_approval(wallet: &str, assurance: AssuranceLevel) -> UnsignedApproval {
+        UnsignedApproval {
+            schema: APPROVAL_SCHEMA_V1.into(),
+            wallet: wallet.into(),
+            surface: "outbox".into(),
+            entry_id: "tx_1".into(),
+            intent_hash: "0".repeat(64),
+            executor_id: "evm".into(),
+            network: "base".into(),
+            assurance,
+            server_nonce: "nonce-1".into(),
+            caps: ApprovalCaps::default(),
+            expiry_ms: u64::MAX,
+            signer_kind: SignerKind::PasskeyBrowser,
+            credential_id: None,
+            review_session_id: None,
+        }
+    }
+
+    fn wallet_with_software_credential(
+        root: &std::path::Path,
+        wallet: &str,
+    ) -> ed25519_dalek::SigningKey {
+        let dir = root.join(wallet);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("kind"), "passkey\n").unwrap();
+        let signing = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]);
+        let cose = COSEKey {
+            type_: COSEAlgorithm::EDDSA,
+            key: COSEKeyType::EC_OKP(COSEOKPKey {
+                curve: EDDSACurve::ED25519,
+                x: signing.verifying_key().to_bytes().to_vec().into(),
+            }),
+        };
+        let passkey_json = serde_json::json!({
+            "cred": {
+                "cred_id": Base64UrlSafeData::from(b"cred-uv-test".to_vec()),
+                "cred": cose,
+                "counter": 0,
+                "transports": null,
+                "user_verified": false,
+                "backup_eligible": false,
+                "backup_state": false,
+                "registration_policy": "preferred",
+                "extensions": {},
+                "attestation": ParsedAttestation::default(),
+                "attestation_format": AttestationFormat::None,
+            }
+        });
+        std::fs::write(
+            dir.join("passkey.json"),
+            serde_json::to_vec(&passkey_json).unwrap(),
+        )
+        .unwrap();
+        signing
+    }
+
+    fn assertion_with_flags(
+        signing: &ed25519_dalek::SigningKey,
+        unsigned: &UnsignedApproval,
+        flags: u8,
+    ) -> ApprovalSignature {
+        let b64 = |b: &[u8]| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b);
+        let challenge = unsigned.challenge_hash().unwrap();
+        let client_data = serde_json::json!({
+            "type": "webauthn.get",
+            "challenge": b64(&challenge),
+            "origin": format!("http://localhost:{CEREMONY_PORT}"),
+            "crossOrigin": false,
+        });
+        let client_data_bytes = serde_json::to_vec(&client_data).unwrap();
+        let mut auth_data = Vec::with_capacity(37);
+        auth_data.extend_from_slice(&Sha256::digest(RP_ID.as_bytes()));
+        auth_data.push(flags);
+        auth_data.extend_from_slice(&0u32.to_be_bytes());
+        let mut signed = auth_data.clone();
+        signed.extend_from_slice(&Sha256::digest(&client_data_bytes));
+        let signature = signing.sign(&signed);
+        ApprovalSignature::WebAuthnAssertion(WebAuthnAssertionRecord {
+            credential_id: b64(b"cred-uv-test"),
+            authenticator_data_b64: b64(&auth_data),
+            client_data_json_b64: b64(&client_data_bytes),
+            signature_b64: b64(&signature.to_bytes()),
+            user_handle_b64: None,
+        })
+    }
+
+    #[tokio::test]
+    async fn hardened_verification_rejects_presence_only_assertion() {
+        let td = tempfile::tempdir().unwrap();
+        let ks = crate::Keystore::new(td.path()).unwrap();
+        let signing = wallet_with_software_credential(td.path(), "uv-wallet");
+        let unsigned = unsigned_approval("uv-wallet", AssuranceLevel::Hardened);
+        let signature = assertion_with_flags(&signing, &unsigned, UP);
+        let err = ks
+            .verify_approval_signature_with_passkey(&unsigned, &signature)
+            .await
+            .unwrap_err();
+        // Rejected by webauthn-rs's Required policy today; the assurance gate
+        // gives the same answer if the library default ever changes.
+        assert!(err.to_string().contains("verified"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn hardened_verification_accepts_user_verified_assertion() {
+        let td = tempfile::tempdir().unwrap();
+        let ks = crate::Keystore::new(td.path()).unwrap();
+        let signing = wallet_with_software_credential(td.path(), "uv-wallet");
+        let unsigned = unsigned_approval("uv-wallet", AssuranceLevel::Hardened);
+        let signature = assertion_with_flags(&signing, &unsigned, UP | UV);
+        ks.verify_approval_signature_with_passkey(&unsigned, &signature)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn convenience_verification_currently_rejects_presence_only_assertion() {
+        let td = tempfile::tempdir().unwrap();
+        let ks = crate::Keystore::new(td.path()).unwrap();
+        let signing = wallet_with_software_credential(td.path(), "uv-wallet");
+        let unsigned = unsigned_approval("uv-wallet", AssuranceLevel::Convenience);
+        let signature = assertion_with_flags(&signing, &unsigned, UP);
+        // Stricter than the Decision 4 minimum (convenience may accept
+        // presence-only): the shared ceremony policy requires UV for every
+        // assertion. Relaxing convenience is a deliberate future change; this
+        // test makes sure it doesn't happen by accident.
+        let err = ks
+            .verify_approval_signature_with_passkey(&unsigned, &signature)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("verified"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn convenience_verification_accepts_user_verified_assertion() {
+        let td = tempfile::tempdir().unwrap();
+        let ks = crate::Keystore::new(td.path()).unwrap();
+        let signing = wallet_with_software_credential(td.path(), "uv-wallet");
+        let unsigned = unsigned_approval("uv-wallet", AssuranceLevel::Convenience);
+        let signature = assertion_with_flags(&signing, &unsigned, UP | UV);
+        ks.verify_approval_signature_with_passkey(&unsigned, &signature)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn verification_rejects_tampered_assertion_signature() {
+        let td = tempfile::tempdir().unwrap();
+        let ks = crate::Keystore::new(td.path()).unwrap();
+        let signing = wallet_with_software_credential(td.path(), "uv-wallet");
+        let unsigned = unsigned_approval("uv-wallet", AssuranceLevel::Convenience);
+        let other = unsigned_approval("uv-wallet", AssuranceLevel::Hardened);
+        // Assertion minted for a different approval payload must not verify,
+        // even though it is a valid signature from the right credential.
+        let ApprovalSignature::WebAuthnAssertion(mut record) =
+            assertion_with_flags(&signing, &other, UP | UV)
+        else {
+            unreachable!()
+        };
+        let challenge = unsigned.challenge_hash().unwrap();
+        let client_data = serde_json::json!({
+            "type": "webauthn.get",
+            "challenge": base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(challenge),
+            "origin": format!("http://localhost:{CEREMONY_PORT}"),
+            "crossOrigin": false,
+        });
+        record.client_data_json_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(serde_json::to_vec(&client_data).unwrap());
+        let err = ks
+            .verify_approval_signature_with_passkey(
+                &unsigned,
+                &ApprovalSignature::WebAuthnAssertion(record),
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("finish_passkey_authentication"),
+            "{err}"
+        );
     }
 }

--- a/crates/bloom-paid-http/src/lib.rs
+++ b/crates/bloom-paid-http/src/lib.rs
@@ -522,7 +522,34 @@ pub fn extract_realm(s: &str) -> Option<String> {
 pub struct PolicyCheck {
     pub rule: String,
     pub result: String,
+    #[serde(default)]
+    pub class: PolicyRuleClass,
     pub detail: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PolicyRuleClass {
+    Informational,
+    Soft,
+    Hard,
+}
+
+impl Default for PolicyRuleClass {
+    fn default() -> Self {
+        Self::Hard
+    }
+}
+
+impl PolicyRuleClass {
+    fn for_result(result: &str) -> Self {
+        match result {
+            "pass" => Self::Informational,
+            "warn" => Self::Soft,
+            "deny" => Self::Hard,
+            _ => Self::Hard,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -714,16 +741,17 @@ pub fn evaluate_payment_policy(policy: &Policy, input: PolicyEvalInput<'_>) -> V
 }
 
 fn push_check(out: &mut Vec<PolicyCheck>, rule: &str, pass_ok: bool, detail: String, warn: bool) {
+    let result = if pass_ok {
+        "pass"
+    } else if warn {
+        "warn"
+    } else {
+        "deny"
+    };
     out.push(PolicyCheck {
         rule: rule.into(),
-        result: if pass_ok {
-            "pass"
-        } else if warn {
-            "warn"
-        } else {
-            "deny"
-        }
-        .into(),
+        result: result.into(),
+        class: PolicyRuleClass::for_result(result),
         detail,
     });
 }
@@ -732,6 +760,7 @@ fn pass(rule: &str, detail: impl Into<String>) -> PolicyCheck {
     PolicyCheck {
         rule: rule.into(),
         result: "pass".into(),
+        class: PolicyRuleClass::Informational,
         detail: detail.into(),
     }
 }
@@ -739,6 +768,7 @@ fn warn_check(rule: &str, detail: impl Into<String>) -> PolicyCheck {
     PolicyCheck {
         rule: rule.into(),
         result: "warn".into(),
+        class: PolicyRuleClass::Soft,
         detail: detail.into(),
     }
 }
@@ -746,6 +776,7 @@ fn deny(rule: &str, detail: impl Into<String>) -> PolicyCheck {
     PolicyCheck {
         rule: rule.into(),
         result: "deny".into(),
+        class: PolicyRuleClass::Hard,
         detail: detail.into(),
     }
 }
@@ -823,19 +854,23 @@ pub fn evaluate_session_policy(
         out.push(PolicyCheck {
             rule: "payments.sessions.enabled".into(),
             result: "deny".into(),
+            class: PolicyRuleClass::Hard,
             detail: "wallet policy has not enabled payment sessions".into(),
         });
     } else {
         out.push(PolicyCheck {
             rule: "payments.sessions.enabled".into(),
             result: "pass".into(),
+            class: PolicyRuleClass::Informational,
             detail: "payment sessions enabled".into(),
         });
     }
     if let (Some(deposit), Some(cap)) = (challenge.deposit_usd, sessions.max_deposit_usd) {
+        let result = if deposit > cap { "deny" } else { "pass" };
         out.push(PolicyCheck {
             rule: "payments.sessions.max_deposit_usd".into(),
-            result: if deposit > cap { "deny" } else { "pass" }.into(),
+            result: result.into(),
+            class: PolicyRuleClass::for_result(result),
             detail: format!(
                 "{} {} {}",
                 trim_money(deposit),
@@ -846,9 +881,11 @@ pub fn evaluate_session_policy(
     }
     if let (Some(amount), Some(cap)) = (challenge.amount_usd, sessions.max_session_spend_usd) {
         let projected = already_spent_usd + amount;
+        let result = if projected > cap { "deny" } else { "pass" };
         out.push(PolicyCheck {
             rule: "payments.sessions.max_session_spend_usd".into(),
-            result: if projected > cap { "deny" } else { "pass" }.into(),
+            result: result.into(),
+            class: PolicyRuleClass::for_result(result),
             detail: format!(
                 "projected cumulative {} {} {}",
                 trim_money(projected),

--- a/crates/bloom-proto/Cargo.toml
+++ b/crates/bloom-proto/Cargo.toml
@@ -11,6 +11,7 @@ serde_json.workspace = true
 toml.workspace = true
 thiserror.workspace = true
 anyhow.workspace = true
+bloom-auth-api.workspace = true
 hex.workspace = true
 blake3.workspace = true
 sha3.workspace = true

--- a/crates/bloom-proto/src/hyperliquid_policy.rs
+++ b/crates/bloom-proto/src/hyperliquid_policy.rs
@@ -61,6 +61,14 @@ pub struct HyperliquidPolicy {
     /// Max single transfer, micro-USD (enforced once a transfer action lands).
     #[serde(default, with = "crate::serde_micro")]
     pub transfer_cap_usd: Option<u64>,
+    /// Permitted Hyperliquid `usdSend` destinations. Empty means no
+    /// destination is authorized for auto-sign/session use.
+    #[serde(default)]
+    pub allowed_usd_send_destinations: BTreeSet<String>,
+    /// Explicitly blocked Hyperliquid `usdSend` destinations. Deny wins over
+    /// allow.
+    #[serde(default)]
+    pub denied_usd_send_destinations: BTreeSet<String>,
     /// Max bounded-session duration in seconds (consumed by Phase 2 sessions).
     #[serde(default)]
     pub max_session_secs: Option<u64>,
@@ -89,6 +97,8 @@ impl HyperliquidPolicy {
             || self.max_leverage.is_some()
             || self.withdrawal_cap_usd.is_some()
             || self.transfer_cap_usd.is_some()
+            || !self.allowed_usd_send_destinations.is_empty()
+            || !self.denied_usd_send_destinations.is_empty()
             || self.max_session_secs.is_some()
             || !self.allow_reduce_only
             || !self.allow_trigger_orders
@@ -136,6 +146,8 @@ impl Default for HyperliquidPolicy {
             max_leverage: None,
             withdrawal_cap_usd: None,
             transfer_cap_usd: None,
+            allowed_usd_send_destinations: BTreeSet::new(),
+            denied_usd_send_destinations: BTreeSet::new(),
             max_session_secs: None,
             allow_reduce_only: true,
             allow_trigger_orders: true,
@@ -163,6 +175,8 @@ pub struct HyperliquidActionCtx {
     pub leverage: Option<u32>,
     /// Order notional (size × price), micro-USD, when computable.
     pub notional_microusd: Option<u64>,
+    /// Destination address for transfer-like actions such as `usdSend`.
+    pub destination: Option<String>,
     // ── caller-fetched live snapshot ──
     /// Current absolute position notional for `asset`, micro-USD.
     pub position_microusd: Option<u64>,
@@ -239,6 +253,59 @@ fn push_vault_check(
     }
 }
 
+fn push_usd_send_destination_check(
+    out: &mut Vec<PolicyCheck>,
+    policy: &HyperliquidPolicy,
+    ctx: &HyperliquidActionCtx,
+) {
+    let Some(destination) = ctx.destination.as_deref().map(normalize_destination) else {
+        out.push(check(
+            "usd_send_destination",
+            PolicyOutcome::Deny,
+            "usdSend destination is unknown; fail closed",
+        ));
+        return;
+    };
+    if contains_destination(&policy.denied_usd_send_destinations, &destination) {
+        out.push(check(
+            "usd_send_destination",
+            PolicyOutcome::Deny,
+            format!("{destination} is denied for usdSend"),
+        ));
+        return;
+    }
+    if policy.allowed_usd_send_destinations.is_empty() {
+        out.push(check(
+            "usd_send_destination",
+            PolicyOutcome::Deny,
+            "usdSend requires allowed_usd_send_destinations in [hyperliquid] policy",
+        ));
+        return;
+    }
+    if contains_destination(&policy.allowed_usd_send_destinations, &destination) {
+        out.push(check(
+            "usd_send_destination",
+            PolicyOutcome::Pass,
+            format!("{destination} is allowed for usdSend"),
+        ));
+    } else {
+        out.push(check(
+            "usd_send_destination",
+            PolicyOutcome::Deny,
+            format!("{destination} is not in allowed_usd_send_destinations"),
+        ));
+    }
+}
+
+fn contains_destination(list: &BTreeSet<String>, destination: &str) -> bool {
+    list.iter()
+        .any(|candidate| normalize_destination(candidate) == destination)
+}
+
+fn normalize_destination(destination: &str) -> String {
+    destination.trim().to_ascii_lowercase()
+}
+
 /// Evaluate one Hyperliquid action. Returns the full check list (passes
 /// included). Deny-level outcomes are not CLI-bypassable; `Warn` is.
 pub fn evaluate_hyperliquid_action(
@@ -259,31 +326,40 @@ pub fn evaluate_hyperliquid_action(
         }
         "usdSend" => {
             // Owner-signed internal USDC transfer. Requires transfer_cap_usd;
-            // no cap configured = deny (transfers are opt-in, not default-allow).
-            return match policy.transfer_cap_usd {
-                None => vec![check(
+            // no cap configured = deny. It also requires a destination allowlist
+            // match so in-policy cannot mean "send capped funds anywhere".
+            let mut checks = Vec::new();
+            checks.push(check(
+                "action",
+                PolicyOutcome::Pass,
+                "action 'usdSend' is recognized",
+            ));
+            match policy.transfer_cap_usd {
+                None => checks.push(check(
                     "action",
                     PolicyOutcome::Deny,
                     "usdSend requires transfer_cap_usd in the wallet [hyperliquid] policy",
-                )],
+                )),
                 Some(cap) => match ctx.notional_microusd {
-                    Some(amount) if amount > cap => vec![check(
+                    Some(amount) if amount > cap => checks.push(check(
                         "transfer_cap_usd",
                         PolicyOutcome::Deny,
                         format!("transfer {} exceeds cap {}", fmt_usd(amount), fmt_usd(cap)),
-                    )],
-                    Some(amount) => vec![check(
+                    )),
+                    Some(amount) => checks.push(check(
                         "transfer_cap_usd",
                         PolicyOutcome::Pass,
                         format!("transfer {} within cap {}", fmt_usd(amount), fmt_usd(cap)),
-                    )],
-                    None => vec![check(
+                    )),
+                    None => checks.push(check(
                         "transfer_cap_usd",
                         PolicyOutcome::Deny,
                         "transfer amount unknown; fail closed",
-                    )],
+                    )),
                 },
-            };
+            }
+            push_usd_send_destination_check(&mut checks, policy, ctx);
+            return checks;
         }
         "withdraw" | "withdraw3" | "spotSend" | "usdClassTransfer" | "agentSendAsset" => {
             // Not yet policy-enforced; deny until mapped.
@@ -565,7 +641,7 @@ mod tests {
     }
 
     #[test]
-    fn usd_send_allowed_within_transfer_cap() {
+    fn usd_send_requires_transfer_cap_and_allowed_destination() {
         let p = HyperliquidPolicy {
             transfer_cap_usd: Some(200 * MICRO_USD),
             ..Default::default()
@@ -573,13 +649,61 @@ mod tests {
         let mut ctx = order_ctx("BTC");
         ctx.action_kind = "usdSend".into();
         ctx.notional_microusd = Some(100 * MICRO_USD);
+        ctx.destination = Some("0xabc".into());
+        assert!(denied(&evaluate_hyperliquid_action(&p, &ctx)));
+
+        let p = HyperliquidPolicy {
+            transfer_cap_usd: Some(200 * MICRO_USD),
+            allowed_usd_send_destinations: BTreeSet::from(["0xAbC".to_string()]),
+            ..Default::default()
+        };
         assert!(!denied(&evaluate_hyperliquid_action(&p, &ctx)));
 
         // Over the cap.
         let mut ctx2 = order_ctx("BTC");
         ctx2.action_kind = "usdSend".into();
         ctx2.notional_microusd = Some(300 * MICRO_USD);
+        ctx2.destination = Some("0xabc".into());
         assert!(denied(&evaluate_hyperliquid_action(&p, &ctx2)));
+
+        let p = HyperliquidPolicy {
+            transfer_cap_usd: Some(200 * MICRO_USD),
+            allowed_usd_send_destinations: BTreeSet::from(["0xabc".to_string()]),
+            denied_usd_send_destinations: BTreeSet::from(["0xABC".to_string()]),
+            ..Default::default()
+        };
+        assert!(denied(&evaluate_hyperliquid_action(&p, &ctx)));
+    }
+
+    #[test]
+    fn usd_send_destination_policy_parses_from_toml() {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            hyperliquid: HyperliquidPolicy,
+        }
+
+        let parsed: Wrapper = toml::from_str(
+            r#"
+[hyperliquid]
+transfer_cap_usd = "25"
+allowed_usd_send_destinations = ["0xabc", "0xdef"]
+denied_usd_send_destinations = ["0xbad"]
+"#,
+        )
+        .unwrap();
+        assert_eq!(parsed.hyperliquid.transfer_cap_usd, Some(25 * MICRO_USD));
+        assert!(
+            parsed
+                .hyperliquid
+                .allowed_usd_send_destinations
+                .contains("0xabc")
+        );
+        assert!(
+            parsed
+                .hyperliquid
+                .denied_usd_send_destinations
+                .contains("0xbad")
+        );
     }
 
     #[test]

--- a/crates/bloom-proto/src/lib.rs
+++ b/crates/bloom-proto/src/lib.rs
@@ -50,9 +50,12 @@ pub use intent::{
 };
 pub use plan::{NftAction, NftRef, PlanRender, StagedTx, TokenRef, TxStatus};
 pub use policy::{
-    AgentAutonomyMode, ApprovalPolicy, AuthorizationSubject, AuthorizationSurface,
-    AutonomyDecision, BroadcastApprovalDecision, BudgetSnapshot, LimitsPolicy, Policy, PolicyCheck,
-    PolicyOutcome, evaluate_action_authorization, evaluate_broadcast_approval, has_deny, has_warn,
+    AgentAutonomyMode, ApprovalPolicy, ApprovalStepUpPolicy, AuthorizationSubject,
+    AuthorizationSurface, AutonomyDecision, BroadcastApprovalDecision, BudgetSnapshot,
+    LimitsPolicy, Policy, PolicyCheck, PolicyEditClass, PolicyOutcome, PolicyRuleClass,
+    StepUpRuleCeiling, StepUpRuleCeilingValidation, classify_policy_edit,
+    evaluate_action_authorization, evaluate_broadcast_approval, has_deny, has_soft_violation,
+    has_warn, validate_step_up_rule_ceilings,
 };
 pub use polymarket_policy::{
     PolicySide, PolymarketOrderCtx, PolymarketPolicy, evaluate_polymarket_order,

--- a/crates/bloom-proto/src/plan.rs
+++ b/crates/bloom-proto/src/plan.rs
@@ -334,16 +334,19 @@ Write `y` to `confirm` to broadcast, `cancel` to discard, `override` to bypass s
             PolicyCheck {
                 rule: "max_value".to_string(),
                 outcome: PolicyOutcome::Pass,
+                class: crate::PolicyRuleClass::Informational,
                 message: "ok".to_string(),
             },
             PolicyCheck {
                 rule: "allowlist".to_string(),
                 outcome: PolicyOutcome::Warn,
+                class: crate::PolicyRuleClass::Soft,
                 message: "recipient not on allowlist".to_string(),
             },
             PolicyCheck {
                 rule: "block_mainnet".to_string(),
                 outcome: PolicyOutcome::Deny,
+                class: crate::PolicyRuleClass::Hard,
                 message: "broadcast denied".to_string(),
             },
         ];

--- a/crates/bloom-proto/src/policy.rs
+++ b/crates/bloom-proto/src/policy.rs
@@ -5,6 +5,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+use bloom_auth_api::AssuranceLevel;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
@@ -221,6 +222,14 @@ pub struct ApprovalPolicy {
     /// signature is required for broadcasts.
     #[serde(default)]
     pub agent_autonomy: Option<AgentAutonomyMode>,
+    /// Assurance level for approval/session grants. `convenience` allows
+    /// password/passphrase or passkey bounded grants. `hardened` requires
+    /// passkey/WebAuthn for grant minting and out-of-policy approvals.
+    #[serde(default)]
+    pub assurance: AssuranceLevel,
+    /// Step-up policy and ceilings for approval-renderable soft violations.
+    #[serde(default)]
+    pub step_up: ApprovalStepUpPolicy,
     /// Legacy boolean from the first approval model. It no longer grants
     /// broadcast authority when false; only `agent_autonomy = "under_policy"`
     /// can authorize agent execution without fresh review.
@@ -229,6 +238,66 @@ pub struct ApprovalPolicy {
     /// Legacy prompt-all flag for policies that predate `agent_autonomy`.
     #[serde(default, skip_serializing_if = "is_false")]
     pub always_prompt_for_broadcast: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ApprovalStepUpPolicy {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_step_up_ttl_secs")]
+    pub ttl_secs: u64,
+    /// In hardened mode, approvals above this require WebAuthn user
+    /// verification. Decimal USD string, parsed to integer micro-USD.
+    #[serde(default)]
+    pub uv_above_usd: Option<String>,
+    #[serde(default)]
+    pub rule_ceilings: BTreeMap<String, StepUpRuleCeiling>,
+}
+
+impl Default for ApprovalStepUpPolicy {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            ttl_secs: default_step_up_ttl_secs(),
+            uv_above_usd: None,
+            rule_ceilings: BTreeMap::new(),
+        }
+    }
+}
+
+impl ApprovalStepUpPolicy {
+    pub fn uv_above_micro_usd(&self) -> Result<Option<i128>, String> {
+        LimitsPolicy::parse_micro_usd(&self.uv_above_usd, "approval.step_up.uv_above_usd")
+    }
+}
+
+fn default_step_up_ttl_secs() -> u64 {
+    120
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StepUpRuleCeiling {
+    #[serde(default)]
+    pub max_usd: Option<String>,
+    #[serde(default)]
+    pub max_u32: Option<u32>,
+    #[serde(default)]
+    pub max_bps: Option<u32>,
+    #[serde(default)]
+    pub max_count: Option<u64>,
+}
+
+impl StepUpRuleCeiling {
+    pub fn max_micro_usd(&self, rule: &str) -> Result<Option<i128>, String> {
+        LimitsPolicy::parse_micro_usd(&self.max_usd, rule)
+    }
+
+    pub fn has_any_limit(&self) -> bool {
+        self.max_usd.is_some()
+            || self.max_u32.is_some()
+            || self.max_bps.is_some()
+            || self.max_count.is_some()
+    }
 }
 
 fn is_false(v: &bool) -> bool {
@@ -488,6 +557,181 @@ pub enum AutonomyDecision {
     },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PolicyEditClass {
+    NotExpanding,
+    AuthorityExpanding { reasons: Vec<String> },
+}
+
+impl PolicyEditClass {
+    pub fn is_authority_expanding(&self) -> bool {
+        matches!(self, PolicyEditClass::AuthorityExpanding { .. })
+    }
+}
+
+/// Classify whether a policy edit expands authority and therefore requires
+/// hardened step-up even when the wallet normally uses convenience mode.
+pub fn classify_policy_edit(before: &Policy, after: &Policy) -> PolicyEditClass {
+    let mut reasons = Vec::new();
+
+    if before.approval.assurance == AssuranceLevel::Hardened
+        && after.approval.assurance == AssuranceLevel::Convenience
+    {
+        reasons.push("approval.assurance hardened -> convenience".to_string());
+    }
+
+    if autonomy_rank(after.effective_agent_autonomy())
+        > autonomy_rank(before.effective_agent_autonomy())
+    {
+        reasons.push("approval.agent_autonomy expands autonomous signing".to_string());
+    }
+
+    check_limit_increase(
+        "limits.max_tx_usd",
+        before.limits.max_tx_micro_usd(),
+        after.limits.max_tx_micro_usd(),
+        &mut reasons,
+    );
+    check_limit_increase(
+        "limits.max_day_usd",
+        before.limits.max_day_micro_usd(),
+        after.limits.max_day_micro_usd(),
+        &mut reasons,
+    );
+    check_limit_increase(
+        "limits.max_week_usd",
+        before.limits.max_week_micro_usd(),
+        after.limits.max_week_micro_usd(),
+        &mut reasons,
+    );
+    check_limit_increase(
+        "limits.max_month_usd",
+        before.limits.max_month_micro_usd(),
+        after.limits.max_month_micro_usd(),
+        &mut reasons,
+    );
+
+    if after.approval.step_up.ttl_secs > before.approval.step_up.ttl_secs {
+        reasons.push("approval.step_up.ttl_secs increased".to_string());
+    }
+    check_limit_increase(
+        "approval.step_up.uv_above_usd",
+        before.approval.step_up.uv_above_micro_usd(),
+        after.approval.step_up.uv_above_micro_usd(),
+        &mut reasons,
+    );
+
+    for (rule, after_ceiling) in &after.approval.step_up.rule_ceilings {
+        match before.approval.step_up.rule_ceilings.get(rule) {
+            Some(before_ceiling) => {
+                check_rule_ceiling_increase(rule, before_ceiling, after_ceiling, &mut reasons);
+            }
+            None if after_ceiling.has_any_limit() => {
+                reasons.push(format!("approval.step_up.rule_ceilings.{rule} added"));
+            }
+            None => {}
+        }
+    }
+
+    check_allow_expansion(
+        "allowlists.recipients",
+        &before.allowlists.recipients,
+        &after.allowlists.recipients,
+        &mut reasons,
+    );
+    check_allow_expansion(
+        "allowlists.contracts",
+        &before.allowlists.contracts,
+        &after.allowlists.contracts,
+        &mut reasons,
+    );
+    check_allow_expansion(
+        "allowlists.tokens",
+        &before.allowlists.tokens,
+        &after.allowlists.tokens,
+        &mut reasons,
+    );
+    check_allow_expansion(
+        "contracts.allow",
+        &before.contracts.allow,
+        &after.contracts.allow,
+        &mut reasons,
+    );
+    check_allow_expansion(
+        "tokens.allow",
+        &before.tokens.allow,
+        &after.tokens.allow,
+        &mut reasons,
+    );
+
+    check_deny_removal(
+        "denylists.recipients",
+        &before.denylists.recipients,
+        &after.denylists.recipients,
+        &mut reasons,
+    );
+    check_deny_removal(
+        "denylists.contracts",
+        &before.denylists.contracts,
+        &after.denylists.contracts,
+        &mut reasons,
+    );
+    check_deny_removal(
+        "denylists.tokens",
+        &before.denylists.tokens,
+        &after.denylists.tokens,
+        &mut reasons,
+    );
+    check_deny_removal(
+        "contracts.deny",
+        &before.contracts.deny,
+        &after.contracts.deny,
+        &mut reasons,
+    );
+    check_deny_removal(
+        "tokens.deny",
+        &before.tokens.deny,
+        &after.tokens.deny,
+        &mut reasons,
+    );
+
+    if reasons.is_empty() {
+        PolicyEditClass::NotExpanding
+    } else {
+        PolicyEditClass::AuthorityExpanding { reasons }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StepUpRuleCeilingValidation {
+    pub unknown_rules: Vec<String>,
+}
+
+impl StepUpRuleCeilingValidation {
+    pub fn is_ok(&self) -> bool {
+        self.unknown_rules.is_empty()
+    }
+}
+
+pub fn validate_step_up_rule_ceilings<'a>(
+    policy: &Policy,
+    emitted_rule_ids: impl IntoIterator<Item = &'a str>,
+) -> StepUpRuleCeilingValidation {
+    let emitted: BTreeSet<String> = emitted_rule_ids
+        .into_iter()
+        .map(|rule| rule.trim().to_string())
+        .collect();
+    let unknown_rules = policy
+        .approval
+        .step_up
+        .rule_ceilings
+        .keys()
+        .filter(|rule| !emitted.contains(rule.as_str()))
+        .cloned()
+        .collect();
+    StepUpRuleCeilingValidation { unknown_rules }
+}
+
 pub fn evaluate_action_authorization(
     policy: &Policy,
     policy_checks: &[PolicyCheck],
@@ -496,10 +740,7 @@ pub fn evaluate_action_authorization(
     reviewed_intent_hash: Option<&str>,
     _surface: AuthorizationSurface,
 ) -> AutonomyDecision {
-    if let Some(deny) = policy_checks
-        .iter()
-        .find(|c| matches!(c.outcome, PolicyOutcome::Deny))
-    {
+    if let Some(deny) = policy_checks.iter().find(|c| c.is_hard_violation()) {
         return AutonomyDecision::Denied {
             reason: format!("policy denied: {}: {}", deny.rule, deny.message),
         };
@@ -529,13 +770,10 @@ pub fn evaluate_action_authorization(
             reason: "agent_autonomy=prompt_all".into(),
         },
         AgentAutonomyMode::UnderPolicy => {
-            if let Some(warn) = policy_checks
-                .iter()
-                .find(|c| matches!(c.outcome, PolicyOutcome::Warn))
-            {
+            if let Some(warn) = policy_checks.iter().find(|c| c.is_soft_violation()) {
                 return AutonomyDecision::NeedsFreshReview {
                     reason: format!(
-                        "policy warning requires review: {}: {}",
+                        "soft policy violation requires review: {}: {}",
                         warn.rule, warn.message
                     ),
                 };
@@ -563,6 +801,107 @@ pub fn evaluate_action_authorization(
                 debit_micro_usd: value,
             }
         }
+    }
+}
+
+fn autonomy_rank(mode: AgentAutonomyMode) -> u8 {
+    match mode {
+        AgentAutonomyMode::Disabled => 0,
+        AgentAutonomyMode::PromptAll => 0,
+        AgentAutonomyMode::UnderPolicy => 1,
+    }
+}
+
+fn check_limit_increase(
+    field: &str,
+    before: Result<Option<i128>, String>,
+    after: Result<Option<i128>, String>,
+    reasons: &mut Vec<String>,
+) {
+    let (Ok(before), Ok(after)) = (before, after) else {
+        reasons.push(format!("{field} parse changed or invalid"));
+        return;
+    };
+    if option_cap_expands_i128(before, after) {
+        reasons.push(format!("{field} increased"));
+    }
+}
+
+fn option_cap_expands_i128(before: Option<i128>, after: Option<i128>) -> bool {
+    match (before, after) {
+        (Some(b), Some(a)) => a > b,
+        (Some(_), None) => true,
+        (None, _) => false,
+    }
+}
+
+fn option_cap_expands_u64(before: Option<u64>, after: Option<u64>) -> bool {
+    match (before, after) {
+        (Some(b), Some(a)) => a > b,
+        (Some(_), None) => true,
+        (None, _) => false,
+    }
+}
+
+fn option_cap_expands_u32(before: Option<u32>, after: Option<u32>) -> bool {
+    match (before, after) {
+        (Some(b), Some(a)) => a > b,
+        (Some(_), None) => true,
+        (None, _) => false,
+    }
+}
+
+fn check_rule_ceiling_increase(
+    rule: &str,
+    before: &StepUpRuleCeiling,
+    after: &StepUpRuleCeiling,
+    reasons: &mut Vec<String>,
+) {
+    check_limit_increase(
+        &format!("approval.step_up.rule_ceilings.{rule}.max_usd"),
+        before.max_micro_usd(rule),
+        after.max_micro_usd(rule),
+        reasons,
+    );
+    if option_cap_expands_u32(before.max_u32, after.max_u32) {
+        reasons.push(format!(
+            "approval.step_up.rule_ceilings.{rule}.max_u32 increased"
+        ));
+    }
+    if option_cap_expands_u32(before.max_bps, after.max_bps) {
+        reasons.push(format!(
+            "approval.step_up.rule_ceilings.{rule}.max_bps increased"
+        ));
+    }
+    if option_cap_expands_u64(before.max_count, after.max_count) {
+        reasons.push(format!(
+            "approval.step_up.rule_ceilings.{rule}.max_count increased"
+        ));
+    }
+}
+
+fn check_allow_expansion(
+    field: &str,
+    before: &BTreeSet<String>,
+    after: &BTreeSet<String>,
+    reasons: &mut Vec<String>,
+) {
+    if before.is_empty() {
+        return;
+    }
+    if after.is_empty() || after.iter().any(|v| !before.contains(v)) {
+        reasons.push(format!("{field} expanded"));
+    }
+}
+
+fn check_deny_removal(
+    field: &str,
+    before: &BTreeSet<String>,
+    after: &BTreeSet<String>,
+    reasons: &mut Vec<String>,
+) {
+    if before.iter().any(|v| !after.contains(v)) {
+        reasons.push(format!("{field} removed entries"));
     }
 }
 
@@ -609,6 +948,8 @@ fn check_limits(policy: &Policy, value: i128, snapshot: &BudgetSnapshot) -> Resu
 pub struct PolicyCheck {
     pub rule: String,
     pub outcome: PolicyOutcome,
+    #[serde(default)]
+    pub class: PolicyRuleClass,
     pub message: String,
 }
 
@@ -623,12 +964,60 @@ impl PolicyCheck {
         Self {
             rule: format!("{venue}.{rule}"),
             outcome,
+            class: PolicyRuleClass::for_outcome(outcome),
             message: message.into(),
         }
     }
+
+    pub fn hard(
+        rule: impl Into<String>,
+        outcome: PolicyOutcome,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            rule: rule.into(),
+            outcome,
+            class: PolicyRuleClass::Hard,
+            message: message.into(),
+        }
+    }
+
+    pub fn soft(
+        rule: impl Into<String>,
+        outcome: PolicyOutcome,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            rule: rule.into(),
+            outcome,
+            class: PolicyRuleClass::Soft,
+            message: message.into(),
+        }
+    }
+
+    pub fn informational(
+        rule: impl Into<String>,
+        outcome: PolicyOutcome,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            rule: rule.into(),
+            outcome,
+            class: PolicyRuleClass::Informational,
+            message: message.into(),
+        }
+    }
+
+    pub fn is_hard_violation(&self) -> bool {
+        self.outcome == PolicyOutcome::Deny && self.class == PolicyRuleClass::Hard
+    }
+
+    pub fn is_soft_violation(&self) -> bool {
+        self.outcome != PolicyOutcome::Pass && self.class == PolicyRuleClass::Soft
+    }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum PolicyOutcome {
     /// Rule passed.
@@ -640,14 +1029,42 @@ pub enum PolicyOutcome {
     Deny,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PolicyRuleClass {
+    Informational,
+    Soft,
+    Hard,
+}
+
+impl Default for PolicyRuleClass {
+    fn default() -> Self {
+        Self::Hard
+    }
+}
+
+impl PolicyRuleClass {
+    pub fn for_outcome(outcome: PolicyOutcome) -> Self {
+        match outcome {
+            PolicyOutcome::Pass => Self::Informational,
+            PolicyOutcome::Warn => Self::Soft,
+            PolicyOutcome::Deny => Self::Hard,
+        }
+    }
+}
+
 /// True when any check is a hard denial.
 pub fn has_deny(checks: &[PolicyCheck]) -> bool {
-    checks.iter().any(|c| c.outcome == PolicyOutcome::Deny)
+    checks.iter().any(PolicyCheck::is_hard_violation)
 }
 
 /// True when any check is a soft warning.
 pub fn has_warn(checks: &[PolicyCheck]) -> bool {
     checks.iter().any(|c| c.outcome == PolicyOutcome::Warn)
+}
+
+pub fn has_soft_violation(checks: &[PolicyCheck]) -> bool {
+    checks.iter().any(PolicyCheck::is_soft_violation)
 }
 
 impl Policy {
@@ -700,6 +1117,9 @@ mod tests {
     fn policy_defaults_when_new_sections_missing() {
         let toml_src = "[caps]\nmax_value_eth = 0.1\n";
         let p: Policy = toml::from_str(toml_src).unwrap();
+        assert_eq!(p.approval.assurance, AssuranceLevel::Convenience);
+        assert!(!p.approval.step_up.enabled);
+        assert_eq!(p.approval.step_up.ttl_secs, 120);
         assert!(!p.private.enabled);
         assert_eq!(p.private.provider, "mev_blocker");
         assert_eq!(p.mev.max_slippage_bps, 100);
@@ -727,6 +1147,18 @@ fail_on_high_risk = true
 [bump]
 stuck_after_secs = 30
 basefee_overrun_pct = 50
+
+[approval]
+assurance = "hardened"
+
+[approval.step_up]
+enabled = true
+ttl_secs = 90
+uv_above_usd = "250"
+
+[approval.step_up.rule_ceilings]
+"limits.max_tx_usd" = { max_usd = "500" }
+"hyperliquid.max_leverage" = { max_u32 = 3 }
 "#;
         let p: Policy = toml::from_str(toml_src).unwrap();
         assert!(p.private.enabled);
@@ -735,6 +1167,131 @@ basefee_overrun_pct = 50
         assert!(p.mev.fail_on_high_risk);
         assert_eq!(p.bump.stuck_after_secs, 30);
         assert_eq!(p.bump.basefee_overrun_pct, 50);
+        assert_eq!(p.approval.assurance, AssuranceLevel::Hardened);
+        assert!(p.approval.step_up.enabled);
+        assert_eq!(p.approval.step_up.ttl_secs, 90);
+        assert_eq!(
+            p.approval.step_up.uv_above_micro_usd().unwrap(),
+            Some(250_000_000)
+        );
+        assert_eq!(
+            p.approval
+                .step_up
+                .rule_ceilings
+                .get("limits.max_tx_usd")
+                .unwrap()
+                .max_micro_usd("limits.max_tx_usd")
+                .unwrap(),
+            Some(500_000_000)
+        );
+        assert_eq!(
+            p.approval
+                .step_up
+                .rule_ceilings
+                .get("hyperliquid.max_leverage")
+                .unwrap()
+                .max_u32,
+            Some(3)
+        );
+    }
+
+    #[test]
+    fn approval_step_up_invalid_usd_fails_closed_when_parsed() {
+        let p: Policy = toml::from_str(
+            r#"
+[approval.step_up]
+uv_above_usd = "1.0000001"
+"#,
+        )
+        .unwrap();
+        let err = p.approval.step_up.uv_above_micro_usd().unwrap_err();
+        assert!(err.contains("at most 6 decimal places"), "{err}");
+    }
+
+    #[test]
+    fn policy_check_constructors_assign_rule_classes() {
+        let pass = PolicyCheck::for_venue("defi", "receiver", PolicyOutcome::Pass, "ok");
+        let warn = PolicyCheck::soft("caps.soft", PolicyOutcome::Warn, "review");
+        let deny = PolicyCheck::hard("geo.block", PolicyOutcome::Deny, "blocked");
+
+        assert_eq!(pass.class, PolicyRuleClass::Informational);
+        assert_eq!(warn.class, PolicyRuleClass::Soft);
+        assert_eq!(deny.class, PolicyRuleClass::Hard);
+        assert!(!has_deny(std::slice::from_ref(&warn)));
+        assert!(has_soft_violation(&[warn]));
+        assert!(has_deny(&[deny]));
+    }
+
+    #[test]
+    fn legacy_policy_check_json_defaults_to_hard() {
+        let check: PolicyCheck = serde_json::from_str(
+            r#"{"rule":"legacy.deny","outcome":"deny","message":"old record"}"#,
+        )
+        .unwrap();
+        assert_eq!(check.class, PolicyRuleClass::Hard);
+        assert!(check.is_hard_violation());
+    }
+
+    #[test]
+    fn soft_deny_requires_review_instead_of_hard_denying() {
+        let mut p = Policy::default();
+        p.approval.agent_autonomy = Some(AgentAutonomyMode::UnderPolicy);
+        p.limits.max_day_usd = Some("100".into());
+        let subject = AuthorizationSubject {
+            kind: "test".into(),
+            wallet: "my-wallet".into(),
+            chain: Some("base".into()),
+            subject_hash: "0".repeat(64),
+            value_moving: true,
+            total_value_usd_micro: Some(1_000_000),
+            calldata_verified: true,
+        };
+        let budget = BudgetSnapshot {
+            spent_day_micro_usd: 0,
+            spent_week_micro_usd: 0,
+            spent_month_micro_usd: 0,
+        };
+        let checks = vec![PolicyCheck::soft(
+            "limits.max_tx_usd",
+            PolicyOutcome::Deny,
+            "can be escalated within ceiling",
+        )];
+
+        assert!(matches!(
+            evaluate_action_authorization(
+                &p,
+                &checks,
+                &subject,
+                Some(&budget),
+                None,
+                AuthorizationSurface::Vfs
+            ),
+            AutonomyDecision::NeedsFreshReview { reason }
+                if reason.contains("soft policy violation")
+        ));
+    }
+
+    #[test]
+    fn step_up_rule_ceiling_validation_rejects_unknown_rule_ids() {
+        let mut p = Policy::default();
+        p.approval.step_up.rule_ceilings.insert(
+            "limits.max_tx_usd".into(),
+            StepUpRuleCeiling {
+                max_usd: Some("25".into()),
+                ..StepUpRuleCeiling::default()
+            },
+        );
+        p.approval.step_up.rule_ceilings.insert(
+            "unknown.rule".into(),
+            StepUpRuleCeiling {
+                max_usd: Some("25".into()),
+                ..StepUpRuleCeiling::default()
+            },
+        );
+
+        let validation = validate_step_up_rule_ceilings(&p, ["limits.max_tx_usd"]);
+        assert_eq!(validation.unknown_rules, vec!["unknown.rule".to_string()]);
+        assert!(!validation.is_ok());
     }
 
     #[test]
@@ -867,5 +1424,77 @@ basefee_overrun_pct = 50
             ),
             AutonomyDecision::Denied { reason } if reason.contains("max_day")
         ));
+    }
+
+    #[test]
+    fn policy_edit_classifier_flags_authority_expansion() {
+        let mut before = Policy::default();
+        before.approval.assurance = AssuranceLevel::Hardened;
+        before.approval.agent_autonomy = Some(AgentAutonomyMode::UnderPolicy);
+        before.limits.max_tx_usd = Some("10".into());
+        before.allowlists.recipients.insert("alice".into());
+        before.approval.step_up.rule_ceilings.insert(
+            "limits.max_tx_usd".into(),
+            StepUpRuleCeiling {
+                max_usd: Some("25".into()),
+                ..StepUpRuleCeiling::default()
+            },
+        );
+
+        let mut after = before.clone();
+        after.approval.assurance = AssuranceLevel::Convenience;
+        after.limits.max_tx_usd = Some("20".into());
+        after.allowlists.recipients.insert("bob".into());
+        after
+            .approval
+            .step_up
+            .rule_ceilings
+            .get_mut("limits.max_tx_usd")
+            .unwrap()
+            .max_usd = Some("50".into());
+
+        let class = classify_policy_edit(&before, &after);
+        let PolicyEditClass::AuthorityExpanding { reasons } = class else {
+            panic!("expected authority expansion");
+        };
+        assert!(
+            reasons
+                .iter()
+                .any(|r| r.contains("hardened -> convenience")),
+            "{reasons:?}"
+        );
+        assert!(
+            reasons.iter().any(|r| r.contains("limits.max_tx_usd")),
+            "{reasons:?}"
+        );
+        assert!(
+            reasons.iter().any(|r| r.contains("allowlists.recipients")),
+            "{reasons:?}"
+        );
+        assert!(
+            reasons
+                .iter()
+                .any(|r| r.contains("rule_ceilings.limits.max_tx_usd")),
+            "{reasons:?}"
+        );
+    }
+
+    #[test]
+    fn policy_edit_classifier_allows_tightening() {
+        let mut before = Policy::default();
+        before.approval.assurance = AssuranceLevel::Convenience;
+        before.approval.agent_autonomy = Some(AgentAutonomyMode::UnderPolicy);
+        before.limits.max_tx_usd = Some("10".into());
+        before.limits.max_day_usd = Some("100".into());
+
+        let mut after = before.clone();
+        after.approval.assurance = AssuranceLevel::Hardened;
+        after.limits.max_tx_usd = Some("5".into());
+        after.denylists.recipients.insert("blocked".into());
+
+        assert_eq!(
+            classify_policy_edit(&before, &after),
+            PolicyEditClass::NotExpanding
+        );
     }
 }

--- a/crates/bloom-tx/Cargo.toml
+++ b/crates/bloom-tx/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 description = "Tx engine, intent parser, policy for bloom"
 
 [dependencies]
+bloom-auth-api.workspace = true
 bloom-proto.workspace = true
 bloom-chain.workspace = true
 bloom-rpc.workspace = true
@@ -24,6 +25,8 @@ tracing.workspace = true
 alloy.workspace = true
 parking_lot.workspace = true
 async-trait.workspace = true
+base64.workspace = true
+rand.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/bloom-tx/src/policy_engine.rs
+++ b/crates/bloom-tx/src/policy_engine.rs
@@ -73,41 +73,41 @@ pub fn evaluate(
 
     if let Some(max) = effective_caps.max_value_eth {
         if value_f > max {
-            out.push(PolicyCheck {
-                rule: "caps.max_value_eth".into(),
-                outcome: PolicyOutcome::Deny,
-                message: format!("value {} > max {}", value_human, max),
-            });
+            out.push(PolicyCheck::hard(
+                "caps.max_value_eth",
+                PolicyOutcome::Deny,
+                format!("value {} > max {}", value_human, max),
+            ));
         } else {
-            out.push(PolicyCheck {
-                rule: "caps.max_value_eth".into(),
-                outcome: PolicyOutcome::Pass,
-                message: format!("value {} <= max {}", value_human, max),
-            });
+            out.push(PolicyCheck::informational(
+                "caps.max_value_eth",
+                PolicyOutcome::Pass,
+                format!("value {} <= max {}", value_human, max),
+            ));
         }
     }
 
     if let Some(soft) = effective_caps.require_override_above_eth
         && value_f > soft
     {
-        out.push(PolicyCheck {
-            rule: "caps.require_override_above_eth".into(),
-            outcome: PolicyOutcome::Warn,
-            message: format!(
+        out.push(PolicyCheck::soft(
+            "caps.require_override_above_eth",
+            PolicyOutcome::Warn,
+            format!(
                 "value {} > soft {} — write `override` to confirm",
                 value_human, soft
             ),
-        });
+        ));
     }
 
     if let Some(auto_below) = policy.automation.auto_confirm_below_eth
         && value_f <= auto_below
     {
-        out.push(PolicyCheck {
-            rule: "automation.auto_confirm_below_eth".into(),
-            outcome: PolicyOutcome::Pass,
-            message: "value within auto-confirm threshold".into(),
-        });
+        out.push(PolicyCheck::informational(
+            "automation.auto_confirm_below_eth",
+            PolicyOutcome::Pass,
+            "value within auto-confirm threshold",
+        ));
     }
 
     // ----- USD caps -----------------------------------------------------------
@@ -123,29 +123,27 @@ pub fn evaluate(
         (true, Some(usd)) => {
             if let Some(max_usd) = effective_caps.per_tx_usd {
                 if usd > max_usd {
-                    out.push(PolicyCheck {
-                        rule: "caps.per_tx_usd".into(),
-                        outcome: PolicyOutcome::Deny,
-                        message: format!("usd {usd:.2} > max {max_usd:.2}"),
-                    });
+                    out.push(PolicyCheck::hard(
+                        "caps.per_tx_usd",
+                        PolicyOutcome::Deny,
+                        format!("usd {usd:.2} > max {max_usd:.2}"),
+                    ));
                 } else {
-                    out.push(PolicyCheck {
-                        rule: "caps.per_tx_usd".into(),
-                        outcome: PolicyOutcome::Pass,
-                        message: format!("usd {usd:.2} <= max {max_usd:.2}"),
-                    });
+                    out.push(PolicyCheck::informational(
+                        "caps.per_tx_usd",
+                        PolicyOutcome::Pass,
+                        format!("usd {usd:.2} <= max {max_usd:.2}"),
+                    ));
                 }
             }
             if let Some(soft_usd) = effective_caps.require_confirm_above_usd
                 && usd > soft_usd
             {
-                out.push(PolicyCheck {
-                    rule: "caps.require_confirm_above_usd".into(),
-                    outcome: PolicyOutcome::Warn,
-                    message: format!(
-                        "usd {usd:.2} > soft {soft_usd:.2} — write override token to confirm"
-                    ),
-                });
+                out.push(PolicyCheck::soft(
+                    "caps.require_confirm_above_usd",
+                    PolicyOutcome::Warn,
+                    format!("usd {usd:.2} > soft {soft_usd:.2} — write override token to confirm"),
+                ));
             }
             // The rolling counter is sourced from the outbox itself by
             // tx_engine::stage (sum of usd_value across this wallet's
@@ -158,39 +156,39 @@ pub fn evaluate(
                     Some(prior) => {
                         let total = prior + usd;
                         if total > per_day {
-                            out.push(PolicyCheck {
-                                rule: "caps.per_day_usd".into(),
-                                outcome: PolicyOutcome::Deny,
-                                message: format!(
+                            out.push(PolicyCheck::hard(
+                                "caps.per_day_usd",
+                                PolicyOutcome::Deny,
+                                format!(
                                     "rolling 24h usd {prior:.2} + {usd:.2} > cap {per_day:.2}"
                                 ),
-                            });
+                            ));
                         } else {
-                            out.push(PolicyCheck {
-                                rule: "caps.per_day_usd".into(),
-                                outcome: PolicyOutcome::Pass,
-                                message: format!(
+                            out.push(PolicyCheck::informational(
+                                "caps.per_day_usd",
+                                PolicyOutcome::Pass,
+                                format!(
                                     "rolling 24h usd {total:.2} <= cap {per_day:.2}"
                                 ),
-                            });
+                            ));
                         }
                     }
-                    None => out.push(PolicyCheck {
-                        rule: "caps.per_day_usd".into(),
-                        outcome: PolicyOutcome::Warn,
-                        message: format!(
+                    None => out.push(PolicyCheck::soft(
+                        "caps.per_day_usd",
+                        PolicyOutcome::Warn,
+                        format!(
                             "per_day_usd cap {per_day:.2} configured but rolling-window state unavailable"
                         ),
-                    }),
+                    )),
                 }
             }
         }
         (true, None) => {
-            out.push(PolicyCheck {
-                rule: "caps.usd".into(),
-                outcome: PolicyOutcome::Warn,
-                message: "USD caps configured but no price quote available; rule skipped".into(),
-            });
+            out.push(PolicyCheck::soft(
+                "caps.usd",
+                PolicyOutcome::Warn,
+                "USD caps configured but no price quote available; rule skipped",
+            ));
         }
         (false, _) => {}
     }
@@ -313,35 +311,35 @@ fn check_allow_deny(
     };
 
     if !block.deny.is_empty() && block.deny.iter().any(|s| matches_one(s)) {
-        out.push(PolicyCheck {
-            rule: format!("{section}.deny"),
-            outcome: PolicyOutcome::Deny,
-            message: format!(
+        out.push(PolicyCheck::hard(
+            format!("{section}.deny"),
+            PolicyOutcome::Deny,
+            format!(
                 "{} on deny list",
                 target.unwrap_or_else(|| symbol.unwrap_or("(unknown)"))
             ),
-        });
+        ));
     }
     if !block.allow.is_empty() {
         let hit = block.allow.iter().any(|s| matches_one(s));
         if hit {
-            out.push(PolicyCheck {
-                rule: format!("{section}.allow"),
-                outcome: PolicyOutcome::Pass,
-                message: format!(
+            out.push(PolicyCheck::informational(
+                format!("{section}.allow"),
+                PolicyOutcome::Pass,
+                format!(
                     "{} on allow list",
                     target.unwrap_or_else(|| symbol.unwrap_or("(unknown)"))
                 ),
-            });
+            ));
         } else {
-            out.push(PolicyCheck {
-                rule: format!("{section}.allow"),
-                outcome: PolicyOutcome::Deny,
-                message: format!(
+            out.push(PolicyCheck::hard(
+                format!("{section}.allow"),
+                PolicyOutcome::Deny,
+                format!(
                     "{} not on allow list",
                     target.unwrap_or_else(|| symbol.unwrap_or("(unknown)"))
                 ),
-            });
+            ));
         }
     }
 }
@@ -368,11 +366,11 @@ fn check_lists(
             // Allowlist with nothing to check is a hard miss — we can't
             // confirm the tx falls inside the list.
             if matches!(mode, ListMode::Allow) {
-                out.push(PolicyCheck {
-                    rule: rule.into(),
-                    outcome: PolicyOutcome::Deny,
-                    message: "allowlist set but tx has no relevant address".into(),
-                });
+                out.push(PolicyCheck::hard(
+                    rule,
+                    PolicyOutcome::Deny,
+                    "allowlist set but tx has no relevant address",
+                ));
             }
             return;
         }
@@ -382,22 +380,22 @@ fn check_lists(
         .iter()
         .any(|s| s.trim().to_ascii_lowercase() == target_lc);
     match (mode, hit) {
-        (ListMode::Deny, true) => out.push(PolicyCheck {
-            rule: rule.into(),
-            outcome: PolicyOutcome::Deny,
-            message: format!("{} is denylisted", target_lc),
-        }),
+        (ListMode::Deny, true) => out.push(PolicyCheck::hard(
+            rule,
+            PolicyOutcome::Deny,
+            format!("{} is denylisted", target_lc),
+        )),
         (ListMode::Deny, false) => {}
-        (ListMode::Allow, true) => out.push(PolicyCheck {
-            rule: rule.into(),
-            outcome: PolicyOutcome::Pass,
-            message: format!("{} is on allowlist", target_lc),
-        }),
-        (ListMode::Allow, false) => out.push(PolicyCheck {
-            rule: rule.into(),
-            outcome: PolicyOutcome::Deny,
-            message: format!("{} not on allowlist", target_lc),
-        }),
+        (ListMode::Allow, true) => out.push(PolicyCheck::informational(
+            rule,
+            PolicyOutcome::Pass,
+            format!("{} is on allowlist", target_lc),
+        )),
+        (ListMode::Allow, false) => out.push(PolicyCheck::hard(
+            rule,
+            PolicyOutcome::Deny,
+            format!("{} not on allowlist", target_lc),
+        )),
     }
 }
 

--- a/crates/bloom-tx/src/tx_engine.rs
+++ b/crates/bloom-tx/src/tx_engine.rs
@@ -13,6 +13,12 @@ use alloy::rpc::types::eth::TransactionRequest;
 use alloy::signers::local::PrivateKeySigner;
 use alloy::sol;
 use alloy::sol_types::SolCall;
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use bloom_auth_api::{
+    Approval, ApprovalVerifier, AssuranceLevel, AuthEntryState, AuthStoreWriter, CanonicalEnvelope,
+    CanonicalIntentHeader, NonceState,
+};
 use bloom_chain::{ChainClient, ChainError, IERC20, NftKind};
 
 // Local NFT-write interfaces. `bloom-chain` declares the read shapes for
@@ -193,6 +199,10 @@ struct TokenMeta {
 type NonceLocks =
     Arc<parking_lot::Mutex<HashMap<(String, String, Address), Arc<tokio::sync::Mutex<()>>>>>;
 
+const OUTBOX_APPROVAL_FILE: &str = "approval.json";
+const OUTBOX_APPROVAL_CHALLENGE_FILE: &str = "approval_challenge.json";
+const OUTBOX_APPROVAL_TTL_MS: u64 = 5 * 60 * 1000;
+
 /// Stage / confirm the lifecycle.
 #[derive(Clone)]
 pub struct TxEngine {
@@ -223,6 +233,8 @@ pub struct TxEngine {
     /// Bounded policy sessions: one ceremony authorizes many in-bounds
     /// confirms without a fresh per-tx review. See [`crate::session`].
     session_store: crate::session::SessionStore,
+    approval_verifier: Option<Arc<dyn ApprovalVerifier>>,
+    auth_writer: Option<Arc<dyn AuthStoreWriter>>,
 }
 
 impl TxEngine {
@@ -238,7 +250,19 @@ impl TxEngine {
             private_rpcs: Arc::new(RwLock::new(BTreeMap::new())),
             nonce_locks: Arc::new(parking_lot::Mutex::new(HashMap::new())),
             session_store: crate::session::SessionStore::new(),
+            approval_verifier: None,
+            auth_writer: None,
         }
+    }
+
+    pub fn with_auth_services(
+        mut self,
+        approval_verifier: Arc<dyn ApprovalVerifier>,
+        auth_writer: Arc<dyn AuthStoreWriter>,
+    ) -> Self {
+        self.approval_verifier = Some(approval_verifier);
+        self.auth_writer = Some(auth_writer);
+        self
     }
 
     /// Access the bounded policy-session store (mint/revoke/list live here).
@@ -1036,16 +1060,20 @@ impl TxEngine {
                 } else {
                     bloom_proto::PolicyOutcome::Pass
                 };
-                staged_policy_extras.push(bloom_proto::PolicyCheck {
-                    rule: "nft.approve_all".into(),
-                    outcome,
-                    message: if *approved {
+                staged_policy_extras.push(if *approved {
+                    bloom_proto::PolicyCheck::soft(
+                        "nft.approve_all",
+                        outcome,
                         format!(
                             "operator-wide approval to {op_disp} — review carefully (write override token to confirm)"
-                        )
-                    } else {
-                        format!("revoking operator-wide approval for {op_disp}")
-                    },
+                        ),
+                    )
+                } else {
+                    bloom_proto::PolicyCheck::informational(
+                        "nft.approve_all",
+                        outcome,
+                        format!("revoking operator-wide approval for {op_disp}"),
+                    )
                 });
             }
             RawIntentBody::Enso { .. } => {}
@@ -1261,11 +1289,13 @@ impl TxEngine {
             debug!(id = %staged.id, session = %sid, "tx.authorized_by_session");
         } else {
             self.ensure_action_authorized(
+                &entry,
                 &staged,
                 policy,
                 reviewed_intent_hash,
                 bloom_proto::AuthorizationSurface::Cli,
-            )?;
+            )
+            .await?;
         }
 
         let tx_hash = match self
@@ -1408,11 +1438,13 @@ impl TxEngine {
                     });
                 }
                 self.ensure_action_authorized(
+                    entry,
                     &entry.staged,
                     policy,
                     reviewed_intent_hash,
                     bloom_proto::AuthorizationSurface::Cli,
-                )?;
+                )
+                .await?;
                 let raw = self.outbox.read_broadcast_raw_tx(
                     entry,
                     BroadcastAttemptKind::Confirm,
@@ -1726,17 +1758,44 @@ impl TxEngine {
         }
     }
 
-    fn ensure_action_authorized(
+    async fn ensure_action_authorized(
         &self,
+        entry: &crate::outbox::OutboxEntry,
         staged: &StagedTx,
         policy: &Policy,
         reviewed_intent_hash: Option<&str>,
         surface: bloom_proto::AuthorizationSurface,
     ) -> Result<(), TxEngineError> {
-        let reviewed_intent_hash =
-            self.verified_reviewed_intent_hash(staged, reviewed_intent_hash)?;
         let budget = self.budget_snapshot(&staged.wallet)?;
         let subject = self.authorization_subject(staged);
+        let initial = bloom_proto::evaluate_action_authorization(
+            policy,
+            &staged.policy_checks,
+            &subject,
+            Some(&budget),
+            None,
+            surface.clone(),
+        );
+        match initial {
+            bloom_proto::AutonomyDecision::ApprovedAutonomous { .. } => return Ok(()),
+            bloom_proto::AutonomyDecision::ApprovedFreshReview { .. } => return Ok(()),
+            bloom_proto::AutonomyDecision::ApprovedCapability { .. } => {
+                return Err(TxEngineError::BroadcastApprovalRequired(
+                    "scoped run capabilities are not implemented; fresh review required".into(),
+                ));
+            }
+            bloom_proto::AutonomyDecision::Denied { reason } => {
+                return Err(TxEngineError::BroadcastApprovalRequired(reason));
+            }
+            bloom_proto::AutonomyDecision::NeedsFreshReview { .. } => {}
+        }
+
+        let reviewed_intent_hash = if self.approval_verifier.is_some() || self.auth_writer.is_some()
+        {
+            Some(self.ensure_layer_b_outbox_approval(entry, staged).await?)
+        } else {
+            self.verified_reviewed_intent_hash(staged, reviewed_intent_hash)?
+        };
         match bloom_proto::evaluate_action_authorization(
             policy,
             &staged.policy_checks,
@@ -1761,6 +1820,90 @@ impl TxEngine {
                 Err(TxEngineError::BroadcastApprovalRequired(reason))
             }
         }
+    }
+
+    async fn ensure_layer_b_outbox_approval(
+        &self,
+        entry: &crate::outbox::OutboxEntry,
+        staged: &StagedTx,
+    ) -> Result<String, TxEngineError> {
+        let verifier = self.approval_verifier.as_ref().ok_or_else(|| {
+            TxEngineError::BroadcastApprovalRequired(
+                "Layer B approval verifier is not wired".into(),
+            )
+        })?;
+        let writer = self.auth_writer.as_ref().ok_or_else(|| {
+            TxEngineError::BroadcastApprovalRequired(
+                "Layer B auth store writer is not wired".into(),
+            )
+        })?;
+        let envelope = outbox_canonical_envelope(staged)?;
+        let auth_entry = writer
+            .stage_entry(envelope, AssuranceLevel::Convenience, now_ms() as u64)
+            .await
+            .map_err(|e| {
+                TxEngineError::BroadcastApprovalRequired(format!(
+                    "stage outbox auth entry failed: {e}"
+                ))
+            })?;
+        if matches!(
+            auth_entry.state,
+            AuthEntryState::Approved | AuthEntryState::Submitting
+        ) && auth_entry.nonce_state == NonceState::Consumed
+        {
+            return Ok(auth_entry.intent_hash);
+        }
+        let approval_path = entry.dir.join(OUTBOX_APPROVAL_FILE);
+        if approval_path.exists() {
+            let approval_body = std::fs::read(&approval_path).map_err(|e| {
+                TxEngineError::BroadcastApprovalRequired(format!("read approval.json: {e}"))
+            })?;
+            let approval: Approval = serde_json::from_slice(&approval_body).map_err(|e| {
+                TxEngineError::BroadcastApprovalRequired(format!(
+                    "stored approval.json is invalid: {e}"
+                ))
+            })?;
+            verifier
+                .verify_and_consume(approval, now_ms() as u64)
+                .await
+                .map_err(|e| {
+                    TxEngineError::BroadcastApprovalRequired(format!(
+                        "Layer B approval rejected: {e}"
+                    ))
+                })?;
+            return Ok(auth_entry.intent_hash);
+        }
+
+        let mut nonce = [0u8; 32];
+        rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut nonce);
+        let nonce = URL_SAFE_NO_PAD.encode(nonce);
+        let challenge = writer
+            .issue_challenge(
+                "outbox",
+                &auth_entry.entry_id,
+                &nonce,
+                (now_ms() as u64).saturating_add(OUTBOX_APPROVAL_TTL_MS),
+                now_ms() as u64,
+            )
+            .await
+            .map_err(|e| {
+                TxEngineError::BroadcastApprovalRequired(format!(
+                    "issue outbox approval challenge failed: {e}"
+                ))
+            })?;
+        let challenge_body = serde_json::to_vec_pretty(&challenge).map_err(|e| {
+            TxEngineError::BroadcastApprovalRequired(format!("encode approval challenge: {e}"))
+        })?;
+        std::fs::write(
+            entry.dir.join(OUTBOX_APPROVAL_CHALLENGE_FILE),
+            challenge_body,
+        )
+        .map_err(|e| {
+            TxEngineError::BroadcastApprovalRequired(format!("write approval challenge: {e}"))
+        })?;
+        Err(TxEngineError::BroadcastApprovalRequired(
+            "outbox confirm requires signed Layer B approval; local password wallets can only auto-confirm actions that remain in policy".into(),
+        ))
     }
 
     fn verified_reviewed_intent_hash(
@@ -2003,19 +2146,21 @@ impl TxEngine {
             bumped.data_hex = data_hex;
             bumped.token = token;
             bumped.nft = nft;
-            bumped.policy_checks.push(bloom_proto::PolicyCheck {
-                rule: "replacement.substitute".into(),
-                outcome: bloom_proto::PolicyOutcome::Deny,
-                message: "same-nonce replacement with substituted to/value/data is disabled; stage a fresh transaction instead".into(),
-            });
+            bumped.policy_checks.push(bloom_proto::PolicyCheck::hard(
+                "replacement.substitute",
+                bloom_proto::PolicyOutcome::Deny,
+                "same-nonce replacement with substituted to/value/data is disabled; stage a fresh transaction instead",
+            ));
         }
         bump_fees_in_place(&mut bumped, bump);
         self.ensure_action_authorized(
+            &entry,
             &bumped,
             policy,
             reviewed_intent_hash,
             bloom_proto::AuthorizationSurface::Cli,
-        )?;
+        )
+        .await?;
 
         let tx_hash = self
             .submit_with_marker(
@@ -2082,11 +2227,13 @@ impl TxEngine {
         cancel_tx.token = None;
         bump_fees_in_place(&mut cancel_tx, bump);
         self.ensure_action_authorized(
+            &entry,
             &cancel_tx,
             policy,
             reviewed_intent_hash,
             bloom_proto::AuthorizationSurface::Cli,
-        )?;
+        )
+        .await?;
 
         let tx_hash = self
             .submit_with_marker(
@@ -2200,6 +2347,35 @@ fn now_ms() -> u128 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis()
+}
+
+fn outbox_entry_id(staged: &StagedTx) -> String {
+    format!("{}:{}", staged.chain_id, staged.id)
+}
+
+fn outbox_canonical_envelope(staged: &StagedTx) -> Result<CanonicalEnvelope, TxEngineError> {
+    let subject = serde_json::to_vec(&serde_json::json!({
+        "schema": "bloom.outbox_subject.v1",
+        "staged": staged,
+    }))
+    .map_err(|e| TxEngineError::BroadcastApprovalRequired(format!("encode outbox subject: {e}")))?;
+    Ok(CanonicalEnvelope::new(
+        CanonicalIntentHeader {
+            schema: "bloom.intent_header.v1".into(),
+            wallet: staged.wallet.clone(),
+            surface: "outbox".into(),
+            entry_id: outbox_entry_id(staged),
+            executor_id: "evm-broadcast".into(),
+            network: staged.chain.clone(),
+            account: staged.from.clone(),
+            action_kind: "evm_confirm".into(),
+            value_movement: true,
+            authority_change: false,
+        },
+        "outbox",
+        "bloom.outbox_subject.v1",
+        subject,
+    ))
 }
 
 fn f64_to_micro_usd(v: f64) -> Option<i128> {
@@ -2360,7 +2536,152 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
+    use bloom_auth_api::{
+        APPROVAL_SCHEMA_V1, ApprovalCaps, ApprovalSignature, AuthApiError, AuthEntryRecord,
+        AuthEntryState, ChallengeRecord, NonceState, SignerKind,
+    };
     use bloom_proto::TxStatus;
+
+    struct RejectingTestVerifier;
+
+    #[async_trait::async_trait]
+    impl ApprovalVerifier for RejectingTestVerifier {
+        async fn verify_and_consume(
+            &self,
+            _approval: Approval,
+            _now_ms: u64,
+        ) -> Result<(), AuthApiError> {
+            Err(AuthApiError::Denied("test verifier rejects".into()))
+        }
+    }
+
+    struct AcceptingTestVerifier;
+
+    #[async_trait::async_trait]
+    impl ApprovalVerifier for AcceptingTestVerifier {
+        async fn verify_and_consume(
+            &self,
+            approval: Approval,
+            _now_ms: u64,
+        ) -> Result<(), AuthApiError> {
+            if approval.surface != "outbox" {
+                return Err(AuthApiError::Denied("wrong surface".into()));
+            }
+            Ok(())
+        }
+    }
+
+    struct ChallengeOnlyWriter;
+
+    #[async_trait::async_trait]
+    impl AuthStoreWriter for ChallengeOnlyWriter {
+        async fn stage_entry(
+            &self,
+            envelope: CanonicalEnvelope,
+            assurance: AssuranceLevel,
+            now_ms: u64,
+        ) -> Result<AuthEntryRecord, AuthApiError> {
+            Ok(AuthEntryRecord {
+                surface: envelope.header.surface.clone(),
+                entry_id: envelope.header.entry_id.clone(),
+                state: AuthEntryState::Staged,
+                intent_hash: envelope.intent_hash()?,
+                assurance,
+                nonce: None,
+                nonce_state: NonceState::Unused,
+                reservation_id: None,
+                updated_ms: now_ms,
+            })
+        }
+
+        async fn issue_challenge(
+            &self,
+            surface: &str,
+            entry_id: &str,
+            server_nonce: &str,
+            expiry_ms: u64,
+            _now_ms: u64,
+        ) -> Result<ChallengeRecord, AuthApiError> {
+            Ok(ChallengeRecord {
+                surface: surface.to_string(),
+                entry_id: entry_id.to_string(),
+                intent_hash: "outbox-intent".to_string(),
+                server_nonce: server_nonce.to_string(),
+                assurance: AssuranceLevel::Convenience,
+                expiry_ms,
+            })
+        }
+
+        async fn issue_review_session(
+            &self,
+            review_session_id: &str,
+            surface: &str,
+            entry_id: &str,
+            expires_ms: u64,
+            now_ms: u64,
+        ) -> Result<bloom_auth_api::ReviewSessionRecord, AuthApiError> {
+            Ok(bloom_auth_api::ReviewSessionRecord {
+                review_session_id: review_session_id.to_string(),
+                surface: surface.to_string(),
+                entry_id: entry_id.to_string(),
+                intent_hash: "outbox-intent".to_string(),
+                assurance: AssuranceLevel::Convenience,
+                expires_ms,
+                consumed_ms: None,
+                created_ms: now_ms,
+            })
+        }
+    }
+
+    struct PreApprovedWriter;
+
+    #[async_trait::async_trait]
+    impl AuthStoreWriter for PreApprovedWriter {
+        async fn stage_entry(
+            &self,
+            envelope: CanonicalEnvelope,
+            assurance: AssuranceLevel,
+            now_ms: u64,
+        ) -> Result<AuthEntryRecord, AuthApiError> {
+            Ok(AuthEntryRecord {
+                surface: envelope.header.surface.clone(),
+                entry_id: envelope.header.entry_id.clone(),
+                state: AuthEntryState::Approved,
+                intent_hash: envelope.intent_hash()?,
+                assurance,
+                nonce: Some("already-consumed".into()),
+                nonce_state: NonceState::Consumed,
+                reservation_id: None,
+                updated_ms: now_ms,
+            })
+        }
+
+        async fn issue_challenge(
+            &self,
+            _surface: &str,
+            _entry_id: &str,
+            _server_nonce: &str,
+            _expiry_ms: u64,
+            _now_ms: u64,
+        ) -> Result<ChallengeRecord, AuthApiError> {
+            Err(AuthApiError::Denied(
+                "pre-approved retry must not issue a new challenge".into(),
+            ))
+        }
+
+        async fn issue_review_session(
+            &self,
+            _review_session_id: &str,
+            _surface: &str,
+            _entry_id: &str,
+            _expires_ms: u64,
+            _now_ms: u64,
+        ) -> Result<bloom_auth_api::ReviewSessionRecord, AuthApiError> {
+            Err(AuthApiError::Denied(
+                "pre-approved retry must not issue a review session".into(),
+            ))
+        }
+    }
 
     fn fake_staged_1559(id: &str) -> StagedTx {
         StagedTx {
@@ -3352,11 +3673,11 @@ mod tests {
         let mut staged = fake_staged_1559("0001-test");
         staged.expires_ms = now_ms() + 60_000;
         // Inject a Warn check directly so the override gate fires.
-        staged.policy_checks = vec![PolicyCheck {
-            rule: "test.warn".into(),
-            outcome: PolicyOutcome::Warn,
-            message: "soft cap".into(),
-        }];
+        staged.policy_checks = vec![PolicyCheck::soft(
+            "test.warn",
+            PolicyOutcome::Warn,
+            "soft cap",
+        )];
         engine.outbox.write_pending(&staged, "p").unwrap();
 
         // "y" must be rejected — needs the policy's override token.
@@ -3430,11 +3751,11 @@ mod tests {
 
         let mut staged = fake_staged_1559("0001-test");
         staged.expires_ms = now_ms() + 60_000;
-        staged.policy_checks = vec![PolicyCheck {
-            rule: "caps.max_value_eth".into(),
-            outcome: PolicyOutcome::Deny,
-            message: "value exceeds max".into(),
-        }];
+        staged.policy_checks = vec![PolicyCheck::hard(
+            "caps.max_value_eth",
+            PolicyOutcome::Deny,
+            "value exceeds max",
+        )];
         engine.outbox.write_pending(&staged, "p").unwrap();
 
         let r = engine
@@ -3480,11 +3801,11 @@ mod tests {
 
         let mut staged = fake_staged_1559("0001-test");
         staged.expires_ms = now_ms() + 60_000;
-        staged.policy_checks = vec![PolicyCheck {
-            rule: "caps.warn_value_eth".into(),
-            outcome: PolicyOutcome::Warn,
-            message: "soft cap exceeded".into(),
-        }];
+        staged.policy_checks = vec![PolicyCheck::soft(
+            "caps.warn_value_eth",
+            PolicyOutcome::Warn,
+            "soft cap exceeded",
+        )];
         engine.outbox.write_pending(&staged, "p").unwrap();
 
         // Wrong text — must be rejected.
@@ -3641,6 +3962,195 @@ mod tests {
         match r {
             Err(TxEngineError::BroadcastApprovalRequired(_)) => {
                 panic!("review hash should satisfy approval gate")
+            }
+            Ok(_) => panic!("unexpected broadcast success on unreachable RPC"),
+            Err(_) => {}
+        }
+    }
+
+    #[tokio::test]
+    async fn wired_auth_outbox_confirm_ignores_legacy_marker_and_issues_challenge() {
+        let (engine, spec, dir) = fake_engine(60_000);
+        let engine = engine.with_auth_services(
+            Arc::new(RejectingTestVerifier),
+            Arc::new(ChallengeOnlyWriter),
+        );
+        let permit = permit_for(&dir);
+        let chain = bloom_chain::ChainClient::new(spec.clone()).unwrap();
+        let signer = alloy::signers::local::PrivateKeySigner::random();
+        let mut policy = bloom_proto::Policy::default();
+        policy.approval.require_broadcast_approval = true;
+
+        let mut staged = fake_staged_1559("0001-layer-b");
+        staged.value_wei = "1".into();
+        staged.usd_value = Some(0.01);
+        staged.expires_ms = now_ms() + 60_000;
+        engine.outbox.write_pending(&staged, "p").unwrap();
+
+        let entry = engine
+            .outbox
+            .read("alice", "anvil", "0001-layer-b")
+            .unwrap();
+        let legacy_hash = "legacy-reviewed-hash";
+        engine
+            .outbox
+            .write_artefact(&entry.dir, "review_intent.json", br#"{"schema":"legacy"}"#)
+            .unwrap();
+        engine
+            .outbox
+            .write_artefact(
+                &entry.dir,
+                "review_approved.json",
+                &serde_json::to_vec_pretty(&serde_json::json!({
+                    "schema": "bloom.review_approved.v1",
+                    "intent_hash": legacy_hash,
+                }))
+                .unwrap(),
+            )
+            .unwrap();
+
+        let r = engine
+            .confirm(
+                &permit,
+                "alice",
+                "anvil",
+                "0001-layer-b",
+                &chain,
+                &signer,
+                &policy,
+                "y",
+                Some(legacy_hash),
+            )
+            .await;
+        assert!(
+            matches!(r, Err(TxEngineError::BroadcastApprovalRequired(ref e)) if e.contains("Layer B")),
+            "expected Layer B challenge refusal, got {r:?}"
+        );
+        let challenge: ChallengeRecord = serde_json::from_slice(
+            &std::fs::read(entry.dir.join(OUTBOX_APPROVAL_CHALLENGE_FILE)).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(challenge.surface, "outbox");
+        assert_eq!(challenge.entry_id, outbox_entry_id(&staged));
+        assert_eq!(challenge.intent_hash, "outbox-intent");
+    }
+
+    #[tokio::test]
+    async fn wired_auth_outbox_confirm_accepts_approval_without_legacy_marker() {
+        let (engine, spec, dir) = fake_engine(60_000);
+        let engine = engine.with_auth_services(
+            Arc::new(AcceptingTestVerifier),
+            Arc::new(ChallengeOnlyWriter),
+        );
+        let permit = permit_for(&dir);
+        let chain = bloom_chain::ChainClient::new(spec.clone()).unwrap();
+        let signer = alloy::signers::local::PrivateKeySigner::random();
+        let mut policy = bloom_proto::Policy::default();
+        policy.approval.require_broadcast_approval = true;
+
+        let mut staged = fake_staged_1559("0001-layer-b-ok");
+        staged.value_wei = "1".into();
+        staged.usd_value = Some(0.01);
+        staged.expires_ms = now_ms() + 60_000;
+        engine.outbox.write_pending(&staged, "p").unwrap();
+        let entry = engine
+            .outbox
+            .read("alice", "anvil", "0001-layer-b-ok")
+            .unwrap();
+        engine
+            .outbox
+            .write_artefact(
+                &entry.dir,
+                OUTBOX_APPROVAL_FILE,
+                &serde_json::to_vec_pretty(&Approval {
+                    schema: APPROVAL_SCHEMA_V1.into(),
+                    wallet: "alice".into(),
+                    surface: "outbox".into(),
+                    entry_id: outbox_entry_id(&staged),
+                    intent_hash: "outbox-intent".into(),
+                    executor_id: "evm-broadcast".into(),
+                    network: "anvil".into(),
+                    assurance: AssuranceLevel::Convenience,
+                    server_nonce: "nonce-1".into(),
+                    caps: ApprovalCaps::default(),
+                    expiry_ms: now_ms() as u64 + 60_000,
+                    signer_kind: SignerKind::Test,
+                    credential_id: None,
+                    review_session_id: None,
+                    signature: ApprovalSignature::Test {
+                        sig_hex: "00".into(),
+                    },
+                })
+                .unwrap(),
+            )
+            .unwrap();
+
+        let r = engine
+            .confirm(
+                &permit,
+                "alice",
+                "anvil",
+                "0001-layer-b-ok",
+                &chain,
+                &signer,
+                &policy,
+                "y",
+                None,
+            )
+            .await;
+        match r {
+            Err(TxEngineError::BroadcastApprovalRequired(e)) => {
+                panic!("signed approval should satisfy approval gate: {e}")
+            }
+            Ok(_) => panic!("unexpected broadcast success on unreachable RPC"),
+            Err(_) => {}
+        }
+        let entry = engine
+            .outbox
+            .read("alice", "anvil", "0001-layer-b-ok")
+            .unwrap();
+        assert!(
+            engine
+                .outbox
+                .read_broadcast_attempt(&entry, BroadcastAttemptKind::Confirm)
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn wired_auth_outbox_confirm_retries_consumed_approval_for_same_intent() {
+        let (engine, spec, dir) = fake_engine(60_000);
+        let engine =
+            engine.with_auth_services(Arc::new(RejectingTestVerifier), Arc::new(PreApprovedWriter));
+        let permit = permit_for(&dir);
+        let chain = bloom_chain::ChainClient::new(spec.clone()).unwrap();
+        let signer = alloy::signers::local::PrivateKeySigner::random();
+        let mut policy = bloom_proto::Policy::default();
+        policy.approval.require_broadcast_approval = true;
+
+        let mut staged = fake_staged_1559("0001-layer-b-retry");
+        staged.value_wei = "1".into();
+        staged.usd_value = Some(0.01);
+        staged.expires_ms = now_ms() + 60_000;
+        engine.outbox.write_pending(&staged, "p").unwrap();
+
+        let r = engine
+            .confirm(
+                &permit,
+                "alice",
+                "anvil",
+                "0001-layer-b-retry",
+                &chain,
+                &signer,
+                &policy,
+                "y",
+                None,
+            )
+            .await;
+        match r {
+            Err(TxEngineError::BroadcastApprovalRequired(e)) => {
+                panic!("consumed approval for same intent should satisfy retry gate: {e}")
             }
             Ok(_) => panic!("unexpected broadcast success on unreachable RPC"),
             Err(_) => {}

--- a/crates/bloom-vfs/Cargo.toml
+++ b/crates/bloom-vfs/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 description = "Path router and handlers for bloom virtual filesystem"
 
 [dependencies]
+bloom-auth-api.workspace = true
 bloom-mempool.workspace = true
 bloom-proto.workspace = true
 bloom-ptb-builder.workspace = true
@@ -47,6 +48,7 @@ url.workspace = true
 lru.workspace = true
 reqwest.workspace = true
 base64.workspace = true
+blake3.workspace = true
 rand.workspace = true
 mpp.workspace = true
 

--- a/crates/bloom-vfs/src/auth.rs
+++ b/crates/bloom-vfs/src/auth.rs
@@ -1,0 +1,81 @@
+use std::sync::Arc;
+
+use bloom_auth_api::{ApprovalVerifier, AuthStoreView, AuthStoreWriter};
+
+use crate::handler::HandlerError;
+
+/// Shared authorization services injected by the daemon.
+///
+/// VFS handlers own most signer-sensitive write surfaces, but the concrete
+/// auth store/verifier belongs outside the NFS-facing crate. This handle keeps
+/// the dependency direction narrow: handlers can ask for Layer-B services when
+/// a surface is migrated, while tests and legacy setups default to no services.
+#[derive(Clone, Default)]
+pub struct AuthServices {
+    approval_verifier: Option<Arc<dyn ApprovalVerifier>>,
+    store: Option<Arc<dyn AuthStoreView>>,
+    writer: Option<Arc<dyn AuthStoreWriter>>,
+}
+
+impl AuthServices {
+    pub fn new(
+        approval_verifier: Option<Arc<dyn ApprovalVerifier>>,
+        store: Option<Arc<dyn AuthStoreView>>,
+        writer: Option<Arc<dyn AuthStoreWriter>>,
+    ) -> Self {
+        Self {
+            approval_verifier,
+            store,
+            writer,
+        }
+    }
+
+    pub fn with_approval_verifier(mut self, verifier: Arc<dyn ApprovalVerifier>) -> Self {
+        self.approval_verifier = Some(verifier);
+        self
+    }
+
+    pub fn with_store(mut self, store: Arc<dyn AuthStoreView>) -> Self {
+        self.store = Some(store);
+        self
+    }
+
+    pub fn with_writer(mut self, writer: Arc<dyn AuthStoreWriter>) -> Self {
+        self.writer = Some(writer);
+        self
+    }
+
+    pub fn approval_verifier(&self) -> Option<&Arc<dyn ApprovalVerifier>> {
+        self.approval_verifier.as_ref()
+    }
+
+    pub fn require_approval_verifier(&self) -> Result<&Arc<dyn ApprovalVerifier>, HandlerError> {
+        self.approval_verifier.as_ref().ok_or_else(|| {
+            HandlerError::Unsupported("Layer B approval verifier is not wired".into())
+        })
+    }
+
+    pub fn store(&self) -> Option<&Arc<dyn AuthStoreView>> {
+        self.store.as_ref()
+    }
+
+    pub fn require_store(&self) -> Result<&Arc<dyn AuthStoreView>, HandlerError> {
+        self.store
+            .as_ref()
+            .ok_or_else(|| HandlerError::Unsupported("Layer B auth store is not wired".into()))
+    }
+
+    pub fn writer(&self) -> Option<&Arc<dyn AuthStoreWriter>> {
+        self.writer.as_ref()
+    }
+
+    pub fn require_writer(&self) -> Result<&Arc<dyn AuthStoreWriter>, HandlerError> {
+        self.writer.as_ref().ok_or_else(|| {
+            HandlerError::Unsupported("Layer B auth store writer is not wired".into())
+        })
+    }
+
+    pub fn is_wired(&self) -> bool {
+        self.approval_verifier.is_some() || self.store.is_some() || self.writer.is_some()
+    }
+}

--- a/crates/bloom-vfs/src/handlers/defi.rs
+++ b/crates/bloom-vfs/src/handlers/defi.rs
@@ -211,6 +211,7 @@ pub struct DefiHandler {
     /// the daemon may override from `[hyperliquid]` config.
     hl_bridge: Address,
     hl_deposit_chain_id: u64,
+    auth_services: crate::AuthServices,
 }
 
 impl DefiHandler {
@@ -238,7 +239,13 @@ impl DefiHandler {
                 .parse()
                 .expect("valid hyperliquid bridge const"),
             hl_deposit_chain_id: bloom_proto::hyperliquid::DEPOSIT_CHAIN_ID,
+            auth_services: crate::AuthServices::default(),
         }
+    }
+
+    pub fn with_auth_services(mut self, auth_services: crate::AuthServices) -> Self {
+        self.auth_services = auth_services;
+        self
     }
 
     /// Override the Hyperliquid bridge address + deposit chain (from

--- a/crates/bloom-vfs/src/handlers/hyperliquid.rs
+++ b/crates/bloom-vfs/src/handlers/hyperliquid.rs
@@ -7,6 +7,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use bloom_auth_api::{Approval, AssuranceLevel, CanonicalEnvelope, CanonicalIntentHeader};
 use bloom_hyperliquid::{
     CancelWire, ExchangeAction, Grouping, HyperliquidClient, HyperliquidNetwork, HyperliquidSigner,
     LimitOrderType, OrderTypeWire, OrderWire, SignSubmit, SignedSubmit, TimeInForce,
@@ -21,6 +24,7 @@ use bloom_proto::{
 };
 use parking_lot::Mutex;
 use rand::RngCore;
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 use crate::handler::{Entry, Handler, HandlerError};
@@ -73,6 +77,28 @@ const SESSION_FILES: [&str; 12] = [
 ];
 const SEALED_AGENT_KEY_FILE: &str = ".agent_key.sealed";
 const AGENT_KEY_KEK_FILE: &str = ".agent_key_kek";
+const APPROVAL_FILE: &str = "approval.json";
+const APPROVAL_CHALLENGE_FILE: &str = "approval_challenge.json";
+const APPROVAL_TTL_MS: u64 = 5 * 60 * 1000;
+const USD_SEND_PENDING_FILE: &str = "usd_send_pending.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PendingUsdSend {
+    destination: String,
+    amount: String,
+    nonce: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct AgentSessionSubject<'a> {
+    schema: &'static str,
+    network: &'a str,
+    wallet: &'a str,
+    session_id: &'a str,
+    agent_name: Option<&'a str>,
+    vault_address: Option<&'a str>,
+    frozen_policy: &'a HyperliquidPolicy,
+}
 
 const README: &[u8] = br#"# Hyperliquid VFS
 
@@ -198,6 +224,7 @@ pub struct HyperliquidHandler {
     store_root: Option<PathBuf>,
     sessions: Arc<Mutex<HashMap<String, Arc<Mutex<ActiveHlSession>>>>>,
     pending_sessions: Arc<Mutex<HashSet<String>>>,
+    auth_services: crate::AuthServices,
 }
 
 impl HyperliquidHandler {
@@ -209,7 +236,13 @@ impl HyperliquidHandler {
             store_root: None,
             sessions: Arc::new(Mutex::new(HashMap::new())),
             pending_sessions: Arc::new(Mutex::new(HashSet::new())),
+            auth_services: crate::AuthServices::default(),
         }
+    }
+
+    pub fn with_auth_services(mut self, auth_services: crate::AuthServices) -> Self {
+        self.auth_services = auth_services;
+        self
     }
 
     pub fn with_store_root(mut self, root: PathBuf) -> Self {
@@ -544,7 +577,15 @@ impl HyperliquidHandler {
         req: AgentSessionCreate,
     ) -> Result<(), HandlerError> {
         let nonce = bloom_hyperliquid::now_ms();
-        let id = req.id.unwrap_or_else(|| format!("hl-{}", nonce));
+        let id = match req.id.clone() {
+            Some(id) => id,
+            None if self.auth_services.is_wired() => {
+                return Err(HandlerError::invalid(
+                    "Hyperliquid Layer B agent-session approval requires an explicit stable id",
+                ));
+            }
+            None => format!("hl-{}", nonce),
+        };
         safe_segment(&id)?;
         let reservation = self.reserve_session_slot(network_name, wallet, &id)?;
         let info = self
@@ -557,6 +598,8 @@ impl HyperliquidHandler {
                 "refusing to create Hyperliquid agent session: wallet [hyperliquid] policy must set allowed_assets, max_notional_usd, max_position_usd, and max_loss_usd",
             ));
         }
+        self.prepare_agent_session_layer_b(network_name, wallet, &id, &req, &policy)
+            .await?;
         let owner_signer = self.keystore.signer(wallet).map_err(|e| {
             HandlerError::PermissionDenied
                 .with_context(format!("wallet '{wallet}' is locked or unavailable: {e}"))
@@ -1752,6 +1795,7 @@ impl HyperliquidHandler {
             wallet: wallet.to_string(),
             action_kind: "usdSend".to_string(),
             notional_microusd: amount_micro,
+            destination: Some(req.destination.clone()),
             snapshot_readable: true,
             ..Default::default()
         };
@@ -1763,12 +1807,14 @@ impl HyperliquidHandler {
                 deny.rule, deny.message
             )));
         }
+        let nonce = self
+            .prepare_usd_send_layer_b(network_name, wallet, &req, &checks)
+            .await?;
         let signer = self.keystore.signer(wallet).map_err(|e| {
             HandlerError::PermissionDenied
                 .with_context(format!("wallet '{wallet}' is locked or unavailable: {e}"))
         })?;
         let signer = HyperliquidSigner::new(signer);
-        let nonce = req.nonce.unwrap_or_else(bloom_hyperliquid::now_ms);
         let (action, signature) = signer
             .sign_usd_send(network, dest, &req.amount, nonce)
             .await
@@ -1776,7 +1822,120 @@ impl HyperliquidHandler {
         let payload = user_signed_payload(action, nonce, signature);
         let response = client.exchange(payload).await.map_err(err_be)?;
         self.persist_response(network_name, wallet, "send_asset.json", &response)?;
+        let _ = self.clear_usd_send_pending(network_name, wallet);
         Ok(())
+    }
+
+    async fn prepare_usd_send_layer_b(
+        &self,
+        network: &str,
+        wallet: &str,
+        req: &UsdSendRequest,
+        checks: &[bloom_proto::PolicyCheck],
+    ) -> Result<u64, HandlerError> {
+        if !self.auth_services.is_wired() {
+            return Ok(req.nonce.unwrap_or_else(bloom_hyperliquid::now_ms));
+        }
+        let pending = self.load_or_create_usd_send_pending(network, wallet, req)?;
+        if pending.destination != req.destination || pending.amount != req.amount {
+            return Err(HandlerError::invalid(
+                "a different Hyperliquid usdSend is already pending approval; approve/cancel it before staging another",
+            ));
+        }
+        let envelope = hyperliquid_usd_send_envelope(network, wallet, &pending, checks)?;
+        let staged = self
+            .auth_services
+            .require_writer()?
+            .stage_entry(envelope, AssuranceLevel::Convenience, now_ms_u64())
+            .await
+            .map_err(|e| {
+                HandlerError::backend(format!("stage Hyperliquid usdSend auth entry: {e}"))
+            })?;
+        let dir = self.usd_send_auth_dir(network, wallet)?;
+        let approval_path = dir.join(APPROVAL_FILE);
+        if approval_path.exists() {
+            let approval: Approval = read_json(&approval_path)?;
+            self.auth_services
+                .require_approval_verifier()?
+                .verify_and_consume(approval, now_ms_u64())
+                .await
+                .map_err(|e| HandlerError::invalid(format!("Layer B approval rejected: {e}")))?;
+            return Ok(pending.nonce);
+        }
+        let mut nonce_bytes = [0u8; 32];
+        rand::rngs::OsRng.fill_bytes(&mut nonce_bytes);
+        let server_nonce = URL_SAFE_NO_PAD.encode(nonce_bytes);
+        let challenge = self
+            .auth_services
+            .require_writer()?
+            .issue_challenge(
+                "hyperliquid",
+                &staged.entry_id,
+                &server_nonce,
+                now_ms_u64().saturating_add(APPROVAL_TTL_MS),
+                now_ms_u64(),
+            )
+            .await
+            .map_err(|e| {
+                HandlerError::backend(format!("issue Hyperliquid usdSend challenge: {e}"))
+            })?;
+        write_json(dir.join(APPROVAL_CHALLENGE_FILE), &challenge)?;
+        Err(HandlerError::PermissionDenied)
+    }
+
+    async fn prepare_agent_session_layer_b(
+        &self,
+        network: &str,
+        wallet: &str,
+        session_id: &str,
+        req: &AgentSessionCreate,
+        policy: &HyperliquidPolicy,
+    ) -> Result<(), HandlerError> {
+        if !self.auth_services.is_wired() {
+            return Ok(());
+        }
+        let envelope =
+            hyperliquid_agent_session_envelope(network, wallet, session_id, req, policy)?;
+        let now = now_ms_u64();
+        let staged = self
+            .auth_services
+            .require_writer()?
+            .stage_entry(envelope, AssuranceLevel::Hardened, now)
+            .await
+            .map_err(|e| {
+                HandlerError::backend(format!("stage Hyperliquid agent-session auth entry: {e}"))
+            })?;
+        let dir = self.session_store_dir(network, wallet, session_id)?;
+        std::fs::create_dir_all(&dir)?;
+        let approval_path = dir.join(APPROVAL_FILE);
+        if approval_path.exists() {
+            let approval: Approval = read_json(&approval_path)?;
+            self.auth_services
+                .require_approval_verifier()?
+                .verify_and_consume(approval, now_ms_u64())
+                .await
+                .map_err(|e| HandlerError::invalid(format!("Layer B approval rejected: {e}")))?;
+            return Ok(());
+        }
+        let mut nonce_bytes = [0u8; 32];
+        rand::rngs::OsRng.fill_bytes(&mut nonce_bytes);
+        let server_nonce = URL_SAFE_NO_PAD.encode(nonce_bytes);
+        let challenge = self
+            .auth_services
+            .require_writer()?
+            .issue_challenge(
+                "hyperliquid",
+                &staged.entry_id,
+                &server_nonce,
+                now_ms_u64().saturating_add(APPROVAL_TTL_MS),
+                now_ms_u64(),
+            )
+            .await
+            .map_err(|e| {
+                HandlerError::backend(format!("issue Hyperliquid agent-session challenge: {e}"))
+            })?;
+        write_json(dir.join(APPROVAL_CHALLENGE_FILE), &challenge)?;
+        Err(HandlerError::PermissionDenied)
     }
 
     /// Evaluate the wallet's verified `[hyperliquid]` policy against an exchange
@@ -1973,6 +2132,53 @@ impl HyperliquidHandler {
             "response": response,
         });
         std::fs::write(dir.join("last_response.json"), pretty_json(&body))?;
+        Ok(())
+    }
+
+    fn usd_send_auth_dir(&self, network: &str, wallet: &str) -> Result<PathBuf, HandlerError> {
+        let Some(root) = &self.store_root else {
+            return Err(HandlerError::NotFound("Hyperliquid store root".into()));
+        };
+        Ok(root
+            .join("exchange")
+            .join(safe_segment(network)?)
+            .join(safe_segment(wallet)?))
+    }
+
+    fn load_or_create_usd_send_pending(
+        &self,
+        network: &str,
+        wallet: &str,
+        req: &UsdSendRequest,
+    ) -> Result<PendingUsdSend, HandlerError> {
+        let dir = self.usd_send_auth_dir(network, wallet)?;
+        std::fs::create_dir_all(&dir)?;
+        let path = dir.join(USD_SEND_PENDING_FILE);
+        if path.exists() {
+            return read_json(path);
+        }
+        let pending = PendingUsdSend {
+            destination: req.destination.clone(),
+            amount: req.amount.clone(),
+            nonce: req.nonce.unwrap_or_else(bloom_hyperliquid::now_ms),
+        };
+        write_json(path, &pending)?;
+        Ok(pending)
+    }
+
+    fn clear_usd_send_pending(&self, network: &str, wallet: &str) -> Result<(), HandlerError> {
+        let dir = self.usd_send_auth_dir(network, wallet)?;
+        for file in [
+            USD_SEND_PENDING_FILE,
+            APPROVAL_FILE,
+            APPROVAL_CHALLENGE_FILE,
+        ] {
+            match std::fs::remove_file(dir.join(file)) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(HandlerError::Io(e)),
+            }
+        }
         Ok(())
     }
 
@@ -3032,7 +3238,7 @@ impl Handler for HyperliquidHandler {
     }
 }
 
-#[derive(Debug, Clone, serde::Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct AgentSessionCreate {
     id: Option<String>,
     agent_name: Option<String>,
@@ -3767,6 +3973,117 @@ fn safe_segment(raw: &str) -> Result<String, HandlerError> {
         return Err(HandlerError::invalid("unsafe hyperliquid store segment"));
     }
     Ok(raw.to_string())
+}
+
+fn now_ms_u64() -> u64 {
+    bloom_hyperliquid::now_ms()
+}
+
+fn write_json(path: impl AsRef<Path>, value: &impl Serialize) -> Result<(), HandlerError> {
+    std::fs::write(path, serde_json::to_vec_pretty(value).map_err(err_json)?)?;
+    Ok(())
+}
+
+fn read_json<T: for<'de> Deserialize<'de>>(path: impl AsRef<Path>) -> Result<T, HandlerError> {
+    let bytes = std::fs::read(path)?;
+    serde_json::from_slice(&bytes).map_err(err_json)
+}
+
+fn hyperliquid_usd_send_entry_id(network: &str, wallet: &str, pending: &PendingUsdSend) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"bloom.hyperliquid.usd_send.entry.v1");
+    hasher.update(network.as_bytes());
+    hasher.update(&[0]);
+    hasher.update(wallet.as_bytes());
+    hasher.update(&[0]);
+    hasher.update(pending.destination.as_bytes());
+    hasher.update(&[0]);
+    hasher.update(pending.amount.as_bytes());
+    hasher.update(&[0]);
+    hasher.update(&pending.nonce.to_be_bytes());
+    format!("hl-usdsend-{}", hasher.finalize().to_hex())
+}
+
+fn hyperliquid_usd_send_envelope(
+    network: &str,
+    wallet: &str,
+    pending: &PendingUsdSend,
+    checks: &[bloom_proto::PolicyCheck],
+) -> Result<CanonicalEnvelope, HandlerError> {
+    let subject = serde_json::to_vec(&json!({
+        "schema": "bloom.hyperliquid_usd_send_subject.v1",
+        "network": network,
+        "wallet": wallet,
+        "destination": pending.destination,
+        "amount": pending.amount,
+        "nonce": pending.nonce,
+        "policy_checks": checks,
+    }))
+    .map_err(err_json)?;
+    Ok(CanonicalEnvelope::new(
+        CanonicalIntentHeader {
+            schema: "bloom.intent_header.v1".into(),
+            wallet: wallet.to_string(),
+            surface: "hyperliquid".into(),
+            entry_id: hyperliquid_usd_send_entry_id(network, wallet, pending),
+            executor_id: "hyperliquid-usd-send".into(),
+            network: network.to_string(),
+            account: wallet.to_string(),
+            action_kind: "usdSend".into(),
+            value_movement: true,
+            authority_change: false,
+        },
+        "hyperliquid_usd_send",
+        "bloom.hyperliquid_usd_send_subject.v1",
+        subject,
+    ))
+}
+
+fn hyperliquid_agent_session_entry_id(network: &str, wallet: &str, session_id: &str) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"bloom.hyperliquid.agent_session.entry.v1");
+    hasher.update(network.as_bytes());
+    hasher.update(&[0]);
+    hasher.update(wallet.as_bytes());
+    hasher.update(&[0]);
+    hasher.update(session_id.as_bytes());
+    format!("hl-session-{}", hasher.finalize().to_hex())
+}
+
+fn hyperliquid_agent_session_envelope(
+    network: &str,
+    wallet: &str,
+    session_id: &str,
+    req: &AgentSessionCreate,
+    policy: &HyperliquidPolicy,
+) -> Result<CanonicalEnvelope, HandlerError> {
+    let subject = AgentSessionSubject {
+        schema: "bloom.hyperliquid_agent_session_subject.v1",
+        network,
+        wallet,
+        session_id,
+        agent_name: req.agent_name.as_deref(),
+        vault_address: req.vault_address.as_deref(),
+        frozen_policy: policy,
+    };
+    let subject = serde_json::to_vec(&subject).map_err(err_json)?;
+    Ok(CanonicalEnvelope::new(
+        CanonicalIntentHeader {
+            schema: "bloom.intent_header.v1".into(),
+            wallet: wallet.to_string(),
+            surface: "hyperliquid".into(),
+            entry_id: hyperliquid_agent_session_entry_id(network, wallet, session_id),
+            executor_id: "hyperliquid-agent-session".into(),
+            network: network.to_string(),
+            account: wallet.to_string(),
+            action_kind: "approveAgent".into(),
+            value_movement: false,
+            authority_change: true,
+        },
+        "hyperliquid_agent_session",
+        "bloom.hyperliquid_agent_session_subject.v1",
+        subject,
+    ))
 }
 
 fn extend_safe_dir_names(

--- a/crates/bloom-vfs/src/handlers/polymarket.rs
+++ b/crates/bloom-vfs/src/handlers/polymarket.rs
@@ -9,6 +9,9 @@ use std::time::Duration;
 
 use alloy::primitives::{Address, U256};
 use async_trait::async_trait;
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use bloom_auth_api::{Approval, AssuranceLevel, CanonicalEnvelope, CanonicalIntentHeader};
 use bloom_chain::ChainClient;
 use bloom_keystore::{Keystore, KeystoreError};
 use bloom_polymarket::eip712::{PUSD, PUSD_DECIMALS};
@@ -23,6 +26,7 @@ use bloom_polymarket::{
 };
 use bloom_proto::audit::{AuditLog, AuditRecord};
 use bloom_proto::polymarket_policy::{self as pm_policy, PolicySide, PolymarketOrderCtx};
+use rand::RngCore;
 use serde::{Deserialize, Serialize};
 
 use crate::handler::{Entry, Handler, HandlerError};
@@ -51,6 +55,9 @@ const DRAFT_FILES: [&str; 5] = [
 ];
 
 const ROOT_FILES: [&str; 1] = ["README.md"];
+const APPROVAL_FILE: &str = "approval.json";
+const APPROVAL_CHALLENGE_FILE: &str = "approval_challenge.json";
+const APPROVAL_TTL_MS: u64 = 5 * 60 * 1000;
 
 const README: &[u8] = br#"# Polymarket Trading
 
@@ -107,8 +114,8 @@ redeem|revoke-approvals|withdraw-pusd`). Print the plan first with the CLI
 `--dry-run` flag. pUSD withdraw requires an explicit `amount` in the body (the
 path carries no amount slot); a bare `confirm` is rejected.
 
-Cancel is risk-reducing and uses stored CLOB credentials (no owner signing), so
-it executes directly in the VFS -- no foreground ceremony is needed:
+Cancel uses stored CLOB credentials (no owner signing), so it executes directly
+in the VFS only after compliance checks pass:
 ```json
  write: /polymarket/trade/<wallet>/orders/<order-id>/cancel          --data confirm
 ```
@@ -185,9 +192,9 @@ Print the plan first with: bloom polymarket withdraw-pusd <wallet> <amount|all> 
 "#;
 const CANCEL_HINT: &[u8] = br#"write "confirm" here to cancel this resting CLOB order.
 
-Cancellation is risk-reducing and executes directly in the VFS -- no wallet
+Cancellation executes directly in the VFS after compliance checks -- no wallet
 unlock is needed because it uses the wallet's stored CLOB credentials (L2 auth
-only). Geoblock is warning-only for cancel.
+only). Geoblock and jurisdiction checks are hard gates for cancel.
 
 Equivalent CLI:
 bloom polymarket cancel <wallet> <order-id>
@@ -212,11 +219,80 @@ fn now_ms_u128() -> u128 {
         .unwrap_or(0)
 }
 
+fn pm_now_ms_u64() -> u64 {
+    now_ms_u128().try_into().unwrap_or(u64::MAX)
+}
+
+fn polymarket_onboard_auth_dir(root: &Path, wallet: &str) -> Result<PathBuf, HandlerError> {
+    validate_wallet_name(wallet).map_err(err_be)?;
+    Ok(root.join(wallet))
+}
+
+fn polymarket_onboard_entry_id(wallet: &str) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"bloom.polymarket.onboard.entry.v1");
+    hasher.update(wallet.as_bytes());
+    format!("pm-onboard-{}", hasher.finalize().to_hex())
+}
+
+fn polymarket_onboard_envelope(
+    wallet: &str,
+    owner_address: &str,
+) -> Result<CanonicalEnvelope, HandlerError> {
+    let subject = serde_json::to_vec(&serde_json::json!({
+        "schema": "bloom.polymarket_onboard_subject.v1",
+        "wallet": wallet,
+        "owner_address": owner_address,
+        "approvals": bloom_polymarket::wallet::V2_APPROVAL_LABELS,
+        "effects": [
+            "deploy_deposit_wallet_if_needed",
+            "approve_v2_spenders",
+            "mint_clob_credentials",
+            "create_builder_key_if_configured",
+            "sync_buying_power"
+        ],
+    }))
+    .map_err(|e| HandlerError::backend(format!("encode Polymarket onboarding intent: {e}")))?;
+    Ok(CanonicalEnvelope::new(
+        CanonicalIntentHeader {
+            schema: "bloom.intent_header.v1".into(),
+            wallet: wallet.to_string(),
+            surface: "polymarket".into(),
+            entry_id: polymarket_onboard_entry_id(wallet),
+            executor_id: "polymarket-onboard".into(),
+            network: "polygon".into(),
+            account: wallet.to_string(),
+            action_kind: "onboard".into(),
+            value_movement: false,
+            authority_change: true,
+        },
+        "polymarket_onboard",
+        "bloom.polymarket_onboard_subject.v1",
+        subject,
+    ))
+}
+
+fn write_json(path: impl AsRef<Path>, value: &impl Serialize) -> Result<(), HandlerError> {
+    fs::write(
+        path,
+        serde_json::to_vec_pretty(value)
+            .map_err(|e| HandlerError::backend(format!("encode auth json: {e}")))?,
+    )?;
+    Ok(())
+}
+
+fn read_json<T: for<'de> Deserialize<'de>>(path: impl AsRef<Path>) -> Result<T, HandlerError> {
+    let bytes = fs::read(path)?;
+    serde_json::from_slice(&bytes)
+        .map_err(|e| HandlerError::backend(format!("read auth json: {e}")))
+}
+
 /// The onboarding/account dependencies, bundled so the read-only handler keeps
 /// its constructor and the daemon opts in via [`PolymarketHandler::with_onboarding`].
 pub struct PolymarketOnboarding {
     pub onboarder: Arc<Onboarder>,
     pub geoblock: Arc<GeoblockClient>,
+    pub auth_dir: PathBuf,
     /// Read access to stored CLOB credentials (for the `account/` views).
     pub creds: CredentialStore,
     /// Chain reads for the `account/` views (same adapter the onboarder uses).
@@ -490,6 +566,7 @@ pub struct PolymarketHandler {
     audit: Option<Arc<AuditLog>>,
     /// Wallets with an onboarding run in flight (single-flight guard).
     running: Arc<StdMutex<HashSet<String>>>,
+    auth_services: crate::AuthServices,
 }
 
 impl PolymarketHandler {
@@ -505,7 +582,13 @@ impl PolymarketHandler {
             builder_store: None,
             audit: None,
             running: Arc::default(),
+            auth_services: crate::AuthServices::default(),
         }
+    }
+
+    pub fn with_auth_services(mut self, auth_services: crate::AuthServices) -> Self {
+        self.auth_services = auth_services;
+        self
     }
 
     /// Enable the `onboard/` + `account/` subtrees.
@@ -635,7 +718,7 @@ impl PolymarketHandler {
     /// foreground ceremony) only if ALL of the following are true:
     /// - No EVM owner signing is required (L2 CLOB credentials only).
     /// - The operation is risk-reducing (cannot move funds or increase risk).
-    /// - Geoblock is warning-only (the operation proceeds even if blocked).
+    /// - Geoblock and jurisdiction checks pass.
     ///
     /// If any criterion is false, the operation MUST go through the foreground
     /// confirm path (`bloom vfs write --unlock-wallet`). Builder-key revoke is
@@ -655,7 +738,7 @@ impl PolymarketHandler {
             )));
         }
         // Resolve all local state first so durable refusals happen before any
-        // network call (geoblock is warning-only for cancel, mirroring the CLI).
+        // network call. Compliance gates are hard, even for cancels.
         let info = self
             .keystore
             .info(wallet)
@@ -670,13 +753,19 @@ impl PolymarketHandler {
             ob.creds.load(wallet).map_err(err_be)?.ok_or_else(|| {
                 HandlerError::invalid("wallet not onboarded (no CLOB credentials)")
             })?;
-        // Geoblock is warning-only for cancel (risk-reducing); it never blocks.
         match ob.geoblock.check().await {
             Ok(geo) if geo.blocked => {
-                tracing::warn!("geoblock reports blocked; cancel proceeds (risk-reducing)");
+                return Err(HandlerError::invalid(format!(
+                    "Polymarket geoblock denied cancel for wallet '{wallet}' (country={}, region={})",
+                    geo.country, geo.region
+                )));
             }
             Ok(_) => {}
-            Err(e) => tracing::warn!("geoblock check unavailable ({e}); cancel proceeds"),
+            Err(e) => {
+                return Err(HandlerError::invalid(format!(
+                    "could not verify Polymarket region availability before cancel: {e}"
+                )));
+            }
         }
         let store = self
             .orders
@@ -1894,8 +1983,9 @@ impl PolymarketHandler {
                     .into(),
             ));
         }
-        // Cancel is risk-reducing and uses stored CLOB creds (no owner signing),
-        // so it executes directly here rather than refusing like the confirm paths.
+        // Cancel uses stored CLOB creds (no owner signing), so it executes
+        // directly here after compliance checks rather than refusing like the
+        // owner-signed confirm paths.
         if segs.len() == 5 && segs[0] == "trade" && segs[2] == "orders" && segs[4] == "cancel" {
             let trimmed = std::str::from_utf8(_data)
                 .map(|s| s.trim().to_ascii_lowercase())
@@ -1955,13 +2045,6 @@ impl PolymarketHandler {
         validate_wallet_name(wallet).map_err(err_be)?;
         // Wallet must exist…
         self.wallet_address(wallet)?;
-        // …and be unlocked: signing (approval batch, ClobAuth) needs the key.
-        let signer_arc = self.keystore.signer(wallet).map_err(|e| match e {
-            KeystoreError::Locked(_) => HandlerError::invalid(format!(
-                "wallet '{wallet}' is locked; unlock it before onboarding"
-            )),
-            other => HandlerError::backend(other.to_string()),
-        })?;
         // Geoblock refuse-line: blocked or unverifiable → refuse. No bypass.
         let geo = ob.geoblock.check().await.map_err(err_be)?;
         if geo.blocked {
@@ -1971,6 +2054,14 @@ impl PolymarketHandler {
                 geo.country, geo.region
             )));
         }
+        self.prepare_onboard_layer_b(ob, wallet).await?;
+        // …and be unlocked: signing (approval batch, ClobAuth) needs the key.
+        let signer_arc = self.keystore.signer(wallet).map_err(|e| match e {
+            KeystoreError::Locked(_) => HandlerError::invalid(format!(
+                "wallet '{wallet}' is locked; unlock it before onboarding"
+            )),
+            other => HandlerError::backend(other.to_string()),
+        })?;
         // Single-flight per wallet.
         if !self.running.lock().unwrap().insert(wallet.to_string()) {
             return Err(HandlerError::invalid(format!(
@@ -2009,6 +2100,61 @@ impl PolymarketHandler {
             }
         });
         Ok(())
+    }
+
+    async fn prepare_onboard_layer_b(
+        &self,
+        ob: &PolymarketOnboarding,
+        wallet: &str,
+    ) -> Result<(), HandlerError> {
+        if !self.auth_services.is_wired() {
+            return Ok(());
+        }
+        let info = self
+            .keystore
+            .info(wallet)
+            .map_err(|e| HandlerError::backend(e.to_string()))?;
+        let envelope = polymarket_onboard_envelope(wallet, &format!("{:#x}", info.address))?;
+        let now = pm_now_ms_u64();
+        let staged = self
+            .auth_services
+            .require_writer()?
+            .stage_entry(envelope, AssuranceLevel::Hardened, now)
+            .await
+            .map_err(|e| {
+                HandlerError::backend(format!("stage Polymarket onboarding auth entry: {e}"))
+            })?;
+        let dir = polymarket_onboard_auth_dir(&ob.auth_dir, wallet)?;
+        fs::create_dir_all(&dir)?;
+        let approval_path = dir.join(APPROVAL_FILE);
+        if approval_path.exists() {
+            let approval: Approval = read_json(&approval_path)?;
+            self.auth_services
+                .require_approval_verifier()?
+                .verify_and_consume(approval, pm_now_ms_u64())
+                .await
+                .map_err(|e| HandlerError::invalid(format!("Layer B approval rejected: {e}")))?;
+            return Ok(());
+        }
+        let mut nonce_bytes = [0u8; 32];
+        rand::rngs::OsRng.fill_bytes(&mut nonce_bytes);
+        let server_nonce = URL_SAFE_NO_PAD.encode(nonce_bytes);
+        let challenge = self
+            .auth_services
+            .require_writer()?
+            .issue_challenge(
+                "polymarket",
+                &staged.entry_id,
+                &server_nonce,
+                pm_now_ms_u64().saturating_add(APPROVAL_TTL_MS),
+                pm_now_ms_u64(),
+            )
+            .await
+            .map_err(|e| {
+                HandlerError::backend(format!("issue Polymarket onboarding challenge: {e}"))
+            })?;
+        write_json(dir.join(APPROVAL_CHALLENGE_FILE), &challenge)?;
+        Err(HandlerError::PermissionDenied)
     }
 
     async fn list_inner(&self, path: &VfsPath) -> Result<Vec<Entry>, HandlerError> {
@@ -2466,9 +2612,9 @@ mod tests {
 
     #[tokio::test]
     async fn cancel_surface_advertises_and_executes_in_handler() {
-        // Cancel is risk-reducing and uses stored CLOB creds (no owner signing),
-        // so it executes directly in the handler — it must NOT refuse with the
-        // foreground guidance like the value-moving confirm paths.
+        // Cancel uses stored CLOB creds (no owner signing), so it executes
+        // directly in the handler after compliance checks. It must NOT refuse
+        // with foreground guidance like the value-moving confirm paths.
         let store_dir = tempfile::tempdir().unwrap();
         let h = handler_with(None, None).with_order_store(OrderStore::new(store_dir.path()));
 
@@ -2559,6 +2705,71 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("foreground CLI VFS path"));
+    }
+
+    #[tokio::test]
+    async fn cancel_geoblock_blocked_is_hard_denial() {
+        let (addr, _s) = spawn_scripted(vec![(
+            "/api/geoblock",
+            r#"{"blocked":true,"ip":"1.1.1.1","country":"XX","region":"YY"}"#.to_string(),
+        )])
+        .await;
+        let f = onboard_fixture(addr, true).await;
+        f.handler
+            .onboarding
+            .as_ref()
+            .unwrap()
+            .creds
+            .save(
+                "alice",
+                &bloom_polymarket::types::Credentials {
+                    key: "k-1".into(),
+                    secret: "c2VjcmV0LXZhbHVl".into(),
+                    passphrase: "pp-hidden".into(),
+                    nonce: 0,
+                },
+            )
+            .unwrap();
+
+        let err = f
+            .handler
+            .write(&p("/trade/alice/orders/0xORDER/cancel"), b"confirm")
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("geoblock denied cancel"), "{err}");
+        assert!(err.to_string().contains("country=XX"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn cancel_geoblock_unavailable_is_hard_denial() {
+        let (addr, _s) = spawn_scripted(vec![]).await;
+        let f = onboard_fixture(addr, true).await;
+        f.handler
+            .onboarding
+            .as_ref()
+            .unwrap()
+            .creds
+            .save(
+                "alice",
+                &bloom_polymarket::types::Credentials {
+                    key: "k-1".into(),
+                    secret: "c2VjcmV0LXZhbHVl".into(),
+                    passphrase: "pp-hidden".into(),
+                    nonce: 0,
+                },
+            )
+            .unwrap();
+
+        let err = f
+            .handler
+            .write(&p("/trade/alice/orders/0xORDER/cancel"), b"confirm")
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("could not verify Polymarket region availability before cancel"),
+            "{err}"
+        );
     }
 
     #[test]
@@ -2668,6 +2879,7 @@ key = "builder-key-2"
             geoblock: Arc::new(
                 GeoblockClient::new().with_base_url_for_tests(format!("{base}/api/geoblock")),
             ),
+            auth_dir: state_dir.path().to_path_buf(),
             creds: CredentialStore::new(state_dir.path()),
             chain,
         })

--- a/crates/bloom-vfs/src/handlers/requests.rs
+++ b/crates/bloom-vfs/src/handlers/requests.rs
@@ -7,6 +7,11 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use bloom_auth_api::{
+    Approval, AssuranceLevel, CanonicalEnvelope, CanonicalIntentHeader, ChallengeRecord,
+};
 use bloom_keystore::Keystore;
 use bloom_paid_http::{
     EmptyPaidHttpChainRpcResolver, NormalizedChallenge, PaidHttpChainRpcResolver, ParsedRequest,
@@ -26,10 +31,14 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 use url::Url;
 
+use crate::auth::AuthServices;
 use crate::handler::{Entry, Handler, HandlerError};
 use crate::path::VfsPath;
 
 const CONFIRM_APPROVAL_FILE: &str = ".confirm_approved.json";
+const APPROVAL_FILE: &str = "approval.json";
+const APPROVAL_CHALLENGE_FILE: &str = "approval_challenge.json";
+const APPROVAL_TTL_MS: u64 = 5 * 60 * 1000;
 
 #[derive(Clone)]
 pub struct RequestsHandler {
@@ -39,6 +48,7 @@ pub struct RequestsHandler {
     client: reqwest::Client,
     x402_signer: Arc<dyn X402PaymentSigner>,
     paid_http_rpc_resolver: Arc<dyn PaidHttpChainRpcResolver>,
+    auth_services: AuthServices,
 }
 
 impl RequestsHandler {
@@ -54,7 +64,13 @@ impl RequestsHandler {
             client: reqwest::Client::new(),
             x402_signer: Arc::new(KeystoreX402PaymentSigner::new(keystore)),
             paid_http_rpc_resolver: Arc::new(EmptyPaidHttpChainRpcResolver),
+            auth_services: AuthServices::default(),
         }
+    }
+
+    pub fn with_auth_services(mut self, auth_services: AuthServices) -> Self {
+        self.auth_services = auth_services;
+        self
     }
 
     pub fn with_x402_signer(mut self, signer: Arc<dyn X402PaymentSigner>) -> Self {
@@ -232,6 +248,17 @@ impl RequestsHandler {
                 dir.join("audit.json"),
                 &json!({"request_id": id, "event": "staged", "reads_spent": false, "dry_run": dry_run}),
             )?;
+            self.stage_auth_entry(
+                &id,
+                &request,
+                &wallet,
+                &host,
+                &challenge,
+                &policy_requirement,
+                &checks,
+                dry_run,
+            )
+            .await?;
             self.write_latest("pending", &id)?;
             Ok(id)
         } else {
@@ -398,6 +425,86 @@ impl RequestsHandler {
         Ok(())
     }
 
+    async fn stage_auth_entry(
+        &self,
+        id: &str,
+        request: &ParsedRequest,
+        wallet: &str,
+        host: &str,
+        challenge: &NormalizedChallenge,
+        requirement: &PaymentRequirement,
+        checks: &[PolicyCheck],
+        dry_run: bool,
+    ) -> Result<(), HandlerError> {
+        let Some(writer) = self.auth_services.writer() else {
+            return Ok(());
+        };
+        let envelope = paid_http_canonical_envelope(
+            id,
+            request,
+            wallet,
+            host,
+            challenge,
+            requirement,
+            checks,
+            dry_run,
+        )?;
+        let staged = writer
+            .stage_entry(envelope, AssuranceLevel::Convenience, now_ms())
+            .await
+            .map_err(|e| HandlerError::backend(format!("stage paid-http auth entry: {e}")))?;
+        fs::write(
+            self.req_dir("pending", id).join("intent_hash"),
+            format!("{}\n", staged.intent_hash),
+        )?;
+        Ok(())
+    }
+
+    async fn require_layer_b_confirm_approval(
+        &self,
+        pending: &Path,
+        id: &str,
+    ) -> Result<(), HandlerError> {
+        if !self.auth_services.is_wired() {
+            return Ok(());
+        }
+        let approval_path = pending.join(APPROVAL_FILE);
+        if approval_path.exists() {
+            let approval: Approval = read_json(&approval_path)?;
+            self.auth_services
+                .require_approval_verifier()?
+                .verify_and_consume(approval, now_ms())
+                .await
+                .map_err(|e| HandlerError::invalid(format!("Layer B approval rejected: {e}")))?;
+            return Ok(());
+        }
+
+        let challenge = self.issue_layer_b_confirm_challenge(id).await?;
+        write_json(pending.join(APPROVAL_CHALLENGE_FILE), &challenge)?;
+        Err(HandlerError::PermissionDenied)
+    }
+
+    async fn issue_layer_b_confirm_challenge(
+        &self,
+        id: &str,
+    ) -> Result<ChallengeRecord, HandlerError> {
+        let now = now_ms();
+        let mut nonce = [0u8; 32];
+        rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut nonce);
+        let nonce = URL_SAFE_NO_PAD.encode(nonce);
+        self.auth_services
+            .require_writer()?
+            .issue_challenge(
+                "requests",
+                id,
+                &nonce,
+                now.saturating_add(APPROVAL_TTL_MS),
+                now,
+            )
+            .await
+            .map_err(|e| HandlerError::backend(format!("issue paid-http approval challenge: {e}")))
+    }
+
     async fn confirm(&self, id: &str, data: &[u8]) -> Result<(), HandlerError> {
         let value = String::from_utf8_lossy(data).trim().to_ascii_lowercase();
         let pending = self.req_dir("pending", id);
@@ -425,7 +532,11 @@ impl RequestsHandler {
             .as_deref()
             .ok_or_else(|| HandlerError::backend("request.toml missing wallet"))?
             .to_string();
-        consume_request_confirm_approved(&pending, &wallet, &value)?;
+        if self.auth_services.is_wired() {
+            self.require_layer_b_confirm_approval(&pending, id).await?;
+        } else {
+            consume_request_confirm_approved(&pending, &wallet, &value)?;
+        }
         let host = request.url.host_str().unwrap_or("unknown").to_string();
         let mut challenge: NormalizedChallenge = read_json(pending.join("challenge.json"))?;
         validate_session_state_target(&challenge, id)?;
@@ -1449,10 +1560,71 @@ fn new_request_id() -> String {
     format!("req_{ms}_{n}")
 }
 
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .min(u128::from(u64::MAX)) as u64
+}
+
+fn paid_http_canonical_envelope(
+    id: &str,
+    request: &ParsedRequest,
+    wallet: &str,
+    host: &str,
+    challenge: &NormalizedChallenge,
+    requirement: &PaymentRequirement,
+    checks: &[PolicyCheck],
+    dry_run: bool,
+) -> Result<CanonicalEnvelope, HandlerError> {
+    let network = requirement
+        .network
+        .as_deref()
+        .or(challenge.network.as_deref())
+        .unwrap_or("unknown")
+        .to_string();
+    let subject = serde_json::to_vec(&json!({
+        "schema": "bloom.paid_http_subject.v1",
+        "request_id": id,
+        "method": request.method,
+        "url": request.url.as_str(),
+        "host": host,
+        "headers": request.headers,
+        "body_sha256": request.body.as_ref().map(|body| bloom_tools::sha256_hex(body.as_bytes())),
+        "challenge": challenge,
+        "selected_requirement": requirement,
+        "policy_checks": checks,
+        "dry_run": dry_run,
+    }))
+    .map_err(|e| HandlerError::backend(e.to_string()))?;
+    Ok(CanonicalEnvelope::new(
+        CanonicalIntentHeader {
+            schema: "bloom.intent_header.v1".into(),
+            wallet: wallet.to_string(),
+            surface: "requests".into(),
+            entry_id: id.to_string(),
+            executor_id: "paid-http".into(),
+            network,
+            account: "default".into(),
+            action_kind: "paid_http_confirm".into(),
+            value_movement: true,
+            authority_change: false,
+        },
+        "paid_http",
+        "bloom.paid_http_subject.v1",
+        subject,
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::path::VfsPath;
+    use bloom_auth_api::{
+        APPROVAL_SCHEMA_V1, ApprovalCaps, ApprovalSignature, ApprovalVerifier, AuthApiError,
+        AuthEntryRecord, AuthEntryState, AuthStoreWriter, NonceState, SignerKind,
+    };
     use bloom_paid_mpp::PaymentExecution;
     use bloom_paid_x402::X402PaymentCredential;
     use mpp::client::{PaymentProvider, TempoProvider};
@@ -1471,6 +1643,88 @@ mod tests {
 
     struct StaticX402Signer {
         calls: Arc<AtomicUsize>,
+    }
+
+    struct ChallengeOnlyWriter;
+
+    struct AcceptingVerifier {
+        calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl ApprovalVerifier for AcceptingVerifier {
+        async fn verify_and_consume(
+            &self,
+            approval: Approval,
+            _now_ms: u64,
+        ) -> Result<(), AuthApiError> {
+            if approval.surface != "requests" {
+                return Err(AuthApiError::Denied("wrong surface".into()));
+            }
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl AuthStoreWriter for ChallengeOnlyWriter {
+        async fn stage_entry(
+            &self,
+            envelope: CanonicalEnvelope,
+            assurance: AssuranceLevel,
+            now_ms: u64,
+        ) -> Result<AuthEntryRecord, AuthApiError> {
+            let intent_hash = envelope.intent_hash()?;
+            Ok(AuthEntryRecord {
+                surface: envelope.header.surface.clone(),
+                entry_id: envelope.header.entry_id.clone(),
+                state: AuthEntryState::Staged,
+                intent_hash,
+                assurance,
+                nonce: None,
+                nonce_state: NonceState::Unused,
+                reservation_id: None,
+                updated_ms: now_ms,
+            })
+        }
+
+        async fn issue_challenge(
+            &self,
+            surface: &str,
+            entry_id: &str,
+            server_nonce: &str,
+            expiry_ms: u64,
+            _now_ms: u64,
+        ) -> Result<ChallengeRecord, AuthApiError> {
+            Ok(ChallengeRecord {
+                surface: surface.to_string(),
+                entry_id: entry_id.to_string(),
+                intent_hash: "abc123".to_string(),
+                server_nonce: server_nonce.to_string(),
+                assurance: AssuranceLevel::Convenience,
+                expiry_ms,
+            })
+        }
+
+        async fn issue_review_session(
+            &self,
+            review_session_id: &str,
+            surface: &str,
+            entry_id: &str,
+            expires_ms: u64,
+            now_ms: u64,
+        ) -> Result<bloom_auth_api::ReviewSessionRecord, AuthApiError> {
+            Ok(bloom_auth_api::ReviewSessionRecord {
+                review_session_id: review_session_id.to_string(),
+                surface: surface.to_string(),
+                entry_id: entry_id.to_string(),
+                intent_hash: "abc123".to_string(),
+                assurance: AssuranceLevel::Convenience,
+                expires_ms,
+                consumed_ms: None,
+                created_ms: now_ms,
+            })
+        }
     }
 
     #[async_trait]
@@ -1525,6 +1779,50 @@ mod tests {
                 .unwrap_err();
         assert!(err.to_string().contains("invalid request id"), "{err}");
         assert!(!pending.join(CONFIRM_APPROVAL_FILE).exists());
+    }
+
+    #[test]
+    fn paid_http_canonical_envelope_commits_to_selected_plan() {
+        let request = parse_request("GET https://merchant.test/pay wallet=alice").unwrap();
+        let challenge = normalize_challenge(
+            &HeaderMap::new(),
+            br#"{"x402Version":1,"accepts":[{"network":"base","asset":"USDC","maxAmountRequired":"1000","payTo":"0x1234"}]}"#,
+            &request.url,
+        );
+        let requirement = challenge.accepts[0].clone();
+        let checks: Vec<PolicyCheck> = vec![];
+        let env = paid_http_canonical_envelope(
+            "req_1",
+            &request,
+            "alice",
+            "merchant.test",
+            &challenge,
+            &requirement,
+            &checks,
+            false,
+        )
+        .unwrap();
+        assert_eq!(env.header.surface, "requests");
+        assert_eq!(env.header.entry_id, "req_1");
+        assert_eq!(env.header.executor_id, "paid-http");
+        assert_eq!(env.header.network, "base");
+        assert_eq!(env.subject_kind, "paid_http");
+        let hash1 = env.intent_hash().unwrap();
+
+        let mut other_req = requirement;
+        other_req.network = Some("polygon".into());
+        let other = paid_http_canonical_envelope(
+            "req_1",
+            &request,
+            "alice",
+            "merchant.test",
+            &challenge,
+            &other_req,
+            &checks,
+            false,
+        )
+        .unwrap();
+        assert_ne!(hash1, other.intent_hash().unwrap());
     }
 
     #[test]
@@ -1788,6 +2086,141 @@ mod tests {
             .unwrap_err();
         assert!(err.to_string().contains("pending"), "{err}");
         assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn wired_auth_confirm_ignores_legacy_marker_and_issues_challenge() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let f = fixture(Some("alice"));
+        let mut policy = Policy::default();
+        policy.payments.enabled = true;
+        policy.payments.require_plan = true;
+        f.handler
+            .keystore
+            .write_policy("alice", toml::to_string_pretty(&policy).unwrap().as_bytes())
+            .unwrap();
+        let auth_services = AuthServices::new(None, None, Some(Arc::new(ChallengeOnlyWriter)));
+        let handler = f
+            .handler
+            .with_auth_services(auth_services)
+            .with_x402_signer(Arc::new(StaticX402Signer {
+                calls: calls.clone(),
+            }));
+        let pending = handler.requests_root().join("pending/req_layer_b");
+        fs::create_dir_all(&pending).unwrap();
+        let challenge = normalize_challenge(
+            &HeaderMap::new(),
+            br#"{"x402Version":1,"accepts":[{"network":"base","asset":"USDC","maxAmountRequired":"1000"}]}"#,
+            &Url::parse("http://127.0.0.1:9/pay").unwrap(),
+        );
+        write_json(pending.join("challenge.json"), &challenge).unwrap();
+        write_json(
+            pending.join("payment_method.json"),
+            &challenge.payment_method(),
+        )
+        .unwrap();
+        let empty_checks: Vec<PolicyCheck> = vec![];
+        write_json(pending.join("policy_check.json"), &empty_checks).unwrap();
+        write_json(
+            pending.join("request.toml"),
+            &json!({"method":"GET","url":"http://127.0.0.1:9/pay","wallet":"alice","headers":{},"dry_run":false}),
+        )
+        .unwrap();
+        fs::write(pending.join("status"), "pending\n").unwrap();
+
+        persist_request_confirm_approved(handler.root.as_path(), "req_layer_b", "alice", "confirm")
+            .unwrap();
+        let err = handler
+            .confirm("req_layer_b", b"confirm")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, HandlerError::PermissionDenied), "{err}");
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        let challenge: ChallengeRecord = read_json(pending.join(APPROVAL_CHALLENGE_FILE)).unwrap();
+        assert_eq!(challenge.surface, "requests");
+        assert_eq!(challenge.entry_id, "req_layer_b");
+        assert_eq!(challenge.intent_hash, "abc123");
+    }
+
+    #[tokio::test]
+    async fn wired_auth_confirm_accepts_approval_without_legacy_marker() {
+        let signer_calls = Arc::new(AtomicUsize::new(0));
+        let verifier_calls = Arc::new(AtomicUsize::new(0));
+        let f = fixture(Some("alice"));
+        let mut policy = Policy::default();
+        policy.payments.enabled = true;
+        policy.payments.require_plan = true;
+        f.handler
+            .keystore
+            .write_policy("alice", toml::to_string_pretty(&policy).unwrap().as_bytes())
+            .unwrap();
+        let auth_services = AuthServices::new(
+            Some(Arc::new(AcceptingVerifier {
+                calls: verifier_calls.clone(),
+            })),
+            None,
+            None,
+        );
+        let handler = f
+            .handler
+            .with_auth_services(auth_services)
+            .with_x402_signer(Arc::new(StaticX402Signer {
+                calls: signer_calls.clone(),
+            }));
+        let pending = handler.requests_root().join("pending/req_layer_b_ok");
+        fs::create_dir_all(&pending).unwrap();
+        let challenge = normalize_challenge(
+            &HeaderMap::new(),
+            br#"{"x402Version":1,"accepts":[{"network":"base","asset":"USDC","maxAmountRequired":"1000"}]}"#,
+            &Url::parse("http://127.0.0.1:9/pay").unwrap(),
+        );
+        write_json(pending.join("challenge.json"), &challenge).unwrap();
+        write_json(
+            pending.join("payment_method.json"),
+            &challenge.payment_method(),
+        )
+        .unwrap();
+        let empty_checks: Vec<PolicyCheck> = vec![];
+        write_json(pending.join("policy_check.json"), &empty_checks).unwrap();
+        write_json(
+            pending.join("request.toml"),
+            &json!({"method":"GET","url":"http://127.0.0.1:9/pay","wallet":"alice","headers":{},"dry_run":false}),
+        )
+        .unwrap();
+        fs::write(pending.join("status"), "pending\n").unwrap();
+        write_json(
+            pending.join(APPROVAL_FILE),
+            &Approval {
+                schema: APPROVAL_SCHEMA_V1.into(),
+                wallet: "alice".into(),
+                surface: "requests".into(),
+                entry_id: "req_layer_b_ok".into(),
+                intent_hash: "abc123".into(),
+                executor_id: "paid-http".into(),
+                network: "base".into(),
+                assurance: AssuranceLevel::Convenience,
+                server_nonce: "nonce-1".into(),
+                caps: ApprovalCaps::default(),
+                expiry_ms: now_ms() + 60_000,
+                signer_kind: SignerKind::Test,
+                credential_id: None,
+                review_session_id: None,
+                signature: ApprovalSignature::Test {
+                    sig_hex: "00".into(),
+                },
+            },
+        )
+        .unwrap();
+
+        handler.confirm("req_layer_b_ok", b"confirm").await.unwrap();
+        assert_eq!(verifier_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(signer_calls.load(Ordering::SeqCst), 1);
+        assert!(
+            handler
+                .requests_root()
+                .join("failed/req_layer_b_ok")
+                .exists()
+        );
     }
 
     #[test]
@@ -2348,6 +2781,7 @@ inline = '{"prompt":"hi"}'
         let current_checks = vec![PolicyCheck {
             rule: "payments.enabled".into(),
             result: "deny".into(),
+            class: bloom_paid_http::PolicyRuleClass::Hard,
             detail: "wallet policy has not enabled paid HTTP".into(),
         }];
 

--- a/crates/bloom-vfs/src/handlers/wallets.rs
+++ b/crates/bloom-vfs/src/handlers/wallets.rs
@@ -25,6 +25,11 @@ use std::sync::Arc;
 
 use alloy::signers::SignerSync;
 use async_trait::async_trait;
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use bloom_auth_api::{
+    Approval, AssuranceLevel, CanonicalEnvelope, CanonicalIntentHeader, ChallengeRecord,
+};
 use bloom_chain::ChainRegistry;
 use bloom_keystore::Keystore;
 use bloom_proto::{
@@ -37,8 +42,13 @@ use bloom_tx::{
     tx_engine::{TxEngine, TxEngineError},
 };
 
+use crate::auth::AuthServices;
 use crate::handler::{Entry, Handler, HandlerError};
 use crate::path::VfsPath;
+
+const APPROVAL_FILE: &str = "approval.json";
+const APPROVAL_CHALLENGE_FILE: &str = "approval_challenge.json";
+const APPROVAL_TTL_MS: u64 = 5 * 60 * 1000;
 
 #[derive(Clone)]
 pub struct WalletsHandler {
@@ -54,6 +64,9 @@ pub struct WalletsHandler {
     pub polymarket_onboard: Option<bloom_polymarket::OnboardStore>,
     /// Optional Hyperliquid handler for capability roll-up aggregation.
     pub hyperliquid_handler: Option<Arc<crate::handlers::hyperliquid::HyperliquidHandler>>,
+    /// Optional Layer-B auth services. Migrated signer paths must use this
+    /// instead of marker files; absent means legacy behavior remains explicit.
+    pub auth_services: AuthServices,
 }
 
 impl WalletsHandler {
@@ -72,7 +85,13 @@ impl WalletsHandler {
             mempool_indexes: Arc::new(std::collections::BTreeMap::new()),
             polymarket_onboard: None,
             hyperliquid_handler: None,
+            auth_services: AuthServices::default(),
         }
+    }
+
+    pub fn with_auth_services(mut self, auth_services: AuthServices) -> Self {
+        self.auth_services = auth_services;
+        self
     }
 
     /// Attach the Polymarket state root so `addresses.json` can surface the
@@ -358,7 +377,7 @@ impl WalletsHandler {
     /// Mint a bounded policy session from a descriptor written to
     /// `policy-session/new`. The descriptor is the security envelope: the
     /// chains, total USD cap, TTL, and the exact pending-tx ids it authorizes.
-    fn mint_policy_session(&self, wallet: &str, data: &[u8]) -> Result<(), HandlerError> {
+    async fn mint_policy_session(&self, wallet: &str, data: &[u8]) -> Result<(), HandlerError> {
         // Each authorized tx is a (chain_id, outbox id) pair — outbox ids are
         // unique only within a chain, so the allowlist must be chain-qualified.
         #[derive(serde::Deserialize)]
@@ -382,28 +401,30 @@ impl WalletsHandler {
                  ttl_secs > 0, and max_usd > 0",
             ));
         }
-        // Minting creates future signing authority, so it must prove the exact
-        // descriptor was human-reviewed — not merely that the daemon is unlocked.
-        // The IPC ceremony lane persists a one-time approval marker keyed by the
-        // reviewed-intent hash of this descriptor; require and consume it here so
-        // the VFS layer is safe regardless of how the write arrives.
         let path = format!("/wallets/{wallet}/policy-session/new");
-        let intent = bloom_proto::policy_session_mint_intent(wallet, &path, data);
-        let home = self
-            .keystore
-            .root()
-            .parent()
-            .ok_or_else(|| HandlerError::backend("keystore root has no parent home dir"))?
-            .to_path_buf();
-        if !crate::policy_session_review::consume_review_approved(
-            &home,
-            wallet,
-            &intent.intent_hash(),
-        ) {
-            return Err(HandlerError::invalid(
-                "policy-session mint requires a fresh reviewed-intent approval; \
-                 mint through the IPC ceremony lane (bloom wallet ... policy-session)",
-            ));
+        if self.auth_services.is_wired() {
+            self.require_layer_b_policy_session_approval(wallet, &path, data)
+                .await?;
+        } else {
+            // Legacy/unwired test mode only. Production daemon wiring must use
+            // the signed Layer-B approval above, not this marker.
+            let intent = bloom_proto::policy_session_mint_intent(wallet, &path, data);
+            let home = self
+                .keystore
+                .root()
+                .parent()
+                .ok_or_else(|| HandlerError::backend("keystore root has no parent home dir"))?
+                .to_path_buf();
+            if !crate::policy_session_review::consume_review_approved(
+                &home,
+                wallet,
+                &intent.intent_hash(),
+            ) {
+                return Err(HandlerError::invalid(
+                    "policy-session mint requires a fresh reviewed-intent approval; \
+                     mint through the IPC ceremony lane (bloom wallet ... policy-session)",
+                ));
+            }
         }
         // Chains are derived from the authorized pairs; the allowlist holds
         // chain-qualified keys so a same-id tx on another chain can't slip in.
@@ -427,6 +448,65 @@ impl WalletsHandler {
         self.tx_engine.session_store().mint(session);
         tracing::info!(wallet, session = %id, "wallet.policy_session.minted");
         Ok(())
+    }
+
+    async fn require_layer_b_policy_session_approval(
+        &self,
+        wallet: &str,
+        path: &str,
+        data: &[u8],
+    ) -> Result<(), HandlerError> {
+        let entry_id = policy_session_entry_id(wallet, data);
+        let envelope = policy_session_canonical_envelope(wallet, path, &entry_id, data)?;
+        self.auth_services
+            .require_writer()?
+            .stage_entry(envelope, AssuranceLevel::Hardened, now_ms_u64())
+            .await
+            .map_err(|e| HandlerError::backend(format!("stage policy-session auth entry: {e}")))?;
+        let approval_path = self
+            .keystore
+            .root()
+            .join(wallet)
+            .join("policy-session")
+            .join(&entry_id)
+            .join(APPROVAL_FILE);
+        if approval_path.exists() {
+            let approval: Approval = read_json(&approval_path)?;
+            self.auth_services
+                .require_approval_verifier()?
+                .verify_and_consume(approval, now_ms_u64())
+                .await
+                .map_err(|e| HandlerError::invalid(format!("Layer B approval rejected: {e}")))?;
+            return Ok(());
+        }
+        let challenge = self.issue_policy_session_challenge(&entry_id).await?;
+        let challenge_path = approval_path.with_file_name(APPROVAL_CHALLENGE_FILE);
+        if let Some(parent) = challenge_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        write_json(challenge_path, &challenge)?;
+        Err(HandlerError::PermissionDenied)
+    }
+
+    async fn issue_policy_session_challenge(
+        &self,
+        entry_id: &str,
+    ) -> Result<ChallengeRecord, HandlerError> {
+        let now = now_ms_u64();
+        let mut nonce = [0u8; 32];
+        rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut nonce);
+        let nonce = URL_SAFE_NO_PAD.encode(nonce);
+        self.auth_services
+            .require_writer()?
+            .issue_challenge(
+                "policy-session",
+                entry_id,
+                &nonce,
+                now.saturating_add(APPROVAL_TTL_MS),
+                now,
+            )
+            .await
+            .map_err(|e| HandlerError::backend(format!("issue policy-session challenge: {e}")))
     }
 
     fn wallet_dir_entries(kind: bloom_keystore::WalletKind) -> Vec<Entry> {
@@ -474,6 +554,69 @@ fn now_ms() -> u128 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis())
         .unwrap_or(0)
+}
+
+fn now_ms_u64() -> u64 {
+    now_ms().min(u128::from(u64::MAX)) as u64
+}
+
+fn write_json(path: impl AsRef<Path>, v: &impl serde::Serialize) -> Result<(), HandlerError> {
+    std::fs::write(
+        path,
+        serde_json::to_vec_pretty(v).map_err(|e| HandlerError::backend(e.to_string()))?,
+    )?;
+    Ok(())
+}
+
+fn read_json<T: for<'de> serde::Deserialize<'de>>(
+    path: impl AsRef<Path>,
+) -> Result<T, HandlerError> {
+    let bytes = std::fs::read(path)?;
+    serde_json::from_slice(&bytes).map_err(|e| HandlerError::backend(e.to_string()))
+}
+
+fn policy_session_entry_id(wallet: &str, data: &[u8]) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"bloom.policy_session.entry.v1");
+    hasher.update(wallet.as_bytes());
+    hasher.update(&[0]);
+    hasher.update(data);
+    format!("ps-{}", hasher.finalize().to_hex())
+}
+
+fn policy_session_canonical_envelope(
+    wallet: &str,
+    path: &str,
+    entry_id: &str,
+    data: &[u8],
+) -> Result<CanonicalEnvelope, HandlerError> {
+    let descriptor: serde_json::Value = serde_json::from_slice(data)
+        .map_err(|e| HandlerError::invalid(format!("policy-session descriptor: {e}")))?;
+    let subject = serde_json::to_vec(&serde_json::json!({
+        "schema": "bloom.policy_session_subject.v1",
+        "wallet": wallet,
+        "path": path,
+        "descriptor": descriptor,
+        "descriptor_blake3": blake3::hash(data).to_hex().to_string(),
+    }))
+    .map_err(|e| HandlerError::backend(e.to_string()))?;
+    Ok(CanonicalEnvelope::new(
+        CanonicalIntentHeader {
+            schema: "bloom.intent_header.v1".into(),
+            wallet: wallet.to_string(),
+            surface: "policy-session".into(),
+            entry_id: entry_id.to_string(),
+            executor_id: "wallet-policy-session".into(),
+            network: "multi-chain".into(),
+            account: "default".into(),
+            action_kind: "policy_session_mint".into(),
+            value_movement: false,
+            authority_change: true,
+        },
+        "policy_session",
+        "bloom.policy_session_subject.v1",
+        subject,
+    ))
 }
 
 /// Parse a state segment (`pending` / `sent` / `failed`) into an
@@ -724,7 +867,7 @@ impl WalletsHandler {
         // write lands for passkey wallets.
         if segs.len() == 3 && segs[1] == "policy-session" && segs[2] == "new" {
             self.write_permit()?;
-            return self.mint_policy_session(wallet, data);
+            return self.mint_policy_session(wallet, data).await;
         }
         if segs.len() == 4 && segs[1] == "policy-session" && segs[3] == "revoke" {
             self.write_permit()?;
@@ -1605,6 +1748,10 @@ fn decode_hex(s: &str) -> Result<Vec<u8>, hex::FromHexError> {
 mod tests {
     use super::*;
     use alloy::primitives::{Address, B256, Signature};
+    use bloom_auth_api::{
+        APPROVAL_SCHEMA_V1, ApprovalCaps, ApprovalSignature, ApprovalVerifier, AuthApiError,
+        AuthEntryRecord, AuthEntryState, AuthStoreWriter, NonceState, SignerKind,
+    };
     use bloom_proto::AddressBook;
     use bloom_tx::outbox::Outbox;
     use bloom_tx::tx_engine::TxEngine;
@@ -1616,6 +1763,85 @@ mod tests {
         wallet_name: String,
         wallet_addr: Address,
         sign_dir: std::path::PathBuf,
+    }
+
+    struct ChallengeOnlyWriter;
+
+    struct AcceptingVerifier;
+
+    #[async_trait]
+    impl ApprovalVerifier for AcceptingVerifier {
+        async fn verify_and_consume(
+            &self,
+            approval: Approval,
+            _now_ms: u64,
+        ) -> Result<(), AuthApiError> {
+            if approval.surface != "policy-session" {
+                return Err(AuthApiError::Denied("wrong surface".into()));
+            }
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl AuthStoreWriter for ChallengeOnlyWriter {
+        async fn stage_entry(
+            &self,
+            envelope: CanonicalEnvelope,
+            assurance: AssuranceLevel,
+            now_ms: u64,
+        ) -> Result<AuthEntryRecord, AuthApiError> {
+            let intent_hash = envelope.intent_hash()?;
+            Ok(AuthEntryRecord {
+                surface: envelope.header.surface.clone(),
+                entry_id: envelope.header.entry_id.clone(),
+                state: AuthEntryState::Staged,
+                intent_hash,
+                assurance,
+                nonce: None,
+                nonce_state: NonceState::Unused,
+                reservation_id: None,
+                updated_ms: now_ms,
+            })
+        }
+
+        async fn issue_challenge(
+            &self,
+            surface: &str,
+            entry_id: &str,
+            server_nonce: &str,
+            expiry_ms: u64,
+            _now_ms: u64,
+        ) -> Result<ChallengeRecord, AuthApiError> {
+            Ok(ChallengeRecord {
+                surface: surface.to_string(),
+                entry_id: entry_id.to_string(),
+                intent_hash: "policy-session-intent".to_string(),
+                server_nonce: server_nonce.to_string(),
+                assurance: AssuranceLevel::Hardened,
+                expiry_ms,
+            })
+        }
+
+        async fn issue_review_session(
+            &self,
+            review_session_id: &str,
+            surface: &str,
+            entry_id: &str,
+            expires_ms: u64,
+            now_ms: u64,
+        ) -> Result<bloom_auth_api::ReviewSessionRecord, AuthApiError> {
+            Ok(bloom_auth_api::ReviewSessionRecord {
+                review_session_id: review_session_id.to_string(),
+                surface: surface.to_string(),
+                entry_id: entry_id.to_string(),
+                intent_hash: "policy-session-intent".to_string(),
+                assurance: AssuranceLevel::Hardened,
+                expires_ms,
+                consumed_ms: None,
+                created_ms: now_ms,
+            })
+        }
     }
 
     fn make_handler() -> Fixture {
@@ -2027,6 +2253,99 @@ mod tests {
         // A degenerate descriptor (no chains/ids) is rejected.
         let bad = br#"{"chains":[],"max_usd":10,"ttl_secs":600,"pending_ids":[]}"#;
         assert!(f.handler.write(&new_p, bad).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn wired_auth_policy_session_mint_ignores_legacy_marker_and_issues_challenge() {
+        let mut f = make_handler();
+        f.handler = f.handler.with_auth_services(AuthServices::new(
+            None,
+            None,
+            Some(Arc::new(ChallengeOnlyWriter)),
+        ));
+        let new_p = VfsPath::parse("/alice/policy-session/new").unwrap();
+        let body =
+            br#"{"max_usd":10,"ttl_secs":600,"pending_ids":[{"chain_id":42161,"id":"0001-a"}]}"#;
+        approve_mint(&f, "alice", body);
+
+        let err = f.handler.write(&new_p, body).await.unwrap_err();
+        assert!(matches!(err, HandlerError::PermissionDenied), "{err}");
+        assert!(
+            f.handler
+                .tx_engine
+                .session_store()
+                .active(now_ms())
+                .iter()
+                .filter(|session| session.wallet == "alice")
+                .next()
+                .is_none()
+        );
+
+        let entry_id = policy_session_entry_id("alice", body);
+        let challenge_path = f
+            .handler
+            .keystore
+            .root()
+            .join("alice")
+            .join("policy-session")
+            .join(&entry_id)
+            .join(APPROVAL_CHALLENGE_FILE);
+        let challenge: ChallengeRecord = read_json(challenge_path).unwrap();
+        assert_eq!(challenge.surface, "policy-session");
+        assert_eq!(challenge.entry_id, entry_id);
+        assert_eq!(challenge.intent_hash, "policy-session-intent");
+        assert_eq!(challenge.assurance, AssuranceLevel::Hardened);
+    }
+
+    #[tokio::test]
+    async fn wired_auth_policy_session_mint_accepts_approval_without_legacy_marker() {
+        let mut f = make_handler();
+        f.handler = f.handler.with_auth_services(AuthServices::new(
+            Some(Arc::new(AcceptingVerifier)),
+            None,
+            Some(Arc::new(ChallengeOnlyWriter)),
+        ));
+        let new_p = VfsPath::parse("/alice/policy-session/new").unwrap();
+        let body =
+            br#"{"max_usd":10,"ttl_secs":600,"pending_ids":[{"chain_id":42161,"id":"0001-a"}]}"#;
+        let entry_id = policy_session_entry_id("alice", body);
+        let approval_dir = f
+            .handler
+            .keystore
+            .root()
+            .join("alice")
+            .join("policy-session")
+            .join(&entry_id);
+        std::fs::create_dir_all(&approval_dir).unwrap();
+        write_json(
+            approval_dir.join(APPROVAL_FILE),
+            &Approval {
+                schema: APPROVAL_SCHEMA_V1.into(),
+                wallet: "alice".into(),
+                surface: "policy-session".into(),
+                entry_id: entry_id.clone(),
+                intent_hash: "policy-session-intent".into(),
+                executor_id: "wallet-policy-session".into(),
+                network: "multi-chain".into(),
+                assurance: AssuranceLevel::Hardened,
+                server_nonce: "nonce-1".into(),
+                caps: ApprovalCaps::default(),
+                expiry_ms: now_ms_u64() + 60_000,
+                signer_kind: SignerKind::Test,
+                credential_id: None,
+                review_session_id: None,
+                signature: ApprovalSignature::Test {
+                    sig_hex: "00".into(),
+                },
+            },
+        )
+        .unwrap();
+
+        f.handler.write(&new_p, body).await.unwrap();
+        let sessions = f.handler.tx_engine.session_store().active(now_ms());
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].wallet, "alice");
+        assert_eq!(sessions[0].max_micro_usd, 10_000_000);
     }
 
     #[tokio::test]

--- a/crates/bloom-vfs/src/lib.rs
+++ b/crates/bloom-vfs/src/lib.rs
@@ -17,6 +17,7 @@
 
 #![forbid(unsafe_code)]
 
+pub mod auth;
 pub mod cache;
 pub mod handler;
 pub mod handlers;
@@ -27,6 +28,7 @@ pub mod policy_session_review;
 pub mod router;
 pub mod tx_handler;
 
+pub use auth::AuthServices;
 pub use cache::PathCache;
 pub use handler::{Entry, EntryKind, Handler, HandlerError};
 pub use paginate::{PAGE_SIZE, Projection, page_indices, page_name, page_slice, parse_page_name};

--- a/crates/bloom/src/commands/polymarket.rs
+++ b/crates/bloom/src/commands/polymarket.rs
@@ -98,34 +98,6 @@ fn home_write_permit(d: &Daemon) -> Result<&HomeWritePermit> {
     })
 }
 
-fn persist_outbox_review_approved(
-    d: &Daemon,
-    wallet: &str,
-    chain_name: &str,
-    id: &str,
-    review_hash: &str,
-) -> Result<()> {
-    let entry = d
-        .tx_engine
-        .outbox
-        .read(wallet, chain_name, id)
-        .with_context(|| format!("read outbox entry {id} before writing review approval"))?;
-    let approved = serde_json::json!({
-        "schema": "bloom.review_approved.v1",
-        "intent_hash": review_hash,
-        "approved_ms": now_ms(),
-    });
-    d.tx_engine
-        .outbox
-        .write_artefact(
-            &entry.dir,
-            "review_approved.json",
-            &serde_json::to_vec_pretty(&approved)?,
-        )
-        .with_context(|| format!("write review approval marker for staged tx {id}"))?;
-    Ok(())
-}
-
 /// Arguments shared by `order` (buy) and `sell`.
 pub struct PlaceArgs {
     pub wallet: String,
@@ -1962,9 +1934,6 @@ pub async fn fund(d: &Daemon, args: FundArgs) -> Result<()> {
         }
     }
     unlock_wallet_with_intent(d, &args.wallet, args.passphrase.as_deref(), Some(intent)).await?;
-    for id in &staged_ids {
-        persist_outbox_review_approved(d, &args.wallet, &chain_name, id, &reviewed_intent_hash)?;
-    }
     let signer = d.keystore.signer(&args.wallet)?;
     let confirm_text = if any_warn {
         info.policy.override_sentinel().to_string()
@@ -2173,13 +2142,6 @@ async fn transfer_pusd_to_funding(
             .write_artefact(&entry.dir, "review_intent.json", &bytes);
     }
     unlock_wallet_with_intent(d, &args.wallet, args.passphrase.as_deref(), Some(intent)).await?;
-    persist_outbox_review_approved(
-        d,
-        &args.wallet,
-        chain_name,
-        &staged.id,
-        &reviewed_intent_hash,
-    )?;
     let signer = d.keystore.signer(&args.wallet)?;
     let confirm_text = if any_warn {
         info.policy.override_sentinel().to_string()

--- a/crates/bloom/src/main.rs
+++ b/crates/bloom/src/main.rs
@@ -1420,7 +1420,6 @@ async fn run(cli: Cli) -> Result<()> {
                                 .map(|(p, _)| p)
                                 .as_deref(),
                         );
-                        let reviewed_intent_hash = intent.intent_hash();
                         persist_outbox_review_intent(&wallet, &p, &d.home.outbox_dir(), &intent)?;
                         let editable_policy = if is_wallet_policy_write(&wallet, &p) {
                             Some(String::from_utf8_lossy(&body).to_string())
@@ -1437,43 +1436,12 @@ async fn run(cli: Cli) -> Result<()> {
                             .await?;
                         if let Some(policy) = edited_policy {
                             body = policy.into_bytes();
-                        } else if is_outbox_confirm_write(&wallet, &p) {
-                            persist_outbox_review_approved(
-                                &wallet,
-                                &p,
-                                &d.home.outbox_dir(),
-                                &reviewed_intent_hash,
-                            )?;
-                            body.extend_from_slice(
-                                format!("\nreview_hash={reviewed_intent_hash}").as_bytes(),
-                            );
                         }
                     }
                     _ => {
                         d.keystore
                             .unlock(&wallet, passphrase.as_deref().unwrap_or(""))?;
                     }
-                }
-                if is_policy_session_new(&wallet, &p) {
-                    let intent = bloom_proto::policy_session_mint_intent(
-                        &wallet,
-                        &p.to_string_path(),
-                        &body,
-                    );
-                    bloom_vfs::policy_session_review::persist_review_approved(
-                        d.home.root(),
-                        &wallet,
-                        &intent.intent_hash(),
-                    )?;
-                }
-                if let Some(id) = request_confirm_id(d.home.root(), &p) {
-                    let confirm_value = String::from_utf8_lossy(&body).trim().to_ascii_lowercase();
-                    bloom_vfs::handlers::requests::persist_request_confirm_approved(
-                        d.home.root(),
-                        &id,
-                        &wallet,
-                        &confirm_value,
-                    )?;
                 }
                 d.vfs.write(&p, &body).await.context("vfs write")?;
 
@@ -1646,14 +1614,6 @@ async fn run(cli: Cli) -> Result<()> {
                         .unlock(&wallet, passphrase.as_deref().unwrap_or(""))?;
                 }
             }
-            let approval_id = request_confirm_id(d.home.root(), &p)
-                .context("request confirm path does not target a pending paid request")?;
-            bloom_vfs::handlers::requests::persist_request_confirm_approved(
-                d.home.root(),
-                &approval_id,
-                &wallet,
-                &String::from_utf8_lossy(&body).trim().to_ascii_lowercase(),
-            )?;
             d.vfs.write(&p, &body).await.context("request confirm")?;
             Ok(())
         }
@@ -2152,19 +2112,6 @@ async fn run(cli: Cli) -> Result<()> {
                     d.keystore
                         .unlock_passkey_with_intent(&wallet, intent)
                         .await?;
-                    if let Some(hash) = &reviewed_intent_hash
-                        && let Ok(entry) = d.tx_engine.outbox.read(&wallet, &chain, &id)
-                    {
-                        let approved = serde_json::json!({
-                            "schema": "bloom.review_approved.v1",
-                            "intent_hash": hash,
-                        });
-                        let _ = d.tx_engine.outbox.write_artefact(
-                            &entry.dir,
-                            "review_approved.json",
-                            &serde_json::to_vec_pretty(&approved)?,
-                        );
-                    }
                 }
                 _ => {
                     d.keystore
@@ -2358,19 +2305,6 @@ async fn run(cli: Cli) -> Result<()> {
                     d.keystore
                         .unlock_passkey_with_intent(&wallet, Some(intent))
                         .await?;
-                    let approved = serde_json::json!({
-                        "schema": "bloom.review_approved.v1",
-                        "intent_hash": hash,
-                        "scope": "batch",
-                    });
-                    let approved_bytes = serde_json::to_vec_pretty(&approved)?;
-                    for entry in &entries {
-                        let _ = d.tx_engine.outbox.write_artefact(
-                            &entry.dir,
-                            "review_approved.json",
-                            &approved_bytes,
-                        );
-                    }
                     reviewed_intent_hash = Some(hash);
                 }
                 _ => {
@@ -2435,7 +2369,8 @@ async fn run(cli: Cli) -> Result<()> {
             info!(home = %d.home.root().display(), chains = ?chains, endpoint = %endpoint.display, socket = %socket.display(), mount = ?mount, "cli.serve.starting");
             let server = IpcServer::new(d.vfs.clone(), env!("CARGO_PKG_VERSION"), chains)
                 .with_keystore(d.keystore.clone())
-                .with_petals(d.petals.clone());
+                .with_petals(d.petals.clone())
+                .with_auth_services(d.auth_services.clone());
             let server2 = server.clone();
             // Trigger graceful shutdown on Ctrl-C or SIGTERM.
             let shutdown = tokio::spawn(async move {
@@ -3170,43 +3105,6 @@ fn is_policy_session_new(wallet: &str, path: &VfsPath) -> bool {
     )
 }
 
-fn request_confirm_id(home: &std::path::Path, path: &VfsPath) -> Option<String> {
-    match path.segments() {
-        [root, reference, action] if root == "requests" && action == "confirm" => {
-            if reference == "latest" {
-                latest_pending_request_id(home)
-            } else {
-                Some(reference.to_string())
-            }
-        }
-        [root, state, id, action]
-            if root == "requests" && state == "pending" && action == "confirm" =>
-        {
-            Some(id.to_string())
-        }
-        _ => None,
-    }
-}
-
-fn latest_pending_request_id(home: &std::path::Path) -> Option<String> {
-    let latest = std::fs::read_to_string(home.join("requests").join("latest")).ok()?;
-    let (state, id) = latest.trim().split_once('/')?;
-    (state == "pending").then(|| id.to_string())
-}
-
-fn is_outbox_confirm_write(wallet: &str, path: &VfsPath) -> bool {
-    matches!(
-        path.segments(),
-        [root, w, chains, _chain, outbox, pending, _id, confirm]
-            if root == "wallets"
-                && w == wallet
-                && chains == "chains"
-                && outbox == "outbox"
-                && pending == "pending"
-                && confirm == "confirm"
-    )
-}
-
 async fn wallet_outbox_action_vfs_write(
     home: HomeDir,
     client_endpoint: &ResolvedEndpoint,
@@ -3663,26 +3561,6 @@ fn persist_outbox_review_intent(
     std::fs::write(
         dir.join("review_intent.json"),
         serde_json::to_vec_pretty(intent)?,
-    )?;
-    Ok(())
-}
-
-fn persist_outbox_review_approved(
-    wallet: &str,
-    path: &VfsPath,
-    outbox_root: &Path,
-    intent_hash: &str,
-) -> Result<()> {
-    let Some(dir) = outbox_confirm_dir(wallet, path, outbox_root) else {
-        return Ok(());
-    };
-    let approved = serde_json::json!({
-        "schema": "bloom.review_approved.v1",
-        "intent_hash": intent_hash,
-    });
-    std::fs::write(
-        dir.join("review_approved.json"),
-        serde_json::to_vec_pretty(&approved)?,
     )?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add Layer B auth API/store crates with sealed intents, signed approvals, nonce burn, review sessions, SQLite WAL/FULL durability, and audit records
- wire auth services through daemon, VFS, paid requests, EVM outbox, DeFi, Hyperliquid, Polymarket, and wallet policy-session paths
- bind passkey approvals to the approval payload hash with hardened UV enforcement; password wallets remain limited to in-policy auto-confirm paths
- harden policy checks for hard/soft rules, Hyperliquid transfer destinations, Polymarket geoblock denial, and approval retry edge cases

## Tests
- cargo check -p bloom-daemon -p bloom-tx -p bloom-auth -p bloom-auth-api -p bloom-keystore
- cargo test -p bloom-auth -p bloom-tx -p bloom-daemon
- cargo test -p bloom-keystore approval -- --nocapture
- cargo test -p bloom-vfs
- cargo test -p bloom-daemon -p bloom-proto -p bloom-paid-http
- cargo test -p bloom --bin bloom
