### PR TITLE
Ceremony UX fixes + design issues from real-tx testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,10 @@ jobs:
         run: rustup show
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
       - name: Free runner disk space
         run: |
           df -h

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -263,8 +263,8 @@ Prereqs: `anvil`, `cast`, `forge`, `jq`, and a built `target/release/bloom`
 
 | # | Scenario | Skipped when |
 |---|----------|--------------|
-| 1 | Native ETH send on a local anvil | (always runs) |
-| 2 | ERC-20 transfer (deploys `MockERC20` via `forge`) | (always runs) |
+| 1 | Native ETH send staged on local Anvil; initial confirm must deny and write central `approval_challenge.json` with `ceremony_url` | (always runs) |
+| 2 | ERC-20 transfer staged with deployed `MockERC20`; initial confirm must deny and write central `approval_challenge.json` with `ceremony_url` | (always runs) |
 | 3 | Uniswap V2 swap on a mainnet fork | `BLOOM_MAINNET_RPC` unset |
 | 4 | Enso intent on a mainnet fork | `BLOOM_MAINNET_RPC` or `BLOOM_ENSO_KEY` unset |
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -161,7 +161,8 @@ BLOOM_HOME=/tmp/bloom-demo \
 ```
 
 When `bloom serve` is running, the unlock survives across calls and you
-can write to `…/pending/<id>/confirm` directly:
+can write to `…/pending/<id>/confirm` directly (this applies to passphrase /
+local wallets — the example below uses one):
 
 ```sh
 BLOOM_HOME=/tmp/bloom-demo cargo run -p bloom -- wallet unlock alice \
