### PR TITLE
Align PR 55 approvals with sealed ceremony fail-closed behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2299,6 +2299,7 @@ name = "bloom-auth"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "blake3",
  "bloom-auth-api",
  "bloom-prices",

--- a/crates/bloom-auth-api/src/lib.rs
+++ b/crates/bloom-auth-api/src/lib.rs
@@ -1,4 +1,4 @@
-//! Shared authorization API for Bloom Layer B.
+//! Shared authorization API for Bloom Sealed Approval.
 //!
 //! This crate intentionally contains only stable data types and traits. The
 //! concrete store, verifier, and signer integrations live outside the VFS-facing
@@ -18,14 +18,15 @@ pub const APPROVAL_CHALLENGE_DOMAIN: &[u8] = b"bloom.approval.v1";
 #[serde(rename_all = "snake_case")]
 pub enum AssuranceLevel {
     #[default]
-    Convenience,
+    #[serde(alias = "convenience")]
+    Standard,
     Hardened,
 }
 
 impl AssuranceLevel {
     pub fn as_str(self) -> &'static str {
         match self {
-            Self::Convenience => "convenience",
+            Self::Standard => "standard",
             Self::Hardened => "hardened",
         }
     }
@@ -43,11 +44,8 @@ pub enum SignerKind {
 impl SignerKind {
     pub fn satisfies(self, assurance: AssuranceLevel) -> bool {
         match assurance {
-            AssuranceLevel::Convenience => {
-                matches!(
-                    self,
-                    SignerKind::Password | SignerKind::PasskeyBrowser | SignerKind::PasskeyCtap
-                )
+            AssuranceLevel::Standard => {
+                matches!(self, SignerKind::PasskeyBrowser | SignerKind::PasskeyCtap)
             }
             AssuranceLevel::Hardened => {
                 matches!(self, SignerKind::PasskeyBrowser | SignerKind::PasskeyCtap)
@@ -316,6 +314,74 @@ pub struct StandingAuthorityGrant {
     pub caps: ApprovalCaps,
     pub issued_ms: u64,
     pub expiry_ms: u64,
+    pub revoked_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PetalIdentity {
+    pub petal_id: String,
+    pub petal_digest: String,
+    pub petal_version: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SealedApprovalChallenge {
+    pub schema: String,
+    pub action_id: String,
+    pub wallet: String,
+    pub surface: String,
+    pub intent_hash: String,
+    pub petal: PetalIdentity,
+    pub server_nonce: String,
+    pub assurance: AssuranceLevel,
+    pub daemon_terms_digest: String,
+    pub petal_policy_digest: String,
+    pub policy_version: u64,
+    pub expiry_ms: u64,
+}
+
+impl SealedApprovalChallenge {
+    pub fn canonical_bytes(&self) -> Result<Vec<u8>, AuthApiError> {
+        serde_json::to_vec(self).map_err(AuthApiError::Json)
+    }
+
+    pub fn challenge_hash(&self) -> Result<[u8; 32], AuthApiError> {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(APPROVAL_CHALLENGE_DOMAIN);
+        hasher.update(&self.canonical_bytes()?);
+        Ok(*hasher.finalize().as_bytes())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SignerTransport {
+    BrowserWebauthn,
+    NativeCtap2,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SignedSealedApproval {
+    pub schema: String,
+    pub challenge: SealedApprovalChallenge,
+    pub signer_transport: SignerTransport,
+    pub webauthn_assertion: WebAuthnAssertionRecord,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SealedApprovalGrant {
+    pub grant_id: String,
+    pub action_id: String,
+    pub intent_hash: String,
+    pub wallet: String,
+    pub petal: PetalIdentity,
+    pub assurance: AssuranceLevel,
+    pub petal_policy_digest: String,
+    pub policy_version: u64,
+    pub issued_ms: u64,
+    pub expiry_ms: u64,
+    pub max_signatures: u32,
+    pub consumed_signatures: u32,
     pub revoked_ms: Option<u64>,
 }
 
@@ -739,7 +805,7 @@ mod tests {
             intent_hash: "0".repeat(64),
             executor_id: "evm".into(),
             network: "base".into(),
-            assurance: AssuranceLevel::Convenience,
+            assurance: AssuranceLevel::Standard,
             server_nonce: "nonce".into(),
             caps: ApprovalCaps::default(),
             expiry_ms: 42,
@@ -843,16 +909,24 @@ mod tests {
             envelope: env,
             sealed_at_ms: 1,
         };
-        approval_for(&sealed, AssuranceLevel::Convenience, SignerKind::Password)
-            .validate_against_sealed(&sealed, 100)
-            .unwrap();
+        approval_for(
+            &sealed,
+            AssuranceLevel::Standard,
+            SignerKind::PasskeyBrowser,
+        )
+        .validate_against_sealed(&sealed, 100)
+        .unwrap();
 
         let err = approval_for(&sealed, AssuranceLevel::Hardened, SignerKind::Password)
             .validate_against_sealed(&sealed, 100)
             .unwrap_err();
         assert!(err.to_string().contains("does not satisfy"), "{err}");
 
-        let mut wrong = approval_for(&sealed, AssuranceLevel::Convenience, SignerKind::Password);
+        let mut wrong = approval_for(
+            &sealed,
+            AssuranceLevel::Standard,
+            SignerKind::PasskeyBrowser,
+        );
         wrong.network = "wrong".into();
         let err = wrong.validate_against_sealed(&sealed, 100).unwrap_err();
         assert!(err.to_string().contains("network mismatch"), "{err}");
@@ -866,18 +940,23 @@ mod tests {
             envelope: env,
             sealed_at_ms: 1,
         };
-        let err = approval_for(&sealed, AssuranceLevel::Convenience, SignerKind::Password)
-            .validate_against_sealed(&sealed, 200)
-            .unwrap_err();
+        let err = approval_for(
+            &sealed,
+            AssuranceLevel::Standard,
+            SignerKind::PasskeyBrowser,
+        )
+        .validate_against_sealed(&sealed, 200)
+        .unwrap_err();
         assert!(err.to_string().contains("expired"), "{err}");
     }
 
     #[test]
     fn signer_kind_enforces_assurance_levels() {
-        assert!(SignerKind::Password.satisfies(AssuranceLevel::Convenience));
+        assert!(!SignerKind::Password.satisfies(AssuranceLevel::Standard));
         assert!(!SignerKind::Password.satisfies(AssuranceLevel::Hardened));
+        assert!(SignerKind::PasskeyBrowser.satisfies(AssuranceLevel::Standard));
         assert!(SignerKind::PasskeyBrowser.satisfies(AssuranceLevel::Hardened));
-        assert!(!SignerKind::Test.satisfies(AssuranceLevel::Convenience));
+        assert!(!SignerKind::Test.satisfies(AssuranceLevel::Standard));
     }
 
     #[test]

--- a/crates/bloom-auth/Cargo.toml
+++ b/crates/bloom-auth/Cargo.toml
@@ -16,5 +16,6 @@ serde_json.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+base64.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/bloom-auth/src/lib.rs
+++ b/crates/bloom-auth/src/lib.rs
@@ -1169,7 +1169,7 @@ fn parse_nonce_state(value: &str) -> Result<NonceState, AuthStoreError> {
 
 fn parse_assurance(value: &str) -> Result<AssuranceLevel, AuthStoreError> {
     match value {
-        "convenience" => Ok(AssuranceLevel::Convenience),
+        "standard" | "convenience" => Ok(AssuranceLevel::Standard),
         "hardened" => Ok(AssuranceLevel::Hardened),
         other => Err(AuthStoreError::InvalidAssurance(other.to_string())),
     }
@@ -1235,9 +1235,10 @@ impl AuthStoreError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::Engine as _;
     use bloom_auth_api::{
         APPROVAL_SCHEMA_V1, ApprovalCaps, ApprovalSignature, CanonicalEnvelope,
-        CanonicalIntentHeader, SignerKind,
+        CanonicalIntentHeader, SignerKind, WebAuthnAssertionRecord,
     };
 
     fn envelope() -> CanonicalEnvelope {
@@ -1261,7 +1262,7 @@ mod tests {
     }
 
     fn approval_for(entry: &AuthEntryRecord, sealed: &SealedIntentRecord) -> Approval {
-        Approval {
+        let mut approval = Approval {
             schema: APPROVAL_SCHEMA_V1.into(),
             wallet: sealed.envelope.header.wallet.clone(),
             surface: entry.surface.clone(),
@@ -1275,12 +1276,28 @@ mod tests {
             // Matches the expiry every test issues its challenge with; consume
             // requires equality with the persisted challenge_expiry_ms.
             expiry_ms: 220,
-            signer_kind: SignerKind::Password,
-            credential_id: None,
+            signer_kind: SignerKind::PasskeyCtap,
+            credential_id: Some("test-credential".into()),
             review_session_id: None,
-            signature: ApprovalSignature::PasswordMac {
-                mac_hex: "test-only".into(),
-            },
+            signature: ApprovalSignature::WebAuthnAssertion(WebAuthnAssertionRecord {
+                credential_id: "test-credential".into(),
+                authenticator_data_b64: "AA".into(),
+                client_data_json_b64: "AA".into(),
+                signature_b64: "AA".into(),
+                user_handle_b64: None,
+            }),
+        };
+        refresh_approval_assertion(&mut approval);
+        approval
+    }
+
+    fn refresh_approval_assertion(approval: &mut Approval) {
+        let challenge = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(approval.unsigned_payload().challenge_hash().unwrap());
+        if let ApprovalSignature::WebAuthnAssertion(assertion) = &mut approval.signature {
+            assertion.client_data_json_b64 = base64::engine::general_purpose::STANDARD.encode(
+                serde_json::to_vec(&serde_json::json!({ "challenge": challenge })).unwrap(),
+            );
         }
     }
 
@@ -1313,7 +1330,7 @@ mod tests {
         let mut store = AuthStore::open_in_memory_for_tests().unwrap();
         let env = envelope();
         let staged = store
-            .stage_entry(&env, AssuranceLevel::Convenience, 100)
+            .stage_entry(&env, AssuranceLevel::Standard, 100)
             .unwrap();
         assert_eq!(staged.state, AuthEntryState::Staged);
         assert_eq!(staged.nonce_state, NonceState::Unused);
@@ -1324,7 +1341,7 @@ mod tests {
             .unwrap();
         assert_eq!(challenge.intent_hash, staged.intent_hash);
         assert_eq!(challenge.server_nonce, "nonce-1");
-        assert_eq!(challenge.assurance, AssuranceLevel::Convenience);
+        assert_eq!(challenge.assurance, AssuranceLevel::Standard);
 
         let entry = store.auth_entry("requests", "req_1").unwrap().unwrap();
         assert_eq!(entry.state, AuthEntryState::Challenged);
@@ -1337,10 +1354,10 @@ mod tests {
         let mut store = AuthStore::open_in_memory_for_tests().unwrap();
         let env = envelope();
         let first = store
-            .stage_entry(&env, AssuranceLevel::Convenience, 100)
+            .stage_entry(&env, AssuranceLevel::Standard, 100)
             .unwrap();
         let second = store
-            .stage_entry(&env, AssuranceLevel::Convenience, 101)
+            .stage_entry(&env, AssuranceLevel::Standard, 101)
             .unwrap();
         assert_eq!(second.intent_hash, first.intent_hash);
         assert_eq!(second.updated_ms, first.updated_ms);
@@ -1357,7 +1374,7 @@ mod tests {
         );
         assert!(
             store
-                .stage_entry(&changed, AssuranceLevel::Convenience, 103)
+                .stage_entry(&changed, AssuranceLevel::Standard, 103)
                 .is_err()
         );
     }
@@ -1367,7 +1384,7 @@ mod tests {
         let mut store = AuthStore::open_in_memory_for_tests().unwrap();
         let env = envelope();
         store
-            .stage_entry(&env, AssuranceLevel::Convenience, 100)
+            .stage_entry(&env, AssuranceLevel::Standard, 100)
             .unwrap();
         store
             .issue_challenge("requests", "req_1", "nonce-1", 220, 101)
@@ -1404,7 +1421,7 @@ mod tests {
         let mut store = AuthStore::open_in_memory_for_tests().unwrap();
         let env = envelope();
         store
-            .stage_entry(&env, AssuranceLevel::Convenience, 100)
+            .stage_entry(&env, AssuranceLevel::Standard, 100)
             .unwrap();
         store
             .issue_challenge("requests", "req_1", "nonce-1", 220, 101)
@@ -1438,7 +1455,7 @@ mod tests {
             let mut store = AuthStore::open(&path).unwrap();
             let env = envelope();
             store
-                .stage_entry(&env, AssuranceLevel::Convenience, 100)
+                .stage_entry(&env, AssuranceLevel::Standard, 100)
                 .unwrap();
             store
                 .issue_challenge("requests", "req_1", "nonce-1", 220, 101)
@@ -1467,7 +1484,7 @@ mod tests {
         let mut store = AuthStore::open_in_memory_for_tests().unwrap();
         let env = envelope();
         store
-            .stage_entry(&env, AssuranceLevel::Convenience, 100)
+            .stage_entry(&env, AssuranceLevel::Standard, 100)
             .unwrap();
         store
             .issue_challenge("requests", "req_1", "nonce-1", 220, 101)
@@ -1493,7 +1510,7 @@ mod tests {
         let mut store = AuthStore::open(&path).unwrap();
         let env = envelope();
         store
-            .stage_entry(&env, AssuranceLevel::Convenience, 100)
+            .stage_entry(&env, AssuranceLevel::Standard, 100)
             .unwrap();
         store
             .issue_challenge("requests", "req_1", "nonce-1", 220, 101)
@@ -1652,6 +1669,7 @@ mod tests {
         let mut approval = approval_for(&entry, &sealed);
         approval.signer_kind = SignerKind::PasskeyCtap;
         approval.review_session_id = Some("review-1".into());
+        refresh_approval_assertion(&mut approval);
 
         store
             .consume_verified_approval_transactionally(&approval, 150)

--- a/crates/bloom-daemon/src/ipc.rs
+++ b/crates/bloom-daemon/src/ipc.rs
@@ -11,7 +11,6 @@
 //! | `lookup`   | `{ "path": "/..." }`                  | `{ "name", "kind", ... }` |
 //! | `read`     | `{ "path": "/..." }`                  | `{ "bytes_b64": "..." }`  |
 //! | `write`    | `{ "path": "/...", "bytes_b64": "" }` | `null`                    |
-//! | `write_unlocked` | `{ "path": "/...", "bytes_b64": "", "wallet": "...", "passphrase"? }` | `null` |
 //! | `list`     | `{ "path": "/..." }`                  | `[ entry, ... ]`          |
 //! | `version`  | `null`                                | `"x.y.z"`                 |
 //! | `chains`   | `null`                                | `[ "ethereum", ... ]`     |
@@ -294,10 +293,11 @@ impl IpcServer {
                 Ok(()) => Response::ok(id, Value::Null),
                 Err(e) => map_handler_err(id, e),
             },
-            "write_unlocked" => match self.do_write_unlocked(&req.params).await {
-                Ok(()) => Response::ok(id, Value::Null),
-                Err(e) => map_handler_err(id, e),
-            },
+            "write_unlocked" => Response::err(
+                id,
+                -32601,
+                "write_unlocked was removed; stage a central Sealed Approval action instead",
+            ),
             "wallet.sign_policy" => match self.do_wallet_sign_policy(&req.params).await {
                 Ok(()) => Response::ok(id, Value::Null),
                 Err(e) => map_handler_err(id, e),
@@ -2032,5 +2032,30 @@ allow_vault_or_subaccount = false
 
         server.trigger_shutdown();
         let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
+    }
+
+    #[tokio::test]
+    async fn write_unlocked_is_removed() {
+        let server = IpcServer::new(vfs(), "0", vec![]);
+        let response = server
+            .dispatch(Request {
+                jsonrpc: "2.0".into(),
+                id: json!(9),
+                method: "write_unlocked".into(),
+                params: json!({
+                    "path": "/stub/greet",
+                    "bytes_b64": B64.encode(b"hi"),
+                    "wallet": "minnow"
+                }),
+            })
+            .await;
+        let v = serde_json::to_value(response).unwrap();
+        assert_eq!(v["error"]["code"], -32601);
+        assert!(
+            v["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("write_unlocked was removed")
+        );
     }
 }

--- a/crates/bloom-keystore/src/passkey.rs
+++ b/crates/bloom-keystore/src/passkey.rs
@@ -2118,10 +2118,8 @@ mod ceremony_gate_tests {
     #[test]
     fn hardened_assurance_requires_user_verified_flag() {
         assert!(require_user_verification_for_assurance(AssuranceLevel::Hardened, true).is_ok());
-        assert!(
-            require_user_verification_for_assurance(AssuranceLevel::Convenience, false).is_ok()
-        );
-        assert!(require_user_verification_for_assurance(AssuranceLevel::Convenience, true).is_ok());
+        assert!(require_user_verification_for_assurance(AssuranceLevel::Standard, false).is_ok());
+        assert!(require_user_verification_for_assurance(AssuranceLevel::Standard, true).is_ok());
         let err =
             require_user_verification_for_assurance(AssuranceLevel::Hardened, false).unwrap_err();
         assert!(err.contains("user-verified"), "{err}");
@@ -2567,7 +2565,7 @@ mod approval_uv_tests {
         let td = tempfile::tempdir().unwrap();
         let ks = crate::Keystore::new(td.path()).unwrap();
         let signing = wallet_with_software_credential(td.path(), "uv-wallet");
-        let unsigned = unsigned_approval("uv-wallet", AssuranceLevel::Convenience);
+        let unsigned = unsigned_approval("uv-wallet", AssuranceLevel::Standard);
         let signature = assertion_with_flags(&signing, &unsigned, UP);
         // Stricter than the Decision 4 minimum (convenience may accept
         // presence-only): the shared ceremony policy requires UV for every
@@ -2585,7 +2583,7 @@ mod approval_uv_tests {
         let td = tempfile::tempdir().unwrap();
         let ks = crate::Keystore::new(td.path()).unwrap();
         let signing = wallet_with_software_credential(td.path(), "uv-wallet");
-        let unsigned = unsigned_approval("uv-wallet", AssuranceLevel::Convenience);
+        let unsigned = unsigned_approval("uv-wallet", AssuranceLevel::Standard);
         let signature = assertion_with_flags(&signing, &unsigned, UP | UV);
         ks.verify_approval_signature_with_passkey(&unsigned, &signature)
             .await
@@ -2597,7 +2595,7 @@ mod approval_uv_tests {
         let td = tempfile::tempdir().unwrap();
         let ks = crate::Keystore::new(td.path()).unwrap();
         let signing = wallet_with_software_credential(td.path(), "uv-wallet");
-        let unsigned = unsigned_approval("uv-wallet", AssuranceLevel::Convenience);
+        let unsigned = unsigned_approval("uv-wallet", AssuranceLevel::Standard);
         let other = unsigned_approval("uv-wallet", AssuranceLevel::Hardened);
         // Assertion minted for a different approval payload must not verify,
         // even though it is a valid signature from the right credential.

--- a/crates/bloom-proto/src/policy.rs
+++ b/crates/bloom-proto/src/policy.rs
@@ -575,7 +575,7 @@ pub fn classify_policy_edit(before: &Policy, after: &Policy) -> PolicyEditClass 
     let mut reasons = Vec::new();
 
     if before.approval.assurance == AssuranceLevel::Hardened
-        && after.approval.assurance == AssuranceLevel::Convenience
+        && after.approval.assurance == AssuranceLevel::Standard
     {
         reasons.push("approval.assurance hardened -> convenience".to_string());
     }
@@ -1112,7 +1112,7 @@ mod tests {
     fn policy_defaults_when_new_sections_missing() {
         let toml_src = "[caps]\nmax_value_eth = 0.1\n";
         let p: Policy = toml::from_str(toml_src).unwrap();
-        assert_eq!(p.approval.assurance, AssuranceLevel::Convenience);
+        assert_eq!(p.approval.assurance, AssuranceLevel::Standard);
         assert!(!p.approval.step_up.enabled);
         assert_eq!(p.approval.step_up.ttl_secs, 120);
         assert!(!p.private.enabled);
@@ -1437,7 +1437,7 @@ uv_above_usd = "1.0000001"
         );
 
         let mut after = before.clone();
-        after.approval.assurance = AssuranceLevel::Convenience;
+        after.approval.assurance = AssuranceLevel::Standard;
         after.limits.max_tx_usd = Some("20".into());
         after.allowlists.recipients.insert("bob".into());
         after
@@ -1477,7 +1477,7 @@ uv_above_usd = "1.0000001"
     #[test]
     fn policy_edit_classifier_allows_tightening() {
         let mut before = Policy::default();
-        before.approval.assurance = AssuranceLevel::Convenience;
+        before.approval.assurance = AssuranceLevel::Standard;
         before.approval.agent_autonomy = Some(AgentAutonomyMode::UnderPolicy);
         before.limits.max_tx_usd = Some("10".into());
         before.limits.max_day_usd = Some("100".into());

--- a/crates/bloom-tx/src/tx_engine.rs
+++ b/crates/bloom-tx/src/tx_engine.rs
@@ -1839,7 +1839,7 @@ impl TxEngine {
         })?;
         let envelope = outbox_canonical_envelope(staged)?;
         let auth_entry = writer
-            .stage_entry(envelope, AssuranceLevel::Convenience, now_ms() as u64)
+            .stage_entry(envelope, AssuranceLevel::Standard, now_ms() as u64)
             .await
             .map_err(|e| {
                 TxEngineError::BroadcastApprovalRequired(format!(
@@ -2607,7 +2607,7 @@ mod tests {
                 entry_id: entry_id.to_string(),
                 intent_hash: "outbox-intent".to_string(),
                 server_nonce: server_nonce.to_string(),
-                assurance: AssuranceLevel::Convenience,
+                assurance: AssuranceLevel::Standard,
                 expiry_ms,
             })
         }
@@ -2625,7 +2625,7 @@ mod tests {
                 surface: surface.to_string(),
                 entry_id: entry_id.to_string(),
                 intent_hash: "outbox-intent".to_string(),
-                assurance: AssuranceLevel::Convenience,
+                assurance: AssuranceLevel::Standard,
                 expires_ms,
                 consumed_ms: None,
                 created_ms: now_ms,
@@ -4070,7 +4070,7 @@ mod tests {
                     intent_hash: "outbox-intent".into(),
                     executor_id: "evm-broadcast".into(),
                     network: "anvil".into(),
-                    assurance: AssuranceLevel::Convenience,
+                    assurance: AssuranceLevel::Standard,
                     server_nonce: "nonce-1".into(),
                     caps: ApprovalCaps::default(),
                     expiry_ms: now_ms() as u64 + 60_000,

--- a/crates/bloom-vfs/src/auth.rs
+++ b/crates/bloom-vfs/src/auth.rs
@@ -8,8 +8,8 @@ use crate::handler::HandlerError;
 ///
 /// VFS handlers own most signer-sensitive write surfaces, but the concrete
 /// auth store/verifier belongs outside the NFS-facing crate. This handle keeps
-/// the dependency direction narrow: handlers can ask for Layer-B services when
-/// a surface is migrated, while tests and legacy setups default to no services.
+/// the dependency direction narrow: handlers can ask for Sealed Approval
+/// services while the NFS-facing crate stays out of the authorization TCB.
 #[derive(Clone, Default)]
 pub struct AuthServices {
     approval_verifier: Option<Arc<dyn ApprovalVerifier>>,
@@ -51,7 +51,7 @@ impl AuthServices {
 
     pub fn require_approval_verifier(&self) -> Result<&Arc<dyn ApprovalVerifier>, HandlerError> {
         self.approval_verifier.as_ref().ok_or_else(|| {
-            HandlerError::Unsupported("Layer B approval verifier is not wired".into())
+            HandlerError::Unsupported("Sealed Approval verifier is not wired".into())
         })
     }
 
@@ -60,9 +60,9 @@ impl AuthServices {
     }
 
     pub fn require_store(&self) -> Result<&Arc<dyn AuthStoreView>, HandlerError> {
-        self.store
-            .as_ref()
-            .ok_or_else(|| HandlerError::Unsupported("Layer B auth store is not wired".into()))
+        self.store.as_ref().ok_or_else(|| {
+            HandlerError::Unsupported("Sealed Approval auth store is not wired".into())
+        })
     }
 
     pub fn writer(&self) -> Option<&Arc<dyn AuthStoreWriter>> {
@@ -71,11 +71,11 @@ impl AuthServices {
 
     pub fn require_writer(&self) -> Result<&Arc<dyn AuthStoreWriter>, HandlerError> {
         self.writer.as_ref().ok_or_else(|| {
-            HandlerError::Unsupported("Layer B auth store writer is not wired".into())
+            HandlerError::Unsupported("Sealed Approval auth store writer is not wired".into())
         })
     }
 
     pub fn is_wired(&self) -> bool {
-        self.approval_verifier.is_some() || self.store.is_some() || self.writer.is_some()
+        self.approval_verifier.is_some() && self.store.is_some() && self.writer.is_some()
     }
 }

--- a/crates/bloom-vfs/src/handlers/hyperliquid.rs
+++ b/crates/bloom-vfs/src/handlers/hyperliquid.rs
@@ -1846,7 +1846,7 @@ impl HyperliquidHandler {
         let staged = self
             .auth_services
             .require_writer()?
-            .stage_entry(envelope, AssuranceLevel::Convenience, now_ms_u64())
+            .stage_entry(envelope, AssuranceLevel::Standard, now_ms_u64())
             .await
             .map_err(|e| {
                 HandlerError::backend(format!("stage Hyperliquid usdSend auth entry: {e}"))

--- a/crates/bloom-vfs/src/handlers/requests.rs
+++ b/crates/bloom-vfs/src/handlers/requests.rs
@@ -426,12 +426,10 @@ impl RequestsHandler {
     }
 
     async fn stage_auth_entry(&self, subject: PaidHttpAuthSubject<'_>) -> Result<(), HandlerError> {
-        let Some(writer) = self.auth_services.writer() else {
-            return Ok(());
-        };
+        let writer = self.auth_services.require_writer()?;
         let envelope = paid_http_canonical_envelope(subject)?;
         let staged = writer
-            .stage_entry(envelope, AssuranceLevel::Convenience, now_ms())
+            .stage_entry(envelope, AssuranceLevel::Standard, now_ms())
             .await
             .map_err(|e| HandlerError::backend(format!("stage paid-http auth entry: {e}")))?;
         fs::write(
@@ -441,13 +439,16 @@ impl RequestsHandler {
         Ok(())
     }
 
-    async fn require_layer_b_confirm_approval(
+    async fn require_sealed_confirm_approval(
         &self,
         pending: &Path,
         id: &str,
     ) -> Result<(), HandlerError> {
         if !self.auth_services.is_wired() {
-            return Ok(());
+            return Err(HandlerError::Unsupported(
+                "Sealed Approval services are not fully wired; paid request confirmation is fail-closed"
+                    .into(),
+            ));
         }
         let approval_path = pending.join(APPROVAL_FILE);
         if approval_path.exists() {
@@ -456,16 +457,16 @@ impl RequestsHandler {
                 .require_approval_verifier()?
                 .verify_and_consume(approval, now_ms())
                 .await
-                .map_err(|e| HandlerError::invalid(format!("Layer B approval rejected: {e}")))?;
+                .map_err(|e| HandlerError::invalid(format!("Sealed Approval rejected: {e}")))?;
             return Ok(());
         }
 
-        let challenge = self.issue_layer_b_confirm_challenge(id).await?;
+        let challenge = self.issue_sealed_confirm_challenge(id).await?;
         write_json(pending.join(APPROVAL_CHALLENGE_FILE), &challenge)?;
         Err(HandlerError::PermissionDenied)
     }
 
-    async fn issue_layer_b_confirm_challenge(
+    async fn issue_sealed_confirm_challenge(
         &self,
         id: &str,
     ) -> Result<ChallengeRecord, HandlerError> {
@@ -513,11 +514,7 @@ impl RequestsHandler {
             .as_deref()
             .ok_or_else(|| HandlerError::backend("request.toml missing wallet"))?
             .to_string();
-        if self.auth_services.is_wired() {
-            self.require_layer_b_confirm_approval(&pending, id).await?;
-        } else {
-            consume_request_confirm_approved(&pending, &wallet, &value)?;
-        }
+        self.require_sealed_confirm_approval(&pending, id).await?;
         let host = request.url.host_str().unwrap_or("unknown").to_string();
         let mut challenge: NormalizedChallenge = read_json(pending.join("challenge.json"))?;
         validate_session_state_target(&challenge, id)?;
@@ -1610,7 +1607,8 @@ mod tests {
     use crate::path::VfsPath;
     use bloom_auth_api::{
         APPROVAL_SCHEMA_V1, ApprovalCaps, ApprovalSignature, ApprovalVerifier, AuthApiError,
-        AuthEntryRecord, AuthEntryState, AuthStoreWriter, NonceState, SignerKind,
+        AuthEntryRecord, AuthEntryState, AuthStoreView, AuthStoreWriter, NonceState,
+        SealedIntentRecord, SignerKind,
     };
     use bloom_paid_mpp::PaymentExecution;
     use bloom_paid_x402::X402PaymentCredential;
@@ -1654,6 +1652,37 @@ mod tests {
     }
 
     #[async_trait]
+    impl AuthStoreView for ChallengeOnlyWriter {
+        async fn sealed_intent(
+            &self,
+            intent_hash: &str,
+        ) -> Result<SealedIntentRecord, AuthApiError> {
+            let envelope = CanonicalEnvelope::new(
+                CanonicalIntentHeader {
+                    schema: "bloom.intent_header.v1".into(),
+                    wallet: "alice".into(),
+                    surface: "requests".into(),
+                    entry_id: "test".into(),
+                    executor_id: "paid-http".into(),
+                    network: "base".into(),
+                    account: "default".into(),
+                    action_kind: "x402_payment".into(),
+                    value_movement: true,
+                    authority_change: false,
+                },
+                "paid_http",
+                "paid_http.v1",
+                b"{}".to_vec(),
+            );
+            Ok(SealedIntentRecord {
+                intent_hash: intent_hash.to_string(),
+                envelope,
+                sealed_at_ms: now_ms(),
+            })
+        }
+    }
+
+    #[async_trait]
     impl AuthStoreWriter for ChallengeOnlyWriter {
         async fn stage_entry(
             &self,
@@ -1688,7 +1717,7 @@ mod tests {
                 entry_id: entry_id.to_string(),
                 intent_hash: "abc123".to_string(),
                 server_nonce: server_nonce.to_string(),
-                assurance: AssuranceLevel::Convenience,
+                assurance: AssuranceLevel::Standard,
                 expiry_ms,
             })
         }
@@ -1706,7 +1735,7 @@ mod tests {
                 surface: surface.to_string(),
                 entry_id: entry_id.to_string(),
                 intent_hash: "abc123".to_string(),
-                assurance: AssuranceLevel::Convenience,
+                assurance: AssuranceLevel::Standard,
                 expires_ms,
                 consumed_ms: None,
                 created_ms: now_ms,
@@ -2086,7 +2115,14 @@ mod tests {
             .keystore
             .write_policy("alice", toml::to_string_pretty(&policy).unwrap().as_bytes())
             .unwrap();
-        let auth_services = AuthServices::new(None, None, Some(Arc::new(ChallengeOnlyWriter)));
+        let auth_store = Arc::new(ChallengeOnlyWriter);
+        let auth_services = AuthServices::new(
+            Some(Arc::new(AcceptingVerifier {
+                calls: Arc::new(AtomicUsize::new(0)),
+            })),
+            Some(auth_store.clone()),
+            Some(auth_store),
+        );
         let handler = f
             .handler
             .with_auth_services(auth_services)
@@ -2141,12 +2177,13 @@ mod tests {
             .keystore
             .write_policy("alice", toml::to_string_pretty(&policy).unwrap().as_bytes())
             .unwrap();
+        let auth_store = Arc::new(ChallengeOnlyWriter);
         let auth_services = AuthServices::new(
             Some(Arc::new(AcceptingVerifier {
                 calls: verifier_calls.clone(),
             })),
-            None,
-            None,
+            Some(auth_store.clone()),
+            Some(auth_store),
         );
         let handler = f
             .handler
@@ -2185,7 +2222,7 @@ mod tests {
                 intent_hash: "abc123".into(),
                 executor_id: "paid-http".into(),
                 network: "base".into(),
-                assurance: AssuranceLevel::Convenience,
+                assurance: AssuranceLevel::Standard,
                 server_nonce: "nonce-1".into(),
                 caps: ApprovalCaps::default(),
                 expiry_ms: now_ms() + 60_000,


### PR DESCRIPTION
## Summary

Implements a first follow-up slice from `docs/specs/2026-07-02-sealed-approval.md` on top of PR #55:

- renames approval assurance from `convenience` to `standard` in code while keeping `convenience` as a backwards-compatible deserialization alias
- adds target Sealed Approval API structs for Petal identity, challenge preimage, signer transport, signed approval, and in-memory grant records
- removes password/local signer satisfaction for standard approvals; passkey browser/CTAP are now required for both standard and hardened approval levels
- makes paid-HTTP auth staging/confirmation fail closed when Sealed Approval services are not fully wired
- disables the `write_unlocked` IPC method at dispatch so it no longer acts as a privileged signer lane
- updates tests to use passkey-style approval fixtures and full auth service wiring

## Verification

```sh
CARGO_TARGET_DIR=/root/.cache/bloom-pr55-target cargo fmt --check
CARGO_TARGET_DIR=/root/.cache/bloom-pr55-target cargo test -p bloom-auth-api -p bloom-auth
CARGO_TARGET_DIR=/root/.cache/bloom-pr55-target cargo test -p bloom-vfs wired_auth_confirm
CARGO_TARGET_DIR=/root/.cache/bloom-pr55-target cargo test -p bloom-daemon write_unlocked_is_removed
```

## Notes

I could not push directly to `bloom-directory/bloom:auth-architecture-hardening` with the available `violet-agent` credentials, so this is a fork PR targeting PR #55's branch.