@@ -169,6 +170,13 @@ BLOOM_HOME=/tmp/bloom-demo cargo run -p bloom -- wallet unlock alice \
 BLOOM_HOME=/tmp/bloom-demo cargo run -p bloom -- vfs write \
   /wallets/alice/chains/anvil/outbox/pending/<id>/confirm --data y
 ```
+
+> **Passkey wallets:** the direct VFS `confirm` write over the serve socket is
+> not available for passkey-gated wallets — the WebAuthn ceremony binds
+> `localhost` and the system browser and is only reachable from the foreground
+> CLI. Stop `bloom serve` (or let the CLI fall back to the in-process path) and
+> run `bloom wallet confirm <wallet> <chain> <id> --text y` to drive the
+> browser ceremony, obtain the Sealed Approval grant, and broadcast in one shot.
 
 The daemon signs, broadcasts, moves the directory to `sent/<id>/`
 (with `tx_hash` inside), and links the tx into

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -261,9 +261,11 @@ home. Exit the subshell to tear everything down.
 
 ## End-to-end acceptance
 
-`scripts/acceptance.sh` boots Anvil, imports the funded test key, and
-drives a native ETH send and an ERC-20 transfer through the
-stage-confirm-broadcast loop on a local devnet. Optional Uniswap V2 /
+`scripts/acceptance.sh` boots Anvil, imports the funded test key, stages a
+native ETH send and an ERC-20 transfer, and verifies the mounted Sealed
+Approval gate: initial confirm is denied, `approval_challenge.json` is
+written in both the wallet projection and central `/outbox/pending/<action_id>`
+store, and the challenge includes a local `ceremony_url`. Optional Uniswap V2 /
 Enso scenarios on a mainnet fork run when `BLOOM_MAINNET_RPC` is set.
 
 `tests/docker/run.sh` is the dockerized harness with six modes:

--- a/crates/bloom-auth-api/src/lib.rs
+++ b/crates/bloom-auth-api/src/lib.rs
@@ -822,13 +822,69 @@ pub struct ApprovalChallenge {
     pub policy_version: u64,
     /// Daemon-issued challenge expiry.
     pub expiry_ms: u64,
+    /// Browser ceremony URL for mounted/daemon flows. Projection metadata only:
+    /// it is intentionally excluded from the WebAuthn challenge hash.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ceremony_url: Option<String>,
 }
 
 impl ApprovalChallenge {
-    /// Canonical preimage bytes. Deterministic: fields serialize in
-    /// declaration order.
+    /// Deterministic local ceremony URL for mounted daemon demos.
+    ///
+    /// The token is derived from `server_nonce` and therefore remains stable
+    /// for an unexpired reused challenge. Full internet relay exposure can
+    /// swap the base URL without changing the signed challenge preimage.
+    pub fn local_ceremony_url(&self) -> String {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"bloom.ceremony_url.v1");
+        hasher.update(self.server_nonce.as_bytes());
+        let token =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(hasher.finalize().as_bytes());
+        format!("http://localhost:18734/ceremony/{token}")
+    }
+
+    pub fn with_local_ceremony_url(mut self) -> Self {
+        self.ceremony_url = Some(self.local_ceremony_url());
+        self
+    }
+
+    /// Canonical preimage bytes. Deterministic: fields serialize in declaration
+    /// order. Projection metadata such as `ceremony_url` is deliberately not
+    /// part of this preimage.
     pub fn canonical_bytes(&self) -> Result<Vec<u8>, AuthApiError> {
-        serde_json::to_vec(self).map_err(AuthApiError::Json)
+        #[derive(Serialize)]
+        struct ApprovalChallengeHashPreimage<'a> {
+            schema: &'a str,
+            action_id: &'a str,
+            wallet: &'a str,
+            surface: &'a str,
+            petal_id: &'a str,
+            petal_digest: &'a str,
+            intent_hash: &'a str,
+            server_nonce: &'a str,
+            assurance: AssuranceLevel,
+            daemon_terms_digest: &'a str,
+            petal_policy_digest: &'a str,
+            policy_version: u64,
+            expiry_ms: u64,
+        }
+
+        serde_json::to_vec(&ApprovalChallengeHashPreimage {
+            schema: &self.schema,
+            action_id: &self.action_id,
+            wallet: &self.wallet,
+            surface: &self.surface,
+            petal_id: &self.petal_id,
+            petal_digest: &self.petal_digest,
+            intent_hash: &self.intent_hash,
+            server_nonce: &self.server_nonce,
+            assurance: self.assurance,
+            daemon_terms_digest: &self.daemon_terms_digest,
+            petal_policy_digest: &self.petal_policy_digest,
+            policy_version: self.policy_version,
+            expiry_ms: self.expiry_ms,
+        })
+        .map_err(AuthApiError::Json)
     }
 
     /// The 32-byte WebAuthn challenge:
@@ -948,6 +1004,7 @@ impl UnsignedApproval {
             petal_policy_digest: self.petal_policy_digest.clone(),
             policy_version: self.policy_version,
             expiry_ms: self.expiry_ms,
+            ceremony_url: None,
         }
     }
 
@@ -3344,6 +3401,7 @@ mod tests {
             petal_policy_digest: "2".repeat(64),
             policy_version: 3,
             expiry_ms: 10_000,
+            ceremony_url: None,
         }
     }
 
@@ -3429,6 +3487,29 @@ mod tests {
     }
 
     #[test]
+    fn ceremony_url_is_projected_but_not_signed() {
+        let base = challenge();
+        let mut with_url = base.clone().with_local_ceremony_url();
+        assert!(with_url.ceremony_url.is_some());
+        assert_eq!(
+            base.challenge_hash().unwrap(),
+            with_url.challenge_hash().unwrap()
+        );
+        with_url.ceremony_url = Some("https://relay.example/ceremony/changed".into());
+        assert_eq!(
+            base.challenge_hash().unwrap(),
+            with_url.challenge_hash().unwrap()
+        );
+    }
+
+    #[test]
+    fn local_ceremony_url_is_stable_for_nonce() {
+        let first = challenge().with_local_ceremony_url();
+        let second = challenge().with_local_ceremony_url();
+        assert_eq!(first.ceremony_url, second.ceremony_url);
+    }
+
+    #[test]
     fn unsigned_approval_challenge_hash_matches_issued_challenge() {
         let c = challenge();
         let unsigned =
@@ -3510,6 +3591,7 @@ mod tests {
             petal_policy_digest: action.petal_policy_digest.clone(),
             policy_version: action.policy_version,
             expiry_ms: 10_000,
+            ceremony_url: None,
         };
         let sealed = SealedIntentRecord {
             intent_hash,

--- a/crates/bloom-auth/src/lib.rs
+++ b/crates/bloom-auth/src/lib.rs
@@ -558,12 +558,14 @@ impl AuthStore {
             Option<String>,
             Option<i64>,
             Option<String>,
+            Option<String>,
+            Option<i64>,
         );
         let row: PendingEntryRow = tx
             .query_row(
                 "SELECT ae.intent_hash, ae.assurance, ae.wallet, ae.petal_id, ae.petal_digest,
                         ae.daemon_terms_digest, ae.petal_policy_digest, ae.policy_version,
-                        si.sealed_action_json
+                        si.sealed_action_json, ae.nonce, ae.challenge_expiry_ms
                  FROM auth_entries ae
                  JOIN sealed_intents si ON si.intent_hash = ae.intent_hash
                  WHERE ae.surface = ?1 AND ae.action_id = ?2 AND ae.nonce_state = 'unused'",
@@ -579,6 +581,8 @@ impl AuthStore {
                         row.get(6)?,
                         row.get(7)?,
                         row.get(8)?,
+                        row.get(9)?,
+                        row.get(10)?,
                     ))
                 },
             )
@@ -594,6 +598,8 @@ impl AuthStore {
             petal_policy_digest,
             policy_version,
             sealed_action_json,
+            existing_nonce,
+            existing_expiry_ms,
         ) = row;
         let (
             Some(wallet),
@@ -639,20 +645,35 @@ impl AuthStore {
                 "auth entry sealed metadata does not match sealed action".into(),
             ));
         }
-        tx.execute(
-            "UPDATE auth_entries
+        let (effective_nonce, effective_expiry_ms, should_update_challenge) =
+            if let (Some(existing_nonce), Some(existing_expiry_ms)) =
+                (existing_nonce, existing_expiry_ms)
+            {
+                let existing_expiry_ms = existing_expiry_ms as u64;
+                if existing_expiry_ms > now_ms {
+                    (existing_nonce, existing_expiry_ms, false)
+                } else {
+                    (server_nonce.to_string(), expiry_ms, true)
+                }
+            } else {
+                (server_nonce.to_string(), expiry_ms, true)
+            };
+        if should_update_challenge {
+            tx.execute(
+                "UPDATE auth_entries
              SET state = ?3, nonce = ?4, nonce_state = ?5, challenge_expiry_ms = ?6, updated_ms = ?7
              WHERE surface = ?1 AND action_id = ?2 AND nonce_state = 'unused'",
-            params![
-                surface,
-                action_id,
-                AuthEntryState::Challenged.as_str(),
-                server_nonce,
-                NonceState::Unused.as_str(),
-                expiry_ms as i64,
-                now_ms as i64,
-            ],
-        )?;
+                params![
+                    surface,
+                    action_id,
+                    AuthEntryState::Challenged.as_str(),
+                    &effective_nonce,
+                    NonceState::Unused.as_str(),
+                    effective_expiry_ms as i64,
+                    now_ms as i64,
+                ],
+            )?;
+        }
         tx.commit()?;
         Ok(ApprovalChallenge {
             schema: APPROVAL_CHALLENGE_SCHEMA_V1.to_string(),
@@ -662,12 +683,13 @@ impl AuthStore {
             petal_id: action.petal_id().to_string(),
             petal_digest: action.petal_digest().to_string(),
             intent_hash: action_intent_hash,
-            server_nonce: server_nonce.to_string(),
+            server_nonce: effective_nonce,
             assurance: parse_assurance(&assurance)?,
             daemon_terms_digest: action_daemon_terms_digest,
             petal_policy_digest: action.petal_policy_digest.clone(),
             policy_version: action.policy_version,
-            expiry_ms,
+            expiry_ms: effective_expiry_ms,
+            ceremony_url: None,
         })
     }
 
@@ -1064,6 +1086,7 @@ impl AuthStore {
             petal_policy_digest,
             policy_version: policy_version as u64,
             expiry_ms: challenge_expiry_ms as u64,
+            ceremony_url: None,
         };
         let (envelope_json, sealed_at_ms, sealed_action_json): (String, i64, Option<String>) = tx
             .query_row(
@@ -3625,6 +3648,46 @@ mod tests {
         store
             .consume_verified_approval_transactionally(&approval_for(&challenge), 150)
             .unwrap();
+    }
+
+    #[test]
+    fn issue_challenge_reuses_unexpired_nonce_and_expiry() {
+        let mut store = AuthStore::open_in_memory_for_tests().unwrap();
+        let action =
+            SealedAction::seal_with_default_terms(envelope(), AssuranceLevel::Standard, 100)
+                .unwrap();
+        store.stage_action(&action, 100).unwrap();
+
+        let first = store
+            .issue_challenge("requests", "req_1", "nonce-1", 220, 101)
+            .unwrap();
+        let second = store
+            .issue_challenge("requests", "req_1", "nonce-2", 400, 150)
+            .unwrap();
+        assert_eq!(second.server_nonce, first.server_nonce);
+        assert_eq!(second.expiry_ms, first.expiry_ms);
+        assert_eq!(
+            second.challenge_hash().unwrap(),
+            first.challenge_hash().unwrap()
+        );
+    }
+
+    #[test]
+    fn issue_challenge_rotates_after_expiry() {
+        let mut store = AuthStore::open_in_memory_for_tests().unwrap();
+        let action =
+            SealedAction::seal_with_default_terms(envelope(), AssuranceLevel::Standard, 100)
+                .unwrap();
+        store.stage_action(&action, 100).unwrap();
+
+        let first = store
+            .issue_challenge("requests", "req_1", "nonce-1", 220, 101)
+            .unwrap();
+        let second = store
+            .issue_challenge("requests", "req_1", "nonce-2", 400, 221)
+            .unwrap();
+        assert_ne!(second.server_nonce, first.server_nonce);
+        assert_ne!(second.expiry_ms, first.expiry_ms);
     }
 
     #[test]

--- a/crates/bloom-daemon/src/lib.rs
+++ b/crates/bloom-daemon/src/lib.rs
@@ -38,6 +38,7 @@ use bloom_revert::{
 use bloom_script::{ChainStateIface, PqSignature, PtbTx};
 use bloom_tx::outbox::{CentralOutboxProjection, Outbox};
 use bloom_tx::tx_engine::TxEngine;
+use bloom_vfs::handlers::outbox::StagedPetalIdentity;
 use bloom_vfs::handlers::polymarket::{ChainClientReader, PolymarketOnboarding, build_onboarder};
 use bloom_vfs::handlers::status::{MempoolBackendStatus, PrivateRpcBackendStatus};
 use bloom_vfs::handlers::{
@@ -91,15 +92,23 @@ impl CentralOutboxProjection for EvmOutboxProjection {
         intent_json: &[u8],
         plan_md: &str,
         policy_check_json: &[u8],
+        petal_id: &str,
+        petal_digest: &str,
+        petal_version: &str,
     ) -> Result<(), String> {
         let intent_hash = bloom_auth_api::intent_hash_of(intent_json);
         self.central
-            .stage(
+            .stage_with_identity(
                 action_id,
                 intent_json,
                 &intent_hash,
                 plan_md,
                 policy_check_json,
+                &StagedPetalIdentity {
+                    petal_id: petal_id.to_string(),
+                    petal_digest: petal_digest.to_string(),
+                    petal_version: petal_version.to_string(),
+                },
             )
             .map_err(|e| e.to_string())
     }
@@ -107,6 +116,18 @@ impl CentralOutboxProjection for EvmOutboxProjection {
     fn transition_action(&self, action_id: &str, from: &str, to: &str) -> Result<(), String> {
         self.central
             .transition(action_id, from, to)
+            .map_err(|e| e.to_string())
+    }
+
+    fn write_action_file(
+        &self,
+        action_id: &str,
+        state: &str,
+        file: &str,
+        data: &[u8],
+    ) -> Result<(), String> {
+        self.central
+            .write_action_file(action_id, state, file, data)
             .map_err(|e| e.to_string())
     }
 }

--- a/crates/bloom-daemon/src/lib.rs
+++ b/crates/bloom-daemon/src/lib.rs
@@ -36,7 +36,7 @@ use bloom_revert::{
     OpenchainDecoder, boxed,
 };
 use bloom_script::{ChainStateIface, PqSignature, PtbTx};
-use bloom_tx::outbox::{CentralOutboxProjection, Outbox};
+use bloom_tx::outbox::{CentralActionIdentity, CentralOutboxProjection, Outbox};
 use bloom_tx::tx_engine::TxEngine;
 use bloom_vfs::handlers::outbox::StagedPetalIdentity;
 use bloom_vfs::handlers::polymarket::{ChainClientReader, PolymarketOnboarding, build_onboarder};
@@ -92,9 +92,7 @@ impl CentralOutboxProjection for EvmOutboxProjection {
         intent_json: &[u8],
         plan_md: &str,
         policy_check_json: &[u8],
-        petal_id: &str,
-        petal_digest: &str,
-        petal_version: &str,
+        identity: CentralActionIdentity<'_>,
     ) -> Result<(), String> {
         let intent_hash = bloom_auth_api::intent_hash_of(intent_json);
         self.central
@@ -105,9 +103,9 @@ impl CentralOutboxProjection for EvmOutboxProjection {
                 plan_md,
                 policy_check_json,
                 &StagedPetalIdentity {
-                    petal_id: petal_id.to_string(),
-                    petal_digest: petal_digest.to_string(),
-                    petal_version: petal_version.to_string(),
+                    petal_id: identity.petal_id.to_string(),
+                    petal_digest: identity.petal_digest.to_string(),
+                    petal_version: identity.petal_version.to_string(),
                 },
             )
             .map_err(|e| e.to_string())

--- a/crates/bloom-it/tests/anvil_e2e.rs
+++ b/crates/bloom-it/tests/anvil_e2e.rs
@@ -168,11 +168,12 @@ async fn anvil_full_stage_confirm_flow() -> Result<()> {
     let _: serde_json::Value =
         serde_json::from_slice(&policy_bytes).context("policy_check.json must be valid JSON")?;
 
-    // 8. Unlock the wallet, mint the same in-memory grant that a successful
-    // Sealed Approval ceremony would mint, then write `confirm` to broadcast.
-    // The Anvil test does not have a browser/WebAuthn device, but this still
-    // exercises the production grant-gated KeystorePetalHost sign_hash path
-    // and raw transaction broadcast.
+    // 8. First confirm must fail closed and emit a Sealed Approval challenge.
+    // Then mint the same in-memory grant that a successful ceremony would mint
+    // for the emitted central action id and retry confirm to broadcast. The
+    // Anvil test does not have a browser/WebAuthn device, but this still
+    // exercises the mounted denial boundary, challenge projection, production
+    // grant-gated KeystorePetalHost sign_hash path, and raw tx broadcast.
     daemon
         .keystore
         .unlock("alice", passphrase)
@@ -181,10 +182,48 @@ async fn anvil_full_stage_confirm_flow() -> Result<()> {
         .auth_services
         .require_grant_store()
         .map_err(|e| anyhow!("grant store: {e}"))?;
+    let confirm_path = VfsPath::parse(&format!(
+        "/wallets/alice/chains/anvil/outbox/pending/{pending_id}/confirm"
+    ))
+    .unwrap();
+    let confirm_body = "y\n";
+    let first_confirm = daemon
+        .vfs
+        .write(&confirm_path, confirm_body.as_bytes())
+        .await;
+    assert!(
+        first_confirm.is_err(),
+        "initial confirm unexpectedly succeeded without Sealed Approval"
+    );
+
+    let challenge_path = VfsPath::parse(&format!(
+        "/wallets/alice/chains/anvil/outbox/pending/{pending_id}/approval_challenge.json"
+    ))
+    .unwrap();
+    let challenge_bytes = daemon
+        .vfs
+        .read(&challenge_path)
+        .await
+        .map_err(|e| anyhow!("read approval_challenge.json: {e}"))?;
+    let challenge: serde_json::Value = serde_json::from_slice(&challenge_bytes)
+        .context("approval_challenge.json must be valid JSON")?;
+    let action_id = challenge
+        .get("action_id")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("approval_challenge.json missing action_id: {challenge}"))?;
+    assert!(
+        challenge
+            .get("ceremony_url")
+            .and_then(|v| v.as_str())
+            .map(|url| url.starts_with("http://localhost") || url.starts_with("http://127.0.0.1"))
+            .unwrap_or(false),
+        "approval_challenge.json missing local ceremony_url: {challenge}"
+    );
+
     mint_evm_test_grant(
         grant_store.as_ref(),
         "alice",
-        &format!("31337:{pending_id}"),
+        action_id,
         "confirm",
         31337,
         &alice_addr,
@@ -192,16 +231,11 @@ async fn anvil_full_stage_confirm_flow() -> Result<()> {
     )
     .await
     .map_err(|e| anyhow!("mint confirm grant: {e}"))?;
-    let confirm_path = VfsPath::parse(&format!(
-        "/wallets/alice/chains/anvil/outbox/pending/{pending_id}/confirm"
-    ))
-    .unwrap();
-    let confirm_body = "y\n";
     daemon
         .vfs
         .write(&confirm_path, confirm_body.as_bytes())
         .await
-        .map_err(|e| anyhow!("confirm write: {e}"))?;
+        .map_err(|e| anyhow!("confirm retry write: {e}"))?;
 
     // 9. Verify the entry now lives in `sent/` with a tx_hash artefact.
     let sent_dir = VfsPath::parse("/wallets/alice/chains/anvil/outbox/sent").unwrap();

--- a/crates/bloom-keystore/src/passkey.rs
+++ b/crates/bloom-keystore/src/passkey.rs
@@ -2130,8 +2130,14 @@ impl super::Keystore {
 
         // Never sign a policy the engine cannot parse — a signed-but-broken
         // policy.toml would brick every wallet operation behind a valid sig.
-        toml::from_str::<bloom_proto::Policy>(&content).map_err(|e| {
+        let policy = toml::from_str::<bloom_proto::Policy>(&content).map_err(|e| {
             KeystoreError::Policy(format!("refusing to sign unparseable policy.toml: {e}"))
+        })?;
+        // Refuse to sign a policy whose autonomy mode is inconsistent with its
+        // limits — a signed-but-unbroadcastable policy would fail at every
+        // confirm with an opaque "broadcast approval required" error.
+        policy.validate_autonomy_limits().map_err(|e| {
+            KeystoreError::Policy(format!("refusing to sign policy.toml: {e}"))
         })?;
 
         let signer = self.cached_signer(name)?; // must be unlocked

--- a/crates/bloom-keystore/src/passkey.rs
+++ b/crates/bloom-keystore/src/passkey.rs
@@ -2846,6 +2846,20 @@ mod approval_uv_tests {
         );
     }
 
+    fn browser_tests_enabled() -> bool {
+        std::env::var("BLOOM_TEST_BROWSER").as_deref() == Ok("1")
+    }
+
+    fn skip_browser_test_if_disabled(test_name: &str) -> bool {
+        if browser_tests_enabled() {
+            return false;
+        }
+        eprintln!(
+            "skipping {test_name}: set BLOOM_TEST_BROWSER=1 and plant a real passkey wallet to run this manual ceremony test"
+        );
+        true
+    }
+
     // ── sealed_approval_ceremony: browser-gated integration tests ───────────
     //
     // These need a real authenticator (the ceremony binds port 18734 and opens
@@ -2855,6 +2869,9 @@ mod approval_uv_tests {
     #[tokio::test]
     #[ignore = "requires a real authenticator; set BLOOM_TEST_BROWSER=1"]
     async fn sealed_approval_ceremony_returns_assertion_and_signer() {
+        if skip_browser_test_if_disabled("sealed_approval_ceremony_returns_assertion_and_signer") {
+            return;
+        }
         let td = tempfile::tempdir().unwrap();
         let ks = crate::Keystore::new(td.path()).unwrap();
         // NOTE: this fixture does NOT create a wallet; a maintainer must first
@@ -2878,6 +2895,9 @@ mod approval_uv_tests {
     #[tokio::test]
     #[ignore = "requires a real authenticator; set BLOOM_TEST_BROWSER=1"]
     async fn sealed_approval_ceremony_fails_when_no_prf_output() {
+        if skip_browser_test_if_disabled("sealed_approval_ceremony_fails_when_no_prf_output") {
+            return;
+        }
         let td = tempfile::tempdir().unwrap();
         let ks = crate::Keystore::new(td.path()).unwrap();
         // Same plant-a-wallet caveat as above; this asserts that an
@@ -2894,6 +2914,11 @@ mod approval_uv_tests {
     #[tokio::test]
     #[ignore = "requires a real authenticator; set BLOOM_TEST_BROWSER=1"]
     async fn sealed_approval_ceremony_fails_when_uv_missing_for_hardened() {
+        if skip_browser_test_if_disabled(
+            "sealed_approval_ceremony_fails_when_uv_missing_for_hardened",
+        ) {
+            return;
+        }
         let td = tempfile::tempdir().unwrap();
         let ks = crate::Keystore::new(td.path()).unwrap();
         // Same plant-a-wallet caveat. A hardened approval must require user

--- a/crates/bloom-proto/src/policy.rs
+++ b/crates/bloom-proto/src/policy.rs
@@ -328,6 +328,24 @@ impl Policy {
             AgentAutonomyMode::Disabled
         }
     }
+
+    /// Load/sign-time consistency check: an `under_policy` autonomy mode
+    /// requires `limits.max_tx_usd` and `limits.max_day_usd` to be set —
+    /// otherwise every broadcast-time authorization fails inside `check_limits`
+    /// (see the `None` arms that return "… is required for under_policy
+    /// autonomy"). Surfacing this at sign time prevents signing a policy that
+    /// would brick every subsequent broadcast.
+    pub fn validate_autonomy_limits(&self) -> Result<(), String> {
+        if matches!(self.effective_agent_autonomy(), AgentAutonomyMode::UnderPolicy) {
+            if self.limits.max_tx_micro_usd()?.is_none() {
+                return Err("limits.max_tx_usd is required for under_policy autonomy".into());
+            }
+            if self.limits.max_day_micro_usd()?.is_none() {
+                return Err("limits.max_day_usd is required for under_policy autonomy".into());
+            }
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/bloom-tx/src/outbox.rs
+++ b/crates/bloom-tx/src/outbox.rs
@@ -8,6 +8,9 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::SystemTime;
 
+use bloom_auth_api::petal_identity::{
+    FIRST_PARTY_PETAL_VERSION_V0, PETAL_ID_EVM_WALLET, PLACEHOLDER_DIGEST_EVM_WALLET,
+};
 use bloom_proto::{StagedTx, TxStatus};
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
@@ -219,10 +222,22 @@ pub trait CentralOutboxProjection: Send + Sync {
         intent_json: &[u8],
         plan_md: &str,
         policy_check_json: &[u8],
+        petal_id: &str,
+        petal_digest: &str,
+        petal_version: &str,
     ) -> Result<(), String>;
 
     /// Move the action from one state to another.
     fn transition_action(&self, action_id: &str, from: &str, to: &str) -> Result<(), String>;
+
+    /// Write a runtime-generated artifact under a central action directory.
+    fn write_action_file(
+        &self,
+        action_id: &str,
+        state: &str,
+        file: &str,
+        data: &[u8],
+    ) -> Result<(), String>;
 }
 
 #[derive(Clone)]
@@ -267,6 +282,54 @@ impl Outbox {
 
     pub fn root(&self) -> &Path {
         &self.inner.root
+    }
+
+    /// Mirror a runtime-generated action artifact into the central outbox
+    /// projection, when one is attached.
+    pub fn write_central_action_artifact(
+        &self,
+        action_id: &str,
+        state: OutboxState,
+        file: &str,
+        data: &[u8],
+    ) -> Result<(), OutboxError> {
+        if file != "approval_challenge.json" && file != "result.json" && file != "status.json" {
+            return Err(OutboxError::Other(format!(
+                "central artifact '{file}' is not runtime-writable"
+            )));
+        }
+        if let Some(projection) = &self.inner.projection {
+            projection
+                .write_action_file(action_id, state.dirname(), file, data)
+                .map_err(OutboxError::Other)?;
+        }
+        Ok(())
+    }
+
+    /// Mirror a runtime-generated pending action artifact into the central
+    /// outbox projection, when one is attached.
+    pub fn write_central_pending_artifact(
+        &self,
+        action_id: &str,
+        file: &str,
+        data: &[u8],
+    ) -> Result<(), OutboxError> {
+        self.write_central_action_artifact(action_id, OutboxState::Pending, file, data)
+    }
+
+    /// Move the central projected action, if a projection is attached.
+    pub fn transition_central_action(
+        &self,
+        action_id: &str,
+        from: OutboxState,
+        to: OutboxState,
+    ) -> Result<(), OutboxError> {
+        if let Some(projection) = &self.inner.projection {
+            projection
+                .transition_action(action_id, from.dirname(), to.dirname())
+                .map_err(OutboxError::Other)?;
+        }
+        Ok(())
     }
 
     fn validate_segment(seg: &str) -> Result<(), OutboxError> {
@@ -320,8 +383,16 @@ impl Outbox {
 
             let intent_json = serde_json::to_vec_pretty(&staged)?;
             let policy_check_json = serde_json::to_vec_pretty(&staged.policy_checks)?;
-            proj.stage_action(&action_id, &intent_json, plan_md, &policy_check_json)
-                .map_err(OutboxError::Other)?;
+            proj.stage_action(
+                &action_id,
+                &intent_json,
+                plan_md,
+                &policy_check_json,
+                PETAL_ID_EVM_WALLET,
+                PLACEHOLDER_DIGEST_EVM_WALLET,
+                FIRST_PARTY_PETAL_VERSION_V0,
+            )
+            .map_err(OutboxError::Other)?;
         }
 
         let dir = self
@@ -1413,6 +1484,7 @@ mod tests {
         staged: Mutex<Vec<String>>,              // action_ids staged
         transitions: Mutex<Vec<(String, String, String)>>, // (id, from, to)
         fail_transition: Mutex<Option<String>>,
+        action_files: Mutex<Vec<(String, String, String)>>,
     }
 
     impl MockProjection {
@@ -1422,6 +1494,7 @@ mod tests {
                 staged: Mutex::new(vec![]),
                 transitions: Mutex::new(vec![]),
                 fail_transition: Mutex::new(None),
+                action_files: Mutex::new(vec![]),
             }
         }
     }
@@ -1446,8 +1519,13 @@ mod tests {
             _intent_json: &[u8],
             _plan_md: &str,
             _policy_check_json: &[u8],
+            petal_id: &str,
+            petal_digest: &str,
+            petal_version: &str,
         ) -> Result<(), String> {
-            self.staged.lock().unwrap().push(action_id.to_string());
+            self.staged.lock().unwrap().push(format!(
+                "{action_id}:{petal_id}:{petal_digest}:{petal_version}"
+            ));
             Ok(())
         }
 
@@ -1459,6 +1537,21 @@ mod tests {
                 action_id.to_string(),
                 from.to_string(),
                 to.to_string(),
+            ));
+            Ok(())
+        }
+
+        fn write_action_file(
+            &self,
+            action_id: &str,
+            state: &str,
+            file: &str,
+            _data: &[u8],
+        ) -> Result<(), String> {
+            self.action_files.lock().unwrap().push((
+                action_id.to_string(),
+                state.to_string(),
+                file.to_string(),
             ));
             Ok(())
         }
@@ -1483,7 +1576,15 @@ mod tests {
 
         // Mock should have recorded the allocation + stage.
         assert_eq!(mock.allocated.lock().unwrap().len(), 1);
-        assert_eq!(mock.staged.lock().unwrap().len(), 1);
+        let staged_actions = mock.staged.lock().unwrap();
+        assert_eq!(staged_actions.len(), 1);
+        assert_eq!(
+            staged_actions[0],
+            format!(
+                "act-0000:{PETAL_ID_EVM_WALLET}:{PLACEHOLDER_DIGEST_EVM_WALLET}:{FIRST_PARTY_PETAL_VERSION_V0}"
+            )
+        );
+        drop(staged_actions);
 
         // Transition to sent.
         ob.transition(&entry, OutboxState::Sent).unwrap();
@@ -1505,6 +1606,22 @@ mod tests {
         ob.write_pending(&staged, "# plan").unwrap();
         let entry = ob.read("alice", "anvil", "no-proj").unwrap();
         assert!(entry.staged.action_id.is_none());
+    }
+
+    #[test]
+    fn projection_writes_runtime_artifacts_in_final_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let mock = Arc::new(MockProjection::new());
+        let ob = Outbox::new_with_projection(dir.path(), mock.clone()).unwrap();
+
+        ob.write_central_action_artifact("act-final", OutboxState::Sent, "result.json", b"{}")
+            .unwrap();
+
+        let files = mock.action_files.lock().unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].0, "act-final");
+        assert_eq!(files[0].1, "sent");
+        assert_eq!(files[0].2, "result.json");
     }
 
     #[test]

--- a/crates/bloom-tx/src/outbox.rs
+++ b/crates/bloom-tx/src/outbox.rs
@@ -140,6 +140,13 @@ pub struct OutboxEntry {
     pub dir: PathBuf,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct CentralActionIdentity<'a> {
+    pub petal_id: &'a str,
+    pub petal_digest: &'a str,
+    pub petal_version: &'a str,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BroadcastTransport {
@@ -222,9 +229,7 @@ pub trait CentralOutboxProjection: Send + Sync {
         intent_json: &[u8],
         plan_md: &str,
         policy_check_json: &[u8],
-        petal_id: &str,
-        petal_digest: &str,
-        petal_version: &str,
+        identity: CentralActionIdentity<'_>,
     ) -> Result<(), String>;
 
     /// Move the action from one state to another.
@@ -388,9 +393,11 @@ impl Outbox {
                 &intent_json,
                 plan_md,
                 &policy_check_json,
-                PETAL_ID_EVM_WALLET,
-                PLACEHOLDER_DIGEST_EVM_WALLET,
-                FIRST_PARTY_PETAL_VERSION_V0,
+                CentralActionIdentity {
+                    petal_id: PETAL_ID_EVM_WALLET,
+                    petal_digest: PLACEHOLDER_DIGEST_EVM_WALLET,
+                    petal_version: FIRST_PARTY_PETAL_VERSION_V0,
+                },
             )
             .map_err(OutboxError::Other)?;
         }
@@ -1519,12 +1526,11 @@ mod tests {
             _intent_json: &[u8],
             _plan_md: &str,
             _policy_check_json: &[u8],
-            petal_id: &str,
-            petal_digest: &str,
-            petal_version: &str,
+            identity: CentralActionIdentity<'_>,
         ) -> Result<(), String> {
             self.staged.lock().unwrap().push(format!(
-                "{action_id}:{petal_id}:{petal_digest}:{petal_version}"
+                "{}:{}:{}:{}",
+                action_id, identity.petal_id, identity.petal_digest, identity.petal_version
             ));
             Ok(())
         }

--- a/crates/bloom-tx/src/tx_engine.rs
+++ b/crates/bloom-tx/src/tx_engine.rs
@@ -206,6 +206,16 @@ pub struct SealedActionExecution {
     pub signing_hash: B256,
 }
 
+struct EvmCentralResult<'a> {
+    action_id: &'a str,
+    state: OutboxState,
+    outcome: &'a str,
+    tx_hash: B256,
+    nonce: u64,
+    signing_hash: &'a B256,
+    action_kind: &'a str,
+}
+
 struct SubmitResult {
     transport: BroadcastTransport,
     returned_hash: Option<B256>,
@@ -1436,15 +1446,15 @@ impl TxEngine {
             staged.tx_hash.as_ref().unwrap().as_bytes(),
         )?;
         if let Some(action_id) = staged.action_id.as_deref() {
-            self.write_central_evm_result(
+            self.write_central_evm_result(EvmCentralResult {
                 action_id,
-                OutboxState::Sent,
-                "sent",
+                state: OutboxState::Sent,
+                outcome: "sent",
                 tx_hash,
-                staged.nonce,
-                &signing_hash,
-                EvmOutboxActionKind::Confirm.action_kind(),
-            )?;
+                nonce: staged.nonce,
+                signing_hash: &signing_hash,
+                action_kind: EvmOutboxActionKind::Confirm.action_kind(),
+            })?;
         }
 
         Ok(staged)
@@ -1599,56 +1609,47 @@ impl TxEngine {
             let signing_hash = self
                 .build_unsigned_evm_tx(&staged, chain)
                 .map(|unsigned| Self::unsigned_signing_hash(&unsigned))?;
-            self.write_central_evm_result(
+            self.write_central_evm_result(EvmCentralResult {
                 action_id,
-                OutboxState::Sent,
-                "sent",
+                state: OutboxState::Sent,
+                outcome: "sent",
                 tx_hash,
-                staged.nonce,
-                &signing_hash,
-                EvmOutboxActionKind::Confirm.action_kind(),
-            )?;
+                nonce: staged.nonce,
+                signing_hash: &signing_hash,
+                action_kind: EvmOutboxActionKind::Confirm.action_kind(),
+            })?;
         }
         Ok(staged)
     }
 
-    fn write_central_evm_result(
-        &self,
-        action_id: &str,
-        state: OutboxState,
-        outcome: &str,
-        tx_hash: B256,
-        nonce: u64,
-        signing_hash: &B256,
-        action_kind: &str,
-    ) -> Result<(), TxEngineError> {
+    fn write_central_evm_result(&self, central: EvmCentralResult<'_>) -> Result<(), TxEngineError> {
         let result = serde_json::json!({
             "schema": "bloom.evm_execution_result.v1",
-            "action_id": action_id,
-            "state": state.dirname(),
-            "outcome": outcome,
-            "action_kind": action_kind,
-            "tx_hash": format!("{:#x}", tx_hash),
-            "nonce": nonce,
-            "signing_hash": format!("{:#x}", signing_hash),
+            "action_id": central.action_id,
+            "state": central.state.dirname(),
+            "outcome": central.outcome,
+            "action_kind": central.action_kind,
+            "tx_hash": format!("{:#x}", central.tx_hash),
+            "nonce": central.nonce,
+            "signing_hash": format!("{:#x}", central.signing_hash),
             "created_ms": now_ms(),
         });
         let status = serde_json::json!({
-            "action_id": action_id,
-            "state": state.dirname(),
-            "outcome": outcome,
-            "tx_hash": format!("{:#x}", tx_hash),
-            "action_kind": action_kind,
+            "action_id": central.action_id,
+            "state": central.state.dirname(),
+            "outcome": central.outcome,
+            "tx_hash": format!("{:#x}", central.tx_hash),
+            "action_kind": central.action_kind,
         });
         self.outbox.write_central_action_artifact(
-            action_id,
-            state,
+            central.action_id,
+            central.state,
             "result.json",
             &serde_json::to_vec_pretty(&result).unwrap(),
         )?;
         self.outbox.write_central_action_artifact(
-            action_id,
-            state,
+            central.action_id,
+            central.state,
             "status.json",
             &serde_json::to_vec_pretty(&status).unwrap(),
         )?;
@@ -2194,15 +2195,15 @@ impl TxEngine {
             OutboxState::Pending,
             OutboxState::Sent,
         )?;
-        self.write_central_evm_result(
-            &subject.action_id,
-            OutboxState::Sent,
-            "sent",
-            signed.hash,
+        self.write_central_evm_result(EvmCentralResult {
+            action_id: &subject.action_id,
+            state: OutboxState::Sent,
+            outcome: "sent",
+            tx_hash: signed.hash,
             nonce,
-            &signing_hash,
-            subject.action_kind.as_str(),
-        )?;
+            signing_hash: &signing_hash,
+            action_kind: subject.action_kind.as_str(),
+        })?;
         Ok(SealedActionExecution {
             action_id: subject.action_id,
             petal_id: subject.petal_id,

--- a/crates/bloom-tx/src/tx_engine.rs
+++ b/crates/bloom-tx/src/tx_engine.rs
@@ -24,11 +24,12 @@ use bloom_auth_api::petal_identity::{
 use bloom_auth_api::{
     ApprovalVerifier, AssuranceLevel, AuthEntryState, AuthStoreWriter, CanonicalEnvelope,
     DaemonGrantTerms, EVM_ERC20_TRANSFER_METHOD, EVM_OWNER_SESSION_USE_ACTION_KIND,
-    EVM_SEALED_INTENT_SUBJECT_SCHEMA_V1, EVM_TX_SIGN_INTENT, EvmCallFact, EvmFeeFacts,
-    EvmNonceIntent, EvmOriginalTxFact, EvmOwnerSessionUseFact, EvmOwnerSigningSessionScope,
-    EvmOwnerSigningSessionUse, EvmSealedActionKind, EvmSealedIntentSubject, EvmTokenFact,
-    EvmUnsignedEnvelopeFacts, EvmValueFact, GrantStore, NonceState, PetalHost, PetalPolicySnapshot,
-    SealedAction, SignHashRequest, SignedApproval, SigningAttestation, StandingSessionRecord,
+    EVM_SEALED_INTENT_SUBJECT_KIND, EVM_SEALED_INTENT_SUBJECT_SCHEMA_V1, EVM_TX_SIGN_INTENT,
+    EvmCallFact, EvmFeeFacts, EvmNonceIntent, EvmOriginalTxFact, EvmOwnerSessionUseFact,
+    EvmOwnerSigningSessionScope, EvmOwnerSigningSessionUse, EvmSealedActionKind,
+    EvmSealedIntentSubject, EvmTokenFact, EvmUnsignedEnvelopeFacts, EvmValueFact, GrantStore,
+    NonceState, PetalHost, PetalPolicySnapshot, SealedAction, SignHashRequest, SignedApproval,
+    SigningAttestation, StandingSessionRecord,
 };
 use bloom_chain::{ChainClient, ChainError, IERC20, NftKind};
 
@@ -189,6 +190,17 @@ impl EvmOutboxActionKind {
 
 #[derive(Debug, Clone)]
 pub struct EvmOwnerSessionExecution {
+    pub tx_hash: B256,
+    pub nonce: u64,
+    pub signing_hash: B256,
+}
+
+#[derive(Debug, Clone)]
+pub struct SealedActionExecution {
+    pub action_id: String,
+    pub petal_id: String,
+    pub petal_digest: String,
+    pub action_kind: String,
     pub tx_hash: B256,
     pub nonce: u64,
     pub signing_hash: B256,
@@ -1364,6 +1376,7 @@ impl TxEngine {
             signing_hash: Self::unsigned_signing_hash(&unsigned),
             unsigned,
         };
+        let signing_hash = prepared.signing_hash;
 
         if let Some((ref sid, _)) = session_debit {
             debug!(id = %staged.id, session = %sid, "tx.authorized_by_session");
@@ -1372,7 +1385,7 @@ impl TxEngine {
                 &entry,
                 &staged,
                 EvmOutboxActionKind::Confirm,
-                &prepared.signing_hash,
+                &signing_hash,
                 policy,
                 bloom_proto::AuthorizationSurface::Cli,
             )
@@ -1422,6 +1435,17 @@ impl TxEngine {
             "tx_hash",
             staged.tx_hash.as_ref().unwrap().as_bytes(),
         )?;
+        if let Some(action_id) = staged.action_id.as_deref() {
+            self.write_central_evm_result(
+                action_id,
+                OutboxState::Sent,
+                "sent",
+                tx_hash,
+                staged.nonce,
+                &signing_hash,
+                EvmOutboxActionKind::Confirm.action_kind(),
+            )?;
+        }
 
         Ok(staged)
     }
@@ -1438,7 +1462,7 @@ impl TxEngine {
             .parse()
             .map_err(|e: alloy::hex::FromHexError| TxEngineError::Address(e.to_string()))?;
         if chain.tx_by_hash(tx_hash).await?.is_some() || chain.receipt(tx_hash).await?.is_some() {
-            return self.finalize_sent(entry, tx_hash);
+            return self.finalize_sent(entry, tx_hash, chain);
         }
 
         let from: Address = attempt
@@ -1544,7 +1568,7 @@ impl TxEngine {
                         returned: format!("{:#x}", returned),
                     });
                 }
-                self.finalize_sent(entry, tx_hash)
+                self.finalize_sent(entry, tx_hash, chain)
             }
         }
     }
@@ -1553,6 +1577,7 @@ impl TxEngine {
         &self,
         entry: &crate::outbox::OutboxEntry,
         tx_hash: B256,
+        chain: &ChainClient,
     ) -> Result<StagedTx, TxEngineError> {
         let mut staged = entry.staged.clone();
         staged.status = TxStatus::Sent;
@@ -1570,7 +1595,64 @@ impl TxEngine {
             "tx_hash",
             staged.tx_hash.as_ref().unwrap().as_bytes(),
         )?;
+        if let Some(action_id) = staged.action_id.as_deref() {
+            let signing_hash = self
+                .build_unsigned_evm_tx(&staged, chain)
+                .map(|unsigned| Self::unsigned_signing_hash(&unsigned))?;
+            self.write_central_evm_result(
+                action_id,
+                OutboxState::Sent,
+                "sent",
+                tx_hash,
+                staged.nonce,
+                &signing_hash,
+                EvmOutboxActionKind::Confirm.action_kind(),
+            )?;
+        }
         Ok(staged)
+    }
+
+    fn write_central_evm_result(
+        &self,
+        action_id: &str,
+        state: OutboxState,
+        outcome: &str,
+        tx_hash: B256,
+        nonce: u64,
+        signing_hash: &B256,
+        action_kind: &str,
+    ) -> Result<(), TxEngineError> {
+        let result = serde_json::json!({
+            "schema": "bloom.evm_execution_result.v1",
+            "action_id": action_id,
+            "state": state.dirname(),
+            "outcome": outcome,
+            "action_kind": action_kind,
+            "tx_hash": format!("{:#x}", tx_hash),
+            "nonce": nonce,
+            "signing_hash": format!("{:#x}", signing_hash),
+            "created_ms": now_ms(),
+        });
+        let status = serde_json::json!({
+            "action_id": action_id,
+            "state": state.dirname(),
+            "outcome": outcome,
+            "tx_hash": format!("{:#x}", tx_hash),
+            "action_kind": action_kind,
+        });
+        self.outbox.write_central_action_artifact(
+            action_id,
+            state,
+            "result.json",
+            &serde_json::to_vec_pretty(&result).unwrap(),
+        )?;
+        self.outbox.write_central_action_artifact(
+            action_id,
+            state,
+            "status.json",
+            &serde_json::to_vec_pretty(&status).unwrap(),
+        )?;
+        Ok(())
     }
 
     fn write_reconcile_ambiguous(
@@ -1953,6 +2035,294 @@ impl TxEngine {
         })
     }
 
+    /// Execute a sealed action through the first-party dispatcher.
+    ///
+    /// Dispatch is Petal-neutral: the selected executor is keyed only by the
+    /// sealed action header's `(petal_id, petal_digest, subject_kind,
+    /// action_kind)`. The current built-in executor is the EVM wallet Petal;
+    /// it reconstructs the transaction solely from sealed subject bytes, signs
+    /// via the wired `PetalHost`, and broadcasts through the existing TxEngine
+    /// transport path.
+    pub async fn execute_sealed_action(
+        &self,
+        sealed: &SealedAction,
+        chain_name: &str,
+        chain: &ChainClient,
+        policy: &Policy,
+    ) -> Result<SealedActionExecution, TxEngineError> {
+        sealed.validate().map_err(|e| {
+            TxEngineError::BroadcastApprovalRequired(format!("invalid sealed action: {e}"))
+        })?;
+        let header = &sealed.envelope.header;
+        match (
+            header.petal_id.as_str(),
+            header.petal_digest.as_str(),
+            sealed.envelope.subject_kind.as_str(),
+            header.action_kind.as_str(),
+        ) {
+            (
+                PETAL_ID_EVM_WALLET,
+                PLACEHOLDER_DIGEST_EVM_WALLET,
+                EVM_SEALED_INTENT_SUBJECT_KIND,
+                "confirm" | "replace" | "cancel" | "owner_session_use",
+            ) => {
+                self.execute_evm_wallet_sealed_subject(sealed, chain_name, chain, policy)
+                    .await
+            }
+            (petal_id, petal_digest, subject_kind, action_kind) => {
+                Err(TxEngineError::BroadcastApprovalRequired(format!(
+                    "no sealed-action executor registered for petal_id={petal_id} petal_digest={petal_digest} subject_kind={subject_kind} action_kind={action_kind}"
+                )))
+            }
+        }
+    }
+
+    async fn execute_evm_wallet_sealed_subject(
+        &self,
+        sealed: &SealedAction,
+        chain_name: &str,
+        chain: &ChainClient,
+        policy: &Policy,
+    ) -> Result<SealedActionExecution, TxEngineError> {
+        self.ensure_broadcast_allowed(chain.spec())?;
+        let subject_bytes = base64::engine::general_purpose::STANDARD
+            .decode(sealed.envelope.subject_bytes_b64.as_bytes())
+            .map_err(|e| {
+                TxEngineError::BroadcastApprovalRequired(format!(
+                    "decode sealed subject bytes: {e}"
+                ))
+            })?;
+        let subject: EvmSealedIntentSubject =
+            serde_json::from_slice(&subject_bytes).map_err(|e| {
+                TxEngineError::BroadcastApprovalRequired(format!("decode EVM sealed subject: {e}"))
+            })?;
+        subject.validate_evm().map_err(|e| {
+            TxEngineError::BroadcastApprovalRequired(format!("invalid EVM sealed subject: {e}"))
+        })?;
+        self.ensure_evm_subject_matches_seal(sealed, &subject)?;
+        if chain.spec().chain_id != subject.chain_id {
+            return Err(TxEngineError::BroadcastApprovalRequired(format!(
+                "sealed action chain mismatch: subject {}, chain {}",
+                subject.chain_id,
+                chain.spec().chain_id
+            )));
+        }
+
+        let from: Address = subject
+            .account
+            .parse()
+            .map_err(|e: alloy::hex::FromHexError| TxEngineError::Address(e.to_string()))?;
+        let nonce = match subject.nonce_intent.nonce {
+            Some(nonce) => nonce,
+            None => chain.nonce(from).await?,
+        };
+        let gas_limit = subject
+            .fee_facts
+            .gas_limit
+            .parse::<u64>()
+            .map_err(|e| TxEngineError::Amount(format!("sealed gas_limit: {e}")))?;
+        let staged = StagedTx {
+            id: subject.action_id.clone(),
+            wallet: subject.wallet.clone(),
+            chain: chain_name.to_string(),
+            chain_id: subject.chain_id,
+            from: bloom_proto::checksum_address(&from),
+            to: subject.call.to.clone(),
+            value_wei: subject.value.native_value_wei.clone(),
+            data_hex: subject.call.calldata_hex.clone(),
+            gas_limit,
+            max_fee_per_gas: subject.fee_facts.max_fee_per_gas_wei.clone(),
+            max_priority_fee_per_gas: subject.fee_facts.max_priority_fee_per_gas_wei.clone(),
+            gas_price: subject.fee_facts.gas_price_wei.clone(),
+            nonce,
+            policy_checks: Vec::new(),
+            created_ms: now_ms(),
+            expires_ms: u128::from(sealed.expires_ms),
+            status: TxStatus::Pending,
+            tx_hash: None,
+            token: subject.token.as_ref().map(|token| TokenRef {
+                address: token.token_address.clone(),
+                symbol: token.symbol.clone(),
+                decimals: token.decimals,
+                recipient: subject.call.recipient.clone().unwrap_or_default(),
+                amount: subject
+                    .value
+                    .token_amount_base_units
+                    .clone()
+                    .unwrap_or_else(|| "0".into()),
+            }),
+            nft: None,
+            usd_value: subject
+                .value
+                .valuation_usd_micro
+                .map(|micro| micro as f64 / 1_000_000.0),
+            depends_on: None,
+            action_id: Some(subject.action_id.clone()),
+        };
+        let unsigned = self.build_unsigned_evm_tx(&staged, chain)?;
+        let signing_hash = Self::unsigned_signing_hash(&unsigned);
+        let sealed_hash: B256 = subject
+            .unsigned_envelope
+            .signing_hash
+            .parse()
+            .map_err(|e| TxEngineError::Signer(format!("sealed signing_hash: {e}")))?;
+        if signing_hash != sealed_hash {
+            return Err(TxEngineError::BroadcastApprovalRequired(
+                "sealed subject signing hash does not match reconstructed transaction".into(),
+            ));
+        }
+        let signature = self
+            .host_sign_evm_sealed_subject_hash(&subject, &signing_hash)
+            .await?;
+        let signed = self.assemble_signed_raw_tx(&staged, unsigned, signature)?;
+        let submitted = self
+            .submit_signed_raw(&staged, chain, policy, &signed)
+            .await?;
+        if matches!(submitted.transport, BroadcastTransport::PublicRpc)
+            && submitted.returned_hash != Some(signed.hash)
+        {
+            return Err(TxEngineError::BroadcastHashMismatch {
+                expected: format!("{:#x}", signed.hash),
+                returned: submitted
+                    .returned_hash
+                    .map(|h| format!("{:#x}", h))
+                    .unwrap_or_else(|| "<none>".into()),
+            });
+        }
+        self.outbox.transition_central_action(
+            &subject.action_id,
+            OutboxState::Pending,
+            OutboxState::Sent,
+        )?;
+        self.write_central_evm_result(
+            &subject.action_id,
+            OutboxState::Sent,
+            "sent",
+            signed.hash,
+            nonce,
+            &signing_hash,
+            subject.action_kind.as_str(),
+        )?;
+        Ok(SealedActionExecution {
+            action_id: subject.action_id,
+            petal_id: subject.petal_id,
+            petal_digest: subject.petal_digest,
+            action_kind: subject.action_kind.as_str().into(),
+            tx_hash: signed.hash,
+            nonce,
+            signing_hash,
+        })
+    }
+
+    fn ensure_evm_subject_matches_seal(
+        &self,
+        sealed: &SealedAction,
+        subject: &EvmSealedIntentSubject,
+    ) -> Result<(), TxEngineError> {
+        let header = &sealed.envelope.header;
+        let subject_envelope = subject.canonical_envelope(sealed.expires_ms).map_err(|e| {
+            TxEngineError::BroadcastApprovalRequired(format!("rebuild sealed EVM envelope: {e}"))
+        })?;
+        let subject_hash = subject_envelope.intent_hash().map_err(|e| {
+            TxEngineError::BroadcastApprovalRequired(format!("hash sealed EVM envelope: {e}"))
+        })?;
+        let sealed_hash = sealed.intent_hash().map_err(|e| {
+            TxEngineError::BroadcastApprovalRequired(format!("hash sealed action: {e}"))
+        })?;
+        if subject_hash != sealed_hash || subject_envelope != sealed.envelope {
+            return Err(TxEngineError::BroadcastApprovalRequired(
+                "sealed subject bytes do not reproduce the sealed action envelope".into(),
+            ));
+        }
+        let expected = [
+            ("wallet", subject.wallet.as_str(), header.wallet.as_str()),
+            ("surface", subject.surface.as_str(), header.surface.as_str()),
+            (
+                "action_id",
+                subject.action_id.as_str(),
+                header.action_id.as_str(),
+            ),
+            (
+                "petal_id",
+                subject.petal_id.as_str(),
+                header.petal_id.as_str(),
+            ),
+            (
+                "petal_digest",
+                subject.petal_digest.as_str(),
+                header.petal_digest.as_str(),
+            ),
+            (
+                "petal_version",
+                subject.petal_version.as_str(),
+                header.petal_version.as_str(),
+            ),
+            ("account", subject.account.as_str(), header.account.as_str()),
+            (
+                "action_kind",
+                subject.action_kind.as_str(),
+                header.action_kind.as_str(),
+            ),
+        ];
+        for (field, actual, expected) in expected {
+            if actual != expected {
+                return Err(TxEngineError::BroadcastApprovalRequired(format!(
+                    "sealed {field} mismatch: subject={actual} header={expected}"
+                )));
+            }
+        }
+        if sealed.daemon_terms != subject.daemon_terms {
+            return Err(TxEngineError::BroadcastApprovalRequired(
+                "sealed daemon terms do not match EVM subject".into(),
+            ));
+        }
+        if sealed.petal_policy != subject.policy_snapshot {
+            return Err(TxEngineError::BroadcastApprovalRequired(
+                "sealed Petal policy does not match EVM subject".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    async fn host_sign_evm_sealed_subject_hash(
+        &self,
+        subject: &EvmSealedIntentSubject,
+        signing_hash: &B256,
+    ) -> Result<Signature, TxEngineError> {
+        let host = self.petal_host.as_ref().ok_or_else(|| {
+            TxEngineError::BroadcastApprovalRequired(
+                "Sealed Approval Petal host is not wired".into(),
+            )
+        })?;
+        let attestation = subject
+            .signing_attestation_facts()
+            .signing_attestation()
+            .map_err(|e| {
+                TxEngineError::BroadcastApprovalRequired(format!(
+                    "build EVM sealed signing attestation: {e}"
+                ))
+            })?;
+        let sealed = host
+            .sign_hash(
+                SignHashRequest {
+                    wallet: subject.wallet.clone(),
+                    action_id: subject.action_id.clone(),
+                    intent: EVM_TX_SIGN_INTENT.into(),
+                    hash_hex: format!("{signing_hash:#x}"),
+                },
+                &attestation,
+                now_ms() as u64,
+            )
+            .await
+            .map_err(|e| {
+                TxEngineError::BroadcastApprovalRequired(format!("host sign_hash denied: {e}"))
+            })?;
+        let raw = base64::engine::general_purpose::STANDARD
+            .decode(sealed.signature_b64.as_bytes())
+            .map_err(|e| TxEngineError::Signer(format!("decode host signature: {e}")))?;
+        Signature::from_raw(&raw).map_err(|e| TxEngineError::Signer(format!("host signature: {e}")))
+    }
+
     async fn host_sign_evm_hash(
         &self,
         staged: &StagedTx,
@@ -2315,17 +2685,31 @@ impl TxEngine {
                 TxEngineError::BroadcastApprovalRequired(format!(
                     "issue outbox approval challenge failed: {e}"
                 ))
-            })?;
+            })?
+            .with_local_ceremony_url();
         let challenge_body = serde_json::to_vec_pretty(&challenge).map_err(|e| {
             TxEngineError::BroadcastApprovalRequired(format!("encode approval challenge: {e}"))
         })?;
         std::fs::write(
             entry.dir.join(OUTBOX_APPROVAL_CHALLENGE_FILE),
-            challenge_body,
+            &challenge_body,
         )
         .map_err(|e| {
             TxEngineError::BroadcastApprovalRequired(format!("write approval challenge: {e}"))
         })?;
+        if let Some(central_action_id) = staged.action_id.as_deref() {
+            self.outbox
+                .write_central_pending_artifact(
+                    central_action_id,
+                    OUTBOX_APPROVAL_CHALLENGE_FILE,
+                    &challenge_body,
+                )
+                .map_err(|e| {
+                    TxEngineError::BroadcastApprovalRequired(format!(
+                        "write central approval challenge: {e}"
+                    ))
+                })?;
+        }
         Err(TxEngineError::BroadcastApprovalRequired(format!(
             "outbox confirm requires signed Sealed Approval; wrote {} in {}; rerun the foreground confirm/write command with the passkey wallet to sign approval.json. local password wallets can only auto-confirm actions that remain in policy",
             OUTBOX_APPROVAL_CHALLENGE_FILE,
@@ -2729,7 +3113,10 @@ fn now_ms() -> u128 {
 
 fn outbox_action_id(staged: &StagedTx, action_kind: EvmOutboxActionKind) -> String {
     match action_kind {
-        EvmOutboxActionKind::Confirm => format!("{}:{}", staged.chain_id, staged.id),
+        EvmOutboxActionKind::Confirm => staged
+            .action_id
+            .clone()
+            .unwrap_or_else(|| format!("{}:{}", staged.chain_id, staged.id)),
         EvmOutboxActionKind::Replace => format!("{}:{}:replace", staged.chain_id, staged.id),
         EvmOutboxActionKind::Cancel => format!("{}:{}:cancel", staged.chain_id, staged.id),
     }
@@ -3570,6 +3957,7 @@ mod tests {
                 petal_policy_digest: "2".repeat(64),
                 policy_version: 0,
                 expiry_ms,
+                ceremony_url: None,
             })
         }
 
@@ -3699,6 +4087,38 @@ mod tests {
             .unwrap()
     }
 
+    fn sealed_action_from_staged(staged: &StagedTx) -> SealedAction {
+        let subject =
+            evm_sealed_subject(staged, EvmOutboxActionKind::Confirm, &test_signing_hash()).unwrap();
+        SealedAction::new(
+            subject
+                .canonical_envelope(u64::try_from(staged.expires_ms).unwrap_or(u64::MAX))
+                .unwrap(),
+            "test plan".into(),
+            Vec::new(),
+            subject.daemon_terms.clone(),
+            subject.policy_snapshot.clone(),
+            1,
+        )
+        .unwrap()
+    }
+
+    fn fake_chain_client(allow_broadcast: bool) -> bloom_chain::ChainClient {
+        let spec = bloom_proto::ChainSpec {
+            name: "anvil".into(),
+            chain_id: 31337,
+            rpc_urls: vec!["http://127.0.0.1:1".into()],
+            rpc_endpoints: Vec::new(),
+            allow_broadcast,
+            etherscan_api_url: None,
+            display_name: None,
+            native_symbol: "ETH".into(),
+            native_decimals: 18,
+            legacy_tx: false,
+        };
+        bloom_chain::ChainClient::new(spec).unwrap()
+    }
+
     fn test_signing_hash() -> B256 {
         B256::repeat_byte(0x11)
     }
@@ -3808,6 +4228,94 @@ mod tests {
             ))
         });
         assert_outbox_intent_hash_changes("expires_ms", |s| s.expires_ms = 123_456);
+    }
+
+    #[test]
+    fn sealed_dispatcher_accepts_exact_evm_subject_bytes() {
+        let (engine, _spec, _dir) = fake_engine(60_000);
+        let mut staged = fake_staged_1559("0001-sealed");
+        staged.action_id = Some("action-0001".into());
+        staged.expires_ms = 10_000;
+        let sealed = sealed_action_from_staged(&staged);
+        let subject_bytes = base64::engine::general_purpose::STANDARD
+            .decode(&sealed.envelope.subject_bytes_b64)
+            .unwrap();
+        let subject: EvmSealedIntentSubject = serde_json::from_slice(&subject_bytes).unwrap();
+
+        engine
+            .ensure_evm_subject_matches_seal(&sealed, &subject)
+            .unwrap();
+    }
+
+    #[test]
+    fn sealed_dispatcher_rejects_tampered_evm_subject_bytes() {
+        let (engine, _spec, _dir) = fake_engine(60_000);
+        let mut staged = fake_staged_1559("0001-sealed");
+        staged.action_id = Some("action-0001".into());
+        staged.expires_ms = 10_000;
+        let sealed = sealed_action_from_staged(&staged);
+        let subject_bytes = base64::engine::general_purpose::STANDARD
+            .decode(&sealed.envelope.subject_bytes_b64)
+            .unwrap();
+        let mut subject: EvmSealedIntentSubject = serde_json::from_slice(&subject_bytes).unwrap();
+        subject.call.to = "0x0000000000000000000000000000000000000005".into();
+
+        let err = engine
+            .ensure_evm_subject_matches_seal(&sealed, &subject)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("sealed subject bytes do not reproduce"),
+            "{err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn sealed_dispatcher_errors_for_unregistered_fake_petal() {
+        let (engine, _spec, _dir) = fake_engine(60_000);
+        let header = bloom_auth_api::CanonicalIntentHeader {
+            schema: bloom_auth_api::CANONICAL_INTENT_HEADER_SCHEMA_V2.into(),
+            wallet: "alice".into(),
+            surface: "fake".into(),
+            action_id: "fake-action".into(),
+            petal_id: "fake-petal".into(),
+            petal_digest: "fake-digest".into(),
+            petal_version: "v0".into(),
+            executor_kind: ExecutorKind::FirstParty,
+            network: "testnet".into(),
+            account: TEST_SIGNER_ADDRESS.into(),
+            action_kind: "fake_execute".into(),
+            value_movement: false,
+            authority_change: false,
+            expires_ms: 10_000,
+        };
+        let envelope = CanonicalEnvelope::new(
+            header.clone(),
+            "fake_subject",
+            "fake.subject.v1",
+            br#"{\"ok\":true}"#.to_vec(),
+        );
+        let policy = PetalPolicySnapshot::minimal(&header);
+        let sealed = SealedAction::new(
+            envelope,
+            "fake plan".into(),
+            Vec::new(),
+            DaemonGrantTerms::minimal(AssuranceLevel::Standard),
+            policy,
+            1,
+        )
+        .unwrap();
+        let chain = fake_chain_client(true);
+
+        let err = engine
+            .execute_sealed_action(&sealed, "anvil", &chain, &Policy::default())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("no sealed-action executor registered for petal_id=fake-petal"),
+            "{err}"
+        );
     }
 
     #[test]

--- a/crates/bloom-vfs/src/docs/agent-guidance.md
+++ b/crates/bloom-vfs/src/docs/agent-guidance.md
@@ -47,6 +47,43 @@ Read `/hyperliquid/README.md` for Hyperliquid trading (session-first).
 Read `/polymarket/README.md` for prediction-market trading.
 Read `/defi/README.md` for DeFi intents via Enso shortcuts.
 
+## Mounted Sealed Approval flow
+
+When working through a mounted tree, a confirm write that needs fresh owner
+approval does **not** open a browser by itself. The daemon exposes the challenge
+first, then denies the triggering write so the writing agent can deliberately
+open or forward the ceremony URL.
+
+Expected mounted flow for value-moving outbox actions:
+
+```sh
+# 1. Stage a Petal action, then discover its concrete central action id.
+ls /bloom/outbox/pending
+cat /bloom/outbox/pending/<action_id>/plan.md
+
+# 2. Confirm through the Petal projection. This should fail with permission denied
+#    after the daemon writes approval_challenge.json.
+printf 'confirm\n' > /bloom/wallets/<wallet>/chains/<chain>/outbox/pending/<id>/confirm
+
+# 3. Read the challenge from the same central action directory.
+cat /bloom/outbox/pending/<action_id>/approval_challenge.json
+```
+
+Before opening the ceremony, verify that `approval_challenge.json` has the same
+`action_id` as the directory you are acting on and that `expiry_ms` is still in
+the future. Then open or forward `ceremony_url`.
+
+The ceremony page offers two modes:
+
+- **grant**: mints only an in-memory daemon grant. Retry the same mounted
+  confirm write to execute from the sealed bytes.
+- **grant + execute**: mints the grant and executes immediately in the daemon.
+
+After execution, inspect `/outbox/sent/<action_id>/` or
+`/outbox/failed/<action_id>/` for `status.json`, `result.json`, and audit/result
+artifacts. Petal-specific wallet paths are projections of the same central
+action id; do not treat them as separate approval queues.
+
 ## Paid HTTP
 
 Paid HTTP requests live under `/requests`. Agents should stage the request,

--- a/crates/bloom-vfs/src/handlers/defi.rs
+++ b/crates/bloom-vfs/src/handlers/defi.rs
@@ -385,14 +385,20 @@ impl DefiHandler {
 
     fn list_sessions_for_wallet(&self, wallet: &str) -> Vec<String> {
         let _ = self.load_wallet_sessions(wallet);
-        let mut out: Vec<String> = self
+        let mut entries: Vec<(u128, String)> = self
             .sessions
             .read()
             .values()
             .filter(|s| s.wallet == wallet)
-            .map(|s| s.id.clone())
+            .map(|s| (s.created_ms, s.id.clone()))
             .collect();
-        out.sort();
+        // Sort by created_ms descending (most recent first). Session ids are
+        // not chronologically ordered — the `<NNNN>` prefix is a per-process
+        // counter that resets to 1 on each daemon start (`allocate_id`,
+        // `next_id`), so a lexicographic id sort can surface a stale session
+        // ahead of a newer one.
+        entries.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
+        let mut out: Vec<String> = entries.into_iter().map(|(_, id)| id).collect();
         out.dedup();
         out
     }

--- a/crates/bloom-vfs/src/handlers/outbox.rs
+++ b/crates/bloom-vfs/src/handlers/outbox.rs
@@ -174,7 +174,26 @@ impl CentralOutbox {
             ));
         }
         std::fs::create_dir_all(self.state_dir(to))?;
-        std::fs::rename(&from_dir, &to_dir)
+        std::fs::rename(&from_dir, &to_dir)?;
+        self.write_status_state(action_id, to)?;
+        Ok(())
+    }
+
+    fn write_status_state(&self, action_id: &str, state: &str) -> std::io::Result<()> {
+        let path = self.action_dir(state, action_id).join("status.json");
+        let mut status = match std::fs::read(&path) {
+            Ok(bytes) => serde_json::from_slice::<serde_json::Value>(&bytes)
+                .unwrap_or_else(|_| serde_json::json!({})),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => serde_json::json!({}),
+            Err(e) => return Err(e),
+        };
+        if !status.is_object() {
+            status = serde_json::json!({});
+        }
+        let obj = status.as_object_mut().expect("status is object");
+        obj.insert("action_id".to_string(), serde_json::json!(action_id));
+        obj.insert("state".to_string(), serde_json::json!(state));
+        std::fs::write(path, serde_json::to_vec_pretty(&status).unwrap_or_default())
     }
 
     /// Write a result file for an action.
@@ -186,6 +205,37 @@ impl CentralOutbox {
     ) -> std::io::Result<()> {
         let dir = self.action_dir(state, action_id);
         std::fs::write(dir.join("result.json"), result_json)
+    }
+
+    /// Write a runtime-generated artifact into an existing central action
+    /// directory. This is intentionally allowlisted so callers cannot use the
+    /// projection as an arbitrary file writer.
+    pub fn write_action_file(
+        &self,
+        action_id: &str,
+        state: &str,
+        file: &str,
+        data: &[u8],
+    ) -> std::io::Result<()> {
+        validate_action_id(action_id)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e.to_string()))?;
+        if !matches!(
+            file,
+            "approval_challenge.json" | "result.json" | "status.json"
+        ) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                format!("runtime artifact '{file}' is not writable"),
+            ));
+        }
+        let dir = self.action_dir(state, action_id);
+        if !dir.exists() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("action {action_id} not found in {state}"),
+            ));
+        }
+        std::fs::write(dir.join(file), data)
     }
 
     /// Find which state an action is in, scanning all states.
@@ -515,6 +565,25 @@ mod tests {
 
         let p = VfsPath::parse("sent/act-003/intent.json").unwrap();
         assert!(h.read(&p).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn transition_updates_canonical_status_state() {
+        let h = handler();
+        h.outbox
+            .stage("act-status", b"{}", "hash", "plan", b"[]")
+            .unwrap();
+
+        h.outbox
+            .transition("act-status", "pending", "sent")
+            .unwrap();
+
+        let status_path = VfsPath::parse("sent/act-status/status.json").unwrap();
+        let status: serde_json::Value =
+            serde_json::from_slice(&h.read(&status_path).await.unwrap())
+                .expect("status.json parses");
+        assert_eq!(status["action_id"], "act-status");
+        assert_eq!(status["state"], "sent");
     }
 
     #[tokio::test]

--- a/crates/bloom-vfs/src/handlers/requests.rs
+++ b/crates/bloom-vfs/src/handlers/requests.rs
@@ -1992,6 +1992,7 @@ mod tests {
                 petal_policy_digest: "2".repeat(64),
                 policy_version: 0,
                 expiry_ms,
+                ceremony_url: None,
             })
         }
 

--- a/crates/bloom-vfs/src/handlers/wallets.rs
+++ b/crates/bloom-vfs/src/handlers/wallets.rs
@@ -2127,6 +2127,9 @@ impl WalletsHandler {
                         TxEngineError::EnsoQuoteStale { .. } => {
                             HandlerError::invalid(e.to_string())
                         }
+                        TxEngineError::BroadcastApprovalRequired(_) => {
+                            HandlerError::PermissionDenied
+                        }
                         other => err_be(other),
                     })?;
                 Ok(())
@@ -2634,6 +2637,7 @@ mod tests {
                 petal_policy_digest: "2".repeat(64),
                 policy_version: 0,
                 expiry_ms,
+                ceremony_url: None,
             })
         }
 
@@ -2757,6 +2761,7 @@ mod tests {
                 petal_policy_digest: "2".repeat(64),
                 policy_version: 0,
                 expiry_ms,
+                ceremony_url: None,
             })
         }
 

--- a/crates/bloom/src/commands/polymarket.rs
+++ b/crates/bloom/src/commands/polymarket.rs
@@ -32,6 +32,7 @@ use bloom_polymarket::{
 };
 use bloom_proto::HomeWritePermit;
 use bloom_proto::polymarket_policy::{self as pm_policy, PolicySide, PolymarketOrderCtx};
+use bloom_tx::TxEngineError;
 
 fn now_ms() -> u128 {
     std::time::SystemTime::now()
@@ -1932,7 +1933,16 @@ pub async fn fund(d: &Daemon, args: FundArgs) -> Result<()> {
             }
         }
     }
-    unlock_wallet_with_intent(d, &args.wallet, args.passphrase.as_deref(), Some(intent)).await?;
+    let passkey_wallet = info.kind == bloom_keystore::WalletKind::PasskeyGated;
+    // For passkey wallets, skip the standalone unlock ceremony — the in-band
+    // sealed-approval ceremony in the confirm loop below self-unlocks via
+    // WebAuthn (matching the `wallet confirm` path at main.rs:2121). For local
+    // wallets, the passphrase unlock is the mechanism that enables in-policy
+    // auto-broadcast.
+    if !passkey_wallet {
+        unlock_wallet_with_intent(d, &args.wallet, args.passphrase.as_deref(), Some(intent.clone())).await?;
+    }
+    let approval_intent = Some(intent);
     let confirm_text = if any_warn {
         info.policy.override_sentinel().to_string()
     } else {
@@ -1952,14 +1962,52 @@ pub async fn fund(d: &Daemon, args: FundArgs) -> Result<()> {
                 &confirm_text,
             )
             .await
-            .with_context(|| format!("confirm staged tx {id}"))
         {
             Ok(s) => s,
+            Err(TxEngineError::BroadcastApprovalRequired(_)) if passkey_wallet => {
+                // In-band sealed-approval ceremony, mirroring `wallet confirm`
+                // (main.rs): the confirm path wrote an approval_challenge.json;
+                // run the browser ceremony to sign it, then retry the confirm.
+                // Without this arm the catch-all below would cancel the staged
+                // tx, forcing a full re-stage and re-ceremony.
+                if crate::sign_outbox_sealed_approval_if_challenged(
+                    d,
+                    &args.wallet,
+                    &chain_name,
+                    id,
+                    approval_intent.clone(),
+                )
+                .await
+                .with_context(|| format!("sign sealed approval for staged tx {id}"))?
+                {
+                    d.tx_engine
+                        .confirm(
+                            home_write_permit(d)?,
+                            &args.wallet,
+                            &chain_name,
+                            id,
+                            &chain,
+                            &info.policy,
+                            &confirm_text,
+                        )
+                        .await
+                        .with_context(|| {
+                            format!("confirm staged tx {id} after sealed approval")
+                        })?
+                } else {
+                    discard(&staged_ids[i..]);
+                    bail!(
+                        "broadcast approval required for staged tx {id} but no \
+                         approval_challenge.json was written"
+                    );
+                }
+            }
             Err(e) => {
                 // Discard this entry if it never broadcast, plus everything
                 // not yet confirmed, so stale pendings can't poison nonces.
                 discard(&staged_ids[i..]);
-                return Err(e);
+                return Err(anyhow::Error::new(e)
+                    .context(format!("confirm staged tx {id}")));
             }
         };
         let hash: alloy::primitives::B256 = staged

--- a/crates/bloom/src/main.rs
+++ b/crates/bloom/src/main.rs
@@ -3003,7 +3003,7 @@ fn outbox_confirm_unlock_intent(
     Some(intent)
 }
 
-async fn sign_outbox_sealed_approval_if_challenged(
+pub(crate) async fn sign_outbox_sealed_approval_if_challenged(
     d: &Daemon,
     wallet: &str,
     chain: &str,

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -5,9 +5,10 @@
 **Workspace:** 15 crates · `cargo build --workspace` clean ·
 `cargo clippy --workspace --all-targets -- -D warnings` clean.
 **Acceptance:** `scripts/acceptance.sh` passes scenarios 1 (native
-send) + 2 (ERC-20 transfer) end-to-end against Anvil. Scenarios 3 + 4
-(Uniswap V2 + Enso on a mainnet fork) auto-skip without
-`BLOOM_MAINNET_RPC`.
+send) + 2 (ERC-20 transfer) through the mounted Sealed Approval gate
+against Anvil: initial confirm is denied and the central
+`approval_challenge.json` includes a local `ceremony_url`. Scenarios 3 + 4
+(Uniswap V2 + Enso on a mainnet fork) auto-skip without `BLOOM_MAINNET_RPC`.
 **Live:** `tests/docker/run.sh --enso-live` exercises Enso + Aave on
 Base mainnet through the mounted filesystem surface.
 

--- a/docs/architecture/Wallet.md
+++ b/docs/architecture/Wallet.md
@@ -1,0 +1,278 @@
+# Wallet Architecture
+
+**Status:** target architecture for passkey wallets and Sealed Approval integration
+**Audience:** Bloom engineers, Petal authors, and implementation agents
+**Primary specs:**
+[`../specs/2026-07-02-sealed-approval.md`](../specs/2026-07-02-sealed-approval.md),
+[`../plans/2026-07-03-sealed-approval-implementation-plan.md`](../plans/2026-07-03-sealed-approval-implementation-plan.md)
+
+This document describes Bloom's wallet setup, passkey ceremony model, and
+key-storage layout. It is written around the target **WS-C: Multi-passkey
+credential layout + wallet DEK** architecture, even where the current codebase
+is still migrating from the legacy single-credential layout.
+
+## Decision Summary
+
+- Bloom wallets that can hold funds are **passkey-gated by default**.
+- A wallet is not bound to one browser credential. A wallet is controlled by a
+  set of non-revoked passkey credentials.
+- The wallet private key is encrypted by one random **wallet DEK**. Passkeys do
+  not encrypt the wallet key directly.
+- Each passkey credential has its own PRF salt and wraps the same wallet DEK.
+- Adding, removing, replacing, or recovering credentials is an
+  authority-changing Sealed Approval action and requires hardened assurance.
+- The Sealed Approval ceremony for value-moving or authority-changing work is a
+  single WebAuthn operation that returns both:
+  1. a WebAuthn assertion over the sealed challenge; and
+  2. PRF output used locally to unwrap the wallet DEK.
+- PRF output, wallet DEK bytes, decrypted private key bytes, and grant-held
+  signer material are never serialized to VFS, `approval.json`, logs, or CLI
+  stdout.
+
+## Concepts
+
+**Wallet**
+
+A named local identity with an owner address and policy. In the target model, a
+fund-holding wallet stores encrypted signing material and one or more enrolled
+passkey credentials. Watch-only wallets may exist for read-only views but cannot
+sign.
+
+**Wallet private key**
+
+The secp256k1 key that owns EVM funds and any venue authority derived from that
+owner key. Petals must not receive this key or a raw `PrivateKeySigner`; they
+request bounded signatures through the host signing API.
+
+**Wallet DEK**
+
+A random data-encryption key generated at wallet creation. The wallet private
+key is encrypted once under this DEK. The DEK is itself wrapped separately for
+each passkey credential.
+
+**Passkey credential**
+
+A WebAuthn credential enrolled for the wallet. Each credential has its own PRF
+salt and wrapped DEK record. Any non-revoked credential can unlock the wallet
+DEK during an approved ceremony.
+
+**Sealed Approval Grant**
+
+A short-lived in-memory capability minted after a valid Sealed Approval
+ceremony. It authorizes a Petal to use bounded signing authority through
+`PetalHost::sign_hash` or an equivalent host API. It is not persisted.
+
+## Target On-Disk Layout
+
+The target wallet directory is:
+
+```text
+wallets/<wallet>/
+  kind                         # "passkey" for fund-holding wallets
+  address                      # checksummed owner address
+  pubkey                       # owner public key
+  encrypted.key                # wallet private key encrypted by wallet_dek
+  policy.toml                  # wallet policy
+  policy.toml.sig              # signature over policy.toml
+  credentials/
+    <credential_id>/
+      passkey.json             # serialized WebAuthn credential metadata
+      prf.salt                 # public 32-byte salt, hex/base64 encoded
+      wrapped_dek              # wallet_dek encrypted/wrapped by PRF output
+      label                    # user-facing credential label
+      created_ms               # enrollment timestamp
+      revoked_ms               # absent/empty when active
+```
+
+Properties:
+
+- `encrypted.key` is wallet-scoped. It does not change when adding or removing
+  a passkey unless the owner key itself is rotated.
+- `credentials/<credential_id>/wrapped_dek` is credential-scoped. Adding a
+  passkey adds a new credential directory and wrapped DEK for that credential.
+- Revocation should set `revoked_ms` or move the credential to an auditable
+  revoked state; it must not silently delete the only audit trail.
+- Removing the last non-revoked credential is forbidden unless the user enters
+  an explicit recovery ceremony that installs replacement authority.
+- The VFS may expose safe metadata, but it must not expose `encrypted.key`,
+  `wrapped_dek`, PRF output, decrypted DEK material, or raw key bytes.
+
+## Wallet Creation
+
+A plain VFS write such as:
+
+```sh
+echo alice > /bloom/wallets/new
+```
+
+means “create a passkey-gated wallet named `alice`”. It must not silently
+create a passphrase wallet.
+
+Target creation flow:
+
+1. Validate the requested wallet name and fail if the wallet already exists.
+2. Generate the owner private key.
+3. Generate a random wallet DEK.
+4. Encrypt the owner private key as `encrypted.key` under the wallet DEK.
+5. Start a WebAuthn registration ceremony for the first passkey credential.
+6. Generate a credential-specific `prf.salt` and request WebAuthn PRF output.
+7. Wrap the wallet DEK with the PRF output and write
+   `credentials/<credential_id>/wrapped_dek`.
+8. Write `passkey.json`, `label`, `created_ms`, and an empty/absent
+   `revoked_ms`.
+9. Write the initial `policy.toml` and sign it with the freshly generated owner
+   key before key material leaves process-local memory.
+10. Atomically commit the wallet directory.
+11. Present recovery material or recovery instructions in a foreground ceremony;
+    never hide a recovery secret in logs or background output.
+
+The wallet-creation registration ceremony is distinct from Sealed Approval for
+later actions. Registration establishes wallet authority; Sealed Approval spends
+or changes that authority for a specific sealed action.
+
+## Sealed Approval Ceremony for Wallet Use
+
+For a value-moving or authority-changing action, the ceremony is action-bound:
+
+```text
+Petal stages action
+Bloom seals canonical action bytes
+Bloom issues approval_challenge.json
+browser performs WebAuthn get() with PRF for an enrolled credential
+daemon verifies assertion and unwraps wallet DEK in memory
+daemon mints a short-lived grant and caches only grant-scoped signer material
+Petal signs or executes through host APIs under that grant
+```
+
+The browser ceremony must use one `navigator.credentials.get()` call for the
+selected credential:
+
+- `challenge` is the Sealed Approval challenge hash.
+- PRF extension input is the selected credential's `prf.salt`.
+- `userVerification` is required for hardened assurance.
+- The responding `credential_id` selects the matching credential directory.
+- Revoked credentials are rejected before any key unwrap.
+
+The ceremony response contains WebAuthn assertion data and PRF output on the
+trusted local ceremony channel. Only assertion data may become `approval.json`.
+The PRF output is consumed to unwrap the wallet DEK and then zeroized.
+
+## Key-Use Rules
+
+Petals and VFS handlers must not use the wallet key directly.
+
+Allowed path:
+
+```text
+active Sealed Approval Grant
+  -> host validates wallet/action/petal/digest/intent/terms/policy/expiry/count
+  -> Petal provides structured signing attestation
+  -> host signs the exact hash or performs the exact authority use
+  -> audit event records what was signed and why
+```
+
+Forbidden paths:
+
+- raw `PrivateKeySigner` flowing into Petal code;
+- arbitrary `/wallets/<wallet>/sign/{message,hash,typed_data}` signing;
+- passphrase/password approvals satisfying Sealed Approval assurance;
+- `write_unlocked` as a privileged passkey signing lane;
+- marker files such as `.confirm_approved.json` or `review_approved.json`;
+- persisting grants, PRF output, wallet DEK, or decrypted owner key bytes.
+
+## Multi-Passkey Operations
+
+Credential changes are authority changes. They must be staged as Sealed Approval
+actions with `assurance = hardened` and clear user-facing plans.
+
+### Add passkey
+
+1. Stage `wallet.add_credential` for the wallet.
+2. Require hardened Sealed Approval with an existing non-revoked credential or
+   recovery ceremony.
+3. Run WebAuthn registration for the new credential.
+4. Unwrap the wallet DEK with the approving credential or recovery path.
+5. Wrap the same wallet DEK for the new credential's PRF output.
+6. Write the new credential directory atomically.
+7. Audit the new credential id, label, timestamp, and approving action id.
+
+### Revoke passkey
+
+1. Stage `wallet.revoke_credential` with the target credential id and label.
+2. Require hardened Sealed Approval.
+3. Deny if revocation would leave zero non-revoked credentials and no recovery
+   ceremony is being completed.
+4. Set `revoked_ms` atomically.
+5. Audit the revoked credential id and action id.
+
+### Replace passkey
+
+A replacement is an add followed by revoke, committed as one authority-changing
+operation when possible. The wallet should never pass through a state with no
+valid credential.
+
+### Recover wallet authority
+
+Recovery must be explicit, foreground, and high-friction. It may install a new
+passkey set, but it must not silently export or print the wallet private key.
+Recovery outputs must be auditable and must not create a passphrase signing lane
+that bypasses Sealed Approval.
+
+## Legacy Migration
+
+Legacy single-credential wallets have approximately this layout:
+
+```text
+wallets/<wallet>/
+  kind
+  address
+  pubkey
+  encrypted.key        # encrypted directly from one credential PRF path
+  prf.salt
+  passkey.json
+  policy.toml
+  policy.toml.sig
+```
+
+Target migration is lazy and atomic:
+
+1. On first successful unlock/ceremony for a legacy passkey wallet, detect the
+   absence of `credentials/`.
+2. Use the legacy PRF path to decrypt the owner key in memory.
+3. Generate a fresh wallet DEK.
+4. Re-encrypt the owner key under the wallet DEK into the target
+   `encrypted.key` format.
+5. Move the legacy credential into `credentials/<credential_id>/` with its
+   `passkey.json`, `prf.salt`, and `wrapped_dek`.
+6. Preserve policy files and wallet address/pubkey.
+7. Commit by atomic rename and keep an owner-only migration backup until the new
+   layout verifies.
+8. Audit migration without logging key material.
+
+Migration must be idempotent. If it fails midway, the wallet must remain usable
+under either the old fully intact layout or the new fully committed layout, not
+a mix.
+
+## VFS and Documentation Contract
+
+- `/wallets/new` creates passkey wallets by default.
+- Passphrase/local/import wallets are legacy or explicit-danger flows and must
+  require an unmistakable opt-in if they remain available during migration.
+- `/wallets/<wallet>/kind` reports `passkey` for passkey-gated wallets.
+- Credential metadata may be exposed through a future safe path such as
+  `/wallets/<wallet>/credentials/`, but secret-bearing files are not VFS files.
+- Mounted writes that need approval should write or expose
+  `approval_challenge.json`, return permission denied, and let the user or
+  agent follow the `ceremony_url` flow described in
+  [`Sealed Approvals.md`](./Sealed%20Approvals.md).
+
+## Current Implementation Notes
+
+The current `feat/mounted-sealed-approval-demo` branch does not yet fully match
+this target layout. In particular, the current passkey keystore path still uses
+one wallet-level `passkey.json` and one wallet-level `prf.salt`, with no
+`credentials/<credential_id>/wrapped_dek` directory and no wallet DEK fan-out
+across multiple credentials.
+
+That gap is tracked by WS-C in the sealed-approval implementation plan and must
+be closed before Bloom can claim true multi-passkey wallet support.

--- a/docs/architecture/mounted-sealed-approval-demo-recipe.md
+++ b/docs/architecture/mounted-sealed-approval-demo-recipe.md
@@ -1,0 +1,164 @@
+# Mounted Sealed Approval ERC20 demo recipe
+
+Status: this recipe documents the intended manual end-to-end path for the mounted Sealed Approval demo. It assumes a local daemon serving the mounted tree and the browser ceremony service on `http://localhost:18734`.
+
+## Prerequisites
+
+```sh
+# From the bloom repo
+cargo build -p bloom
+command -v anvil
+```
+
+If `anvil` is missing, install Foundry before running the demo.
+
+## Terminal 1: local chain
+
+```sh
+anvil --host 127.0.0.1 --port 8545 --chain-id 31337
+```
+
+Expected: anvil prints funded development accounts and listens on `http://127.0.0.1:8545`.
+
+## Terminal 2: daemon + mounted VFS
+
+```sh
+mkdir -p /tmp/bloom-mount
+RUST_LOG=info cargo run -p bloom -- serve --mount /tmp/bloom-mount
+```
+
+Expected artifacts:
+
+```sh
+ls /tmp/bloom-mount
+ls /tmp/bloom-mount/outbox
+ls /tmp/bloom-mount/wallets
+```
+
+## Provision ERC20 demo state
+
+Use the existing ERC20 E2E/acceptance assets where possible:
+
+```sh
+# Reuse the repo's acceptance harness for anvil/mock ERC20 setup.
+scripts/acceptance.sh
+```
+
+For a pure manual run, deploy `MockERC20`, create/import a passkey wallet, fund its native gas balance, and mint/fund ERC20 into that wallet using the same fixture values used by `crates/bloom-it/tests/erc20_e2e.rs`.
+
+Expected:
+
+- wallet appears under `/tmp/bloom-mount/wallets/<wallet>`;
+- chain appears under `/tmp/bloom-mount/wallets/<wallet>/chains/31337` or configured chain alias;
+- ERC20 balance is visible before transfer.
+
+## Stage transfer through wallet Petal projection
+
+The exact staging file depends on the current wallet projection shape. Use `/docs/agent-guidance.md` and the per-wallet `README.md` from the mount to discover the live staging path, then stage an ERC20 transfer.
+
+Example shape:
+
+```sh
+WALLET=<wallet>
+CHAIN=31337
+TOKEN=<mock_erc20_address>
+TO=<recipient_address>
+AMOUNT=1000000000000000000
+
+# Example only: adapt to the mounted staging file advertised by the tree.
+printf 'token=%s\nto=%s\namount=%s\n' "$TOKEN" "$TO" "$AMOUNT" \
+  > /tmp/bloom-mount/wallets/$WALLET/chains/$CHAIN/outbox/new
+```
+
+Expected:
+
+```sh
+ls /tmp/bloom-mount/outbox/pending
+ACTION_ID=$(basename "$(find /tmp/bloom-mount/outbox/pending -mindepth 1 -maxdepth 1 -type d | head -1)")
+cat /tmp/bloom-mount/outbox/pending/$ACTION_ID/plan.md
+cat /tmp/bloom-mount/outbox/pending/$ACTION_ID/status.json
+```
+
+`status.json` should include Petal identity such as `petal_id`, and the wallet projection should point at the same action id.
+
+## Confirm: challenge projection + permission denied
+
+```sh
+# Confirm through the Petal/wallet projection for the staged item.
+printf 'confirm\n' > /tmp/bloom-mount/wallets/$WALLET/chains/$CHAIN/outbox/pending/<wallet_projection_id>/confirm
+```
+
+Expected:
+
+- shell write fails with permission denied;
+- central challenge exists before the write returns:
+
+```sh
+cat /tmp/bloom-mount/outbox/pending/$ACTION_ID/approval_challenge.json
+```
+
+Validate:
+
+```sh
+jq -r .action_id /tmp/bloom-mount/outbox/pending/$ACTION_ID/approval_challenge.json
+jq -r .expiry_ms /tmp/bloom-mount/outbox/pending/$ACTION_ID/approval_challenge.json
+jq -r .ceremony_url /tmp/bloom-mount/outbox/pending/$ACTION_ID/approval_challenge.json
+```
+
+Expected:
+
+- `.action_id == "$ACTION_ID"`;
+- `.expiry_ms` is in the future;
+- `.ceremony_url` is present;
+- repeating the same confirm before expiry reuses the same `server_nonce`, `expiry_ms`, and `ceremony_url`.
+
+## Grant-only variant
+
+```sh
+open "$(jq -r .ceremony_url /tmp/bloom-mount/outbox/pending/$ACTION_ID/approval_challenge.json)"
+```
+
+In the browser, choose **grant**.
+
+Expected: browser ceremony succeeds and only an in-memory daemon grant is minted. Then retry:
+
+```sh
+printf 'confirm\n' > /tmp/bloom-mount/wallets/$WALLET/chains/$CHAIN/outbox/pending/<wallet_projection_id>/confirm
+```
+
+Expected artifacts:
+
+```sh
+ls /tmp/bloom-mount/outbox/sent/$ACTION_ID || ls /tmp/bloom-mount/outbox/failed/$ACTION_ID
+cat /tmp/bloom-mount/outbox/sent/$ACTION_ID/result.json 2>/dev/null || cat /tmp/bloom-mount/outbox/failed/$ACTION_ID/result.json
+cat /tmp/bloom-mount/outbox/sent/$ACTION_ID/status.json 2>/dev/null || cat /tmp/bloom-mount/outbox/failed/$ACTION_ID/status.json
+```
+
+Verify ERC20 balances changed by exactly `AMOUNT` plus no unexpected token movement.
+
+## Grant + execute variant
+
+Repeat staging for a second transfer. On the ceremony page, choose **grant + execute**.
+
+Expected:
+
+- ceremony mints the in-memory grant;
+- daemon dispatches execution immediately from the sealed action bytes;
+- central and wallet projections transition together to `sent` or `failed`;
+- `result.json`/audit artifacts are visible under the final central action directory.
+
+## Runtime/Petal split
+
+Generic runtime behavior:
+
+- challenge lifecycle and unexpired challenge reuse;
+- `ceremony_url` projection and exclusion from signed challenge hash;
+- central `/outbox/pending/<action_id>` artifact projection;
+- mounted confirm denial as permission denied;
+- grant minting and signer cache reuse via existing sealed ceremony plumbing.
+
+ERC20 demo glue:
+
+- ERC20 staging/broadcast via `TxEngine`;
+- EVM sealed subject and `PetalHost::sign_hash` attestation;
+- balance verification against the local MockERC20/anvil fixture.

--- a/docs/architecture/mounted-sealed-approval-implementation-plan.md
+++ b/docs/architecture/mounted-sealed-approval-implementation-plan.md
@@ -1,0 +1,62 @@
+# Mounted Sealed Approval implementation plan
+
+Target branch: `auth-architecture-hardening`
+
+## A. Generic mounted ceremony runtime
+
+- `crates/bloom-auth-api/src/lib.rs`
+  - Add optional `ceremony_url` to `ApprovalChallenge` as projection metadata.
+  - Keep `ceremony_url` out of `ApprovalChallenge::canonical_bytes()` / `challenge_hash()`.
+  - Add deterministic local ceremony URL helper from `server_nonce` for the mounted daemon demo path.
+- `crates/bloom-daemon/src/sealed_ceremony.rs` / daemon ceremony serving
+  - Reuse the existing passkey ceremony, approval verifier, grant store, and signer cache for grant minting.
+  - Add grant-only and grant+execute API wiring via the generic dispatcher.
+
+## B. Challenge lifecycle and mounted denial contract
+
+- `crates/bloom-auth/src/lib.rs`
+  - Make `AuthStore::issue_challenge` idempotently return an existing unexpired nonce/expiry instead of rotating on retry.
+- `crates/bloom-tx/src/tx_engine.rs`
+  - Populate `approval_challenge.json` with `ceremony_url` before returning approval-required.
+- `crates/bloom-vfs/src/handlers/wallets.rs`
+  - Map EVM `BroadcastApprovalRequired` to `HandlerError::PermissionDenied` so mounted writes return EACCES after artifacts are written.
+- `crates/bloom-mount/src/adapter.rs`
+  - Keep raw signer paths pre-denied; allow Sealed Approval-aware confirm paths to reach VFS handlers so they can stage the challenge before denying.
+
+## C. Generic sealed-action execution dispatcher
+
+- Add a runtime dispatcher keyed by `petal_id`, `petal_digest`, `subject_kind`, and `action_kind`.
+- Keep ceremony grant/execution mode generic: `grant` mints only; `grant+execute` mints and calls the dispatcher.
+- Register ERC20/EVM wallet as the first executor rather than embedding EVM behavior in ceremony logic.
+
+## D. Central outbox as canonical queue
+
+- `crates/bloom-vfs/src/handlers/outbox.rs`
+  - Add a safe helper for runtime-written action artifacts such as `approval_challenge.json`.
+- `crates/bloom-tx/src/outbox.rs` and `crates/bloom-daemon/src/lib.rs`
+  - Extend the central outbox projection to write pending artifacts and include Petal identity in status/projection output.
+- Wallet projections continue mirroring `plan.md`, `approval_challenge.json`, `status.json`, `result.json`, and sent/failed transitions from the same action id.
+
+## E. Execute from sealed bytes
+
+- `crates/bloom-tx/src/tx_engine.rs`
+  - Reuse existing EVM sealed subject, daemon terms, signing attestation, `PetalHost::sign_hash`, and broadcast code.
+  - Add a hard sealed-vs-projection consistency check for transitional paths.
+
+## F. ERC20 mounted manual demo harness
+
+- Reuse `crates/bloom-it/tests/erc20_e2e.rs` and `scripts/acceptance.sh` assets.
+- Add demo notes covering anvil, MockERC20 deploy, passkey wallet creation/import, funding, `bloom serve --mount`, VFS staging/confirm, ceremony URL, grant retry, grant+execute, balances, and outbox artifacts.
+
+## G. Agent-facing docs
+
+- `crates/bloom-vfs/src/docs/agent-guidance.md`
+  - Document mounted confirm → permission denied → read `approval_challenge.json` → validate `action_id`/`expiry_ms` → open `ceremony_url` → choose mode → retry/inspect artifacts.
+
+## H. Acceptance and regression tests
+
+- `crates/bloom-auth-api`: URL projection and URL-excluded hash tests.
+- `crates/bloom-auth`: challenge reuse/rotation tests.
+- `crates/bloom-vfs` / `crates/bloom-mount`: permission-denied contract and projection visibility tests.
+- `crates/bloom-daemon`: grant-only, grant+execute, restart-loses-grant, fake Petal dispatcher tests.
+- `crates/bloom-it/tests/erc20_e2e.rs`: first real ERC20 manual/integration path.

--- a/docs/issues/2026-07-04-real-tx-ceremony-ux/C10-evm-batch-ceremony-not-wired.md
+++ b/docs/issues/2026-07-04-real-tx-ceremony-ux/C10-evm-batch-ceremony-not-wired.md
@@ -1,0 +1,265 @@
+# C10 — EVM batch ceremony infrastructure exists but is not wired in
+
+**Severity:** High · **Category:** Architectural / Functional
+**Observed:** 2026-07-04, inferred from code analysis during the real-tx ceremony
+UX review. Confirmed by tracing the sealed-approval ceremony, signer cache, and
+`confirm-batch` paths end-to-end.
+
+---
+
+## What happened
+
+`bloom wallet confirm-batch` with `--policy-session` on a passkey wallet
+presents itself as a single-ceremony operation:
+
+```
+passkey confirm-batch requires --policy-session so the one ceremony is explicit
+```
+
+(`main.rs:2237`). But the code actually runs **one WebAuthn ceremony per
+transaction**. For a batch of N pre-staged txs, the user performs N passkey
+ceremonies. The "one ceremony" language is aspirational — the code does not
+deliver it.
+
+This is not a missing feature: the infrastructure for one-ceremony-many-signatures
+already exists in the sealed-approval subsystem. It is simply not connected to
+the batch command path.
+
+## Why it happens
+
+### The batch loop calls the ceremony per tx
+
+`confirm-batch` (`main.rs:2306-2346`) iterates over the staged txs and, for
+each one that is challenged, calls `sign_outbox_sealed_approval_if_challenged`:
+
+```rust
+for (chain, id) in refs {
+    let confirm_once = || { d.tx_engine.confirm(...) };
+    let staged = match confirm_once().await {
+        Err(TxEngineError::BroadcastApprovalRequired(reason)) if passkey_wallet => {
+            sign_outbox_sealed_approval_if_challenged(
+                &d, &wallet, &chain, &id, approval_intent.clone(),  // ← per-tx call
+            ).await?;
+            confirm_once().await?
+        }
+        ...
+    };
+}
+```
+
+Each call to `sign_outbox_sealed_approval_if_challenged` reads **that tx's own**
+`approval_challenge.json` (per-tx `intent_hash`, per-tx `action_id`) and calls
+`run_sealed_approval_ceremony` (`main.rs:3070`), which **unconditionally**
+launches a new WebAuthn assertion:
+
+```rust
+// sealed_ceremony.rs:31-35
+let (assertion, signer) = keystore
+    .sealed_approval_ceremony_with_intent(&wallet, &unsigned, intent)
+    .await?;
+```
+
+There is no check for an existing live grant or cached signer before launching
+the ceremony. Each ceremony mints a **new grant** with its own `grant_id`.
+
+### The action kind is `Confirm` — one-shot by design
+
+Each tx's sealed action uses `EvmSealedActionKind::Confirm`, which is one-shot
+(`bloom-auth-api/src/lib.rs:1496-1498`):
+
+```rust
+fn is_one_shot(self) -> bool {
+    matches!(self, Self::Confirm | Self::Replace | Self::Cancel)
+}
+```
+
+One-shot actions are **forced** to `max_signatures: 1` (`lib.rs:1696-1699`):
+
+```rust
+if self.action_kind.is_one_shot() && self.daemon_terms.max_signatures != 1 {
+    return Err(AuthApiError::InvalidSubject(
+        "EVM one-shot actions must allow exactly one signature".into(),
+    ));
+}
+```
+
+So each grant is exhausted after one `sign_hash` call, the cached signer is
+dropped (`petal_host.rs:455-458`), and the next tx needs a fresh ceremony.
+
+## The infrastructure for batch IS already built
+
+Three components were designed for one-ceremony-many-signatures, but the batch
+command does not use them:
+
+### 1. `EvmSealedActionKind::OwnerSessionUse` — not one-shot
+
+`bloom-auth-api/src/lib.rs:1479-1498`:
+
+```rust
+pub enum EvmSealedActionKind {
+    Confirm,
+    Replace,
+    Cancel,
+    OwnerSessionUse,  // ← NOT one-shot
+}
+
+fn is_one_shot(self) -> bool {
+    matches!(self, Self::Confirm | Self::Replace | Self::Cancel)
+    // OwnerSessionUse is excluded → can have max_signatures > 1
+}
+```
+
+`OwnerSessionUse` can carry `max_signatures > 1` — the validation at line 1696
+does not fire for it. Test code confirms this works
+(`lib.rs:4292`: `subject.action_kind = EvmSealedActionKind::OwnerSessionUse`,
+`lib.rs:4302`: `max_signatures: 10`).
+
+### 2. `SignerCache` — caches the decrypted signer across `sign_hash` calls
+
+`crates/bloom-keystore/src/petal_host.rs:49-97`:
+
+```rust
+pub struct SignerCache { ... }
+
+impl SignerCache {
+    pub fn get(&self, grant_id: &str) -> Option<Arc<PrivateKeySigner>> { ... }
+    pub fn insert(&self, grant_id: String, signer: Arc<PrivateKeySigner>, ...) { ... }
+    pub fn drop_on_completion(&self, grant_id: &str) { ... }
+}
+```
+
+After `run_sealed_approval_ceremony` completes, the decrypted signer is cached
+(`sealed_ceremony.rs:52-57`):
+
+```rust
+signer_cache.insert(
+    grant.grant_id.clone(),
+    signer,
+    wallet.clone(),
+    grant.expiry_ms,
+);
+```
+
+### 3. `sign_hash` reuses the cached signer without a ceremony
+
+`petal_host.rs:405-407`:
+
+```rust
+let signer = if let Some(cache) = &self.signer_cache {
+    if let Some(cached) = cache.get(&grant.grant_id) {
+        cached  // ← no WebAuthn ceremony; signer reused
+    } else { ... }
+};
+```
+
+And the signer is **only dropped** when all signatures are consumed
+(`petal_host.rs:455-458`):
+
+```rust
+if updated_grant.consumed_signature_count >= updated_grant.max_signatures
+    && let Some(cache) = &self.signer_cache
+{
+    cache.drop_on_completion(&grant.grant_id);
+}
+```
+
+### What a true batch path would look like
+
+1. Stage **one** `OwnerSessionUse` sealed action with `max_signatures = N`,
+   referencing all N txs by id/chain/hash.
+2. Run **one** ceremony → mints one grant → caches the signer.
+3. For each tx: `PetalHost::sign_hash` with the same `grant_id` → cache hit →
+   sign without ceremony → `consume_signature` decrements the counter.
+4. After the Nth signature, `drop_on_completion` cleans up.
+
+The sealed-approval ceremony, grant minting, signer caching, signature
+consumption, and audit logging all already work. Only the batch command path
+doesn't use them.
+
+## The alternative batch path (`unlock-once-sign-many`) is broken by `417b830`
+
+Before the sealed-approval migration, Polymarket onboarding demonstrated a
+different one-ceremony-many-signatures pattern:
+
+1. `unlock_passkey_with_intent(wallet, Some(intent))` — one WebAuthn ceremony
+   that decrypts and caches the `PrivateKeySigner`.
+2. `KeystoreSigner::new(d.keystore.signer(&wallet)?)` — retrieves the cached
+   signer.
+3. `onboarder.run(&signer)` — signs ~10 messages (deploy, approvals,
+   credential mint, sync) reusing the cached key.
+
+This is the "unlock-once-sign-many" pattern. It works because
+`unlock_passkey_with_intent` caches the decrypted key and `signer()` returns
+it.
+
+But commit `417b830` ("Guard passkey wallet signer access",
+`lib.rs:857-866`) made `Keystore::signer()` **refuse** passkey wallets:
+
+```rust
+pub fn signer(&self, name: &str) -> Result<Arc<PrivateKeySigner>, KeystoreError> {
+    let info = self.info_unverified(name)?;
+    if info.kind == WalletKind::PasskeyGated {
+        return Err(KeystoreError::Signer(
+            "passkey wallet signing requires a Sealed Approval grant via PetalHost::sign_hash"
+                .into(),
+        ));
+    }
+    self.cached_signer(name)
+}
+```
+
+The replacement (`PetalHost::sign_hash`) returns a `SealedSignature` (base64
+ECDSA + `intent_hash`), not an `Arc<PrivateKeySigner>`. The callers that use
+`KeystoreSigner` (`polymarket.rs:565,1162,2683,2837,2962`, `main.rs:4305`)
+expect an `Arc<PrivateKeySigner>` and cannot consume `SealedSignature` without
+a redesign.
+
+So `417b830` is a **half-completed migration**: it gated `signer()` for passkey
+wallets but migrated zero callers and provided no public bridge from
+`SealedSignature` to the `PrivateKeySigner`-based signing APIs that the
+Polymarket and Hyperliquid commands depend on.
+
+### Affected commands (all broken for passkey after `417b830`)
+
+| Call site | Command | Uses `signer()`? | Passkey status |
+|---|---|---|---|
+| `polymarket.rs:565` | `polymarket order`, `polymarket sell` | yes | **BROKEN** |
+| `polymarket.rs:1162` | `polymarket onboard` | yes | **BROKEN** |
+| `polymarket.rs:2683` | `polymarket redeem` | yes | **BROKEN** |
+| `polymarket.rs:2837` | `polymarket withdraw-pusd` | yes | **BROKEN** |
+| `polymarket.rs:2962` | `polymarket revoke-approvals` | yes | **BROKEN** |
+| `main.rs:4305` | `hl order` | yes | **BROKEN** |
+
+Only `polymarket fund` survives — it uses the EVM outbox path (sealed-approval
+grants via `tx_engine.confirm`), not `keystore.signer()`.
+
+## Impact
+
+- **Batch EVM operations require N ceremonies.** A 5-tx batch (e.g., approve +
+  swap + transfer + stake + claim) requires 5 passkey ceremonies. This defeats
+  the purpose of `confirm-batch` — the user could just as easily run `confirm`
+  five times.
+
+- **The "one ceremony" UX promise is broken.** `confirm-batch` with
+  `--policy-session` explicitly claims to be a single ceremony
+  (`main.rs:2237,2251`). It is not. A user who trusts this message will be
+  surprised by the second, third, ... ceremony prompt.
+
+- **`417b830` blocks the only working batch pattern.** The unlock-once-sign-many
+  pattern (used by onboarding) was the only path that delivered true
+  one-ceremony-many-signatures for passkey wallets. By gating `signer()`,
+  `417b830` cut it off without providing a replacement. The intended replacement
+  (`PetalHost::sign_hash`) exists but returns a different type that callers
+  can't consume.
+
+- **All non-EVM-outbox signing is broken for passkey.** Until the callers are
+  migrated from `Keystore::signer()` to `PetalHost::sign_hash` (or a public
+  bridge is added), Polymarket orders, onboarding, redeem, withdraw, revoke, and
+  Hyperliquid orders all hard-fail for passkey wallets.
+
+## Summary of the two gaps
+
+| Gap | Root cause | Fix complexity |
+|---|---|---|
+| `confirm-batch` does N ceremonies | batch loop uses per-tx `Confirm` (one-shot) instead of one `OwnerSessionUse` grant with `max_signatures = N` | Medium — restructure the batch path to stage one `OwnerSessionUse` action, reuse the grant_id |
+| `417b830` breaks unlock-once-sign-many | `signer()` refuses passkey; callers not migrated to `PetalHost::sign_hash` | Medium — either revert the gate, expose `cached_signer()` publicly as a bridge, or migrate all 6 callers to the `SealedSignature` API |

--- a/docs/issues/2026-07-04-real-tx-ceremony-ux/C2-serve-socket-passkey-ceremony.md
+++ b/docs/issues/2026-07-04-real-tx-ceremony-ux/C2-serve-socket-passkey-ceremony.md
@@ -1,0 +1,215 @@
+# C2 — serve-socket cannot reach the passkey ceremony
+
+**Severity:** High · **Category:** Functional / Design
+**Observed:** 2026-07-04, during a real mainnet USDC bridge + Polymarket fund
+run through a passkey-gated wallet on the sealed-approval demo branch.
+
+---
+
+## What happened
+
+When `bloom serve` (the long-running daemon) is running, a passkey-wallet
+broadcast cannot be completed through its Unix-domain JSON-RPC socket. Two
+distinct failure modes were observed:
+
+1. **Plain VFS write to `…/pending/<id>/confirm`** → JSON-RPC error
+   `-32007 "permission denied"`. No approval challenge is surfaced to the
+   caller, and no ceremony is offered.
+
+2. **`bloom wallet confirm <wallet> <chain> <id>`** (which routes through the
+   socket when serve is up) → JSON-RPC error
+   `-32008 "unsupported: write_unlocked is disabled for passkey wallets; stage
+   a Sealed Approval action and sign through PetalHost::sign_hash"`.
+
+The passkey ceremony (the browser-based WebAuthn flow that decrypts the wallet
+key and mints a Sealed Approval grant) is **only reachable via the in-process
+foreground CLI with `bloom serve` stopped**. Stopping serve and re-running
+`bloom wallet confirm` succeeds: it runs the ceremony, obtains the grant,
+broadcasts, and returns the tx hash.
+
+## Sequence to hit it
+
+```
+# 1. serve is running
+bloom serve &
+
+# 2a. plain VFS confirm write → fails
+bloom vfs write /wallets/<wallet>/chains/<chain>/outbox/pending/<id>/confirm --data y
+# → -32007 permission denied
+
+# 2b. wallet confirm (routes through socket) → fails
+bloom wallet confirm <wallet> <chain> <id> --text y
+# → -32008 write_unlocked is disabled for passkey wallets
+
+# 3. stop serve, retry in foreground → succeeds
+# (kill serve)
+bloom wallet confirm <wallet> <chain> <id> --text y
+# → browser ceremony → broadcast → tx hash
+```
+
+## Evidence
+
+### The `-32008` gate: `write_unlocked` hard-rejected for passkey
+
+`crates/bloom-daemon/src/ipc.rs:135-145`:
+
+```rust
+const PASSKEY_WRITE_UNLOCKED_DISABLED: &str = "write_unlocked is disabled for passkey wallets; \
+stage a Sealed Approval action and sign through PetalHost::sign_hash";
+
+fn reject_passkey_write_unlocked(kind: WalletKind) -> Result<(), HandlerError> {
+    if kind == WalletKind::PasskeyGated {
+        return Err(HandlerError::Unsupported(
+            PASSKEY_WRITE_UNLOCKED_DISABLED.into(),
+        ));
+    }
+    Ok(())
+}
+```
+
+Invoked inside `do_write_unlocked` at `ipc.rs:397-400`:
+
+```rust
+match info.kind {
+    WalletKind::PasskeyGated => {
+        reject_passkey_write_unlocked(info.kind)?;
+    }
+    _ => { keystore.unlock(wallet, passphrase.unwrap_or(""))... }
+```
+
+`HandlerError::Unsupported` → `-32008` at `ipc.rs:1447`:
+
+```rust
+HandlerError::Unsupported(s) => (-32008, format!("unsupported: {s}")),
+```
+
+The CLI routes `wallet confirm` through the socket first (`main.rs:2029-2044`,
+`try_ipc`), and a `-32008` error response surfaces as `Err` — the in-process
+fallback is only reached when the socket is absent/stale (`NotFound` /
+`ConnectionRefused`).
+
+### The `-32007` path: the typed ceremony signal is destroyed at the VFS boundary
+
+The IPC `write` gate (`write_path_uses_wallet_signer`, `ipc.rs:690-776`)
+deliberately lets `confirm` through to the VFS wallets handler (it only forces
+`cancel`/`replace` onto `write_unlocked`). So a plain confirm write reaches
+`tx_engine.confirm(...)` → `ensure_action_authorized` (`tx_engine.rs:1394`) →
+`ensure_sealed_outbox_approval` (`tx_engine.rs:2567`).
+
+For a passkey wallet with no active grant and no `approval.json`, the engine
+writes `approval_challenge.json` to disk (`tx_engine.rs:2694-2700`) and returns:
+
+```rust
+Err(TxEngineError::BroadcastApprovalRequired(format!(
+    "outbox confirm requires signed Sealed Approval; wrote {} in {}; \
+     rerun the foreground confirm/write command with the passkey wallet ...",
+    OUTBOX_APPROVAL_CHALLENGE_FILE, entry.dir.display(),
+)))
+```
+(`tx_engine.rs:2714-2718`)
+
+But the wallets handler **discards the reason string** and downgrades the typed
+error to opaque `PermissionDenied` (`crates/bloom-vfs/src/handlers/wallets.rs:2126-2134`):
+
+```rust
+TxEngineError::BroadcastApprovalRequired(_) => HandlerError::PermissionDenied,
+```
+
+And `PermissionDenied` → bare `-32007 "permission denied"` (`ipc.rs:1445`).
+The challenge file was written on the daemon's disk, but the IPC response
+carries no path, no nonce, no intent hash — the socket client cannot discover
+where it is or act on it.
+
+### The ceremony is foreground-only by construction
+
+The ceremony orchestrator `run_sealed_approval_ceremony`
+(`crates/bloom-daemon/src/sealed_ceremony.rs:21-73`) is called from **exactly
+one site in the entire codebase**: the CLI at `main.rs:3070`, inside
+`sign_outbox_sealed_approval_if_challenged` (`main.rs:3006-3087`). No daemon
+IPC handler references it.
+
+The IPC dispatch table (`ipc.rs:294-358`) exposes these methods:
+
+```
+version, chains, shutdown, lookup, read, write, write_unlocked,
+sign_hash, wallet.sign_policy, list,
+petals.install, petals.run, petals.list, petals.resolve, petals.name, petals.uninstall
+```
+
+There is no `ceremony.*`, `sealed_approval.*`, or `browser.*` method. The only
+signing method over the socket is `sign_hash` (`ipc.rs:318-321`), which is the
+**consumer** of a grant + cached signer, not a producer of one.
+
+The browser step itself — `auth_ceremony` (`passkey.rs:436-536`) — binds a local
+TCP listener on `127.0.0.1:{CEREMONY_PORT}` (`passkey.rs:479`) and opens
+`http://localhost:{port}/?t=...` in the system browser (`passkey.rs:488-504`).
+The RP ID is `"localhost"` (`passkey.rs:66,274`); origin checks hard-require
+`http://localhost:{port}` (`passkey.rs:643-660`). This is only meaningful in an
+interactive process sharing the user's desktop session.
+
+### The bridge that DOES cross the socket: the SignerCache
+
+What IS reachable over the socket is signing with an **already-obtained** grant.
+The ceremony populates an in-memory `SignerCache`
+(`crates/bloom-keystore/src/petal_host.rs:49-109`) at `sealed_ceremony.rs:52-58`,
+keyed by `grant_id`. Subsequent `sign_hash` IPC calls read
+`cache.get(&grant.grant_id)` (`petal_host.rs:405-425`) and sign without
+re-running a ceremony. So the model is:
+
+```
+ceremony (in-process, once) → grant + SignerCache entry → many sign_hash calls (over socket)
+```
+
+The daemon can **consume** a grant but cannot **produce** one.
+
+## Why it happens
+
+This is a deliberate architectural property, not an oversight. Three structural
+facts combine:
+
+1. **The dispatch table has no ceremony method.** The daemon's IPC surface
+   cannot open a browser or run WebAuthn. `write_unlocked` (which would unlock
+   + sign in one round-trip) is hard-rejected for passkey because the decrypted
+   EVM key must never be transported across the socket (`ipc.rs:163-165`: "The
+   daemon remains the single writer; the client only requests the ceremony").
+
+2. **The ceremony is intrinsically local + browser-mediated.** A background
+   daemon has no defined way to open a browser on the owning user's interactive
+   desktop session. The `localhost` RP ID and origin checks make the WebAuthn
+   contract meaningful only from the foreground process.
+
+3. **The typed signal is destroyed at the VFS boundary.** Even though the
+   engine writes `approval_challenge.json` and returns a rich
+   `BroadcastApprovalRequired(reason)` naming the file, the wallets handler
+   discards the reason and returns opaque `-32007`. So even a sophisticated
+   socket client (e.g. an agent) cannot discover the challenge, and there is no
+   IPC method to consume a signed `approval.json` even if it could.
+
+The security rationale is explicit in the codebase: the passkey wallet's
+decrypted key must never exist in a context the socket controls, and the
+ceremony model requires human presence (WebAuthn `user_verified=true` for
+Hardened assurance). Gating `policy-session/new` onto the same ceremony lane
+(`ipc.rs:732-739`) carries the same rationale: "an agent cannot silently mint a
+broad batch-signing session."
+
+## Impact
+
+- **Agent/automation flows for passkey wallets are blocked under `bloom serve`.**
+  Any agent relying on the long-running daemon for passkey-wallet broadcasts
+  hits a dead end. The only working path is stopping serve and running the
+  foreground CLI — which requires a human at the machine for every broadcast.
+
+- **The error messages are not actionable.** A socket client sees `-32007
+  "permission denied"` with no indication that a challenge file was written, no
+  path to it, and no instruction. The `-32008` message at least names the
+  alternative (`PetalHost::sign_hash`), but neither tells the caller "stop serve
+  and run the foreground CLI."
+
+- **QUICKSTART §6 overstates the serve path.** The doc implies direct VFS
+  `confirm` writes work under serve for any wallet (the example uses a
+  passphrase wallet, with no passkey carve-out). See companion code fix C8.
+
+- **The SignerCache is in-memory only** (`petal_host.rs:48`: "the daemon process
+  restarts (cache is in-memory only)"). So even the one-ceremony-then-many-sign
+  model does not survive a daemon restart — each restart requires a fresh
+  foreground ceremony.

--- a/docs/issues/2026-07-04-real-tx-ceremony-ux/C3-dependent-cross-chain-no-shared-ceremony.md
+++ b/docs/issues/2026-07-04-real-tx-ceremony-ux/C3-dependent-cross-chain-no-shared-ceremony.md
@@ -1,0 +1,238 @@
+# C3 — dependent cross-chain flows cannot share one ceremony
+
+**Severity:** Medium · **Category:** Architectural
+**Observed:** 2026-07-04, during a real mainnet USDC bridge (Base → Polygon)
+followed by a USDC → pUSD fund, both through a passkey-gated wallet.
+
+---
+
+## What happened
+
+A two-leg cross-chain sequence — (1) bridge USDC from Base to Polygon, then
+(2) swap the arrived USDC for pUSD on Polygon — required **two separate passkey
+ceremonies**, one per broadcast. This is inherent (one ceremony per broadcast is
+the baseline). But the reason a single ceremony **cannot** cover both legs is
+structural: the second leg's outbox id does not exist until the first leg
+settles on the destination chain, and bloom's policy-session mechanism can only
+authorize exact ids that are enumerated and signed for at ceremony time.
+
+So even though bloom already implements a multi-tx-one-ceremony primitive
+(policy sessions via `confirm-batch --policy-session` and the `SessionStore`),
+it cannot help a **dependent** sequence — one where leg N+1 cannot even be
+staged until leg N settles.
+
+## Sequence to hit it
+
+```
+# Leg 1: bridge USDC Base → Polygon (defi intent)
+bloom vfs write /defi/intents/<wallet>/new --data '{"intent":"swap 7 usdc to usdc","chain":"base","destination_chain":"polygon"}'
+# → stages outbox tx <base-id> on Base
+bloom wallet confirm <wallet> base <base-id> --text y
+# → ceremony #1 → broadcast → relay delivers USDC to Polygon EOA
+
+# Leg 2: swap arrived USDC → pUSD on Polygon
+bloom polymarket fund <wallet> --target-pusd 6.9 --max-spend 6.976 --from-token <poly-usdc>
+# → stages outbox tx <poly-id> on Polygon  (id unknown until leg 1 settled)
+bloom wallet confirm <wallet> polygon <poly-id> --text y
+# → ceremony #2 (cannot be covered by ceremony #1's session)
+```
+
+The `<poly-id>` did not exist when ceremony #1 ran, so it could not have been
+allowlisted. There is no way to pre-authorize "the eventual Polygon swap" at
+ceremony #1 time.
+
+## Evidence
+
+### The `ActiveSession` allowlist is exact chain-qualified ids
+
+`crates/bloom-tx/src/session.rs:22-39`:
+
+```rust
+/// A live, bounded authorization minted by one ceremony.
+#[derive(Debug, Clone)]
+pub struct ActiveSession {
+    pub id: SessionId,
+    pub wallet: String,
+    /// Chain ids this session may authorize.
+    pub chains: BTreeSet<u64>,
+    /// Unix-ms expiry; confirms at or after this are not covered.
+    pub expires_ms: u128,
+    /// Total spend cap in micro-USD across the session.
+    pub max_micro_usd: i128,
+    /// Micro-USD already debited by authorized confirms.
+    pub spent_micro_usd: i128,
+    /// Exact **chain-qualified** outbox ids this session may broadcast, keyed
+    /// `"{chain_id}:{outbox_id}"`. Outbox ids are unique only within a chain, so
+    /// qualifying by chain prevents a same-id tx on another listed chain from
+    /// being authorized by a session minted for a different chain's tx.
+    pub allowed_pending_ids: BTreeSet<String>,
+}
+```
+
+The chain-qualified keying helper — `session.rs:42-44`:
+
+```rust
+pub fn pending_key(chain_id: u64, outbox_id: &str) -> String {
+    format!("{chain_id}:{outbox_id}")
+}
+```
+
+### `authorize_and_debit` requires exact id membership
+
+`crates/bloom-tx/src/session.rs:110-149` — the coverage check is a single AND of
+five predicates, evaluated per session:
+
+```rust
+pub fn authorize_and_debit(
+    &self, wallet: &str, chain_id: u64, pending_id: &str,
+    tx_micro_usd: Option<i128>, value_moving: bool, now_ms: u128,
+) -> Option<(SessionId, i128)> {
+    let key = pending_key(chain_id, pending_id);
+    let mut guard = self.inner.write();
+    for s in guard.values_mut() {
+        if s.wallet != wallet
+            || s.expires_ms <= now_ms
+            || !s.chains.contains(&chain_id)
+            || !s.allowed_pending_ids.contains(&key)   // ← exact membership
+        {
+            continue;
+        }
+        // ... debit under cap ...
+        return Some((s.id.clone(), debit));
+    }
+    None
+}
+```
+
+The five predicates: (1) wallet matches, (2) not expired, (3) chain in set,
+(4) **exact `"{chain_id}:{pending_id}"` in allowlist**, (5) cumulative USD
+under cap. A session miss is not an error — the caller falls back to per-tx
+authorization (`tx_engine.rs:1376-1403`), which for a passkey wallet means a
+fresh ceremony.
+
+### Minting requires non-empty exact ids and a Hardened ceremony
+
+`crates/bloom-vfs/src/handlers/wallets.rs:416-468` — the mint descriptor:
+
+```rust
+#[derive(serde::Deserialize)]
+struct Descriptor {
+    max_usd: f64,
+    ttl_secs: u64,
+    #[serde(default)]
+    pending_ids: Vec<PendingId>,   // ← {chain_id, id} pairs
+};
+...
+if d.pending_ids.is_empty() || d.ttl_secs == 0 || d.max_usd <= 0.0 {
+    return Err(HandlerError::invalid(
+        "policy-session requires non-empty pending_ids ({chain_id,id} pairs), \
+         ttl_secs > 0, and max_usd > 0",
+    ));
+}
+```
+
+You **cannot** mint a session with a budget + expiry alone — `pending_ids` must
+be non-empty. The `allowed_pending_ids` is built by mapping each supplied
+`(chain_id, id)` through `pending_key`. There is no wildcarding and no
+post-hoc growth: the set is frozen at mint time.
+
+The mint is gated behind a Hardened-assurance Sealed Approval
+(`wallets.rs:621-657`, `AssuranceLevel::Hardened` at `wallets.rs:631`), meaning
+the WebAuthn assertion must carry `user_verified=true`. The human signs over the
+literal descriptor JSON — the exact ids, cap, and TTL are what is reviewed in
+the browser.
+
+### No plan/flow/descriptor binding exists anywhere
+
+Search of `crates/bloom-tx` for `plan|flow|descriptor|leg|sequence|dependent`:
+the words `plan`, `flow`, `descriptor`, `leg`, `sequence`, `dependent` do not
+appear in `session.rs` at all. Only `allowlist` appears, and it always refers to
+`allowed_pending_ids` (the exact-id set). The only fields bounding a session are
+the five in the struct above: `wallet`, `chains`, `expires_ms`, `max_micro_usd`
+(+ `spent_micro_usd`), `allowed_pending_ids`. There is no `plan_id`, no
+`flow_id`, no per-leg descriptors, no "cap + expiry without id list" mode.
+
+(`tx_engine.rs:2416` and `reconcile.rs:7` mention "dependent same-chain tx" but
+that is about **nonce ordering** within the outbox — whether a dependent tx may
+broadcast before its predecessor confirms. It has nothing to do with
+`SessionStore` authorization and does not relax the exact-id check.)
+
+### `confirm-batch --policy-session` is NOT a SessionStore mint
+
+`bloom wallet confirm-batch --policy-session` (`main.rs:2197-2353`) does not
+insert anything into `SessionStore`. It builds one aggregate `CeremonyIntent`
+("Authorize Batch Transaction Session") covering every tx in the batch
+(`main.rs:2240-2302`), then for each `(chain, id)` runs `confirm_once()`; on
+`BroadcastApprovalRequired` it calls `sign_outbox_sealed_approval_if_challenged`
+per-tx (`main.rs:2322-2341`). It batches per-tx grants behind one **review**
+ceremony — but it still requires every `(chain, id)` to be known up front (it's
+a batch of already-staged txs), so it cannot help a dependent sequence either.
+
+## Why it happens
+
+The `SessionStore` was designed around a security property stated in its module
+doc (`session.rs:9-12`):
+
+> The store lives on the `TxEngine` (where confirms are authorized) — **not** on
+> the keystore's unlocked-signer cache, which has an unbounded lifetime. A
+> session therefore expires independently and can never resurrect a locked key.
+
+The exact-id allowlist is the maximally safe authorization envelope: a session
+can broadcast **only** what was enumerated and signed for at ceremony time, up
+to the signed dollar cap, before the signed expiry. Nothing about an
+un-enumerated id — not even one staged seconds later by the same wallet — can
+slip through. Combined with the `SignerCache` (also in-memory, also per-grant),
+this means one ceremony unlocks a bounded, fully-specified set of broadcasts.
+
+The constraint this imposes on dependent flows: a leg whose outbox id is not
+known at ceremony time cannot be covered. In a cross-chain bridge, the
+destination-leg tx cannot be staged until the source-leg settles and the relay
+delivers (minutes later), so its id does not exist when the source-leg ceremony
+runs. The two ceremonies are therefore unavoidable under the current model.
+
+This is the tradeoff the design chose: **safety over ergonomics for dependent
+sequences**. The exact-id allowlist makes it impossible for an agent to broaden
+a session's scope after the fact (no descriptor creep, no wildcard exhaustion),
+but it also makes it impossible to pre-authorize a flow whose legs materialize
+dynamically.
+
+## Impact
+
+- **Every dependent multi-leg flow pays one ceremony per leg.** A cross-chain
+  bridge + swap = 2 ceremonies. A longer chain (bridge → swap → stake → …) =
+  one per broadcast. Each ceremony requires human presence (browser WebAuthn).
+
+- **The cost is amplified by C1/C4.** When `polymarket fund` ran its own
+  ceremony AND required a separate sealed-approval confirm, a single-leg flow
+  cost two ceremonies — see companion code fix. With C1/C4 fixed, a
+  single-leg flow is back to one ceremony, but multi-leg dependent flows still
+  cannot collapse.
+
+- **The ceremony cannot be deferred to flow-completion.** Because the
+  `SignerCache` is in-memory and the session is exact-id, there is no mechanism
+  to obtain one human approval and let the engine broadcast legs as they become
+  ready over minutes/hours.
+
+- **Sessions do not survive daemon restart** (`SessionStore` is in-memory,
+  `session.rs` is `Arc<RwLock<HashMap<...>>>`; `petal_host.rs:48`: "the daemon
+  process restarts (cache is in-memory only)"). A restart mid-flow invalidates
+  any session, forcing re-ceremony for remaining legs.
+
+## What would need planning
+
+This is recorded as a design issue, not a bug. Any change to allow dependent
+flows to share a ceremony would need to answer hard questions:
+
+- **What can a leg bind to instead of an exact id?** Chain + token + receiver +
+  max amount? A route hash? A plan/flow identifier?
+- **How is the total cap enforced?** Cumulative USD across legs (current model)
+  vs per-leg caps vs both.
+- **What are the partial-failure semantics?** If leg 1 broadcasts but leg 2's
+  route expires, does the session remain valid for a re-staged leg 2? What if
+  leg 1 succeeds but leg 2 is never staged?
+- **How to prevent descriptor over-permissioning?** A descriptor like "any tx
+  on Polygon up to $7" is convenient but far broader than "this exact outbox
+  id." Where is the line?
+- **Expiry vs settlement time.** Cross-chain relay settlement takes minutes;
+  the session TTL must accommodate it without becoming a long-lived broad
+  authority.

--- a/docs/issues/2026-07-04-real-tx-ceremony-ux/C9-policy-pricing-native-only.md
+++ b/docs/issues/2026-07-04-real-tx-ceremony-ux/C9-policy-pricing-native-only.md
@@ -1,0 +1,231 @@
+# C9 — the policy engine can only price native-token sends
+
+**Severity:** High · **Category:** Architectural / Functional
+**Observed:** 2026-07-04, inferred from code analysis during the real-tx ceremony
+UX review. Confirmed by tracing the staging → authorization path end-to-end.
+
+---
+
+## What happened
+
+The policy engine exists to let agents execute transactions autonomously within
+bounded USD limits (`max_tx_usd`, `max_day_usd`, etc.) under `under_policy`
+autonomy. But the USD valuation path only prices **native-token value** (ETH,
+MATIC). ERC-20 transfers, ERC-20 approvals, NFT transfers, and contract calls
+(swaps, staking, etc.) all carry their value in calldata rather than the tx's
+native `value` field, so their `value_wei` is zero, and the oracle is never
+invoked. These transactions end up unpriced (`usd_value = None`), which makes
+them **Denied** at authorization time — the policy engine treats them as having
+unknown value and refuses to auto-broadcast.
+
+In practice, `under_policy` autonomy can only autonomously approve plain
+native-token sends. For a wallet whose primary use case is DeFi (swaps,
+transfers, funding), this means virtually every meaningful operation still
+requires a ceremony.
+
+## Why it happens
+
+### The oracle is gated on native value only
+
+At staging time (`crates/bloom-tx/src/tx_engine.rs:1184-1197`):
+
+```rust
+policy_ctx.usd_value = intent.usd_value_hint.as_deref()
+    .and_then(|s| s.parse::<f64>().ok())
+    .filter(|v| v.is_finite() && *v >= 0.0);
+if policy_ctx.usd_value.is_none() && needs_usd && value_wei > U256::ZERO {
+    policy_ctx.usd_value = if let Some(oracle) = &self.price_oracle {
+        oracle.native_usd(&spec.name, value_wei, spec.native_decimals).await
+    } else {
+        None
+    };
+}
+```
+
+The oracle call is guarded on `value_wei > U256::ZERO`. Every non-native intent
+sets `value_wei = U256::ZERO` because the amount travels in calldata:
+
+- ERC-20 `Send`: `tx_engine.rs:694` → `(token_addr, U256::ZERO, calldata, ...)`
+- ERC-20 `Approve`: `tx_engine.rs:736` → `(token_addr, U256::ZERO, calldata, ...)`
+- NFT `Transfer`: `tx_engine.rs:812` → `(contract_addr, U256::ZERO, calldata, ...)`
+
+So the oracle is structurally unreachable for any calldata-based tx.
+
+### The `PriceOracle` trait is native-only
+
+`crates/bloom-tx/src/oracle.rs:24-30`:
+
+```rust
+#[async_trait]
+pub trait PriceOracle: Send + Sync {
+    async fn native_usd(
+        &self,
+        chain_name: &str,
+        value_wei: U256,
+        native_decimals: u8,
+    ) -> Option<f64>;
+}
+```
+
+The trait has a single method for native assets. There is no ERC-20 pricing
+method on this trait. The production implementation
+(`crates/bloom-daemon/src/price_oracle.rs:42-59`) maps the chain to a DefiLlama
+coin id (ETH or MATIC), scales wei to units, and multiplies by the spot price.
+
+### `value_moving` is over-broad — ERC-20 approves are "value-moving"
+
+`crates/bloom-tx/src/tx_engine.rs:2722-2731`:
+
+```rust
+let value_wei = U256::from_str_radix(&staged.value_wei, 10).unwrap_or(U256::ZERO);
+let data_nonempty = staged.data_hex.trim_start_matches("0x").bytes().any(|b| b != b'0');
+let value_moving = value_wei > U256::ZERO
+    || staged.token.is_some()
+    || staged.nft.is_some()
+    || data_nonempty;
+```
+
+`value_moving` is `true` if **any** of: native value present, token ref present,
+NFT ref present, or **any non-zero calldata byte**. An ERC-20 `approve` produces
+ABI-encoded calldata (selector `0x095ea7b3…`), so `data_nonempty = true`, so
+`value_moving = true` — even though an approve grants spending permission and
+moves no value. There is no approve-vs-transfer distinction.
+
+### Unpriced + value-moving → Denied
+
+At authorization time (`crates/bloom-proto/src/policy.rs:734-766`):
+
+```rust
+// Non-value-moving short-circuits to autonomous approval (debit 0).
+if !subject.value_moving {
+    return AutonomyDecision::ApprovedAutonomous { ... };
+}
+// ...
+// UnderPolicy + unpriced + value-moving => DENIED
+let Some(value) = subject.total_value_usd_micro else {
+    return AutonomyDecision::Denied {
+        reason: "USD valuation unavailable".into(),
+    };
+};
+```
+
+And for policy sessions (`crates/bloom-tx/src/session.rs:129-145`):
+
+```rust
+let debit = match tx_micro_usd {
+    Some(v) => { /* check against cap, debit */ }
+    None if value_moving => continue,  // fail-closed: no session covers it
+    None => 0,                          // value-neutral: debit 0
+};
+```
+
+So an unpriced value-moving tx is Denied under `under_policy` autonomy and
+cannot be covered by a policy session. The only escape is passing an explicit
+`usd_value_hint` in the intent (parsed at `intent_parser.rs:69,532-546`), which
+bypasses the oracle entirely.
+
+## A richer oracle exists but is not wired in
+
+The codebase has a **second** `PriceOracle` trait that can price arbitrary
+assets, including ERC-20s:
+
+`crates/bloom-auth-api/src/lib.rs:2646-2653`:
+
+```rust
+#[async_trait]
+pub trait PriceOracle: Send + Sync {
+    async fn quote_usd(
+        &self,
+        asset_id: &str,
+        amount_base_units: &str,
+        now_ms: u128,
+    ) -> Result<ValuationQuote>;
+}
+```
+
+Its implementation `BloomPricesOracle` (`crates/bloom-auth/src/lib.rs:2157-2200`)
+calls the same DefiLlama `PricesClient`, and `bloom-prices` already supports
+ERC-20 coin ids:
+
+```rust
+// crates/bloom-prices/src/lib.rs:54-65
+pub enum CoinId {
+    Erc20 { chain: String, address: Address },
+    Native(String),
+    Symbol(String),
+}
+```
+
+But this oracle is invoked **only** from the standing-session reservation
+surface (`crates/bloom-auth/src/lib.rs:1276-1314`,
+`AuthStore::create_reservation_with_valuation`). It is **not** wired into the
+EVM outbox staging/confirm path that populates `usd_value` on `StagedTx`. The
+infrastructure to price ERC-20s exists — it is not connected to the policy
+engine.
+
+The staging path already has the token contract address available in the
+`TokenRef` (`crates/bloom-proto/src/plan.rs:87-98`: `contract`, `decimals`,
+`symbol`). So the inputs needed for an ERC-20 price lookup are present at
+staging time; the pricing call just isn't made.
+
+## The stablecoin assumption is unimplemented
+
+`ValuationQuote` has a `stablecoin_assumption: bool` field
+(`bloom-auth-api/src/lib.rs:2294`), and `ValuationPolicy` distinguishes freshness
+windows for volatile (30s) vs stablecoin (120s) assets
+(`bloom-auth-api/src/lib.rs:2553-2554`). But `BloomPricesOracle::quote_usd`
+**always returns `stablecoin_assumption: false`**
+(`crates/bloom-auth/src/lib.rs:2198`). No production code path classifies an
+asset as a stablecoin. So even USDC and USDT — which would reasonably be
+assumed ≈$1 — are always queried live as volatile assets, with no fallback if
+DefiLlama is unavailable.
+
+The bloom-tx native-only oracle path has no stablecoin concept at all.
+
+## Impact
+
+- **`under_policy` autonomy is limited to native sends.** Any ERC-20 transfer,
+  swap, approval, or NFT operation under `under_policy` autonomy is Denied
+  unless the caller passes a `usd_value_hint`. This makes the autonomy model
+  largely theoretical for DeFi — the wallet's primary use case.
+
+- **Policy sessions are undermined.** Sessions debit USD per confirmed tx
+  (`session.rs:110-149`), but since most DeFi txs are unpriced, they fail-closed
+  and can't be covered by a session. The multi-tx-one-ceremony mechanism (see
+  C3) becomes mostly useless for real DeFi flows — you can pre-authorize the
+  ids, but the session won't cover unpriced txs.
+
+- **ERC-20 approvals are misclassified as value-moving.** An approve that
+  grants unlimited spending permission on a token is classified identically to
+  a transfer — and then Denied for lack of USD value. Yet an unlimited approve
+  is arguably **more** dangerous than a bounded transfer; the classification
+  is both wrong (approve ≠ value-moving) and the denial reason is misleading
+  ("USD valuation unavailable" when the real concern is permission grant).
+
+- **The `usd_value_hint` workaround pushes valuation to the caller.** An agent
+  must price its own transactions and pass the hint. There is no verification
+  that the hint is accurate or current — a stale or manipulated hint would be
+  accepted at face value and debited against the session cap.
+
+- **Day/week/month caps degrade silently.** `Outbox::sum_usd_since`
+  (`crates/bloom-tx/src/outbox.rs:974-1007`) skips entries without a
+  `usd_value`. So the rolling 24h spend total is a best-effort sum of priced
+  sends only — unpriced sends contribute zero, understating actual spend.
+
+- **DefiLlama is a single point of failure.** No on-chain oracle, no Chainlink,
+  no DEX TWAP fallback (despite the design spec at
+  `docs/specs/2026-05-08-bloom-design.md` mentioning CoinGecko + Pyth +
+  Uniswap V3 TWAP). If DefiLlama is down, even native sends become unpriced
+  and Denied.
+
+## Representative end-to-end outcomes
+
+| Intent | `value_wei` | `value_moving` | Priced? | UnderPolicy decision |
+|---|---|---|---|---|
+| Send 1 ETH | `1e18` | true | oracle (ETH spot) | priced; `check_limits` runs |
+| Send 100 USDC | 0 | true | **no** (unless hint) | **Denied "USD valuation unavailable"** |
+| Approve USDC spender | 0 | true (calldata) | **no** | **Denied "USD valuation unavailable"** |
+| Transfer NFT | 0 | true | **no** | **Denied "USD valuation unavailable"** |
+| Swap via router contract | 0 | true (calldata) | **no** | **Denied "USD valuation unavailable"** |
+| ETH send, DefiLlama down | `1e18` | true | **no** (oracle None) | **Denied "USD valuation unavailable"** |
+| Empty calldata, zero value | 0 | **false** | n/a | **ApprovedAutonomous** (debit 0) |

--- a/docs/issues/2026-07-04-real-tx-ceremony-ux/README.md
+++ b/docs/issues/2026-07-04-real-tx-ceremony-ux/README.md
@@ -1,0 +1,58 @@
+# Real-tx ceremony UX — design issues (2026-07-04)
+
+**Scope:** UX/correctness issues observed while exercising the mounted
+sealed-approval demo branch against real mainnet — a cross-chain USDC bridge
+(Base → Polygon) followed by a USDC → pUSD fund for Polymarket trading, driven
+through a passkey-gated wallet. This was an end-to-end real-funds run, not a
+dry-run or unit test.
+
+**What this directory is for:** larger-scale design questions that need
+comprehensive planning or carry genuine tradeoffs. These are **not** bugs with
+obvious fixes — those were filed as code changes on this same branch.
+
+**Companion code fixes (non-controversial, on this branch):**
+
+| ID | Issue | Status |
+|---|---|---|
+| C1 | `polymarket fund` double-ceremony (manual rerun) | code fix |
+| C4 | `polymarket fund` cancels tx on sealed-approval handoff | code fix (same change as C1) |
+| C5 | policy-config debt (`under_policy` + empty `[limits]`) surfaced only at broadcast | code fix |
+| C6 | `/defi/intents/<wallet>/` "latest" not time-sorted | code fix |
+| C8 | QUICKSTART overstates serve + passkey write path | code fix |
+
+## Design issues that need planning
+
+- **[C2 — serve-socket cannot reach the passkey ceremony](./C2-serve-socket-passkey-ceremony.md)**
+  With `bloom serve` running, passkey-wallet broadcasts are structurally
+  unreachable over the socket. The ceremony is foreground-only by construction.
+  The controversy: should an unattended daemon be able to trigger a
+  human-in-the-loop browser ceremony at all?
+
+- **[C3 — dependent cross-chain flows cannot share one ceremony](./C3-dependent-cross-chain-no-shared-ceremony.md)**
+  Policy sessions authorize by exact chain-qualified outbox id, so a dependent
+  leg whose id isn't known until an earlier leg settles can't be covered by one
+  ceremony. The controversy: exact-id allowlist (safe) vs descriptor/plan-scoped
+  sessions (usable for dependent flows).
+
+- **[C9 — the policy engine can only price native-token sends](./C9-policy-pricing-native-only.md)**
+  USD valuation is gated on `value_wei > 0`, so ERC-20 transfers, approvals,
+  NFT transfers, and contract calls (swaps) are all unpriced and Denied under
+  `under_policy` autonomy. A richer ERC-20-capable oracle exists but is not
+  wired into the policy path. This makes `under_policy` autonomy effectively
+  limited to plain ETH/MATIC sends.
+
+- **[C10 — EVM batch ceremony infrastructure exists but is not wired in](./C10-evm-batch-ceremony-not-wired.md)**
+  `confirm-batch --policy-session` claims "one ceremony" but actually runs N
+  per-tx ceremonies. The `OwnerSessionUse` action kind, `SignerCache`, and
+  `max_signatures > 1` plumbing all exist for true one-ceremony-many-sigs, but
+  the batch command doesn't use them. Additionally, `417b830` broke the only
+  working batch pattern (unlock-once-sign-many) by gating `Keystore::signer()`
+  for passkey wallets without migrating any callers.
+
+## Redaction note
+
+Per the repo's no-personal-wallets policy, all wallet aliases, addresses, and
+transaction hashes from the real-funds run are redacted with placeholders
+(`<passkey-wallet>`, `<owner-eoa>`, `<deposit-wallet>`, `<base-tx-hash>`).
+Staged outbox ids and defi session ids are bloom-internal identifiers and do
+not identify the developer.

--- a/scripts/acceptance.sh
+++ b/scripts/acceptance.sh
@@ -33,6 +33,28 @@ ok()   { printf '\033[1;32m[ok]\033[0m %s\n' "$*"; }
 
 bloom() { RUST_LOG=error "$BLOOM_BIN" --home "$HOME_DIR" "$@" 2>/dev/null; }
 
+expect_sealed_challenge() {
+  local staged_id=$1 label=$2 err_file central_id challenge
+  err_file="$HOME_DIR/${label// /_}.confirm.err"
+  if BLOOM_PASSPHRASE=acceptance-pass "$BLOOM_BIN" --home "$HOME_DIR" wallet confirm \
+      alice local "$staged_id" --passphrase acceptance-pass --text y --quiet \
+      >"$HOME_DIR/${label// /_}.confirm.out" 2>"$err_file"; then
+    fail "$label: confirm unexpectedly succeeded without Sealed Approval"
+  fi
+  grep -q "broadcast approval required" "$err_file" \
+    || fail "$label: confirm did not report sealed approval requirement"
+  test -f "$HOME_DIR/outbox/alice/local/pending/$staged_id/approval_challenge.json" \
+    || fail "$label: wallet projection missing approval_challenge.json"
+  central_id=$(jq -r '.action_id' "$HOME_DIR/outbox/alice/local/pending/$staged_id/approval_challenge.json")
+  challenge="$HOME_DIR/central_outbox/pending/$central_id/approval_challenge.json"
+  test -f "$challenge" || fail "$label: central outbox missing approval_challenge.json for $central_id"
+  jq -e '.ceremony_url | strings | (startswith("http://localhost") or startswith("http://127.0.0.1"))' "$challenge" >/dev/null \
+    || fail "$label: central approval_challenge.json missing local ceremony_url"
+  jq -e --arg id "$central_id" '.action_id == $id' "$challenge" >/dev/null \
+    || fail "$label: central challenge action_id mismatch"
+  ok "$label staged $staged_id -> central /outbox/pending/$central_id with ceremony_url"
+}
+
 # Anvil's default mnemonic — first account, 10000 ETH.
 ANVIL_KEY=$ANVIL_KEY_0
 ANVIL_ADDR=$ANVIL_ADDR_0
@@ -74,20 +96,22 @@ EOF
 
 # 0b. Import the anvil key.
 log "importing anvil key"
-BLOOM_PASSPHRASE="acceptance-pass" bloom wallet import alice "$ANVIL_KEY" --passphrase acceptance-pass >/dev/null
+PASSPHRASE_FILE="$HOME_DIR/acceptance-passphrase"
+printf '%s\n' "acceptance-pass" > "$PASSPHRASE_FILE"
+chmod 600 "$PASSPHRASE_FILE"
+bloom wallet import alice "$ANVIL_KEY" \
+  --local \
+  --allow-passphrase-wallet \
+  --passphrase-file "$PASSPHRASE_FILE" \
+  >/dev/null
 bloom wallet list
 
 # ============================================================== 1. native
-log "scenario 1: native ETH send"
+log "scenario 1: native ETH send sealed-approval gate"
 INTENT='{"to":"'"$DEST_ADDR"'","value":"0.5 ETH","chain":"local"}'
 STAGED=$(BLOOM_PASSPHRASE=acceptance-pass bloom wallet stage alice local --intent "$INTENT")
 log "staged id: $STAGED"
-BEFORE=$(cast balance "$DEST_ADDR" --rpc-url http://127.0.0.1:8545)
-BLOOM_PASSPHRASE=acceptance-pass bloom wallet confirm alice local "$STAGED" --passphrase acceptance-pass --text y
-sleep 1
-AFTER=$(cast balance "$DEST_ADDR" --rpc-url http://127.0.0.1:8545)
-[ "$AFTER" != "$BEFORE" ] || fail "native send: balance unchanged"
-ok "native send delta: $BEFORE -> $AFTER"
+expect_sealed_challenge "$STAGED" "native send"
 
 # ============================================================== 2. ERC-20
 log "scenario 2: ERC-20 transfer"
@@ -144,11 +168,7 @@ SOL
   ERC20_INTENT='{"chain":"local","token":"'"$TOKEN_ADDR"'","to":"'"$DEST_ADDR"'","value":"100"}'
   STAGED=$(BLOOM_PASSPHRASE=acceptance-pass bloom wallet stage alice local --intent "$ERC20_INTENT")
   log "erc20 staged id: $STAGED"
-  BLOOM_PASSPHRASE=acceptance-pass bloom wallet confirm alice local "$STAGED" --passphrase acceptance-pass --text y
-  sleep 1
-  TOKEN_BAL=$(cast call "$TOKEN_ADDR" "balanceOf(address)(uint256)" "$DEST_ADDR" --rpc-url http://127.0.0.1:8545)
-  [ "$TOKEN_BAL" != "0" ] || fail "erc20: dest balance still zero"
-  ok "erc20 dest balance: $TOKEN_BAL"
+  expect_sealed_challenge "$STAGED" "erc20 transfer"
   rm -rf "$TMPDIR_FORGE"
 fi
 


### PR DESCRIPTION
## Summary

Real-mainnet testing of the mounted sealed-approval demo branch with a passkey-gated wallet (USDC bridge Base→Polygon, USDC→pUSD fund, multi-chain batch self-transfers). This PR contains non-controversial code fixes and design-issue documentation, rebased on top of `feat/mounted-sealed-approval-demo`.

## Code fixes

| ID | Issue | Files |
|---|---|---|
| C1/C4 | `polymarket fund` double-ceremony + tx cancellation on sealed-approval handoff — added in-band `BroadcastApprovalRequired` handling + skip-redundant-unlock for passkey | `polymarket.rs`, `main.rs` |
| C5 | Policy-config debt surfaced only at broadcast — `validate_autonomy_limits()` refuses to sign `under_policy` without `max_tx_usd`/`max_day_usd` | `policy.rs`, `passkey.rs` |
| C6 | `/defi/intents/<wallet>/` session list sorted lexicographic by id (resets per-process) — now sorted by `created_ms` desc | `defi.rs` |
| C8 | QUICKSTART overstates serve + passkey write path — added passkey carve-out note | `QUICKSTART.md` |

## Design issues (docs only, need planning)

- **C2** — serve socket cannot reach passkey ceremony (by construction)
- **C3** — dependent cross-chain flows cannot share one ceremony (exact-id allowlist)
- **C9** — policy engine only prices native-token sends (ERC-20s unpriced → Denied)
- **C10** — EVM batch ceremony infrastructure exists (`OwnerSessionUse` + `SignerCache` + `max_signatures>1`) but `confirm-batch` does N ceremonies instead of 1. Verified empirically: 3-chain batch required 3 separate browser ceremonies.

## Known blocker on base branch

Commit `417b830` gates `Keystore::signer()` for passkey wallets but migrates zero callers. All Polymarket/Hyperliquid passkey operations are broken (`order`, `sell`, `onboard`, `redeem`, `withdraw-pusd`, `revoke-approvals`, `hl order`). Only `fund` and EVM outbox txs work. See C10 doc for details.

## Verification

- Compiles clean (`cargo build`)
- `polymarket fund` proven end-to-end with real mainnet tx (1 ceremony)
- `confirm-batch` tested with real mainnet txs on Polygon + Base (2 of 3 succeeded; Arbitrum timed out on 3rd ceremony — operator fatigue, not a code bug)