### PR TITLE
feat: /requests (x402 + MPP) and VFS policy editing via Sealed Approval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2689,6 +2689,7 @@ dependencies = [
 name = "bloom-paid-http"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "base64 0.22.1",
  "bloom-proto",
  "mpp",
@@ -2703,14 +2704,15 @@ dependencies = [
 name = "bloom-paid-mpp"
 version = "0.1.0"
 dependencies = [
+ "alloy 2.0.5",
  "async-trait",
- "bloom-keystore",
  "bloom-paid-http",
  "bloom-proto",
  "bloom-tools",
  "mpp",
  "reqwest 0.12.28",
  "serde_json",
+ "tempo-alloy",
  "tokio",
 ]
 
@@ -2720,7 +2722,7 @@ version = "0.1.0"
 dependencies = [
  "alloy 2.0.5",
  "async-trait",
- "bloom-keystore",
+ "base64 0.22.1",
  "bloom-paid-http",
  "reqwest 0.12.28",
  "serde_json",

--- a/crates/bloom-auth-api/src/lib.rs
+++ b/crates/bloom-auth-api/src/lib.rs
@@ -37,6 +37,13 @@ pub const EVM_SEALED_INTENT_SUBJECT_KIND: &str = "evm_wallet_tx";
 pub const EVM_SIGNING_ATTESTATION_FACTS_SCHEMA_V1: &str = "bloom.evm.signing_facts.v1";
 /// EVM wallet signing intent.
 pub const EVM_TX_SIGN_INTENT: &str = "evm.tx.sign";
+/// Typed facts schema embedded in [`SigningAttestation::facts`] for the
+/// paid-HTTP (`paid-http`) signing intents (`x402.sign`, `paid-http.mpp.sign`).
+pub const PAID_HTTP_SIGNING_ATTESTATION_FACTS_SCHEMA_V1: &str = "bloom.paid_http.signing_facts.v1";
+/// Paid-HTTP x402 signing intent.
+pub const PAID_HTTP_X402_SIGN_INTENT: &str = "x402.sign";
+/// Paid-HTTP Tempo MPP signing intent.
+pub const PAID_HTTP_MPP_SIGN_INTENT: &str = "paid-http.mpp.sign";
 /// Schema tag for [`CanonicalEnvelope`].
 ///
 /// v2: the canonical header gained Petal identity (`petal_id`, `petal_digest`,
@@ -2197,8 +2204,129 @@ impl SigningAttestationSchemaRegistry for DefaultAttestationRegistry {
         {
             EvmSigningAttestationFacts::from_attestation(attestation)?;
         }
+        if attestation.petal_id == petal_identity::PETAL_ID_PAID_HTTP
+            && matches!(
+                attestation.intent.as_str(),
+                PAID_HTTP_X402_SIGN_INTENT | PAID_HTTP_MPP_SIGN_INTENT
+            )
+        {
+            validate_paid_http_signing_facts(&attestation.intent, &attestation.facts)?;
+        }
         Ok(())
     }
+}
+
+/// Fetch a required, non-empty string fact for a paid-HTTP attestation.
+fn paid_http_required_str<'a>(
+    facts: &'a BTreeMap<String, serde_json::Value>,
+    key: &str,
+) -> Result<&'a str, AuthApiError> {
+    match facts.get(key) {
+        Some(serde_json::Value::String(s)) if !s.trim().is_empty() => Ok(s.as_str()),
+        _ => Err(AuthApiError::Denied(format!(
+            "paid-http attestation facts must include non-empty string {key}"
+        ))),
+    }
+}
+
+/// Assert an optional paid-HTTP string fact is either absent, null, or a string.
+fn paid_http_optional_str(
+    facts: &BTreeMap<String, serde_json::Value>,
+    key: &str,
+) -> Result<(), AuthApiError> {
+    match facts.get(key) {
+        None | Some(serde_json::Value::Null) | Some(serde_json::Value::String(_)) => Ok(()),
+        Some(_) => Err(AuthApiError::Denied(format!(
+            "paid-http attestation fact {key} must be a string when present"
+        ))),
+    }
+}
+
+/// Shape validation for `(paid-http, x402.sign|paid-http.mpp.sign)` attestation
+/// `facts` (spec §8). This is a trust-boundary shape check only: it asserts the
+/// fact map projected by `RequestsHandler` is well formed and internally
+/// consistent (protocol matches the intent, hashes/digests are well formed). It
+/// does NOT reconstruct the sealed subject or protocol signing digest — that
+/// trust boundary stays with the handler.
+fn validate_paid_http_signing_facts(
+    intent: &str,
+    facts: &BTreeMap<String, serde_json::Value>,
+) -> Result<(), AuthApiError> {
+    let schema = paid_http_required_str(facts, "facts_schema")?;
+    if schema != PAID_HTTP_SIGNING_ATTESTATION_FACTS_SCHEMA_V1 {
+        return Err(AuthApiError::Denied(format!(
+            "unsupported paid-http attestation facts schema {schema}"
+        )));
+    }
+    for key in ["action_id", "wallet", "request_id", "method", "url", "host"] {
+        paid_http_required_str(facts, key)?;
+    }
+    let signing_hash = paid_http_required_str(facts, "signing_hash")?;
+    validate_hash32_hex("signing_hash", signing_hash).map_err(denied_from_invalid)?;
+
+    // `protocol` must be present and must match the signing intent.
+    let protocol = paid_http_required_str(facts, "protocol")?;
+    let expected_protocol = match intent {
+        PAID_HTTP_X402_SIGN_INTENT => "x402",
+        PAID_HTTP_MPP_SIGN_INTENT => "mpp",
+        other => {
+            return Err(AuthApiError::Denied(format!(
+                "unsupported paid-http signing intent {other}"
+            )));
+        }
+    };
+    if protocol != expected_protocol {
+        return Err(AuthApiError::Denied(format!(
+            "paid-http attestation protocol {protocol} does not match intent {intent}"
+        )));
+    }
+
+    // Sealed `/requests` always projects the policy snapshot digest, so require
+    // it as a well-formed digest string.
+    let digest = paid_http_required_str(facts, "policy_snapshot_digest")?;
+    validate_digest_hex("policy_snapshot_digest", digest).map_err(denied_from_invalid)?;
+
+    for key in [
+        "network",
+        "asset",
+        "amount",
+        "pay_to",
+        "resource",
+        "scheme",
+        "charge_id",
+        "session_id",
+        "channel_id",
+    ] {
+        paid_http_optional_str(facts, key)?;
+    }
+
+    match facts.get("chain_id") {
+        None | Some(serde_json::Value::Null) => {}
+        Some(serde_json::Value::Number(n)) if n.as_u64().is_some_and(|v| v > 0) => {}
+        Some(_) => {
+            return Err(AuthApiError::Denied(
+                "paid-http attestation chain_id must be a positive integer when present".into(),
+            ));
+        }
+    }
+
+    // The selected payment requirement is bound for legibility; accept the
+    // staged requirement JSON (object) or an explicit null, but reject an
+    // obviously invalid scalar echo.
+    match facts.get("selected_requirement") {
+        Some(serde_json::Value::Object(_)) | Some(serde_json::Value::Null) => {}
+        None => {
+            return Err(AuthApiError::Denied(
+                "paid-http attestation is missing selected_requirement".into(),
+            ));
+        }
+        Some(_) => {
+            return Err(AuthApiError::Denied(
+                "paid-http attestation selected_requirement must be an object or null".into(),
+            ));
+        }
+    }
+    Ok(())
 }
 
 // ── PetalHost (WS-1 host signing API) ────────────────────────────────────────
@@ -4620,6 +4748,14 @@ mod tests {
             );
             let att = if petal_id == PETAL_ID_EVM_WALLET && intent == EVM_TX_SIGN_INTENT {
                 typed_evm_attestation_for_registry()
+            } else if petal_id == PETAL_ID_PAID_HTTP {
+                SigningAttestation {
+                    schema: SIGNING_ATTESTATION_SCHEMA_V1.into(),
+                    petal_id: petal_id.into(),
+                    petal_digest: PLACEHOLDER_DIGEST_PAID_HTTP.into(),
+                    intent: intent.into(),
+                    facts: paid_http_facts_for_intent(intent),
+                }
             } else {
                 SigningAttestation {
                     schema: SIGNING_ATTESTATION_SCHEMA_V1.into(),
@@ -4670,6 +4806,133 @@ mod tests {
                 .contains("unsupported attestation schema for"),
             "{err}"
         );
+    }
+
+    /// A structurally valid paid-HTTP facts map for the given signing intent,
+    /// mirroring what `RequestsHandler` projects.
+    fn paid_http_facts_for_intent(intent: &str) -> BTreeMap<String, serde_json::Value> {
+        let protocol = if intent == PAID_HTTP_MPP_SIGN_INTENT {
+            "mpp"
+        } else {
+            "x402"
+        };
+        let mut facts = BTreeMap::new();
+        facts.insert(
+            "facts_schema".into(),
+            serde_json::json!(PAID_HTTP_SIGNING_ATTESTATION_FACTS_SCHEMA_V1),
+        );
+        facts.insert("action_id".into(), serde_json::json!("req_1"));
+        facts.insert("wallet".into(), serde_json::json!("my-wallet"));
+        facts.insert("request_id".into(), serde_json::json!("req_1"));
+        facts.insert("method".into(), serde_json::json!("GET"));
+        facts.insert(
+            "url".into(),
+            serde_json::json!("https://api.example.com/paid"),
+        );
+        facts.insert("host".into(), serde_json::json!("api.example.com"));
+        facts.insert("protocol".into(), serde_json::json!(protocol));
+        facts.insert("network".into(), serde_json::json!("base"));
+        facts.insert("chain_id".into(), serde_json::json!(8453));
+        facts.insert("asset".into(), serde_json::json!("USDC"));
+        facts.insert("amount".into(), serde_json::json!("1000000"));
+        facts.insert(
+            "pay_to".into(),
+            serde_json::json!("0x0000000000000000000000000000000000000009"),
+        );
+        facts.insert(
+            "resource".into(),
+            serde_json::json!("https://api.example.com/paid"),
+        );
+        facts.insert("scheme".into(), serde_json::json!("exact"));
+        facts.insert("charge_id".into(), serde_json::Value::Null);
+        facts.insert("session_id".into(), serde_json::Value::Null);
+        facts.insert("channel_id".into(), serde_json::Value::Null);
+        facts.insert(
+            "signing_hash".into(),
+            serde_json::json!(format!("0x{}", "a".repeat(64))),
+        );
+        facts.insert(
+            "policy_snapshot_digest".into(),
+            serde_json::json!("d".repeat(64)),
+        );
+        facts.insert(
+            "selected_requirement".into(),
+            serde_json::json!({"scheme": "exact", "network": protocol}),
+        );
+        facts
+    }
+
+    fn paid_http_attestation_for_intent(intent: &str) -> SigningAttestation {
+        SigningAttestation {
+            schema: SIGNING_ATTESTATION_SCHEMA_V1.into(),
+            petal_id: PETAL_ID_PAID_HTTP.into(),
+            petal_digest: PLACEHOLDER_DIGEST_PAID_HTTP.into(),
+            intent: intent.into(),
+            facts: paid_http_facts_for_intent(intent),
+        }
+    }
+
+    #[test]
+    fn paid_http_registry_accepts_valid_x402_and_mpp_facts() {
+        let r = DefaultAttestationRegistry::new();
+        r.validate_attestation(&paid_http_attestation_for_intent(
+            PAID_HTTP_X402_SIGN_INTENT,
+        ))
+        .unwrap();
+        r.validate_attestation(&paid_http_attestation_for_intent(PAID_HTTP_MPP_SIGN_INTENT))
+            .unwrap();
+    }
+
+    #[test]
+    fn paid_http_registry_rejects_malformed_facts() {
+        let r = DefaultAttestationRegistry::new();
+
+        // Missing required string.
+        let mut att = paid_http_attestation_for_intent(PAID_HTTP_X402_SIGN_INTENT);
+        att.facts.remove("url");
+        let err = r.validate_attestation(&att).unwrap_err();
+        assert!(err.to_string().contains("url"), "{err}");
+
+        // Wrong facts schema.
+        let mut att = paid_http_attestation_for_intent(PAID_HTTP_X402_SIGN_INTENT);
+        att.facts
+            .insert("facts_schema".into(), serde_json::json!("bloom.wrong.v1"));
+        let err = r.validate_attestation(&att).unwrap_err();
+        assert!(err.to_string().contains("facts schema"), "{err}");
+
+        // Protocol does not match the signing intent (x402 facts under the MPP
+        // intent).
+        let mut att = paid_http_attestation_for_intent(PAID_HTTP_MPP_SIGN_INTENT);
+        att.facts
+            .insert("protocol".into(), serde_json::json!("x402"));
+        let err = r.validate_attestation(&att).unwrap_err();
+        assert!(err.to_string().contains("does not match intent"), "{err}");
+
+        // signing_hash is not a 32-byte hex hash.
+        let mut att = paid_http_attestation_for_intent(PAID_HTTP_X402_SIGN_INTENT);
+        att.facts
+            .insert("signing_hash".into(), serde_json::json!("0xdeadbeef"));
+        let err = r.validate_attestation(&att).unwrap_err();
+        assert!(err.to_string().contains("signing_hash"), "{err}");
+
+        // Optional string field present as a non-string.
+        let mut att = paid_http_attestation_for_intent(PAID_HTTP_X402_SIGN_INTENT);
+        att.facts.insert("asset".into(), serde_json::json!(42));
+        let err = r.validate_attestation(&att).unwrap_err();
+        assert!(err.to_string().contains("asset"), "{err}");
+
+        // chain_id present but not a positive integer.
+        let mut att = paid_http_attestation_for_intent(PAID_HTTP_X402_SIGN_INTENT);
+        att.facts.insert("chain_id".into(), serde_json::json!(0));
+        let err = r.validate_attestation(&att).unwrap_err();
+        assert!(err.to_string().contains("chain_id"), "{err}");
+
+        // selected_requirement echoed as a scalar.
+        let mut att = paid_http_attestation_for_intent(PAID_HTTP_X402_SIGN_INTENT);
+        att.facts
+            .insert("selected_requirement".into(), serde_json::json!("nope"));
+        let err = r.validate_attestation(&att).unwrap_err();
+        assert!(err.to_string().contains("selected_requirement"), "{err}");
     }
 
     #[test]

--- a/crates/bloom-daemon/src/ceremony_server.rs
+++ b/crates/bloom-daemon/src/ceremony_server.rs
@@ -430,10 +430,21 @@ async fn complete(
     );
     daemon.signer_cache.prune_expired(now);
 
-    // Persist approval.json as an audit artifact beside the challenge.
-    if let Err(e) = daemon
-        .tx_engine
-        .persist_outbox_ceremony_approval(&action, &signed)
+    // Whether this sealed action broadcasts an EVM transaction. Only broadcast
+    // actions have a chain, a per-wallet outbox entry, and a tx to execute.
+    // Non-broadcast first-party actions (wallet-policy updates, policy-session
+    // mints) have none of these — the minted grant is their authorization, and
+    // they are installed by retrying their own mounted write. So we route the
+    // outbox-only tx-engine persistence/execution below only for broadcasts;
+    // calling into the tx engine for a non-tx action would be a layering error
+    // (and previously failed with "missing chain_name", revoking the grant).
+    let is_broadcast = action.chain_name().is_some();
+
+    // Persist approval.json into the outbox projection — broadcast actions only.
+    if is_broadcast
+        && let Err(e) = daemon
+            .tx_engine
+            .persist_outbox_ceremony_approval(&action, &signed)
     {
         revoke_grant_and_drop_cache(daemon, grant_store.as_ref(), &grant.grant_id, now).await;
         return err_json(
@@ -445,7 +456,18 @@ async fn complete(
     // grant + execute: broadcast immediately from sealed bytes.
     let mut executed = false;
     let mut tx_hash: Option<String> = None;
-    if execute {
+    // For a non-broadcast action, "approve + execute" is equivalent to "approve":
+    // mint the grant and let the caller retry the write. Failing here would
+    // revoke the valid grant.
+    let broadcastable = execute && is_broadcast;
+    if execute && !broadcastable {
+        tracing::info!(
+            wallet = %wallet,
+            action_id = %action.action_id(),
+            "ceremony.execute.non_broadcast_action: grant minted, install happens on write retry"
+        );
+    }
+    if broadcastable {
         // The chain registry is keyed by the human chain name ("base"), not the
         // CAIP-2 `network` header ("eip155:8453"), so resolve it from the sealed
         // policy snapshot rather than the header.

--- a/crates/bloom-daemon/src/ipc.rs
+++ b/crates/bloom-daemon/src/ipc.rs
@@ -720,21 +720,6 @@ fn write_path_uses_wallet_signer(path: &VfsPath) -> bool {
         {
             true
         }
-        // Confirming a paid HTTP request is a first-party Sealed Approval action:
-        // the requests handler stages an approval challenge on the first write and
-        // only signs the x402/Tempo MPP credential under a grant-gated PetalHost
-        // signature. It therefore never consumes a cached signer silently, so the
-        // plain write lane must forward it through to `vfs.write` rather than deny
-        // it here — the old write_unlocked confirm lane is disabled for passkey
-        // wallets, which would otherwise leave mounted confirm with no working path.
-        // Minting a bounded policy session authorizes many future broadcasts; gate
-        // it behind the same human-presence ceremony as a signature so an agent
-        // cannot silently mint a broad batch-signing session.
-        [root, _wallet, ps, leaf]
-            if root == "wallets" && ps == "policy-session" && leaf == "new" =>
-        {
-            true
-        }
         // Hyperliquid owner-signer writes either approve a standing API wallet
         // or sign actions directly with the owner wallet. They require the
         // write_unlocked ceremony; already-approved agent-session actions stay
@@ -765,13 +750,23 @@ fn write_path_uses_wallet_signer(path: &VfsPath) -> bool {
         {
             true
         }
-        // Wallet policy writes (policy.toml) are handled by the VFS wallets
-        // handler as a first-party Sealed Approval action: passkey wallets stage
-        // a challenge and install only under a grant-gated PetalHost signature;
-        // local wallets write immediately (their policy is unsigned). Neither
-        // path silently consumes a cached signer, so the plain write lane must
-        // forward these through to `vfs.write` rather than deny them here — the
-        // old write_unlocked re-sign lane is disabled for passkey wallets.
+        // Everything else reaches the VFS handler through the plain write lane.
+        // In particular these first-party Sealed Approval actions are NOT raw
+        // signer lanes and must forward through to `vfs.write` rather than be
+        // denied here:
+        //   * Wallet policy writes (`policy.toml`): passkey wallets stage a
+        //     challenge and install only under a grant-gated PetalHost signature;
+        //     local wallets write immediately (their policy is unsigned).
+        //   * Policy-session minting (`policy-session/new`): the wallets handler
+        //     stages an approval challenge and mints the bounded session only
+        //     under a grant-gated signature — exactly like `policy.toml`.
+        //   * Paid HTTP confirm (`/requests/<id>/confirm`): the requests handler
+        //     stages an approval challenge on the first write and signs the
+        //     x402/Tempo MPP credential only under a grant-gated PetalHost
+        //     signature.
+        // None of these silently consumes a cached signer, and the old
+        // write_unlocked lane is disabled for passkey wallets — denying them here
+        // would leave mounted confirm/mint with no working path.
         _ => false,
     }
 }
@@ -1539,6 +1534,10 @@ mod tests {
             // policy.toml now reaches the VFS handler, which stages a Sealed
             // Approval for passkey wallets rather than being denied at the lane.
             "/wallets/minnow/policy.toml",
+            // policy-session/new likewise reaches the wallets handler, which
+            // stages a Sealed Approval challenge and mints the bounded session
+            // only under a grant-gated signature (handler-owned, not a raw lane).
+            "/wallets/minnow/policy-session/new",
             "/wallets/minnow/chains/polygon/outbox/new.tx",
             "/wallets/minnow/chains/polygon/outbox/pending/0001/confirm",
             // Paid-request confirm likewise reaches the VFS handler: the first

--- a/crates/bloom-daemon/src/ipc.rs
+++ b/crates/bloom-daemon/src/ipc.rs
@@ -720,15 +720,13 @@ fn write_path_uses_wallet_signer(path: &VfsPath) -> bool {
         {
             true
         }
-        // Confirming a paid HTTP request can sign x402 or Tempo MPP payment
-        // credentials. It must go through write_unlocked rather than plain IPC
-        // so a cached daemon signer is not consumed silently.
-        [root, _reference, action] if root == "requests" && action == "confirm" => true,
-        [root, state, _id, action]
-            if root == "requests" && state == "pending" && action == "confirm" =>
-        {
-            true
-        }
+        // Confirming a paid HTTP request is a first-party Sealed Approval action:
+        // the requests handler stages an approval challenge on the first write and
+        // only signs the x402/Tempo MPP credential under a grant-gated PetalHost
+        // signature. It therefore never consumes a cached signer silently, so the
+        // plain write lane must forward it through to `vfs.write` rather than deny
+        // it here — the old write_unlocked confirm lane is disabled for passkey
+        // wallets, which would otherwise leave mounted confirm with no working path.
         // Minting a bounded policy session authorizes many future broadcasts; gate
         // it behind the same human-presence ceremony as a signature so an agent
         // cannot silently mint a broad batch-signing session.
@@ -1522,9 +1520,6 @@ mod tests {
             "/wallets/minnow/sign/hash",
             "/wallets/minnow/sign/typed_data",
             "/polymarket/onboard/minnow/begin",
-            "/requests/latest/confirm",
-            "/requests/req_123/confirm",
-            "/requests/pending/req_123/confirm",
             "/hyperliquid/mainnet/agent_sessions/minnow/new.json",
             "/hyperliquid/mainnet/agent_sessions/minnow/session-1/orphan_cancel_all",
             "/hyperliquid/mainnet/agent_sessions/minnow/session-1/orphan_close_all",
@@ -1546,6 +1541,12 @@ mod tests {
             "/wallets/minnow/policy.toml",
             "/wallets/minnow/chains/polygon/outbox/new.tx",
             "/wallets/minnow/chains/polygon/outbox/pending/0001/confirm",
+            // Paid-request confirm likewise reaches the VFS handler: the first
+            // write stages a Sealed Approval challenge and signing only happens
+            // under a grant-gated PetalHost signature.
+            "/requests/latest/confirm",
+            "/requests/req_123/confirm",
+            "/requests/pending/req_123/confirm",
             "/requests/new",
             "/requests/pending/req_123/cancel",
             "/hyperliquid/mainnet/agent_sessions/minnow/session-1/schedule_cancel.json",

--- a/crates/bloom-daemon/src/ipc.rs
+++ b/crates/bloom-daemon/src/ipc.rs
@@ -767,10 +767,13 @@ fn write_path_uses_wallet_signer(path: &VfsPath) -> bool {
         {
             true
         }
-        // Wallet policy writes (policy.toml) redefine what the daemon allows.
-        // They must go through write_unlocked so the user reviews the change
-        // before the re-sign — never silently re-signed with a cached signer.
-        [root, _wallet, file] if root == "wallets" && file == "policy.toml" => true,
+        // Wallet policy writes (policy.toml) are handled by the VFS wallets
+        // handler as a first-party Sealed Approval action: passkey wallets stage
+        // a challenge and install only under a grant-gated PetalHost signature;
+        // local wallets write immediately (their policy is unsigned). Neither
+        // path silently consumes a cached signer, so the plain write lane must
+        // forward these through to `vfs.write` rather than deny them here — the
+        // old write_unlocked re-sign lane is disabled for passkey wallets.
         _ => false,
     }
 }
@@ -1518,7 +1521,6 @@ mod tests {
             "/wallets/minnow/sign/message",
             "/wallets/minnow/sign/hash",
             "/wallets/minnow/sign/typed_data",
-            "/wallets/minnow/policy.toml",
             "/polymarket/onboard/minnow/begin",
             "/requests/latest/confirm",
             "/requests/req_123/confirm",
@@ -1539,6 +1541,9 @@ mod tests {
         for path in [
             "/defi/intents/minnow/0001/confirm",
             "/polymarket/trade/minnow/new",
+            // policy.toml now reaches the VFS handler, which stages a Sealed
+            // Approval for passkey wallets rather than being denied at the lane.
+            "/wallets/minnow/policy.toml",
             "/wallets/minnow/chains/polygon/outbox/new.tx",
             "/wallets/minnow/chains/polygon/outbox/pending/0001/confirm",
             "/requests/new",

--- a/crates/bloom-keystore/src/petal_host.rs
+++ b/crates/bloom-keystore/src/petal_host.rs
@@ -391,6 +391,68 @@ impl PetalHost for KeystorePetalHost {
                 )
                 .await;
         }
+        if attestation.petal_id == bloom_auth_api::petal_identity::PETAL_ID_PAID_HTTP {
+            if attestation.intent != request.intent {
+                return self
+                    .deny(
+                        "petal.sign.deny",
+                        Some(request.wallet.clone()),
+                        Some(request.action_id.clone()),
+                        "attestation intent does not match sign-hash request intent",
+                        Some(serde_json::json!({
+                            "request_intent": request.intent,
+                            "attestation_intent": attestation.intent,
+                        })),
+                    )
+                    .await;
+            }
+            if attestation_fact_str(attestation, "wallet") != Some(request.wallet.as_str()) {
+                return self
+                    .deny(
+                        "petal.sign.deny",
+                        Some(request.wallet.clone()),
+                        Some(request.action_id.clone()),
+                        "attestation wallet does not match sign-hash request wallet",
+                        None,
+                    )
+                    .await;
+            }
+            if attestation_fact_str(attestation, "action_id") != Some(request.action_id.as_str()) {
+                return self
+                    .deny(
+                        "petal.sign.deny",
+                        Some(request.wallet.clone()),
+                        Some(request.action_id.clone()),
+                        "attestation action_id does not match sign-hash request action_id",
+                        None,
+                    )
+                    .await;
+            }
+            if !attestation_signing_hash_matches(attestation, &request.hash_hex) {
+                return self
+                    .deny(
+                        "petal.sign.deny",
+                        Some(request.wallet.clone()),
+                        Some(request.action_id.clone()),
+                        "attestation signing_hash does not match sign-hash request hash",
+                        None,
+                    )
+                    .await;
+            }
+            if attestation_fact_str(attestation, "policy_snapshot_digest")
+                != Some(grant.petal_policy_digest.as_str())
+            {
+                return self
+                    .deny(
+                        "petal.sign.deny",
+                        Some(request.wallet.clone()),
+                        Some(request.action_id.clone()),
+                        "attestation policy_snapshot_digest does not match the sealed grant",
+                        None,
+                    )
+                    .await;
+            }
+        }
 
         // Step 7: ensure the signer is in memory. A per-grant signer cache
         // (set by the daemon after `sealed_approval_ceremony`) lets us reuse
@@ -587,6 +649,23 @@ fn parse_hash_hex(s: &str) -> Result<B256, String> {
     let mut out = [0u8; 32];
     out.copy_from_slice(&bytes);
     Ok(B256::from(out))
+}
+
+fn attestation_fact_str<'a>(attestation: &'a SigningAttestation, key: &str) -> Option<&'a str> {
+    attestation.facts.get(key).and_then(|v| v.as_str())
+}
+
+fn attestation_signing_hash_matches(attestation: &SigningAttestation, request_hash: &str) -> bool {
+    let Some(attested) = attestation_fact_str(attestation, "signing_hash") else {
+        return false;
+    };
+    strip_0x(attested).eq_ignore_ascii_case(strip_0x(request_hash))
+}
+
+fn strip_0x(s: &str) -> &str {
+    s.strip_prefix("0x")
+        .or_else(|| s.strip_prefix("0X"))
+        .unwrap_or(s)
 }
 
 // `SealedApprovalGrant` must remain in scope for downstream use (the host

--- a/crates/bloom-mount/src/adapter.rs
+++ b/crates/bloom-mount/src/adapter.rs
@@ -189,12 +189,11 @@ fn mount_write_path_uses_wallet_signer(path: &VfsPath) -> bool {
         {
             true
         }
-        [root, _wallet, leaf] if root == "wallets" && leaf == "policy.toml" => true,
-        [root, _wallet, chains, _chain, leaf]
-            if root == "wallets" && chains == "chains" && leaf == "policy.toml" =>
-        {
-            true
-        }
+        // policy.toml writes flow through to the VFS wallets handler, which
+        // stages a first-party Sealed Approval for passkey wallets (challenge +
+        // grant-gated install) and writes local policy immediately. They no
+        // longer route through the disabled write_unlocked re-sign lane, so the
+        // mount must forward them to `vfs.write` rather than deny on flush.
         _ => false,
     }
 }

--- a/crates/bloom-mount/src/adapter.rs
+++ b/crates/bloom-mount/src/adapter.rs
@@ -152,15 +152,6 @@ fn mount_write_path_uses_wallet_signer(path: &VfsPath) -> bool {
         {
             true
         }
-        // Confirming a paid HTTP request is a first-party Sealed Approval action:
-        // the requests handler stages an approval challenge on the first write and
-        // only signs under a grant-gated PetalHost signature, so it must reach the
-        // VFS handler rather than be denied at the mount lane (mirrors policy.toml).
-        [root, _wallet, ps, leaf]
-            if root == "wallets" && ps == "policy-session" && leaf == "new" =>
-        {
-            true
-        }
         [root, _network, branch, _wallet, leaf]
             if root == "hyperliquid" && branch == "agent_sessions" && leaf == "new.json" =>
         {
@@ -187,11 +178,12 @@ fn mount_write_path_uses_wallet_signer(path: &VfsPath) -> bool {
         {
             true
         }
-        // policy.toml writes flow through to the VFS wallets handler, which
-        // stages a first-party Sealed Approval for passkey wallets (challenge +
-        // grant-gated install) and writes local policy immediately. They no
-        // longer route through the disabled write_unlocked re-sign lane, so the
-        // mount must forward them to `vfs.write` rather than deny on flush.
+        // policy.toml and policy-session/new writes flow through to the VFS
+        // wallets handler, which stages a first-party Sealed Approval for passkey
+        // wallets (challenge + grant-gated install/mint) and writes local policy
+        // immediately. They no longer route through the disabled write_unlocked
+        // re-sign lane, so the mount must forward them to `vfs.write` rather than
+        // deny on flush.
         _ => false,
     }
 }
@@ -1414,6 +1406,33 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, FsError::PermissionDenied));
+    }
+
+    #[test]
+    fn mount_classifier_forwards_handler_owned_sealed_approval_writes() {
+        // Handler-owned Sealed Approval actions must reach the VFS handler, not
+        // be denied at the mount signer lane. policy-session/new now behaves
+        // like policy.toml: the wallets handler enforces Sealed Approval.
+        for path in [
+            "/wallets/minnow/policy.toml",
+            "/wallets/minnow/policy-session/new",
+            "/requests/pending/req_1/confirm",
+        ] {
+            let p = VfsPath::parse(path).unwrap();
+            assert!(!mount_write_path_uses_wallet_signer(&p), "{path}");
+        }
+        // Truly raw signer lanes remain denied at the mount lane.
+        for path in [
+            "/wallets/minnow/sign/message",
+            "/wallets/minnow/sign/hash",
+            "/wallets/minnow/sign/typed_data",
+            "/wallets/minnow/chains/polygon/outbox/pending/0001/cancel",
+            "/wallets/minnow/chains/polygon/outbox/pending/0001/replace",
+            "/hyperliquid/mainnet/exchange/minnow/order.json",
+        ] {
+            let p = VfsPath::parse(path).unwrap();
+            assert!(mount_write_path_uses_wallet_signer(&p), "{path}");
+        }
     }
 
     #[tokio::test]

--- a/crates/bloom-mount/src/adapter.rs
+++ b/crates/bloom-mount/src/adapter.rs
@@ -152,12 +152,10 @@ fn mount_write_path_uses_wallet_signer(path: &VfsPath) -> bool {
         {
             true
         }
-        [root, _reference, action] if root == "requests" && action == "confirm" => true,
-        [root, state, _id, action]
-            if root == "requests" && state == "pending" && action == "confirm" =>
-        {
-            true
-        }
+        // Confirming a paid HTTP request is a first-party Sealed Approval action:
+        // the requests handler stages an approval challenge on the first write and
+        // only signs under a grant-gated PetalHost signature, so it must reach the
+        // VFS handler rather than be denied at the mount lane (mirrors policy.toml).
         [root, _wallet, ps, leaf]
             if root == "wallets" && ps == "policy-session" && leaf == "new" =>
         {

--- a/crates/bloom-paid-http/Cargo.toml
+++ b/crates/bloom-paid-http/Cargo.toml
@@ -7,6 +7,7 @@ description = "Shared paid HTTP request lifecycle, challenge normalization, and 
 
 [dependencies]
 bloom-proto.workspace = true
+async-trait.workspace = true
 base64.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/bloom-paid-http/src/lib.rs
+++ b/crates/bloom-paid-http/src/lib.rs
@@ -10,6 +10,62 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use url::Url;
 
+/// Protocol-neutral, secret-free facts describing a single paid-HTTP signing
+/// request. The Bloom runtime turns these into the structured
+/// `SigningAttestation` it records for every host signature (see the Sealed
+/// Approvals architecture). No credential material, PRF output, or raw
+/// signatures are ever carried here — only public request/payment metadata and
+/// digests.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PaidHttpSigningFacts {
+    pub request_id: String,
+    pub method: String,
+    pub url: String,
+    pub host: String,
+    /// `"x402"` or `"mpp"`.
+    pub protocol: String,
+    pub network: Option<String>,
+    pub chain_id: Option<u64>,
+    pub asset: Option<String>,
+    pub amount: Option<String>,
+    pub pay_to: Option<String>,
+    /// The paid resource URL/id if distinct from `url`.
+    pub resource: Option<String>,
+    pub scheme: Option<String>,
+    pub charge_id: Option<String>,
+    pub session_id: Option<String>,
+    pub channel_id: Option<String>,
+    /// Digest of the sealed Petal policy snapshot the action was approved under.
+    pub policy_snapshot_digest: Option<String>,
+    /// The selected payment requirement (redacted/public JSON) chosen for this
+    /// signature, bound into the attestation for legibility and later
+    /// verification.
+    pub selected_requirement: Option<serde_json::Value>,
+}
+
+/// Host signing seam for paid-HTTP protocol adapters.
+///
+/// x402 and MPP adapters must never touch wallet key material or a
+/// `PrivateKeySigner`. Instead they present the exact 32-byte hash they need
+/// signed to this seam; the Bloom runtime enforces the live Sealed Approval
+/// grant, records a `SigningAttestation` built from `facts`, atomically
+/// consumes one signature allowance, and returns the 65-byte secp256k1
+/// signature (`r || s || v`). The concrete implementation lives in the Bloom
+/// runtime (it wraps the host `PetalHost::sign_hash`), keeping key custody and
+/// grant enforcement out of the protocol crates.
+#[async_trait::async_trait]
+pub trait PaidHttpHostSigner: Send + Sync {
+    /// Sign `signing_hash` under the live paid-HTTP grant for `intent`
+    /// (e.g. `"x402.sign"` or `"paid-http.mpp.sign"`). Returns the 65-byte
+    /// secp256k1 signature, or an error string if no live grant authorizes it.
+    async fn sign_paid_http_hash(
+        &self,
+        intent: &str,
+        signing_hash: [u8; 32],
+        facts: &PaidHttpSigningFacts,
+    ) -> Result<[u8; 65], String>;
+}
+
 pub trait PaidHttpChainRpcResolver: Send + Sync {
     fn http_rpc_urls_for_chain_id(&self, chain_id: u64) -> Vec<String>;
 

--- a/crates/bloom-paid-mpp/Cargo.toml
+++ b/crates/bloom-paid-mpp/Cargo.toml
@@ -6,14 +6,15 @@ license.workspace = true
 description = "Tempo MPP adapter for Bloom paid HTTP requests"
 
 [dependencies]
+alloy.workspace = true
 bloom-paid-http.workspace = true
-bloom-keystore.workspace = true
 bloom-proto.workspace = true
 bloom-tools.workspace = true
 serde_json.workspace = true
 async-trait.workspace = true
 reqwest.workspace = true
 mpp.workspace = true
+tempo-alloy = "=1.8.0"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/bloom-paid-mpp/src/lib.rs
+++ b/crates/bloom-paid-mpp/src/lib.rs
@@ -273,32 +273,30 @@ async fn prepare_session_credential(
         .map_err(|_| mpp::MppError::InvalidConfig("invalid RPC URL".to_string()))?;
     let provider = ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(rpc_url);
 
-    if let Some(cid_str) = session_req.channel_id() {
-        if let Ok(channel_id) = cid_str.parse::<B256>() {
-            if let Some(mut recovered) = try_recover_channel(
-                &provider,
-                escrow_contract,
-                channel_id,
-                chain_id,
-                payer,
-                payee,
-                currency,
-                payer,
-            )
-            .await
-            {
-                recovered.cumulative_amount += amount;
-                let payload = create_voucher_payload(
-                    signer,
-                    recovered.channel_id,
-                    recovered.cumulative_amount,
-                    escrow_contract,
-                    chain_id,
-                )
-                .await?;
-                return Ok(build_credential(challenge, payload, chain_id, payer));
-            }
-        }
+    if let Some(cid_str) = session_req.channel_id()
+        && let Ok(channel_id) = cid_str.parse::<B256>()
+        && let Some(mut recovered) = try_recover_channel(
+            &provider,
+            escrow_contract,
+            channel_id,
+            chain_id,
+            payer,
+            payee,
+            currency,
+            payer,
+        )
+        .await
+    {
+        recovered.cumulative_amount += amount;
+        let payload = create_voucher_payload(
+            signer,
+            recovered.channel_id,
+            recovered.cumulative_amount,
+            escrow_contract,
+            chain_id,
+        )
+        .await?;
+        return Ok(build_credential(challenge, payload, chain_id, payer));
     }
 
     let deposit = resolve_session_deposit(session_req.suggested_deposit.as_deref(), max_deposit)?;

--- a/crates/bloom-paid-mpp/src/lib.rs
+++ b/crates/bloom-paid-mpp/src/lib.rs
@@ -1,15 +1,28 @@
 //! Tempo MPP protocol adapter for Bloom paid HTTP requests.
 
+use alloy::primitives::{Address, B256, Signature};
+use alloy::providers::ProviderBuilder;
+use alloy::signers::{Error as SignerError, Result as SignerResult, Signer};
 use async_trait::async_trait;
-use bloom_keystore::{Keystore, KeystoreError, WalletKind};
 use bloom_paid_http::{
-    EmptyPaidHttpChainRpcResolver, NormalizedChallenge, PaidHttpChainRpcResolver, ParsedRequest,
-    usd_to_atomic_units,
+    EmptyPaidHttpChainRpcResolver, NormalizedChallenge, PaidHttpChainRpcResolver,
+    PaidHttpHostSigner, PaidHttpSigningFacts, ParsedRequest, usd_to_atomic_units,
 };
 use bloom_proto::Policy;
-use mpp::client::{PaymentProvider, TempoProvider, TempoSessionProvider};
+use mpp::client::tempo::charge::{SignOptions, TempoCharge};
+use mpp::client::tempo::session::channel_ops::{
+    OpenPayloadOptions, build_credential, create_open_payload, create_voucher_payload,
+    resolve_chain_id, resolve_escrow, try_recover_channel,
+};
+use mpp::client::tempo::signing::TempoSigningMode;
+use mpp::protocol::intents::SessionRequest;
+use mpp::protocol::methods::tempo::session::TempoSessionExt;
 use serde_json::json;
 use std::sync::Arc;
+use tempo_alloy::TempoNetwork;
+
+/// The `sign-hash` intent string every Tempo MPP host signature is authorized under.
+pub const MPP_SIGN_INTENT: &str = "paid-http.mpp.sign";
 
 #[async_trait]
 pub trait PaymentBackend: Send + Sync {
@@ -25,49 +38,95 @@ pub trait PaymentBackend: Send + Sync {
 }
 
 pub struct RealMppBackend {
-    pub keystore: Keystore,
     pub client: reqwest::Client,
     pub rpc_resolver: Arc<dyn PaidHttpChainRpcResolver>,
+    pub wallet_address: Address,
+    pub host_signer: Arc<dyn PaidHttpHostSigner>,
+    pub facts: PaidHttpSigningFacts,
 }
 
 impl RealMppBackend {
     pub fn new(
-        keystore: Keystore,
         client: reqwest::Client,
         rpc_resolver: Arc<dyn PaidHttpChainRpcResolver>,
+        wallet_address: Address,
+        host_signer: Arc<dyn PaidHttpHostSigner>,
+        facts: PaidHttpSigningFacts,
     ) -> Self {
         Self {
-            keystore,
             client,
             rpc_resolver,
+            wallet_address,
+            host_signer,
+            facts,
         }
     }
 
-    pub fn without_rpc_resolver(keystore: Keystore, client: reqwest::Client) -> Self {
-        Self::new(keystore, client, Arc::new(EmptyPaidHttpChainRpcResolver))
+    pub fn without_rpc_resolver(
+        client: reqwest::Client,
+        wallet_address: Address,
+        host_signer: Arc<dyn PaidHttpHostSigner>,
+        facts: PaidHttpSigningFacts,
+    ) -> Self {
+        Self::new(
+            client,
+            Arc::new(EmptyPaidHttpChainRpcResolver),
+            wallet_address,
+            host_signer,
+            facts,
+        )
+    }
+}
+
+/// Adapter that satisfies the upstream Alloy signer contract by routing every
+/// digest through Bloom's paid-HTTP host signing seam.
+#[derive(Clone)]
+struct HostMppSigner {
+    host: Arc<dyn PaidHttpHostSigner>,
+    address: Address,
+    facts: Arc<PaidHttpSigningFacts>,
+    chain_id: Option<u64>,
+}
+
+impl HostMppSigner {
+    fn new(
+        host: Arc<dyn PaidHttpHostSigner>,
+        address: Address,
+        facts: PaidHttpSigningFacts,
+        chain_id: Option<u64>,
+    ) -> Self {
+        Self {
+            host,
+            address,
+            facts: Arc::new(facts),
+            chain_id,
+        }
+    }
+}
+
+#[async_trait]
+impl Signer for HostMppSigner {
+    async fn sign_hash(&self, hash: &B256) -> SignerResult<Signature> {
+        let mut digest = [0u8; 32];
+        digest.copy_from_slice(hash.as_slice());
+        let raw = self
+            .host
+            .sign_paid_http_hash(MPP_SIGN_INTENT, digest, &self.facts)
+            .await
+            .map_err(SignerError::other)?;
+        Signature::from_raw(&raw).map_err(SignerError::other)
     }
 
-    fn signer_error(&self, wallet: &str, err: KeystoreError) -> String {
-        match err {
-            KeystoreError::Locked(_) => {
-                let kind = self
-                    .keystore
-                    .raw_policy(wallet)
-                    .ok()
-                    .map(|(_, kind)| kind)
-                    .or_else(|| self.keystore.info(wallet).ok().map(|info| info.kind));
-                if kind == Some(WalletKind::PasskeyGated) {
-                    format!(
-                        "passkey wallet '{wallet}' is locked; run the foreground passkey unlock flow (`unlock-passkey` / Keystore::unlock_passkey) before confirming Tempo MPP payments"
-                    )
-                } else {
-                    format!(
-                        "wallet '{wallet}' is locked; unlock it before confirming Tempo MPP payments"
-                    )
-                }
-            }
-            other => format!("wallet '{wallet}' cannot be used for Tempo MPP signing: {other}"),
-        }
+    fn address(&self) -> Address {
+        self.address
+    }
+
+    fn chain_id(&self) -> Option<u64> {
+        self.chain_id
+    }
+
+    fn set_chain_id(&mut self, chain_id: Option<u64>) {
+        self.chain_id = chain_id;
     }
 }
 
@@ -87,7 +146,7 @@ impl PaymentBackend for RealMppBackend {
         &self,
         challenge: &NormalizedChallenge,
         request: &ParsedRequest,
-        wallet: &str,
+        _wallet: &str,
         policy: &Policy,
         _request_id: &str,
     ) -> Result<PaymentExecution, String> {
@@ -97,10 +156,6 @@ impl PaymentBackend for RealMppBackend {
                 "only Tempo MPP challenges can be confirmed by the real MPP backend".to_string(),
             );
         }
-        let signer = self
-            .keystore
-            .signer(wallet)
-            .map_err(|e| self.signer_error(wallet, e))?;
         let chain_id = challenge
             .chain_id
             .ok_or_else(|| "Tempo MPP challenge missing chainId".to_string())?;
@@ -111,24 +166,26 @@ impl PaymentBackend for RealMppBackend {
                 format!("no configured HTTP RPC URL for Tempo MPP chain_id {chain_id}")
             })?;
         let payment_challenge = parse_stored_mpp_challenge(challenge)?;
+        let signer = HostMppSigner::new(
+            Arc::clone(&self.host_signer),
+            self.wallet_address,
+            self.facts.clone(),
+            Some(chain_id),
+        );
         let credential = match challenge.intent.as_str() {
-            "charge" => {
-                let provider = TempoProvider::new((*signer).clone(), &rpc_url)
-                    .map_err(|e| format!("TempoProvider: {e}"))?;
-                provider.pay(&payment_challenge).await
-            }
+            "charge" => prepare_charge_credential(&payment_challenge, &signer, &rpc_url).await,
             "session" => {
-                let mut provider = TempoSessionProvider::new((*signer).clone(), &rpc_url)
-                    .map_err(|e| format!("TempoSessionProvider: {e}"))?;
-                if let Some(max) = policy
-                    .payments
-                    .sessions
-                    .max_deposit_usd
-                    .and_then(|usd| usd_to_atomic_units(challenge.asset.as_deref(), usd))
-                {
-                    provider = provider.with_max_deposit(max);
-                }
-                provider.pay(&payment_challenge).await
+                prepare_session_credential(
+                    &payment_challenge,
+                    &signer,
+                    &rpc_url,
+                    policy
+                        .payments
+                        .sessions
+                        .max_deposit_usd
+                        .and_then(|usd| usd_to_atomic_units(challenge.asset.as_deref(), usd)),
+                )
+                .await
             }
             other => {
                 return Err(format!("unsupported MPP intent '{other}'"));
@@ -161,6 +218,122 @@ impl PaymentBackend for RealMppBackend {
             header_name: "Authorization",
             header_value: authorization,
         })
+    }
+}
+
+async fn prepare_charge_credential(
+    challenge: &mpp::PaymentChallenge,
+    signer: &HostMppSigner,
+    rpc_url: &str,
+) -> Result<mpp::PaymentCredential, mpp::MppError> {
+    let mut charge = TempoCharge::from_challenge(challenge)?;
+    if charge.memo().is_none() {
+        let memo = mpp::tempo::attribution::encode(&challenge.id, &challenge.realm, None);
+        charge = charge.with_memo(memo);
+    }
+    let signed = charge
+        .sign_with_options(
+            signer,
+            SignOptions {
+                rpc_url: Some(rpc_url.to_string()),
+                signing_mode: Some(TempoSigningMode::Direct),
+                ..Default::default()
+            },
+        )
+        .await?;
+    Ok(signed.into_credential())
+}
+
+async fn prepare_session_credential(
+    challenge: &mpp::PaymentChallenge,
+    signer: &HostMppSigner,
+    rpc_url: &str,
+    max_deposit: Option<u128>,
+) -> Result<mpp::PaymentCredential, mpp::MppError> {
+    challenge.validate_for_session(mpp::protocol::methods::tempo::METHOD_NAME)?;
+    let chain_id = resolve_chain_id(challenge);
+    let escrow_contract = resolve_escrow(challenge, chain_id, None)?;
+    let session_req: SessionRequest = challenge.request.decode()?;
+    let payee: Address = session_req
+        .recipient
+        .as_deref()
+        .ok_or_else(|| {
+            mpp::MppError::InvalidConfig("session challenge missing recipient".to_string())
+        })?
+        .parse()
+        .map_err(|_| mpp::MppError::InvalidConfig("invalid recipient address".to_string()))?;
+    let currency: Address = session_req
+        .currency
+        .parse()
+        .map_err(|_| mpp::MppError::InvalidConfig("invalid currency address".to_string()))?;
+    let amount = session_req.parse_amount()?;
+    let payer = signer.address();
+    let rpc_url = rpc_url
+        .parse()
+        .map_err(|_| mpp::MppError::InvalidConfig("invalid RPC URL".to_string()))?;
+    let provider = ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(rpc_url);
+
+    if let Some(cid_str) = session_req.channel_id() {
+        if let Ok(channel_id) = cid_str.parse::<B256>() {
+            if let Some(mut recovered) = try_recover_channel(
+                &provider,
+                escrow_contract,
+                channel_id,
+                chain_id,
+                payer,
+                payee,
+                currency,
+                payer,
+            )
+            .await
+            {
+                recovered.cumulative_amount += amount;
+                let payload = create_voucher_payload(
+                    signer,
+                    recovered.channel_id,
+                    recovered.cumulative_amount,
+                    escrow_contract,
+                    chain_id,
+                )
+                .await?;
+                return Ok(build_credential(challenge, payload, chain_id, payer));
+            }
+        }
+    }
+
+    let deposit = resolve_session_deposit(session_req.suggested_deposit.as_deref(), max_deposit)?;
+    let (_entry, payload) = create_open_payload(
+        &provider,
+        signer,
+        Some(&TempoSigningMode::Direct),
+        payer,
+        OpenPayloadOptions {
+            authorized_signer: None,
+            escrow_contract,
+            payee,
+            currency,
+            deposit,
+            initial_amount: amount,
+            chain_id,
+            fee_payer: session_req.fee_payer(),
+        },
+    )
+    .await?;
+    Ok(build_credential(challenge, payload, chain_id, payer))
+}
+
+fn resolve_session_deposit(
+    suggested_deposit: Option<&str>,
+    max_deposit: Option<u128>,
+) -> Result<u128, mpp::MppError> {
+    let suggested = suggested_deposit.and_then(|s| s.parse::<u128>().ok());
+    match (suggested, max_deposit) {
+        (Some(suggested), Some(max)) => Ok(suggested.min(max)),
+        (Some(suggested), None) => Ok(suggested),
+        (None, Some(max)) => Ok(max),
+        (None, None) => Err(mpp::MppError::InvalidConfig(
+            "No deposit amount available. Set `max_deposit_usd` or ensure the server challenge includes `suggestedDeposit`.".to_string(),
+        )),
     }
 }
 

--- a/crates/bloom-paid-x402/Cargo.toml
+++ b/crates/bloom-paid-x402/Cargo.toml
@@ -7,7 +7,7 @@ description = "x402 adapter for Bloom paid HTTP requests"
 
 [dependencies]
 bloom-paid-http.workspace = true
-bloom-keystore.workspace = true
+base64.workspace = true
 serde_json.workspace = true
 alloy.workspace = true
 async-trait.workspace = true

--- a/crates/bloom-paid-x402/src/lib.rs
+++ b/crates/bloom-paid-x402/src/lib.rs
@@ -1,17 +1,32 @@
 //! x402 protocol adapter for Bloom paid HTTP requests.
+//!
+//! This adapter never touches wallet key material. It selects the matching
+//! x402 payment candidate and asks the Bloom runtime's host signing seam
+//! ([`PaidHttpHostSigner`]) to sign the exact EIP-712 digest under a live
+//! Sealed Approval grant. The upstream x402 clients are generic over
+//! [`SignerLike`], so injecting a host-backed signer reuses all of the
+//! crate's EIP-712 construction and header assembly without a
+//! `PrivateKeySigner` ever entering this crate.
 
-use alloy::primitives::U256;
+use std::sync::Arc;
+
+use alloy::primitives::{Address, FixedBytes, Signature, U256};
 use async_trait::async_trait;
-use bloom_keystore::{Keystore, KeystoreError, WalletKind};
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as B64;
 use bloom_paid_http::{
-    NormalizedChallenge, PaidHttpChainRpcResolver, ParsedRequest, PaymentRequirement,
-    networks_equivalent,
+    NormalizedChallenge, PaidHttpChainRpcResolver, PaidHttpHostSigner, PaidHttpSigningFacts,
+    ParsedRequest, PaymentRequirement, networks_equivalent,
 };
 use serde_json::json;
+use x402_chain_eip155::v1_eip155_exact::SignerLike;
 use x402_chain_eip155::{V1Eip155ExactClient, V2Eip155ExactClient};
 use x402_types::proto::{self, OriginalJson};
 use x402_types::scheme::client::X402SchemeClient;
 use x402_types::util::Base64Bytes;
+
+/// The `sign-hash` intent string every x402 host signature is authorized under.
+pub const X402_SIGN_INTENT: &str = "x402.sign";
 
 #[async_trait]
 pub trait X402PaymentSigner: Send + Sync {
@@ -28,6 +43,13 @@ pub struct X402SignContext<'a> {
     pub challenge: &'a NormalizedChallenge,
     pub requirement: &'a PaymentRequirement,
     pub rpc_resolver: &'a dyn PaidHttpChainRpcResolver,
+    /// EVM owner address of `wallet` (public; fills the x402 `from` field).
+    pub wallet_address: Address,
+    /// Host signing seam. Signing is gated on a live paid-HTTP Sealed Approval
+    /// grant and never exposes key material to this crate.
+    pub host_signer: &'a Arc<dyn PaidHttpHostSigner>,
+    /// Secret-free facts recorded in the host `SigningAttestation`.
+    pub facts: &'a PaidHttpSigningFacts,
 }
 
 pub struct X402PaymentCredential {
@@ -39,39 +61,72 @@ pub struct X402PaymentCredential {
     pub public_metadata: serde_json::Value,
 }
 
-pub struct KeystoreX402PaymentSigner {
-    keystore: Keystore,
+/// Adapter that satisfies the upstream x402 [`SignerLike`] contract by routing
+/// the EIP-712 digest through the Bloom host signing seam. Cloneable (the x402
+/// clients require `Clone`); the clone is a cheap `Arc` bump.
+#[derive(Clone)]
+struct HostSignerAdapter {
+    host: Arc<dyn PaidHttpHostSigner>,
+    address: Address,
+    facts: Arc<PaidHttpSigningFacts>,
 }
 
-impl KeystoreX402PaymentSigner {
-    pub fn new(keystore: Keystore) -> Self {
-        Self { keystore }
+#[async_trait]
+impl SignerLike for HostSignerAdapter {
+    fn address(&self) -> Address {
+        self.address
+    }
+
+    async fn sign_hash(&self, hash: &FixedBytes<32>) -> Result<Signature, alloy::signers::Error> {
+        let mut digest = [0u8; 32];
+        digest.copy_from_slice(hash.as_slice());
+        let sig65 = self
+            .host
+            .sign_paid_http_hash(X402_SIGN_INTENT, digest, &self.facts)
+            .await
+            .map_err(alloy::signers::Error::message)?;
+        Signature::from_raw(&sig65).map_err(alloy::signers::Error::message)
+    }
+}
+
+/// x402 payment signer backed by the Bloom host signing seam.
+///
+/// Stateless: the per-request host signer, wallet address, and attestation
+/// facts arrive on the [`X402SignContext`], so the same instance serves every
+/// request without holding a keystore or any key material.
+#[derive(Default)]
+pub struct HostX402PaymentSigner;
+
+impl HostX402PaymentSigner {
+    pub fn new() -> Self {
+        Self
     }
 }
 
 #[async_trait]
-impl X402PaymentSigner for KeystoreX402PaymentSigner {
+impl X402PaymentSigner for HostX402PaymentSigner {
     async fn sign_x402_payment(
         &self,
         ctx: &X402SignContext<'_>,
     ) -> Result<X402PaymentCredential, String> {
-        let signer = self
-            .keystore
-            .signer(ctx.wallet)
-            .map_err(|e| x402_keystore_signer_error(ctx.wallet, &self.keystore, e))?;
-        let info = self
-            .keystore
-            .info(ctx.wallet)
-            .map_err(|e| format!("x402 signer wallet metadata unavailable: {e}"))?;
         let payment_required = parse_payment_required(ctx.challenge)?;
+        let adapter = HostSignerAdapter {
+            host: ctx.host_signer.clone(),
+            address: ctx.wallet_address,
+            facts: Arc::new(ctx.facts.clone()),
+        };
         let candidate =
-            select_candidate(&payment_required, signer, ctx.requirement)?.ok_or_else(|| {
+            select_candidate(&payment_required, adapter, ctx.requirement)?.ok_or_else(|| {
                 "x402 upstream signer found no matching selected payment option".to_string()
             })?;
+        // `candidate.sign()` computes the EIP-712 digest and calls back into the
+        // host seam (which enforces the grant and consumes exactly one signature
+        // allowance), then assembles the header value from the returned
+        // signature.
         let header_value = candidate
             .sign()
             .await
-            .map_err(|e| format!("x402 upstream signing failed: {e}"))?;
+            .map_err(|e| format!("x402 host signing failed: {e}"))?;
         let header_name = match payment_required {
             proto::PaymentRequired::V1(_) => "X-Payment",
             proto::PaymentRequired::V2(_) => "Payment-Signature",
@@ -83,10 +138,9 @@ impl X402PaymentSigner for KeystoreX402PaymentSigner {
             header_name,
             header_value,
             public_metadata: json!({
-                "signer_backend": "x402-chain-eip155",
+                "signer_backend": "x402-chain-eip155/host-signing",
                 "wallet": ctx.wallet,
-                "wallet_kind": wallet_kind_label(info.kind),
-                "address": info.address.to_string(),
+                "address": ctx.wallet_address.to_string(),
                 "scheme": candidate.scheme,
                 "x402_version": candidate.x402_version,
                 "network": candidate.chain_id.to_string(),
@@ -100,6 +154,15 @@ impl X402PaymentSigner for KeystoreX402PaymentSigner {
             }),
         })
     }
+}
+
+/// Decode a base64 secp256k1 signature returned by the host into 65 raw bytes.
+pub fn decode_host_signature_b64(signature_b64: &str) -> Result<[u8; 65], String> {
+    let bytes = B64
+        .decode(signature_b64)
+        .map_err(|e| format!("decode host signature: {e}"))?;
+    <[u8; 65]>::try_from(bytes.as_slice())
+        .map_err(|_| format!("host signature is {} bytes, expected 65", bytes.len()))
 }
 
 fn parse_payment_required(
@@ -123,11 +186,14 @@ fn parse_payment_required(
     Ok(proto::PaymentRequired::V1(parsed))
 }
 
-fn select_candidate(
+fn select_candidate<S>(
     payment_required: &proto::PaymentRequired,
-    signer: std::sync::Arc<alloy::signers::local::PrivateKeySigner>,
+    signer: S,
     requirement: &PaymentRequirement,
-) -> Result<Option<x402_types::scheme::client::PaymentCandidate>, String> {
+) -> Result<Option<x402_types::scheme::client::PaymentCandidate>, String>
+where
+    S: SignerLike + Clone + Send + Sync + 'static,
+{
     let mut candidates = V2Eip155ExactClient::new(signer.clone()).accept(payment_required);
     candidates.extend(V1Eip155ExactClient::new(signer).accept(payment_required));
     for candidate in candidates {
@@ -178,28 +244,6 @@ fn eip155_chain_id_u64(chain_id: &x402_types::chain::ChainId) -> Option<u64> {
     (chain_id.namespace() == "eip155")
         .then(|| chain_id.reference().parse().ok())
         .flatten()
-}
-
-fn wallet_kind_label(kind: WalletKind) -> &'static str {
-    match kind {
-        WalletKind::Local => "local",
-        WalletKind::Watch => "watch",
-        WalletKind::PasskeyGated => "passkey",
-    }
-}
-
-fn x402_keystore_signer_error(wallet: &str, keystore: &Keystore, err: KeystoreError) -> String {
-    match err {
-        KeystoreError::Locked(_) => match keystore.info(wallet).map(|i| i.kind) {
-            Ok(WalletKind::PasskeyGated) => format!(
-                "wallet '{wallet}' is locked; passkey wallets must be foreground-unlocked with unlock_passkey before confirming this paid request"
-            ),
-            _ => format!(
-                "wallet '{wallet}' is locked; unlock the wallet before confirming this paid request"
-            ),
-        },
-        other => format!("x402 keystore signer unavailable for wallet '{wallet}': {other}"),
-    }
 }
 
 #[cfg(test)]

--- a/crates/bloom-tx/src/tx_engine.rs
+++ b/crates/bloom-tx/src/tx_engine.rs
@@ -2390,6 +2390,12 @@ impl TxEngine {
         // The outbox is keyed by the human chain name ("base"), not the CAIP-2
         // `network` header ("eip155:8453"). Using the header here silently missed
         // the per-wallet entry and dropped approval.json.
+        //
+        // This method persists into the EVM outbox and is only meaningful for a
+        // broadcast action. Callers must not invoke it for non-broadcast
+        // first-party actions (wallet-policy updates, policy-session mints),
+        // which have no chain and no outbox entry — a missing chain_name here is
+        // a caller error, not a routine case.
         let chain_name = sealed.chain_name().ok_or_else(|| {
             TxEngineError::BroadcastApprovalRequired(
                 "sealed action is missing chain_name in its policy snapshot".into(),
@@ -4779,6 +4785,54 @@ mod tests {
         let outbox = crate::outbox::Outbox::new(dir.path()).unwrap();
         let engine = TxEngine::new(outbox, 60_000, false);
         (engine, dir)
+    }
+
+    /// `persist_outbox_ceremony_approval` is an outbox-only method: it requires
+    /// a broadcast action's `chain_name`. Non-broadcast first-party actions
+    /// (wallet-policy updates, policy-session mints) must not be routed here by
+    /// the ceremony server — this test pins the contract so the caller-side gate
+    /// (which skips this call for non-broadcast actions) stays load-bearing.
+    #[test]
+    fn persist_ceremony_approval_requires_broadcast_chain_name() {
+        let (engine, _dir) = nonce_conflict_engine();
+        let staged = fake_staged_1559("0001-policy-like");
+        let mut action = sealed_action_from_staged(&staged);
+        action.petal_policy.config.remove("chain_name");
+        assert_eq!(action.chain_name(), None, "precondition: no chain_name");
+
+        let approval = SignedApproval {
+            schema: APPROVAL_SCHEMA_V1.into(),
+            action_id: action.action_id().to_string(),
+            wallet: action.wallet().to_string(),
+            surface: "wallet-policy".into(),
+            petal_id: action.petal_id().to_string(),
+            petal_digest: action.petal_digest().to_string(),
+            intent_hash: "policy-intent".into(),
+            server_nonce: "nonce-1".into(),
+            assurance: AssuranceLevel::Standard,
+            daemon_terms_digest: "1".repeat(64),
+            petal_policy_digest: "2".repeat(64),
+            policy_version: 0,
+            expiry_ms: now_ms() as u64 + 60_000,
+            signer_transport: SignerTransport::BrowserWebauthn,
+            credential_id: "cred-1".into(),
+            review_session_id: None,
+            webauthn_assertion: WebAuthnAssertionRecord {
+                credential_id: "cred-1".into(),
+                authenticator_data_b64: "AA".into(),
+                client_data_json_b64: "e30".into(),
+                signature_b64: "AA".into(),
+                user_handle_b64: None,
+            },
+        };
+
+        let err = engine
+            .persist_outbox_ceremony_approval(&action, &approval)
+            .expect_err("outbox persistence must reject a non-broadcast action");
+        assert!(
+            matches!(err, TxEngineError::BroadcastApprovalRequired(_)),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/bloom-vfs/src/docs/agent-guidance.md
+++ b/crates/bloom-vfs/src/docs/agent-guidance.md
@@ -88,8 +88,30 @@ action id; do not treat them as separate approval queues.
 
 Paid HTTP requests live under `/requests`. Agents should stage the request,
 read `plan.md`, and confirm only when the quoted cost, network, asset, and
-merchant match the task. Bloom handles x402 internally; agents should not look
-for a separate `/x402` path.
+merchant match the task. Bloom handles x402 and Tempo MPP internally; agents
+should not look for separate `/x402` or `/mpp` paths.
+
+If paid confirmation needs passkey approval, the first confirm write may return
+permission denied after writing
+`/requests/pending/<id>/approval_challenge.json`. Read that file, check
+`action_id`, `expiry_ms`, merchant/payment details in `plan.md`, then open or
+forward `ceremony_url`. The foreground `bloom request confirm` command follows
+the same Sealed Approval ceremony and retry path.
+
+The ceremony mints a short-lived in-memory grant for the sealed request. x402
+and MPP then ask Bloom's host signer to sign the exact payment digest under that
+grant; one allowance is consumed atomically only when a signature is produced.
+Failed policy checks, bad attestations, failed credential preparation, or retry
+failures before signing do not consume the grant. Raw payment authorization
+headers, signed payloads, passkey material, and PRF output are not written to
+VFS artifacts; credential metadata is redacted.
+
+Request confirmation executes from the daemon's sealed paid-HTTP subject bytes
+and sealed policy snapshot. Files such as `request.toml`, `challenge.json`, and
+`policy_check.json` are views for agents. If a pending projection differs from
+the sealed subject, or `private/request_body` no longer matches the sealed body
+hash, confirmation fails before signing or minting credentials. Live policy may
+narrow or deny, but it cannot widen the already sealed payment terms.
 
 Example paid search:
 

--- a/crates/bloom-vfs/src/docs/agent-guidance.md
+++ b/crates/bloom-vfs/src/docs/agent-guidance.md
@@ -84,6 +84,51 @@ After execution, inspect `/outbox/sent/<action_id>/` or
 artifacts. Petal-specific wallet paths are projections of the same central
 action id; do not treat them as separate approval queues.
 
+## Editing a passkey wallet policy
+
+For a passkey (WebAuthn-gated) wallet, `policy.toml` is signed authorization
+state (`policy.toml.sig`). Editing it through the mount is a Sealed Approval
+action — the daemon installs both the new `policy.toml` and its matching
+signature only after owner approval. Local (passphrase) wallets keep their
+old behavior: the write applies immediately.
+
+```sh
+# 1. Read the current signed policy and edit it locally.
+cat /bloom/wallets/<wallet>/policy.toml
+
+# 2. Write the proposed policy. For a passkey wallet the first write fails with
+#    permission denied after the daemon stages a Sealed Approval challenge.
+printf '%s' "$edited_policy" > /bloom/wallets/<wallet>/policy.toml
+
+# 3. Discover and read the challenge through the mount (no BLOOM_HOME access).
+ls /bloom/wallets/<wallet>/policy-updates
+cat /bloom/wallets/<wallet>/policy-updates/<action_id>/status.json
+cat /bloom/wallets/<wallet>/policy-updates/<action_id>/approval_challenge.json
+
+# 4. Open or forward ceremony_url, approve, then retry the identical write.
+printf '%s' "$edited_policy" > /bloom/wallets/<wallet>/policy.toml
+```
+
+The retry must send the **same** proposed bytes: the action id (and therefore
+the grant) is bound to `blake3(old_policy)` and `blake3(proposed_policy)`.
+Different retry bytes re-derive a fresh action id and start a new challenge
+rather than reusing the prior approval. On the approved retry Bloom also
+re-checks that the current on-disk policy still matches the sealed baseline,
+signs the approved proposed policy through the host signer, writes
+`policy.toml.sig`, then installs `policy.toml` — so the wallet is never left with
+a new policy that lacks its matching signature.
+
+`status.json` and `approval_challenge.json` are read-only views: they carry
+bounded challenge metadata and `ceremony_url` only, never the signed approval or
+any key/PRF/grant material.
+
+Direct edits to `BLOOM_HOME/keystore/<wallet>/policy.toml` are **unsupported**
+for this flow. If a policy is mutated out of band and its `policy.toml.sig` goes
+stale, the passkey wallet fails closed on every signed path (including the first
+VFS policy write) with the signed-policy error; the mounted flow does not repair
+it. Recovering an externally-broken policy needs the admin helper
+`bloom wallet sign-policy <wallet>`, not this edit surface.
+
 ## Paid HTTP
 
 Paid HTTP requests live under `/requests`. Agents should stage the request,

--- a/crates/bloom-vfs/src/handlers/requests.rs
+++ b/crates/bloom-vfs/src/handlers/requests.rs
@@ -1136,6 +1136,17 @@ impl Handler for RequestsHandler {
             [state, id] if matches!(state.as_str(), "pending" | "sent" | "failed" | "sessions") => {
                 Ok(Entry::dir(id))
             }
+            [state, _id, name]
+                if matches!(state.as_str(), "pending" | "sent" | "failed")
+                    && name == "response" =>
+            {
+                // `response` is a subdirectory (its files are handled by the
+                // 4-segment arm below and listed by `list`). Without this the
+                // generic file arm reports it as a 0-byte file, so a mounted
+                // client caches it as a file and descending into it fails with
+                // ENOTDIR.
+                Ok(Entry::dir("response"))
+            }
             [state, _id, name] if matches!(state.as_str(), "pending" | "sent" | "failed") => {
                 if matches!(name.as_str(), "confirm" | "cancel") {
                     Ok(Entry::writable_file(name))
@@ -1185,7 +1196,21 @@ impl Handler for RequestsHandler {
                 list_dirs(self.requests_root().join(state))
             }
             [state, id] if matches!(state.as_str(), "pending" | "sent" | "failed") => {
-                list_entries(self.req_dir(state, id))
+                let mut entries = list_entries(self.req_dir(state, id))?;
+                // Always advertise the pending control files even before
+                // they've been written, so agents can `printf y > confirm`
+                // (mirrors the EVM ln pending listing in wallets.rs). These
+                // are virtual write-only sinks that never exist on disk, so
+                // without this they'd be invisible to `ls`.
+                if state.as_str() == "pending" {
+                    for ctrl in ["cancel", "confirm"] {
+                        if !entries.iter().any(|e| e.name == ctrl) {
+                            entries.push(Entry::writable_file(ctrl));
+                        }
+                    }
+                    entries.sort_by(|a, b| a.name.cmp(&b.name));
+                }
+                Ok(entries)
             }
             [state, id] if state == "sessions" => {
                 list_entries(self.requests_root().join("sessions").join(id))
@@ -3118,6 +3143,77 @@ mod tests {
         assert_eq!(headers["set-cookie"], "redacted");
         assert_eq!(headers["payment-receipt"], "redacted");
         assert_eq!(headers["content-type"], "application/json");
+    }
+
+    #[tokio::test]
+    async fn response_resolves_as_a_directory_via_lookup() {
+        let f = fixture(Some("alice"));
+        let (url, _hits) = mock_server(200, &[("content-type", "application/json")], b"{}").await;
+        let id = f
+            .handler
+            .create_request(format!("GET {url}").as_bytes(), false)
+            .await
+            .unwrap();
+        // `response` must resolve as a directory, not a 0-byte file — otherwise a
+        // mounted client caches it as a file and descending into it is ENOTDIR.
+        let entry = f
+            .handler
+            .lookup(&VfsPath::parse(&format!("/sent/{id}/response")).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(entry.kind, crate::handler::EntryKind::Dir);
+        // And a file inside it still resolves as a file.
+        let body = f
+            .handler
+            .lookup(&VfsPath::parse(&format!("/sent/{id}/response/body")).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(body.kind, crate::handler::EntryKind::File);
+    }
+
+    #[tokio::test]
+    async fn pending_request_listing_advertises_confirm_and_cancel() {
+        let f = fixture(Some("alice"));
+        let pending = f.handler.requests_root().join("pending/req_ctrl");
+        fs::create_dir_all(&pending).unwrap();
+        fs::write(pending.join("status"), "pending\n").unwrap();
+        write_json(
+            pending.join("request.toml"),
+            &json!({"method":"GET","url":"http://127.0.0.1:9/pay","wallet":"alice","headers":{},"dry_run":false}),
+        )
+        .unwrap();
+
+        let entries = f
+            .handler
+            .list(&VfsPath::parse("/pending/req_ctrl").unwrap())
+            .await
+            .unwrap();
+        for ctrl in ["confirm", "cancel"] {
+            let e = entries
+                .iter()
+                .find(|e| e.name == ctrl)
+                .unwrap_or_else(|| panic!("pending listing must advertise {ctrl}"));
+            // Control files are writable sinks, not read-only metadata.
+            assert!(e.mode & 0o200 != 0, "{ctrl} must be writable");
+        }
+
+        // Non-pending states must NOT advertise control files (they can
+        // no longer be confirmed or cancelled).
+        let sent = f.handler.requests_root().join("sent/req_ctrl");
+        fs::create_dir_all(&sent).unwrap();
+        fs::write(sent.join("status"), "sent\n").unwrap();
+        let sent_entries = f
+            .handler
+            .list(&VfsPath::parse("/sent/req_ctrl").unwrap())
+            .await
+            .unwrap();
+        assert!(
+            !sent_entries
+                .iter()
+                .any(|e| e.name == "confirm" || e.name == "cancel"),
+            "sent request must not advertise control files: {:?}",
+            sent_entries.iter().map(|e| &e.name).collect::<Vec<_>>()
+        );
     }
 
     #[tokio::test]

--- a/crates/bloom-vfs/src/handlers/requests.rs
+++ b/crates/bloom-vfs/src/handlers/requests.rs
@@ -786,6 +786,15 @@ impl RequestsHandler {
                     policy_override: Some(&policy),
                     checks_override: Some(checks),
                     sentinel_override: Some(&sentinel),
+                    // Execute from the sealed request/challenge/requirement we
+                    // validated above, not from the mutable pending projection.
+                    sealed_execution: Some(ConfirmExecutionInputs {
+                        request: &request,
+                        challenge: &challenge,
+                        requirement: &requirement,
+                        wallet: &wallet,
+                        dry_run: sealed_inputs.dry_run,
+                    }),
                     ..Default::default()
                 },
             )
@@ -1331,6 +1340,22 @@ struct ConfirmBackendOptions<'a> {
     policy_override: Option<&'a Policy>,
     checks_override: Option<Vec<PolicyCheck>>,
     sentinel_override: Option<&'a str>,
+    /// Sealed execution inputs already validated by the caller. When present,
+    /// `confirm_with_backend` uses these bytes instead of re-reading the
+    /// mutable pending projection (`challenge.json`, `request.toml`), closing
+    /// the TOCTOU between sealed validation and backend execution.
+    sealed_execution: Option<ConfirmExecutionInputs<'a>>,
+}
+
+/// Sealed request/challenge/requirement values threaded into
+/// `confirm_with_backend` so it executes from the sealed action bytes rather
+/// than re-reading the mutable pending projection.
+struct ConfirmExecutionInputs<'a> {
+    request: &'a ParsedRequest,
+    challenge: &'a NormalizedChallenge,
+    requirement: &'a PaymentRequirement,
+    wallet: &'a str,
+    dry_run: bool,
 }
 
 async fn confirm_with_backend(
@@ -1369,14 +1394,45 @@ async fn confirm_with_backend(
             "payment policy warning requires override sentinel '{sentinel}'"
         )));
     }
-    let challenge: NormalizedChallenge = read_json(pending.join("challenge.json"))?;
+    // Prefer the caller's sealed values over the mutable pending projection:
+    // for the MPP path the caller has already validated the sealed action and
+    // its request/challenge/requirement, so re-reading `challenge.json` /
+    // `request.toml` here would reopen a TOCTOU against a tampered projection.
+    let (challenge, request, wallet, requirement, dry_run) = match &options.sealed_execution {
+        Some(sealed) => (
+            sealed.challenge.clone(),
+            sealed.request.clone(),
+            sealed.wallet.to_string(),
+            sealed.requirement.clone(),
+            sealed.dry_run,
+        ),
+        None => {
+            let challenge: NormalizedChallenge = read_json(pending.join("challenge.json"))?;
+            let request_value: serde_json::Value = read_json(pending.join("request.toml"))?;
+            let dry_run = request_value
+                .get("dry_run")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            let request = parsed_request_from_dir(&pending)?;
+            let wallet = request_value
+                .get("wallet")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| HandlerError::backend("request artifact missing wallet"))?
+                .to_string();
+            let requirement = PaymentRequirement {
+                scheme: None,
+                network: challenge.network.clone(),
+                asset: challenge.asset.clone(),
+                amount: challenge.amount.clone(),
+                pay_to: None,
+                resource: None,
+                raw: json!({}),
+            };
+            (challenge, request, wallet, requirement, dry_run)
+        }
+    };
     validate_session_state_target(&challenge, id)?;
-    let request_value: serde_json::Value = read_json(pending.join("request.toml"))?;
-    if request_value
-        .get("dry_run")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false)
-    {
+    if dry_run {
         return Err(HandlerError::invalid(
             "dry-run paid requests cannot be confirmed; stage a fresh request with /requests/new",
         ));
@@ -1386,12 +1442,6 @@ async fn confirm_with_backend(
             "this pending request already minted a payment credential; cancel and stage a fresh request instead of re-confirming",
         ));
     }
-    let request = parsed_request_from_dir(&pending)?;
-    let wallet = request_value
-        .get("wallet")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| HandlerError::backend("request artifact missing wallet"))?
-        .to_string();
     let fallback_policy;
     let policy = match options.policy_override {
         Some(policy) => policy,
@@ -1417,15 +1467,6 @@ async fn confirm_with_backend(
         &execution.header_value,
     )
     .await;
-    let requirement = PaymentRequirement {
-        scheme: None,
-        network: challenge.network.clone(),
-        asset: challenge.asset.clone(),
-        amount: challenge.amount.clone(),
-        pay_to: None,
-        resource: None,
-        raw: json!({}),
-    };
     let amount_usd = selected_requirement_amount_usd(&challenge, &requirement);
     let final_state = finalize_paid_retry(
         &requests_root,
@@ -3728,6 +3769,9 @@ mod tests {
         let facts = PaidHttpSigningFacts {
             protocol: "x402".into(),
             request_id: "req-x402".into(),
+            method: "GET".into(),
+            url: "https://merchant.test/pay".into(),
+            host: "merchant.test".into(),
             policy_snapshot_digest: Some(action.petal_policy_digest.clone()),
             ..Default::default()
         };
@@ -3786,6 +3830,10 @@ mod tests {
         };
         let facts = PaidHttpSigningFacts {
             protocol: "x402".into(),
+            request_id: "req-intent".into(),
+            method: "GET".into(),
+            url: "https://merchant.test/pay".into(),
+            host: "merchant.test".into(),
             policy_snapshot_digest: Some(action.petal_policy_digest.clone()),
             ..Default::default()
         };
@@ -3813,6 +3861,9 @@ mod tests {
         let facts = PaidHttpSigningFacts {
             protocol: "x402".into(),
             request_id: "req-facts".into(),
+            method: "GET".into(),
+            url: "https://merchant.test/pay".into(),
+            host: "merchant.test".into(),
             policy_snapshot_digest: Some(action.petal_policy_digest.clone()),
             ..Default::default()
         };
@@ -3891,6 +3942,9 @@ mod tests {
         let facts = PaidHttpSigningFacts {
             protocol: "x402".into(),
             request_id: "req-petal".into(),
+            method: "GET".into(),
+            url: "https://merchant.test/pay".into(),
+            host: "merchant.test".into(),
             policy_snapshot_digest: Some(action.petal_policy_digest.clone()),
             ..Default::default()
         };
@@ -4643,6 +4697,143 @@ inline = '{"prompt":"hi"}'
         assert!(!pending.join("private/credential_minted.json").exists());
     }
 
+    /// Backend double that records the request/challenge/wallet it is prepared
+    /// with, so a test can prove which bytes reached execution.
+    #[derive(Clone, Default)]
+    struct CapturingMppBackend {
+        seen: Arc<std::sync::Mutex<Option<(String, String, String)>>>,
+    }
+
+    #[async_trait]
+    impl PaymentBackend for CapturingMppBackend {
+        fn name(&self) -> &'static str {
+            "capturing_mpp_test_double"
+        }
+
+        async fn prepare(
+            &self,
+            challenge: &NormalizedChallenge,
+            request: &ParsedRequest,
+            wallet: &str,
+            _policy: &Policy,
+            _request_id: &str,
+        ) -> Result<PaymentExecution, String> {
+            *self.seen.lock().unwrap() = Some((
+                challenge.merchant.clone(),
+                request.url.to_string(),
+                wallet.to_string(),
+            ));
+            Ok(PaymentExecution {
+                credential_metadata: json!({
+                    "redacted": true,
+                    "backend": self.name(),
+                    "secret_material_in_vfs": false,
+                    "raw_authorization_stored": false,
+                    "raw_signed_payload_stored": false
+                }),
+                header_name: "Authorization",
+                header_value: "Payment test".into(),
+            })
+        }
+    }
+
+    /// Regression: once the MPP path has validated its sealed action, the
+    /// backend must execute against the sealed request/challenge/requirement,
+    /// not a `challenge.json` / `request.toml` projection an attacker tampered
+    /// with after sealing.
+    #[tokio::test]
+    async fn mpp_confirm_uses_sealed_execution_not_tampered_projection() {
+        let dir = tempfile::tempdir().unwrap();
+        let pending = dir.path().join("requests/pending/req_sealed_exec");
+        fs::create_dir_all(&pending).unwrap();
+        fs::write(pending.join("status"), "pending\n").unwrap();
+
+        // The sealed retry target the caller validated.
+        let (sealed_url, sealed_hits) = mock_server(
+            200,
+            &[("payment-receipt", r#"{"status":"success"}"#)],
+            b"sealed paid response\n",
+        )
+        .await;
+        // A second server that must NEVER be contacted (the tampered target).
+        let (tampered_url, tampered_hits) = mock_server(200, &[], b"tampered response\n").await;
+
+        let sealed_challenge = normalize_challenge(
+            &HeaderMap::new(),
+            br#"{"protocol":"tempo-mpp","type":"Charge","network":"tempo","asset":"pathUSD","amount":"0.10","amountUsd":0.10}"#,
+            &Url::parse(&sealed_url).unwrap(),
+        );
+        let sealed_request = ParsedRequest {
+            method: "GET".into(),
+            url: Url::parse(&sealed_url).unwrap(),
+            wallet: Some("sealed-wallet".into()),
+            max_amount_usd: None,
+            headers: BTreeMap::new(),
+            body: None,
+        };
+        let sealed_requirement = PaymentRequirement {
+            scheme: Some("exact".into()),
+            network: Some("tempo".into()),
+            asset: Some("pathUSD".into()),
+            amount: Some("0.10".into()),
+            pay_to: None,
+            resource: Some(sealed_url.clone()),
+            raw: json!({"scheme": "exact"}),
+        };
+
+        // Tamper the mutable pending projection after sealing: a different
+        // merchant/URL/wallet that would divert the payment if it were read.
+        let tampered_challenge = normalize_challenge(
+            &HeaderMap::new(),
+            br#"{"protocol":"tempo-mpp","type":"Charge","network":"tempo","asset":"pathUSD","amount":"9.99","amountUsd":9.99}"#,
+            &Url::parse(&tampered_url).unwrap(),
+        );
+        write_json(pending.join("challenge.json"), &tampered_challenge).unwrap();
+        write_json(
+            pending.join("request.toml"),
+            &json!({"method":"GET","url":tampered_url,"wallet":"tamper-wallet","headers":{}}),
+        )
+        .unwrap();
+
+        let backend = CapturingMppBackend::default();
+        let result = confirm_with_backend(
+            dir.path(),
+            "req_sealed_exec",
+            b"confirm",
+            &backend,
+            ConfirmBackendOptions {
+                checks_override: Some(vec![]),
+                sealed_execution: Some(ConfirmExecutionInputs {
+                    request: &sealed_request,
+                    challenge: &sealed_challenge,
+                    requirement: &sealed_requirement,
+                    wallet: "sealed-wallet",
+                    dry_run: false,
+                }),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.final_state, "sent");
+
+        // The backend saw the sealed request/challenge/wallet, never the
+        // tampered projection.
+        let (merchant, url, wallet) = backend.seen.lock().unwrap().clone().unwrap();
+        let sealed_host = Url::parse(&sealed_url)
+            .unwrap()
+            .host_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(merchant, sealed_host);
+        assert_eq!(url, sealed_url);
+        assert_eq!(wallet, "sealed-wallet");
+
+        // The sealed retry target was contacted; the tampered one was not.
+        assert_eq!(sealed_hits.load(Ordering::SeqCst), 1);
+        assert_eq!(tampered_hits.load(Ordering::SeqCst), 0);
+    }
+
     #[test]
     fn mpp_session_id_must_be_single_safe_segment() {
         let dir = tempfile::tempdir().unwrap();
@@ -4788,6 +4979,7 @@ inline = '{"prompt":"hi"}'
                 policy_override: Some(&policy),
                 checks_override: Some(Vec::new()),
                 sentinel_override: Some("override"),
+                ..Default::default()
             },
         )
         .await
@@ -4946,6 +5138,9 @@ inline = '{"prompt":"hi"}'
             PaidHttpSigningFacts {
                 protocol: "mpp".into(),
                 request_id: "req_mpp_host".into(),
+                method: "GET".into(),
+                url: "https://merchant.test/pay".into(),
+                host: "merchant.test".into(),
                 policy_snapshot_digest: Some(action.petal_policy_digest.clone()),
                 ..Default::default()
             },
@@ -5030,6 +5225,9 @@ inline = '{"prompt":"hi"}'
             PaidHttpSigningFacts {
                 protocol: "mpp".into(),
                 request_id: "req_mpp_wrong_intent".into(),
+                method: "GET".into(),
+                url: "https://merchant.test/pay".into(),
+                host: "merchant.test".into(),
                 policy_snapshot_digest: Some(action.petal_policy_digest.clone()),
                 ..Default::default()
             },

--- a/crates/bloom-vfs/src/handlers/requests.rs
+++ b/crates/bloom-vfs/src/handlers/requests.rs
@@ -3,27 +3,31 @@
 //! This handler owns the `/requests` VFS tree. Reads only expose durable
 //! artefacts; payment/signing boundaries are writable control files.
 
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
 use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as B64_STD;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use bloom_auth_api::{
     ApprovalChallenge, AssuranceLevel, CanonicalEnvelope, CanonicalIntentHeader, DaemonGrantTerms,
-    ExecutorKind, PolicyCheckClass, PolicyCheckResult, SealedAction, SealedApprovalGrant,
-    SignedApproval, petal_identity,
+    ExecutorKind, PetalHost, PolicyCheckClass, PolicyCheckResult, SIGNING_ATTESTATION_SCHEMA_V1,
+    SealedAction, SealedApprovalGrant, SignHashRequest, SignedApproval, SigningAttestation,
+    petal_identity,
 };
 use bloom_keystore::Keystore;
 use bloom_paid_http::{
-    EmptyPaidHttpChainRpcResolver, NormalizedChallenge, PaidHttpChainRpcResolver, ParsedRequest,
-    PaymentRequirement, PolicyCheck, PolicyEvalInput, evaluate_payment_policy,
-    evaluate_session_policy, is_sensitive_paid_http_header, json_number, normalize_challenge,
-    paid_http_intent_label, parse_money, parse_payment_amount_usd, parse_request,
-    select_payment_requirement, selected_requirement_amount_usd, trim_money,
+    EmptyPaidHttpChainRpcResolver, NormalizedChallenge, PaidHttpChainRpcResolver,
+    PaidHttpHostSigner, PaidHttpSigningFacts, ParsedRequest, PaymentRequirement, PolicyCheck,
+    PolicyEvalInput, evaluate_payment_policy, evaluate_session_policy,
+    is_sensitive_paid_http_header, json_number, normalize_challenge, paid_http_intent_label,
+    parse_money, parse_payment_amount_usd, parse_request, select_payment_requirement,
+    selected_requirement_amount_usd, trim_money,
 };
 use bloom_paid_mpp::{PaymentBackend, RealMppBackend};
-use bloom_paid_x402::{KeystoreX402PaymentSigner, X402PaymentSigner, X402SignContext};
+use bloom_paid_x402::{HostX402PaymentSigner, X402PaymentSigner, X402SignContext};
 use bloom_proto::Policy;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use serde::{Deserialize, Serialize};
@@ -65,7 +69,7 @@ impl RequestsHandler {
             keystore: keystore.clone(),
             default_wallet,
             client: reqwest::Client::new(),
-            x402_signer: Arc::new(KeystoreX402PaymentSigner::new(keystore)),
+            x402_signer: Arc::new(HostX402PaymentSigner::new()),
             paid_http_rpc_resolver: Arc::new(EmptyPaidHttpChainRpcResolver),
             auth_services: AuthServices::default(),
         }
@@ -259,6 +263,7 @@ impl RequestsHandler {
                 challenge: &challenge,
                 requirement: &policy_requirement,
                 checks: &checks,
+                policy: &policy,
                 dry_run,
             })
             .await?;
@@ -516,6 +521,73 @@ impl RequestsHandler {
             .map_err(|e| HandlerError::backend(format!("lookup paid-http grant: {e}")))
     }
 
+    async fn sealed_execution_inputs(
+        &self,
+        pending: &Path,
+        request_id: &str,
+    ) -> Result<PaidHttpExecutionInputs, HandlerError> {
+        let Some(intent_hash) = fs::read_to_string(pending.join("intent_hash"))
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+        else {
+            return Err(HandlerError::invalid(
+                "pending paid-http request is missing sealed intent_hash; re-stage the request",
+            ));
+        };
+        let sealed = self
+            .auth_services
+            .require_store()?
+            .sealed_intent(&intent_hash)
+            .await
+            .map_err(|e| HandlerError::backend(format!("read sealed paid-http action: {e}")))?;
+        let action = sealed.action.ok_or_else(|| {
+            HandlerError::invalid("sealed paid-http action is missing; re-stage the request")
+        })?;
+        action
+            .validate()
+            .map_err(|e| HandlerError::invalid(format!("invalid sealed paid-http action: {e}")))?;
+        if action.surface() != "requests"
+            || action.petal_id() != petal_identity::PETAL_ID_PAID_HTTP
+            || action.petal_digest() != petal_identity::PLACEHOLDER_DIGEST_PAID_HTTP
+            || action.envelope.subject_kind != "paid_http"
+            || action.envelope.subject_schema != "bloom.paid_http_subject.v1"
+        {
+            return Err(HandlerError::invalid(
+                "sealed action is not a paid-http request confirmation",
+            ));
+        }
+        let subject_bytes = B64_STD
+            .decode(&action.envelope.subject_bytes_b64)
+            .map_err(|e| HandlerError::invalid(format!("decode sealed paid-http subject: {e}")))?;
+        let subject: PaidHttpSealedSubject = serde_json::from_slice(&subject_bytes)
+            .map_err(|e| HandlerError::invalid(format!("decode sealed paid-http subject: {e}")))?;
+        subject.validate_basic(request_id, action.wallet())?;
+        validate_pending_projection_matches_subject(pending, &subject)?;
+        let mut request = subject.to_request(action.wallet())?;
+        if let Some(body_sha256) = subject.body_sha256.as_deref() {
+            let body = fs::read_to_string(pending.join("private/request_body"))?;
+            let actual = bloom_tools::sha256_hex(body.as_bytes());
+            if actual != body_sha256 {
+                return Err(HandlerError::invalid(
+                    "private/request_body does not match the sealed request body hash",
+                ));
+            }
+            request.body = Some(body);
+        }
+        let policy = policy_from_paid_http_snapshot(&action.petal_policy);
+        Ok(PaidHttpExecutionInputs {
+            request,
+            host: subject.host,
+            challenge: subject.challenge,
+            requirement: subject.selected_requirement,
+            checks: subject.policy_checks,
+            dry_run: subject.dry_run,
+            policy,
+            policy_snapshot_digest: action.petal_policy_digest,
+        })
+    }
+
     async fn request_action_id(&self, request_id: &str) -> Result<String, HandlerError> {
         let Some(writer) = self.auth_services.writer() else {
             return Ok(request_id.to_string());
@@ -559,6 +631,23 @@ impl RequestsHandler {
             .map_err(|e| HandlerError::invalid(format!("consume paid-http grant: {e}")))
     }
 
+    /// Build the paid-HTTP host signing seam for a wallet/action. When a
+    /// [`PetalHost`] is wired, signatures flow through it (grant-gated,
+    /// attestation-recorded, one allowance consumed atomically). When it is
+    /// not wired, a stub is returned that errors if a signature is actually
+    /// requested, so misconfiguration surfaces at signing time rather than
+    /// silently signing outside a grant.
+    fn paid_http_host_signer(&self, wallet: &str, action_id: &str) -> Arc<dyn PaidHttpHostSigner> {
+        match self.auth_services.petal_host() {
+            Some(host) => Arc::new(PaidHttpPetalHostSigner {
+                petal_host: host.clone(),
+                wallet: wallet.to_string(),
+                action_id: action_id.to_string(),
+            }),
+            None => Arc::new(UnwiredPaidHttpHostSigner),
+        }
+    }
+
     async fn issue_sealed_confirm_challenge(
         &self,
         id: &str,
@@ -578,6 +667,13 @@ impl RequestsHandler {
                 now,
             )
             .await
+            .map(|challenge| {
+                // Project the stable local ceremony URL for mounted/Bloom-Machine
+                // flows, matching the EVM outbox. The URL token is derived from
+                // the (reused-while-unexpired) `server_nonce`, so repeated confirm
+                // writes surface the same challenge and the same `ceremony_url`.
+                challenge.with_local_ceremony_url()
+            })
             .map_err(|e| HandlerError::backend(format!("issue paid-http approval challenge: {e}")))
     }
 
@@ -587,12 +683,8 @@ impl RequestsHandler {
         if !pending.exists() {
             return Err(HandlerError::NotFound(format!("/requests/pending/{id}")));
         }
-        let request_json: serde_json::Value = read_json(pending.join("request.toml"))?;
-        if request_json
-            .get("dry_run")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false)
-        {
+        let sealed_inputs = self.sealed_execution_inputs(&pending, id).await?;
+        if sealed_inputs.dry_run {
             return Err(HandlerError::invalid(
                 "dry-run paid requests cannot be confirmed; stage a fresh request with /requests/new",
             ));
@@ -602,16 +694,17 @@ impl RequestsHandler {
                 "this pending request already minted a payment credential; cancel and stage a fresh request instead of re-confirming",
             ));
         }
-        let request = parsed_request_from_dir(&pending)?;
+        let request = sealed_inputs.request;
         let wallet = request
             .wallet
             .as_deref()
-            .ok_or_else(|| HandlerError::backend("request.toml missing wallet"))?
+            .ok_or_else(|| HandlerError::backend("sealed request missing wallet"))?
             .to_string();
-        let host = request.url.host_str().unwrap_or("unknown").to_string();
-        let mut challenge: NormalizedChallenge = read_json(pending.join("challenge.json"))?;
+        let host = sealed_inputs.host;
+        let mut challenge = sealed_inputs.challenge;
         validate_session_state_target(&challenge, id)?;
-        let policy = self.wallet_policy(&wallet)?;
+        let live_policy = self.wallet_policy(&wallet)?;
+        let policy = sealed_inputs.policy;
         let sentinel = policy.override_sentinel().to_ascii_lowercase();
         if !matches!(value.as_str(), "y" | "yes" | "confirm") && value != sentinel.as_str() {
             return Err(HandlerError::invalid(format!(
@@ -634,8 +727,9 @@ impl RequestsHandler {
                     .and_then(|s| parse_money(&s))
                 })
                 .unwrap_or(0.0);
-            let mut checks = evaluate_payment_policy(
-                &policy,
+            let mut checks = sealed_inputs.checks.clone();
+            let mut live_checks = evaluate_payment_policy(
+                &live_policy,
                 PolicyEvalInput {
                     host: &host,
                     asset: challenge.asset.as_deref(),
@@ -643,29 +737,45 @@ impl RequestsHandler {
                     intent: &challenge.intent,
                     amount_usd: selected_requirement_amount_usd(
                         &challenge,
-                        &PaymentRequirement {
-                            scheme: None,
-                            network: challenge.network.clone(),
-                            asset: challenge.asset.clone(),
-                            amount: challenge.amount.clone(),
-                            pay_to: None,
-                            resource: None,
-                            raw: json!({}),
-                        },
+                        &sealed_inputs.requirement,
                     ),
                     request_max_amount_usd: request.max_amount_usd,
                     spent_24h_usd: self.sum_paid_usd_last_24h(&wallet)?,
                 },
             );
-            checks.extend(evaluate_session_policy(&policy, &challenge, already_spent));
+            live_checks.extend(evaluate_session_policy(
+                &live_policy,
+                &challenge,
+                already_spent,
+            ));
+            checks.extend(live_checks.into_iter().filter(|c| c.result == "deny"));
             self.ensure_sealed_confirm_approval(&pending, id).await?;
-            let _grant = self
-                .consume_paid_http_grant(id, &wallet, PAID_HTTP_MPP_SIGN_INTENT)
-                .await?;
+            let action_id = self.request_action_id(id).await?;
+            let wallet_address = self
+                .keystore
+                .info(&wallet)
+                .map_err(|e| HandlerError::backend(format!("wallet address unavailable: {e}")))?
+                .address;
+            let policy_snapshot_digest = Some(sealed_inputs.policy_snapshot_digest.clone());
+            let mut requirement = sealed_inputs.requirement.clone();
+            if requirement.resource.is_none() {
+                requirement.resource = Some(request.url.to_string());
+            }
+            let host_signer = self.paid_http_host_signer(&wallet, &action_id);
+            let facts = paid_http_mpp_facts(
+                id,
+                &request,
+                &host,
+                &challenge,
+                &requirement,
+                policy_snapshot_digest,
+            );
             let backend = RealMppBackend {
-                keystore: self.keystore.clone(),
                 client: self.client.clone(),
                 rpc_resolver: Arc::clone(&self.paid_http_rpc_resolver),
+                wallet_address,
+                host_signer,
+                facts,
             };
             let result = confirm_with_backend(
                 &self.root,
@@ -673,10 +783,10 @@ impl RequestsHandler {
                 data,
                 &backend,
                 ConfirmBackendOptions {
-                    grant_consumer: Some((self, &wallet, PAID_HTTP_MPP_SIGN_INTENT)),
                     policy_override: Some(&policy),
                     checks_override: Some(checks),
                     sentinel_override: Some(&sentinel),
+                    ..Default::default()
                 },
             )
             .await?;
@@ -688,32 +798,27 @@ impl RequestsHandler {
             }
             return Ok(());
         }
-        let requirement = select_payment_requirement(&challenge, &policy, &host)
-            .or_else(|| challenge.accepts.first().cloned())
-            .unwrap_or_else(|| PaymentRequirement {
-                scheme: None,
-                network: challenge.network.clone(),
-                asset: challenge.asset.clone(),
-                amount: challenge.amount.clone(),
-                pay_to: None,
-                resource: None,
-                raw: json!({}),
-            });
+        let requirement = sealed_inputs.requirement;
         challenge.network = requirement.network.clone();
         challenge.asset = requirement.asset.clone();
         challenge.amount = requirement.amount.clone();
         let amount_usd = selected_requirement_amount_usd(&challenge, &requirement);
-        let checks = evaluate_payment_policy(
-            &policy,
-            PolicyEvalInput {
-                host: &host,
-                asset: challenge.asset.as_deref(),
-                network: challenge.network.as_deref(),
-                intent: &challenge.intent,
-                amount_usd,
-                request_max_amount_usd: request.max_amount_usd,
-                spent_24h_usd: self.sum_paid_usd_last_24h(&wallet)?,
-            },
+        let mut checks = sealed_inputs.checks;
+        checks.extend(
+            evaluate_payment_policy(
+                &live_policy,
+                PolicyEvalInput {
+                    host: &host,
+                    asset: challenge.asset.as_deref(),
+                    network: challenge.network.as_deref(),
+                    intent: &challenge.intent,
+                    amount_usd,
+                    request_max_amount_usd: request.max_amount_usd,
+                    spent_24h_usd: self.sum_paid_usd_last_24h(&wallet)?,
+                },
+            )
+            .into_iter()
+            .filter(|c| c.result == "deny"),
         );
         if checks.iter().any(|c| c.result == "deny") {
             return Err(HandlerError::invalid(
@@ -726,6 +831,25 @@ impl RequestsHandler {
             )));
         }
         self.ensure_sealed_confirm_approval(&pending, id).await?;
+        // Sign the x402 credential through the host signing seam. The grant's
+        // one signature allowance is consumed atomically inside host signing;
+        // there is no separate bookkeeping consume around a direct signature.
+        let action_id = self.request_action_id(id).await?;
+        let wallet_address = self
+            .keystore
+            .info(&wallet)
+            .map_err(|e| HandlerError::backend(format!("wallet address unavailable: {e}")))?
+            .address;
+        let policy_snapshot_digest = Some(sealed_inputs.policy_snapshot_digest);
+        let host_signer = self.paid_http_host_signer(&wallet, &action_id);
+        let facts = paid_http_x402_facts(
+            id,
+            &request,
+            &host,
+            &challenge,
+            &requirement,
+            policy_snapshot_digest,
+        );
         let credential = self
             .x402_signer
             .sign_x402_payment(&X402SignContext {
@@ -735,12 +859,12 @@ impl RequestsHandler {
                 challenge: &challenge,
                 requirement: &requirement,
                 rpc_resolver: self.paid_http_rpc_resolver.as_ref(),
+                wallet_address,
+                host_signer: &host_signer,
+                facts: &facts,
             })
             .await
             .map_err(HandlerError::backend)?;
-        let _grant = self
-            .consume_paid_http_grant(id, &wallet, PAID_HTTP_X402_SIGN_INTENT)
-            .await?;
 
         let credential_metadata = json!({
             "redacted": true,
@@ -784,6 +908,195 @@ impl RequestsHandler {
         };
         self.write_latest(final_state, id)?;
         Ok(())
+    }
+}
+
+/// Concrete paid-HTTP host signer: wraps the daemon [`PetalHost`] and turns a
+/// protocol adapter's signing request into a grant-gated, attestation-recorded
+/// [`PetalHost::sign_hash`] call. Key custody and grant enforcement stay in the
+/// runtime; the adapters only ever see the returned signature bytes.
+struct PaidHttpPetalHostSigner {
+    petal_host: Arc<dyn PetalHost>,
+    wallet: String,
+    action_id: String,
+}
+
+#[async_trait]
+impl PaidHttpHostSigner for PaidHttpPetalHostSigner {
+    async fn sign_paid_http_hash(
+        &self,
+        intent: &str,
+        signing_hash: [u8; 32],
+        facts: &PaidHttpSigningFacts,
+    ) -> Result<[u8; 65], String> {
+        let hash_hex = format!("0x{}", hex_lower(&signing_hash));
+        let attestation =
+            paid_http_signing_attestation(intent, &hash_hex, &self.wallet, &self.action_id, facts);
+        let sealed = self
+            .petal_host
+            .sign_hash(
+                SignHashRequest {
+                    wallet: self.wallet.clone(),
+                    action_id: self.action_id.clone(),
+                    intent: intent.to_string(),
+                    hash_hex,
+                },
+                &attestation,
+                now_ms(),
+            )
+            .await
+            .map_err(|e| format!("paid-http host signing denied: {e}"))?;
+        let bytes = B64_STD
+            .decode(&sealed.signature_b64)
+            .map_err(|e| format!("decode host signature: {e}"))?;
+        <[u8; 65]>::try_from(bytes.as_slice())
+            .map_err(|_| format!("host signature is {} bytes, expected 65", bytes.len()))
+    }
+}
+
+/// Stub used when no [`PetalHost`] is wired. It never signs; it fails loudly so
+/// a missing host wiring cannot degrade into an unauthorized signing path.
+struct UnwiredPaidHttpHostSigner;
+
+#[async_trait]
+impl PaidHttpHostSigner for UnwiredPaidHttpHostSigner {
+    async fn sign_paid_http_hash(
+        &self,
+        _intent: &str,
+        _signing_hash: [u8; 32],
+        _facts: &PaidHttpSigningFacts,
+    ) -> Result<[u8; 65], String> {
+        Err(
+            "paid-http host signing requires a wired PetalHost under a live Sealed Approval grant"
+                .to_string(),
+        )
+    }
+}
+
+/// Lowercase hex for a 32-byte hash without pulling an extra dep.
+fn hex_lower(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push_str(&format!("{b:02x}"));
+    }
+    out
+}
+
+/// Build the structured [`SigningAttestation`] recorded for every paid-HTTP
+/// host signature. Carries only public request/payment facts and digests — no
+/// credential material, PRF output, or raw signatures.
+fn paid_http_signing_attestation(
+    intent: &str,
+    signing_hash_hex: &str,
+    wallet: &str,
+    action_id: &str,
+    facts: &PaidHttpSigningFacts,
+) -> SigningAttestation {
+    let mut map = std::collections::BTreeMap::new();
+    let mut put = |k: &str, v: serde_json::Value| {
+        map.insert(k.to_string(), v);
+    };
+    put("facts_schema", json!("bloom.paid_http.signing_facts.v1"));
+    put("action_id", json!(action_id));
+    put("wallet", json!(wallet));
+    put("request_id", json!(facts.request_id));
+    put("method", json!(facts.method));
+    put("url", json!(facts.url));
+    put("host", json!(facts.host));
+    put("protocol", json!(facts.protocol));
+    put("network", json!(facts.network));
+    put("chain_id", json!(facts.chain_id));
+    put("asset", json!(facts.asset));
+    put("amount", json!(facts.amount));
+    put("pay_to", json!(facts.pay_to));
+    put("resource", json!(facts.resource));
+    put("scheme", json!(facts.scheme));
+    put("charge_id", json!(facts.charge_id));
+    put("session_id", json!(facts.session_id));
+    put("channel_id", json!(facts.channel_id));
+    put("signing_hash", json!(signing_hash_hex));
+    put(
+        "policy_snapshot_digest",
+        json!(facts.policy_snapshot_digest),
+    );
+    put(
+        "selected_requirement",
+        facts
+            .selected_requirement
+            .clone()
+            .unwrap_or(serde_json::Value::Null),
+    );
+    SigningAttestation {
+        schema: SIGNING_ATTESTATION_SCHEMA_V1.to_string(),
+        petal_id: petal_identity::PETAL_ID_PAID_HTTP.to_string(),
+        petal_digest: petal_identity::PLACEHOLDER_DIGEST_PAID_HTTP.to_string(),
+        intent: intent.to_string(),
+        facts: map,
+    }
+}
+
+/// Assemble the secret-free x402 signing facts from the staged request and the
+/// selected payment requirement.
+fn paid_http_x402_facts(
+    request_id: &str,
+    request: &ParsedRequest,
+    host: &str,
+    challenge: &NormalizedChallenge,
+    requirement: &PaymentRequirement,
+    policy_snapshot_digest: Option<String>,
+) -> PaidHttpSigningFacts {
+    PaidHttpSigningFacts {
+        request_id: request_id.to_string(),
+        method: request.method.clone(),
+        url: request.url.to_string(),
+        host: host.to_string(),
+        protocol: "x402".to_string(),
+        network: requirement.network.clone(),
+        chain_id: challenge.chain_id,
+        asset: requirement.asset.clone(),
+        amount: requirement.amount.clone(),
+        pay_to: requirement.pay_to.clone(),
+        resource: requirement
+            .resource
+            .clone()
+            .or_else(|| Some(request.url.to_string())),
+        scheme: requirement.scheme.clone(),
+        charge_id: challenge.charge_id.clone(),
+        session_id: challenge.session_id.clone(),
+        channel_id: challenge.channel_id.clone(),
+        policy_snapshot_digest,
+        selected_requirement: Some(requirement.raw.clone()),
+    }
+}
+
+/// Assemble the secret-free Tempo MPP signing facts from the staged request
+/// and normalized challenge.
+fn paid_http_mpp_facts(
+    request_id: &str,
+    request: &ParsedRequest,
+    host: &str,
+    challenge: &NormalizedChallenge,
+    requirement: &PaymentRequirement,
+    policy_snapshot_digest: Option<String>,
+) -> PaidHttpSigningFacts {
+    PaidHttpSigningFacts {
+        request_id: request_id.to_string(),
+        method: request.method.clone(),
+        url: request.url.to_string(),
+        host: host.to_string(),
+        protocol: "mpp".to_string(),
+        network: challenge.network.clone(),
+        chain_id: challenge.chain_id,
+        asset: challenge.asset.clone(),
+        amount: challenge.amount.clone(),
+        pay_to: requirement.pay_to.clone(),
+        resource: Some(request.url.to_string()),
+        scheme: requirement.scheme.clone(),
+        charge_id: challenge.charge_id.clone(),
+        session_id: challenge.session_id.clone(),
+        channel_id: challenge.channel_id.clone(),
+        policy_snapshot_digest,
+        selected_requirement: Some(requirement.raw.clone()),
     }
 }
 
@@ -1140,6 +1453,96 @@ fn parsed_request_from_artifact(v: &serde_json::Value) -> Result<ParsedRequest, 
         headers,
         body: v.get("body").and_then(|v| v.as_str()).map(str::to_string),
     })
+}
+
+fn validate_pending_projection_matches_subject(
+    pending: &Path,
+    subject: &PaidHttpSealedSubject,
+) -> Result<(), HandlerError> {
+    let request_value: serde_json::Value = read_json(pending.join("request.toml"))?;
+    let artifact = parsed_request_from_artifact(&request_value)?;
+    if artifact.method != subject.method
+        || artifact.url.as_str() != subject.url
+        || artifact.max_amount_usd != subject.max_amount_usd
+    {
+        return Err(HandlerError::invalid(
+            "request.toml projection differs from the sealed request subject",
+        ));
+    }
+    let artifact_headers = request_value
+        .get("headers")
+        .and_then(|v| serde_json::from_value::<BTreeMap<String, String>>(v.clone()).ok())
+        .unwrap_or_default();
+    if serde_json::to_value(&artifact_headers).map_err(|e| HandlerError::backend(e.to_string()))?
+        != redacted_headers(&subject.headers)
+    {
+        return Err(HandlerError::invalid(
+            "request.toml header projection differs from the sealed request subject",
+        ));
+    }
+    let artifact_body_hash = request_value
+        .get("body_sha256")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    if artifact_body_hash != subject.body_sha256 {
+        return Err(HandlerError::invalid(
+            "request.toml body hash differs from the sealed request subject",
+        ));
+    }
+    let private_body = pending.join("private/request_body");
+    match subject.body_sha256.as_deref() {
+        Some(expected) => {
+            let body = fs::read_to_string(&private_body)?;
+            let actual = bloom_tools::sha256_hex(body.as_bytes());
+            if actual != expected {
+                return Err(HandlerError::invalid(
+                    "private/request_body does not match the sealed request body hash",
+                ));
+            }
+        }
+        None if private_body.exists() => {
+            return Err(HandlerError::invalid(
+                "private/request_body exists but the sealed request subject has no body hash",
+            ));
+        }
+        None => {}
+    }
+    let challenge: NormalizedChallenge = read_json(pending.join("challenge.json"))?;
+    if serde_json::to_value(&challenge).map_err(|e| HandlerError::backend(e.to_string()))?
+        != serde_json::to_value(&subject.challenge)
+            .map_err(|e| HandlerError::backend(e.to_string()))?
+    {
+        return Err(HandlerError::invalid(
+            "challenge.json projection differs from the sealed request subject",
+        ));
+    }
+    Ok(())
+}
+
+fn policy_from_paid_http_snapshot(snapshot: &bloom_auth_api::PetalPolicySnapshot) -> Policy {
+    let mut policy = Policy::default();
+    policy.payments.enabled = true;
+    policy.payments.require_plan = true;
+    policy.caps.per_tx_usd = snapshot_f64(snapshot, "caps.per_tx_usd");
+    policy.caps.per_day_usd = snapshot_f64(snapshot, "caps.per_day_usd");
+    policy.caps.require_confirm_above_usd =
+        snapshot_f64(snapshot, "caps.require_confirm_above_usd");
+    policy.payments.http.per_request_usd = snapshot_f64(snapshot, "payments.http.per_request_usd");
+    policy.payments.http.per_day_usd = snapshot_f64(snapshot, "payments.http.per_day_usd");
+    policy.payments.sessions.enabled = snapshot
+        .caps
+        .get("payments.sessions.enabled")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    policy.payments.sessions.max_deposit_usd =
+        snapshot_f64(snapshot, "payments.sessions.max_deposit_usd");
+    policy.payments.sessions.max_session_spend_usd =
+        snapshot_f64(snapshot, "payments.sessions.max_session_spend_usd");
+    policy
+}
+
+fn snapshot_f64(snapshot: &bloom_auth_api::PetalPolicySnapshot, key: &str) -> Option<f64> {
+    snapshot.caps.get(key).and_then(json_number)
 }
 
 fn backend_policy_for_wallet(root: &Path, wallet: &str) -> Result<Policy, HandlerError> {
@@ -1640,6 +2043,73 @@ fn now_ms() -> u64 {
         .min(u128::from(u64::MAX)) as u64
 }
 
+#[derive(Debug)]
+struct PaidHttpExecutionInputs {
+    request: ParsedRequest,
+    host: String,
+    challenge: NormalizedChallenge,
+    requirement: PaymentRequirement,
+    checks: Vec<PolicyCheck>,
+    dry_run: bool,
+    policy: Policy,
+    policy_snapshot_digest: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PaidHttpSealedSubject {
+    schema: String,
+    request_id: String,
+    method: String,
+    url: String,
+    host: String,
+    #[serde(default)]
+    max_amount_usd: Option<f64>,
+    #[serde(default)]
+    headers: BTreeMap<String, String>,
+    #[serde(default)]
+    body_sha256: Option<String>,
+    challenge: NormalizedChallenge,
+    selected_requirement: PaymentRequirement,
+    #[serde(default)]
+    policy_checks: Vec<PolicyCheck>,
+    #[serde(default)]
+    dry_run: bool,
+}
+
+impl PaidHttpSealedSubject {
+    fn validate_basic(&self, request_id: &str, wallet: &str) -> Result<(), HandlerError> {
+        if self.schema != "bloom.paid_http_subject.v1" {
+            return Err(HandlerError::invalid(
+                "unsupported paid-http subject schema",
+            ));
+        }
+        if self.request_id != request_id {
+            return Err(HandlerError::invalid(
+                "sealed subject request_id does not match pending request",
+            ));
+        }
+        if wallet.trim().is_empty() {
+            return Err(HandlerError::invalid("sealed subject wallet is empty"));
+        }
+        Url::parse(&self.url)
+            .map_err(|e| HandlerError::invalid(format!("sealed subject URL is invalid: {e}")))?;
+        Ok(())
+    }
+
+    fn to_request(&self, wallet: &str) -> Result<ParsedRequest, HandlerError> {
+        Ok(ParsedRequest {
+            method: self.method.clone(),
+            url: Url::parse(&self.url).map_err(|e| {
+                HandlerError::invalid(format!("sealed subject URL is invalid: {e}"))
+            })?,
+            wallet: Some(wallet.to_string()),
+            max_amount_usd: self.max_amount_usd,
+            headers: self.headers.clone(),
+            body: None,
+        })
+    }
+}
+
 #[derive(Clone, Copy)]
 struct PaidHttpAuthSubject<'a> {
     id: &'a str,
@@ -1649,6 +2119,7 @@ struct PaidHttpAuthSubject<'a> {
     challenge: &'a NormalizedChallenge,
     requirement: &'a PaymentRequirement,
     checks: &'a [PolicyCheck],
+    policy: &'a Policy,
     dry_run: bool,
 }
 
@@ -1663,19 +2134,24 @@ fn paid_http_canonical_envelope(
         .or(input.challenge.network.as_deref())
         .unwrap_or("unknown")
         .to_string();
-    let subject = serde_json::to_vec(&json!({
-        "schema": "bloom.paid_http_subject.v1",
-        "request_id": input.id,
-        "method": input.request.method,
-        "url": input.request.url.as_str(),
-        "host": input.host,
-        "headers": input.request.headers,
-        "body_sha256": input.request.body.as_ref().map(|body| bloom_tools::sha256_hex(body.as_bytes())),
-        "challenge": input.challenge,
-        "selected_requirement": input.requirement,
-        "policy_checks": input.checks,
-        "dry_run": input.dry_run,
-    }))
+    let subject = serde_json::to_vec(&PaidHttpSealedSubject {
+        schema: "bloom.paid_http_subject.v1".into(),
+        request_id: input.id.to_string(),
+        method: input.request.method.clone(),
+        url: input.request.url.as_str().to_string(),
+        host: input.host.to_string(),
+        max_amount_usd: input.request.max_amount_usd,
+        headers: input.request.headers.clone(),
+        body_sha256: input
+            .request
+            .body
+            .as_ref()
+            .map(|body| bloom_tools::sha256_hex(body.as_bytes())),
+        challenge: input.challenge.clone(),
+        selected_requirement: input.requirement.clone(),
+        policy_checks: input.checks.to_vec(),
+        dry_run: input.dry_run,
+    })
     .map_err(|e| HandlerError::backend(e.to_string()))?;
     Ok(CanonicalEnvelope::new(
         CanonicalIntentHeader {
@@ -1731,6 +2207,77 @@ fn paid_http_sealed_action(
         input
             .request
             .max_amount_usd
+            .map(serde_json::Value::from)
+            .unwrap_or(serde_json::Value::Null),
+    );
+    snapshot.caps.insert(
+        "caps.per_tx_usd".to_string(),
+        input
+            .policy
+            .caps
+            .per_tx_usd
+            .map(serde_json::Value::from)
+            .unwrap_or(serde_json::Value::Null),
+    );
+    snapshot.caps.insert(
+        "caps.per_day_usd".to_string(),
+        input
+            .policy
+            .caps
+            .per_day_usd
+            .map(serde_json::Value::from)
+            .unwrap_or(serde_json::Value::Null),
+    );
+    snapshot.caps.insert(
+        "caps.require_confirm_above_usd".to_string(),
+        input
+            .policy
+            .caps
+            .require_confirm_above_usd
+            .map(serde_json::Value::from)
+            .unwrap_or(serde_json::Value::Null),
+    );
+    snapshot.caps.insert(
+        "payments.http.per_request_usd".to_string(),
+        input
+            .policy
+            .payments
+            .http
+            .per_request_usd
+            .map(serde_json::Value::from)
+            .unwrap_or(serde_json::Value::Null),
+    );
+    snapshot.caps.insert(
+        "payments.http.per_day_usd".to_string(),
+        input
+            .policy
+            .payments
+            .http
+            .per_day_usd
+            .map(serde_json::Value::from)
+            .unwrap_or(serde_json::Value::Null),
+    );
+    snapshot.caps.insert(
+        "payments.sessions.enabled".to_string(),
+        serde_json::Value::Bool(input.policy.payments.sessions.enabled),
+    );
+    snapshot.caps.insert(
+        "payments.sessions.max_deposit_usd".to_string(),
+        input
+            .policy
+            .payments
+            .sessions
+            .max_deposit_usd
+            .map(serde_json::Value::from)
+            .unwrap_or(serde_json::Value::Null),
+    );
+    snapshot.caps.insert(
+        "payments.sessions.max_session_spend_usd".to_string(),
+        input
+            .policy
+            .payments
+            .sessions
+            .max_session_spend_usd
             .map(serde_json::Value::from)
             .unwrap_or(serde_json::Value::Null),
     );
@@ -1790,13 +2337,14 @@ mod tests {
     use crate::path::VfsPath;
     use bloom_auth_api::{
         APPROVAL_CHALLENGE_SCHEMA_V1, APPROVAL_SCHEMA_V1, ApprovalVerifier, AuthApiError,
-        AuthEntryRecord, AuthEntryState, AuthStoreWriter, GrantStore, NonceState, SignerTransport,
-        WebAuthnAssertionRecord,
+        AuthEntryRecord, AuthEntryState, AuthStoreView, AuthStoreWriter, GrantStore, NonceState,
+        SealedIntentRecord, SignerTransport, WebAuthnAssertionRecord,
     };
     use bloom_paid_mpp::PaymentExecution;
     use bloom_paid_x402::X402PaymentCredential;
     use mpp::client::{PaymentProvider, TempoProvider};
     use std::collections::BTreeMap;
+    use std::sync::Mutex;
     use std::sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
@@ -1818,6 +2366,35 @@ mod tests {
     }
 
     struct ChallengeOnlyWriter;
+
+    struct StaticSealedStore {
+        records: Mutex<BTreeMap<String, SealedIntentRecord>>,
+    }
+
+    impl StaticSealedStore {
+        fn new(record: SealedIntentRecord) -> Self {
+            let mut records = BTreeMap::new();
+            records.insert(record.intent_hash.clone(), record);
+            Self {
+                records: Mutex::new(records),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl AuthStoreView for StaticSealedStore {
+        async fn sealed_intent(
+            &self,
+            intent_hash: &str,
+        ) -> Result<SealedIntentRecord, AuthApiError> {
+            self.records
+                .lock()
+                .map_err(|_| AuthApiError::Store("test sealed store mutex poisoned".into()))?
+                .get(intent_hash)
+                .cloned()
+                .ok_or_else(|| AuthApiError::NotFound(format!("sealed intent {intent_hash}")))
+        }
+    }
 
     struct AcceptingVerifier {
         calls: Arc<AtomicUsize>,
@@ -1974,10 +2551,15 @@ mod tests {
             &self,
             surface: &str,
             action_id: &str,
-            server_nonce: &str,
-            expiry_ms: u64,
+            _server_nonce: &str,
+            _expiry_ms: u64,
             _now_ms: u64,
         ) -> Result<ApprovalChallenge, AuthApiError> {
+            // Model the real `AuthStore`, which reuses an existing unexpired
+            // challenge's `server_nonce` and `expiry_ms` rather than the freshly
+            // generated values the handler passes on each confirm. Stable nonce
+            // + expiry are what make the challenge hash and the derived
+            // `ceremony_url` identical across repeated confirm writes.
             Ok(ApprovalChallenge {
                 schema: APPROVAL_CHALLENGE_SCHEMA_V1.to_string(),
                 action_id: action_id.to_string(),
@@ -1986,12 +2568,12 @@ mod tests {
                 petal_id: petal_identity::PETAL_ID_PAID_HTTP.to_string(),
                 petal_digest: petal_identity::PLACEHOLDER_DIGEST_PAID_HTTP.to_string(),
                 intent_hash: "abc123".to_string(),
-                server_nonce: server_nonce.to_string(),
+                server_nonce: "reused-server-nonce".to_string(),
                 assurance: AssuranceLevel::Standard,
                 daemon_terms_digest: "1".repeat(64),
                 petal_policy_digest: "2".repeat(64),
                 policy_version: 0,
-                expiry_ms,
+                expiry_ms: 9_999_999_999_999,
                 ceremony_url: None,
             })
         }
@@ -2067,6 +2649,7 @@ mod tests {
         );
         let requirement = challenge.accepts[0].clone();
         let checks: Vec<PolicyCheck> = vec![];
+        let policy = Policy::default();
         let env = paid_http_canonical_envelope(
             PaidHttpAuthSubject {
                 id: "req_1",
@@ -2076,6 +2659,7 @@ mod tests {
                 challenge: &challenge,
                 requirement: &requirement,
                 checks: &checks,
+                policy: &policy,
                 dry_run: false,
             },
             "requests-0001",
@@ -2103,12 +2687,234 @@ mod tests {
                 challenge: &challenge,
                 requirement: &other_req,
                 checks: &checks,
+                policy: &policy,
                 dry_run: false,
             },
             "requests-0001",
         )
         .unwrap();
         assert_ne!(hash1, other.intent_hash().unwrap());
+    }
+
+    fn sealed_request_fixture(
+        handler: &RequestsHandler,
+        id: &str,
+        body: Option<&str>,
+        sealed_policy: &Policy,
+        dry_run: bool,
+    ) -> (PathBuf, SealedAction, NormalizedChallenge) {
+        let mut request = parse_request("POST https://merchant.test/pay wallet=alice").unwrap();
+        request.max_amount_usd = Some(1.0);
+        request.body = body.map(str::to_string);
+        let challenge = normalize_challenge(
+            &HeaderMap::new(),
+            br#"{"x402Version":1,"accepts":[{"network":"base","asset":"USDC","maxAmountRequired":"1","payTo":"0x1234"}]}"#,
+            &request.url,
+        );
+        let requirement = challenge.accepts[0].clone();
+        let checks = evaluate_payment_policy(
+            sealed_policy,
+            PolicyEvalInput {
+                host: "merchant.test",
+                asset: requirement.asset.as_deref(),
+                network: requirement.network.as_deref(),
+                intent: &challenge.intent,
+                amount_usd: selected_requirement_amount_usd(&challenge, &requirement),
+                request_max_amount_usd: request.max_amount_usd,
+                spent_24h_usd: 0.0,
+            },
+        );
+        let pending = handler.requests_root().join("pending").join(id);
+        fs::create_dir_all(&pending).unwrap();
+        write_request_artifacts(&pending, &request, "alice", "pending", dry_run).unwrap();
+        write_json(pending.join("challenge.json"), &challenge).unwrap();
+        write_json(pending.join("policy_check.json"), &checks).unwrap();
+        fs::write(pending.join("status"), "pending\n").unwrap();
+        let subject = PaidHttpAuthSubject {
+            id,
+            request: &request,
+            wallet: "alice",
+            host: "merchant.test",
+            challenge: &challenge,
+            requirement: &requirement,
+            checks: &checks,
+            policy: sealed_policy,
+            dry_run,
+        };
+        let envelope = paid_http_canonical_envelope(subject, id).unwrap();
+        let action = paid_http_sealed_action(envelope, subject, now_ms()).unwrap();
+        fs::write(
+            pending.join("intent_hash"),
+            format!("{}\n", action.intent_hash().unwrap()),
+        )
+        .unwrap();
+        (pending, action, challenge)
+    }
+
+    fn seal_existing_pending_request(
+        pending: &Path,
+        id: &str,
+        policy: &Policy,
+    ) -> SealedIntentRecord {
+        let request = parsed_request_from_dir(pending).unwrap();
+        let wallet = request.wallet.as_deref().unwrap();
+        let host = request.url.host_str().unwrap_or("unknown").to_string();
+        let challenge: NormalizedChallenge = read_json(pending.join("challenge.json")).unwrap();
+        let checks: Vec<PolicyCheck> = read_json(pending.join("policy_check.json")).unwrap();
+        let requirement = select_payment_requirement(&challenge, policy, &host)
+            .or_else(|| challenge.accepts.first().cloned())
+            .unwrap_or_else(|| PaymentRequirement {
+                scheme: None,
+                network: challenge.network.clone(),
+                asset: challenge.asset.clone(),
+                amount: challenge.amount.clone(),
+                pay_to: None,
+                resource: None,
+                raw: json!({}),
+            });
+        let request_value: serde_json::Value = read_json(pending.join("request.toml")).unwrap();
+        let dry_run = request_value
+            .get("dry_run")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let subject = PaidHttpAuthSubject {
+            id,
+            request: &request,
+            wallet,
+            host: &host,
+            challenge: &challenge,
+            requirement: &requirement,
+            checks: &checks,
+            policy,
+            dry_run,
+        };
+        let envelope = paid_http_canonical_envelope(subject, id).unwrap();
+        let action = paid_http_sealed_action(envelope, subject, now_ms()).unwrap();
+        let intent_hash = action.intent_hash().unwrap();
+        fs::write(pending.join("intent_hash"), format!("{intent_hash}\n")).unwrap();
+        SealedIntentRecord {
+            intent_hash,
+            envelope: action.envelope.clone(),
+            sealed_at_ms: action.created_ms,
+            action: Some(action),
+        }
+    }
+
+    #[tokio::test]
+    async fn sealed_request_execution_rejects_projection_drift_and_body_tamper() {
+        let f = fixture(Some("alice"));
+        let mut sealed_policy = Policy::default();
+        sealed_policy.payments.enabled = true;
+        sealed_policy.payments.require_plan = true;
+        sealed_policy.payments.http.per_request_usd = Some(1.0);
+        let (pending, action, challenge) = sealed_request_fixture(
+            &f.handler,
+            "req_sealed_projection",
+            Some("original body"),
+            &sealed_policy,
+            false,
+        );
+        let record = SealedIntentRecord {
+            intent_hash: action.intent_hash().unwrap(),
+            envelope: action.envelope.clone(),
+            sealed_at_ms: action.created_ms,
+            action: Some(action),
+        };
+        let handler = f.handler.with_auth_services(
+            AuthServices::default().with_store(Arc::new(StaticSealedStore::new(record))),
+        );
+
+        let inputs = handler
+            .sealed_execution_inputs(&pending, "req_sealed_projection")
+            .await
+            .unwrap();
+        assert_eq!(inputs.request.body.as_deref(), Some("original body"));
+
+        let mut projected_challenge = challenge.clone();
+        projected_challenge.amount = Some("1000".into());
+        write_json(pending.join("challenge.json"), &projected_challenge).unwrap();
+        let err = handler
+            .sealed_execution_inputs(&pending, "req_sealed_projection")
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("challenge.json projection differs"),
+            "{err}"
+        );
+
+        write_json(pending.join("challenge.json"), &challenge).unwrap();
+        fs::write(pending.join("private/request_body"), "tampered body").unwrap();
+        let err = handler
+            .sealed_execution_inputs(&pending, "req_sealed_projection")
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("private/request_body"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn sealed_request_execution_requires_sealed_intent_hash() {
+        let f = fixture(Some("alice"));
+        let mut policy = Policy::default();
+        policy.payments.enabled = true;
+        policy.payments.require_plan = true;
+        let (pending, _action, _challenge) =
+            sealed_request_fixture(&f.handler, "req_missing_seal", None, &policy, false);
+        fs::remove_file(pending.join("intent_hash")).unwrap();
+
+        let err = f
+            .handler
+            .sealed_execution_inputs(&pending, "req_missing_seal")
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("missing sealed intent_hash"),
+            "{err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn sealed_request_execution_uses_sealed_policy_snapshot_when_live_policy_widens() {
+        let f = fixture(Some("alice"));
+        let mut sealed_policy = Policy::default();
+        sealed_policy.payments.enabled = true;
+        sealed_policy.payments.require_plan = true;
+        sealed_policy.payments.http.per_request_usd = Some(1.0);
+        let (pending, action, _challenge) =
+            sealed_request_fixture(&f.handler, "req_sealed_policy", None, &sealed_policy, false);
+        let mut live_policy = sealed_policy.clone();
+        live_policy.payments.http.per_request_usd = Some(1_000.0);
+        f.handler
+            .keystore
+            .write_policy(
+                "alice",
+                toml::to_string_pretty(&live_policy).unwrap().as_bytes(),
+            )
+            .unwrap();
+        let record = SealedIntentRecord {
+            intent_hash: action.intent_hash().unwrap(),
+            envelope: action.envelope.clone(),
+            sealed_at_ms: action.created_ms,
+            action: Some(action),
+        };
+        let handler = f.handler.with_auth_services(
+            AuthServices::default().with_store(Arc::new(StaticSealedStore::new(record))),
+        );
+
+        let inputs = handler
+            .sealed_execution_inputs(&pending, "req_sealed_policy")
+            .await
+            .unwrap();
+        assert_eq!(inputs.policy.payments.http.per_request_usd, Some(1.0));
+        assert_eq!(
+            handler
+                .wallet_policy("alice")
+                .unwrap()
+                .payments
+                .http
+                .per_request_usd,
+            Some(1_000.0)
+        );
     }
 
     #[test]
@@ -2234,22 +3040,29 @@ mod tests {
     #[tokio::test]
     async fn dry_run_paid_request_cannot_be_confirmed() {
         let f = fixture(Some("alice"));
-        let body = br#"{"accepts":[{"network":"base","asset":"USDC","maxAmountRequired":"1000"}]}"#;
-        let (url, _hits) = mock_server(402, &[("x-payment-required", "1")], body).await;
-        let id = f
-            .handler
-            .create_request(format!("GET {url}").as_bytes(), true)
-            .await
-            .unwrap();
+        let mut policy = Policy::default();
+        policy.payments.enabled = true;
+        policy.payments.require_plan = true;
+        let (pending, action, _challenge) =
+            sealed_request_fixture(&f.handler, "req_dry_run", None, &policy, true);
+        let record = SealedIntentRecord {
+            intent_hash: action.intent_hash().unwrap(),
+            envelope: action.envelope.clone(),
+            sealed_at_ms: action.created_ms,
+            action: Some(action),
+        };
+        let handler = f.handler.with_auth_services(
+            AuthServices::default().with_store(Arc::new(StaticSealedStore::new(record))),
+        );
 
-        let err = f
-            .handler
+        let err = handler
             .write(
-                &VfsPath::parse(&format!("/pending/{id}/confirm")).unwrap(),
+                &VfsPath::parse("/pending/req_dry_run/confirm").unwrap(),
                 b"confirm",
             )
             .await
             .unwrap_err();
+        assert!(pending.exists());
         assert!(err.to_string().contains("dry-run"), "{err}");
     }
 
@@ -2355,6 +3168,12 @@ mod tests {
         )
         .unwrap();
         fs::write(pending.join("status"), "pending\n").unwrap();
+        let record = seal_existing_pending_request(&pending, "req_retry_fail", &policy);
+        let auth_services = handler
+            .auth_services
+            .clone()
+            .with_store(Arc::new(StaticSealedStore::new(record)));
+        let handler = handler.with_auth_services(auth_services);
 
         write_json(
             pending.join(APPROVAL_FILE),
@@ -2440,6 +3259,12 @@ mod tests {
         )
         .unwrap();
         fs::write(pending.join("status"), "pending\n").unwrap();
+        let record = seal_existing_pending_request(&pending, "req_sealed", &policy);
+        let auth_services = handler
+            .auth_services
+            .clone()
+            .with_store(Arc::new(StaticSealedStore::new(record)));
+        let handler = handler.with_auth_services(auth_services);
 
         persist_request_confirm_approved(handler.root.as_path(), "req_sealed", "alice", "confirm")
             .unwrap();
@@ -2451,6 +3276,82 @@ mod tests {
         assert_eq!(challenge.surface, "requests");
         assert_eq!(challenge.action_id, "req_sealed");
         assert_eq!(challenge.intent_hash, "abc123");
+        // The mounted/Bloom-Machine projection must carry the stable local
+        // ceremony URL derived from the challenge `server_nonce`.
+        let url = challenge
+            .ceremony_url
+            .as_deref()
+            .expect("approval_challenge.json must include ceremony_url");
+        assert_eq!(url, challenge.local_ceremony_url());
+        assert!(url.contains(&challenge.ceremony_token()));
+        assert!(!url.is_empty());
+    }
+
+    #[tokio::test]
+    async fn wired_auth_confirm_reuses_ceremony_url_across_retries() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let f = fixture(Some("alice"));
+        let mut policy = Policy::default();
+        policy.payments.enabled = true;
+        policy.payments.require_plan = true;
+        f.handler
+            .keystore
+            .write_policy("alice", toml::to_string_pretty(&policy).unwrap().as_bytes())
+            .unwrap();
+        let auth_services = AuthServices::new(None, None, Some(Arc::new(ChallengeOnlyWriter)));
+        let handler = f
+            .handler
+            .with_auth_services(auth_services)
+            .with_x402_signer(Arc::new(StaticX402Signer {
+                calls: calls.clone(),
+            }));
+        let pending = handler.requests_root().join("pending/req_reuse");
+        fs::create_dir_all(&pending).unwrap();
+        let challenge = normalize_challenge(
+            &HeaderMap::new(),
+            br#"{"x402Version":1,"accepts":[{"network":"base","asset":"USDC","maxAmountRequired":"1000"}]}"#,
+            &Url::parse("http://127.0.0.1:9/pay").unwrap(),
+        );
+        write_json(pending.join("challenge.json"), &challenge).unwrap();
+        write_json(
+            pending.join("payment_method.json"),
+            &challenge.payment_method(),
+        )
+        .unwrap();
+        let empty_checks: Vec<PolicyCheck> = vec![];
+        write_json(pending.join("policy_check.json"), &empty_checks).unwrap();
+        write_json(
+            pending.join("request.toml"),
+            &json!({"method":"GET","url":"http://127.0.0.1:9/pay","wallet":"alice","headers":{},"dry_run":false}),
+        )
+        .unwrap();
+        fs::write(pending.join("status"), "pending\n").unwrap();
+        let record = seal_existing_pending_request(&pending, "req_reuse", &policy);
+        let auth_services = handler
+            .auth_services
+            .clone()
+            .with_store(Arc::new(StaticSealedStore::new(record)));
+        let handler = handler.with_auth_services(auth_services);
+
+        // First confirm stages the challenge and denies.
+        let err = handler.confirm("req_reuse", b"confirm").await.unwrap_err();
+        assert!(matches!(err, HandlerError::PermissionDenied), "{err}");
+        let first: ApprovalChallenge = read_json(pending.join(APPROVAL_CHALLENGE_FILE)).unwrap();
+
+        // Second confirm before expiry must reuse the same nonce and URL.
+        let err = handler.confirm("req_reuse", b"confirm").await.unwrap_err();
+        assert!(matches!(err, HandlerError::PermissionDenied), "{err}");
+        let second: ApprovalChallenge = read_json(pending.join(APPROVAL_CHALLENGE_FILE)).unwrap();
+
+        assert_eq!(first.server_nonce, second.server_nonce);
+        assert_eq!(
+            first.challenge_hash_hex().unwrap(),
+            second.challenge_hash_hex().unwrap()
+        );
+        assert_eq!(first.ceremony_url, second.ceremony_url);
+        assert!(first.ceremony_url.is_some());
+        // No signature was produced across the denied retries.
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]
@@ -2493,6 +3394,12 @@ mod tests {
         )
         .unwrap();
         fs::write(pending.join("status"), "pending\n").unwrap();
+        let record = seal_existing_pending_request(&pending, "req_sealed_ok", &policy);
+        let auth_services = handler
+            .auth_services
+            .clone()
+            .with_store(Arc::new(StaticSealedStore::new(record)));
+        let handler = handler.with_auth_services(auth_services);
         write_json(
             pending.join(APPROVAL_FILE),
             &SignedApproval {
@@ -2574,6 +3481,12 @@ mod tests {
         )
         .unwrap();
         fs::write(pending.join("status"), "pending\n").unwrap();
+        let record = seal_existing_pending_request(&pending, "req_signer_fail", &policy);
+        let auth_services = handler
+            .auth_services
+            .clone()
+            .with_store(Arc::new(StaticSealedStore::new(record)));
+        let handler = handler.with_auth_services(auth_services);
         write_json(
             pending.join(APPROVAL_FILE),
             &SignedApproval {
@@ -2621,6 +3534,324 @@ mod tests {
         );
     }
 
+    fn paid_http_test_sealed_action(
+        wallet: &str,
+        action_id: &str,
+        allowed_sign_intents: &[&str],
+        max_signatures: u32,
+        issued_ms: u64,
+    ) -> SealedAction {
+        let header = CanonicalIntentHeader {
+            schema: bloom_auth_api::CANONICAL_INTENT_HEADER_SCHEMA_V2.into(),
+            wallet: wallet.into(),
+            surface: "requests".into(),
+            action_id: action_id.into(),
+            petal_id: petal_identity::PETAL_ID_PAID_HTTP.into(),
+            petal_digest: petal_identity::PLACEHOLDER_DIGEST_PAID_HTTP.into(),
+            petal_version: petal_identity::FIRST_PARTY_PETAL_VERSION_V0.into(),
+            executor_kind: ExecutorKind::FirstParty,
+            network: "base".into(),
+            account: "default".into(),
+            action_kind: "paid_http_confirm".into(),
+            value_movement: true,
+            authority_change: false,
+            expires_ms: issued_ms.saturating_add(APPROVAL_TTL_MS),
+        };
+        let envelope = CanonicalEnvelope::new(
+            header,
+            "paid_http",
+            "bloom.paid_http_subject.v1",
+            serde_json::to_vec(&json!({"schema":"bloom.paid_http_subject.v1","test":true}))
+                .unwrap(),
+        );
+        let terms = DaemonGrantTerms {
+            max_ttl_secs: APPROVAL_TTL_MS / 1_000,
+            max_signatures,
+            allowed_sign_intents: allowed_sign_intents.iter().map(|s| s.to_string()).collect(),
+            assurance: AssuranceLevel::Standard,
+            extra: std::collections::BTreeMap::new(),
+        };
+        let mut snapshot = bloom_auth_api::PetalPolicySnapshot::minimal(&envelope.header);
+        snapshot.caps.clear();
+        snapshot.config.clear();
+        snapshot.budget_state.clear();
+        SealedAction::new(
+            envelope,
+            "plan".into(),
+            Vec::new(),
+            terms,
+            snapshot,
+            issued_ms,
+        )
+        .expect("sealed action")
+    }
+
+    /// Build a real `KeystorePetalHost` over a shared grant store so paid-HTTP
+    /// host signing exercises the same gate the daemon enforces.
+    fn wired_petal_host(
+        ks_dir: &Path,
+    ) -> (
+        Arc<dyn PetalHost>,
+        Arc<bloom_auth::grant_store::InMemoryGrantStore>,
+        alloy::primitives::Address,
+    ) {
+        use bloom_auth_api::{DefaultAttestationRegistry, SigningAttestationSchemaRegistry};
+        use bloom_keystore::petal_host::KeystorePetalHost;
+        use bloom_proto::AuditLog;
+
+        let keystore = Arc::new(Keystore::new(ks_dir.join("keystore")).unwrap());
+        keystore.create_local("alice", "pw").unwrap();
+        keystore.unlock("alice", "pw").unwrap();
+        let address = keystore.info("alice").unwrap().address;
+        let grant_store = Arc::new(bloom_auth::grant_store::InMemoryGrantStore::new());
+        let registry = Arc::new(DefaultAttestationRegistry::new());
+        let audit = Arc::new(AuditLog::open(ks_dir.join("audit.jsonl")).unwrap());
+        let grant_dyn: Arc<dyn GrantStore> = grant_store.clone();
+        let registry_dyn: Arc<dyn SigningAttestationSchemaRegistry> = registry.clone();
+        let host: Arc<dyn PetalHost> = Arc::new(KeystorePetalHost::new(
+            keystore,
+            grant_dyn,
+            registry_dyn,
+            audit,
+        ));
+        (host, grant_store, address)
+    }
+
+    #[tokio::test]
+    async fn x402_host_signing_is_grant_gated_and_consumes_one_allowance() {
+        use bloom_auth_api::GrantStore as _;
+        let dir = tempfile::tempdir().unwrap();
+        let (petal_host, grant_store, _address) = wired_petal_host(dir.path());
+        let signer = PaidHttpPetalHostSigner {
+            petal_host,
+            wallet: "alice".into(),
+            action_id: "act-x402".into(),
+        };
+        let now = now_ms();
+        let action = paid_http_test_sealed_action("alice", "act-x402", &["x402.sign"], 1, now);
+        let facts = PaidHttpSigningFacts {
+            protocol: "x402".into(),
+            request_id: "req-x402".into(),
+            policy_snapshot_digest: Some(action.petal_policy_digest.clone()),
+            ..Default::default()
+        };
+        let hash = [7u8; 32];
+
+        // (a) No live grant → host signing is denied.
+        let err = signer
+            .sign_paid_http_hash("x402.sign", hash, &facts)
+            .await
+            .unwrap_err();
+        assert!(err.contains("no live grant"), "unexpected: {err}");
+
+        // Mint a one-shot paid-http grant for this action allowing x402.sign.
+        grant_store
+            .mint(&action, now.saturating_add(120_000), now)
+            .await
+            .unwrap();
+
+        // (b) First signature succeeds and returns a 65-byte secp256k1 sig.
+        let sig = signer
+            .sign_paid_http_hash("x402.sign", hash, &facts)
+            .await
+            .expect("host signs under a live grant");
+        assert_eq!(sig.len(), 65);
+
+        // (c) The one-shot allowance is consumed; replay denies.
+        let err = signer
+            .sign_paid_http_hash("x402.sign", hash, &facts)
+            .await
+            .unwrap_err();
+        assert!(err.contains("no live grant"), "replay: {err}");
+    }
+
+    #[tokio::test]
+    async fn x402_host_signing_denies_intent_outside_grant_terms() {
+        use bloom_auth_api::GrantStore as _;
+        let dir = tempfile::tempdir().unwrap();
+        let (petal_host, grant_store, _address) = wired_petal_host(dir.path());
+        // Grant allows only the MPP intent, not x402.
+        let now = now_ms();
+        let action = paid_http_test_sealed_action(
+            "alice",
+            "act-intent",
+            &[PAID_HTTP_MPP_SIGN_INTENT],
+            3,
+            now,
+        );
+        grant_store
+            .mint(&action, now.saturating_add(120_000), now)
+            .await
+            .unwrap();
+        let signer = PaidHttpPetalHostSigner {
+            petal_host,
+            wallet: "alice".into(),
+            action_id: "act-intent".into(),
+        };
+        let facts = PaidHttpSigningFacts {
+            protocol: "x402".into(),
+            policy_snapshot_digest: Some(action.petal_policy_digest.clone()),
+            ..Default::default()
+        };
+        let err = signer
+            .sign_paid_http_hash("x402.sign", [1u8; 32], &facts)
+            .await
+            .unwrap_err();
+        assert!(
+            err.contains("allowed_sign_intents"),
+            "intent not in grant terms should deny: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn paid_http_host_signing_denies_mismatched_attestation_facts_without_consuming() {
+        use bloom_auth_api::GrantStore as _;
+        let dir = tempfile::tempdir().unwrap();
+        let (petal_host, grant_store, _address) = wired_petal_host(dir.path());
+        let now = now_ms();
+        let action = paid_http_test_sealed_action("alice", "act-facts", &["x402.sign"], 3, now);
+        let grant = grant_store
+            .mint(&action, now.saturating_add(120_000), now)
+            .await
+            .unwrap();
+        let facts = PaidHttpSigningFacts {
+            protocol: "x402".into(),
+            request_id: "req-facts".into(),
+            policy_snapshot_digest: Some(action.petal_policy_digest.clone()),
+            ..Default::default()
+        };
+        let request = SignHashRequest {
+            wallet: "alice".into(),
+            action_id: "act-facts".into(),
+            intent: "x402.sign".into(),
+            hash_hex: format!("0x{}", "1".repeat(64)),
+        };
+
+        for (label, mutate) in [
+            (
+                "wrong action_id",
+                Box::new(|att: &mut SigningAttestation| {
+                    att.facts.insert("action_id".into(), json!("other-action"));
+                }) as Box<dyn Fn(&mut SigningAttestation)>,
+            ),
+            (
+                "wrong signing_hash",
+                Box::new(|att: &mut SigningAttestation| {
+                    att.facts.insert(
+                        "signing_hash".into(),
+                        json!(format!("0x{}", "2".repeat(64))),
+                    );
+                }),
+            ),
+            (
+                "wrong policy digest",
+                Box::new(|att: &mut SigningAttestation| {
+                    att.facts
+                        .insert("policy_snapshot_digest".into(), json!("3".repeat(64)));
+                }),
+            ),
+        ] {
+            let mut att = paid_http_signing_attestation(
+                "x402.sign",
+                &request.hash_hex,
+                "alice",
+                "act-facts",
+                &facts,
+            );
+            mutate(&mut att);
+            let err = petal_host
+                .sign_hash(request.clone(), &att, now + 1)
+                .await
+                .unwrap_err();
+            assert!(err.to_string().contains("attestation"), "{label}: {err}");
+        }
+
+        let active = grant_store
+            .get_active(
+                "alice",
+                "act-facts",
+                petal_identity::PETAL_ID_PAID_HTTP,
+                petal_identity::PLACEHOLDER_DIGEST_PAID_HTTP,
+                now + 10,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(active.grant_id, grant.grant_id);
+        assert_eq!(active.consumed_signature_count, 0);
+    }
+
+    #[tokio::test]
+    async fn paid_http_host_signing_denies_wrong_petal_identity_without_consuming() {
+        use bloom_auth_api::GrantStore as _;
+        let dir = tempfile::tempdir().unwrap();
+        let (petal_host, grant_store, _address) = wired_petal_host(dir.path());
+        let now = now_ms();
+        let action = paid_http_test_sealed_action("alice", "act-petal", &["x402.sign"], 2, now);
+        grant_store
+            .mint(&action, now.saturating_add(120_000), now)
+            .await
+            .unwrap();
+        let facts = PaidHttpSigningFacts {
+            protocol: "x402".into(),
+            request_id: "req-petal".into(),
+            policy_snapshot_digest: Some(action.petal_policy_digest.clone()),
+            ..Default::default()
+        };
+        let request = SignHashRequest {
+            wallet: "alice".into(),
+            action_id: "act-petal".into(),
+            intent: "x402.sign".into(),
+            hash_hex: format!("0x{}", "1".repeat(64)),
+        };
+        let base = paid_http_signing_attestation(
+            "x402.sign",
+            &request.hash_hex,
+            "alice",
+            "act-petal",
+            &facts,
+        );
+        let mut wrong_id = base.clone();
+        wrong_id.petal_id = petal_identity::PETAL_ID_EVM_WALLET.into();
+        let err = petal_host
+            .sign_hash(request.clone(), &wrong_id, now + 1)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("not allowed"), "{err}");
+
+        let mut wrong_digest = base;
+        wrong_digest.petal_digest = petal_identity::PLACEHOLDER_DIGEST_EVM_WALLET.into();
+        let err = petal_host
+            .sign_hash(request, &wrong_digest, now + 2)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("no live grant"), "{err}");
+
+        let active = grant_store
+            .get_active(
+                "alice",
+                "act-petal",
+                petal_identity::PETAL_ID_PAID_HTTP,
+                petal_identity::PLACEHOLDER_DIGEST_PAID_HTTP,
+                now + 10,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(active.consumed_signature_count, 0);
+    }
+
+    #[tokio::test]
+    async fn unwired_paid_http_host_signer_refuses_to_sign() {
+        let signer = UnwiredPaidHttpHostSigner;
+        let facts = PaidHttpSigningFacts::default();
+        let err = signer
+            .sign_paid_http_hash("x402.sign", [0u8; 32], &facts)
+            .await
+            .unwrap_err();
+        assert!(err.contains("requires a wired PetalHost"), "{err}");
+    }
+
     #[tokio::test]
     async fn invalid_confirm_text_does_not_consume_sealed_approval() {
         let signer_calls = Arc::new(AtomicUsize::new(0));
@@ -2661,6 +3892,12 @@ mod tests {
         )
         .unwrap();
         fs::write(pending.join("status"), "pending\n").unwrap();
+        let record = seal_existing_pending_request(&pending, "req_bad_confirm", &policy);
+        let auth_services = handler
+            .auth_services
+            .clone()
+            .with_store(Arc::new(StaticSealedStore::new(record)));
+        let handler = handler.with_auth_services(auth_services);
         write_json(
             pending.join(APPROVAL_FILE),
             &SignedApproval {
@@ -3552,98 +4789,175 @@ inline = '{"prompt":"hi"}'
         );
     }
 
+    struct FixedTempoRpcResolver;
+
+    impl PaidHttpChainRpcResolver for FixedTempoRpcResolver {
+        fn http_rpc_urls_for_chain_id(&self, chain_id: u64) -> Vec<String> {
+            if chain_id == 42431 {
+                vec!["https://rpc.example.com".into()]
+            } else {
+                Vec::new()
+            }
+        }
+    }
+
+    fn zero_amount_tempo_charge_challenge() -> NormalizedChallenge {
+        let request = mpp::Base64UrlJson::from_value(&json!({
+            "amount": "0",
+            "currency": "0x20c0000000000000000000000000000000000000",
+            "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
+            "methodDetails": { "chainId": 42431 }
+        }))
+        .unwrap();
+        let challenge = mpp::PaymentChallenge::new(
+            "challenge-mpp-host",
+            "merchant.test",
+            "tempo",
+            "charge",
+            request,
+        );
+        let header = mpp::format_www_authenticate(&challenge).unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            reqwest::header::WWW_AUTHENTICATE,
+            HeaderValue::from_str(&header).unwrap(),
+        );
+        normalize_challenge(
+            &headers,
+            b"",
+            &Url::parse("https://merchant.test/pay").unwrap(),
+        )
+    }
+
     #[tokio::test]
-    async fn locked_local_wallet_fails_before_tempo_signing_with_clear_error() {
+    async fn mpp_host_signing_is_grant_gated_and_consumes_one_allowance() {
+        use bloom_auth_api::GrantStore as _;
         let dir = tempfile::tempdir().unwrap();
-        let keystore = Keystore::new(dir.path().join("keystore")).unwrap();
-        keystore.create_local("alice", "secret").unwrap();
-        let backend = RealMppBackend::without_rpc_resolver(keystore, reqwest::Client::new());
-        let challenge = NormalizedChallenge {
-            protocol: "mpp".into(),
-            intent: "charge".into(),
-            merchant: "merchant.test".into(),
-            realm: Some("merchant.test".into()),
-            network: Some("tempo".into()),
-            asset: Some("pathUSD".into()),
-            amount: Some("0".into()),
-            amount_usd: Some(0.0),
-            charge_id: Some("ch_locked".into()),
-            session_id: None,
-            deposit_amount: None,
-            deposit_usd: None,
-            chain_id: Some(42431),
-            unit_type: None,
-            channel_id: None,
-            challenge_id: Some("challenge-locked".into()),
-            request: None,
-            headers: BTreeMap::new(),
-            accepts: Vec::new(),
-        };
+        let (petal_host, grant_store, address) = wired_petal_host(dir.path());
+        let now = now_ms();
+        let action =
+            paid_http_test_sealed_action("alice", "act-mpp", &[PAID_HTTP_MPP_SIGN_INTENT], 1, now);
+        let host_signer: Arc<dyn PaidHttpHostSigner> = Arc::new(PaidHttpPetalHostSigner {
+            petal_host,
+            wallet: "alice".into(),
+            action_id: "act-mpp".into(),
+        });
+        let backend = RealMppBackend::new(
+            reqwest::Client::new(),
+            Arc::new(FixedTempoRpcResolver),
+            address,
+            host_signer,
+            PaidHttpSigningFacts {
+                protocol: "mpp".into(),
+                request_id: "req_mpp_host".into(),
+                policy_snapshot_digest: Some(action.petal_policy_digest.clone()),
+                ..Default::default()
+            },
+        );
+        let challenge = zero_amount_tempo_charge_challenge();
         let request = parse_request("GET https://merchant.test/pay wallet=alice").unwrap();
 
-        let msg = match backend
+        let err = match backend
             .prepare(
                 &challenge,
                 &request,
                 "alice",
                 &Policy::default(),
-                "req_locked",
+                "req_mpp_host",
             )
             .await
         {
-            Ok(_) => panic!("locked wallet unexpectedly signed Tempo MPP credential"),
-            Err(err) => err.to_string(),
+            Ok(_) => panic!("MPP host signing unexpectedly succeeded without a grant"),
+            Err(err) => err,
         };
-        assert!(msg.contains("wallet 'alice' is locked"), "{msg}");
-        assert!(msg.contains("unlock"), "{msg}");
-    }
+        assert!(err.contains("no live grant"), "no-grant error: {err}");
 
-    #[tokio::test]
-    async fn locked_passkey_wallet_error_points_to_sealed_approval_flow() {
-        let dir = tempfile::tempdir().unwrap();
-        let keystore = Keystore::new(dir.path().join("keystore")).unwrap();
-        keystore.create_local("passkey_alice", "secret").unwrap();
-        fs::write(dir.path().join("keystore/passkey_alice/kind"), b"passkey").unwrap();
-        let backend = RealMppBackend::without_rpc_resolver(keystore, reqwest::Client::new());
-        let challenge = NormalizedChallenge {
-            protocol: "mpp".into(),
-            intent: "charge".into(),
-            merchant: "merchant.test".into(),
-            realm: Some("merchant.test".into()),
-            network: Some("tempo".into()),
-            asset: Some("pathUSD".into()),
-            amount: Some("0".into()),
-            amount_usd: Some(0.0),
-            charge_id: Some("ch_passkey_locked".into()),
-            session_id: None,
-            deposit_amount: None,
-            deposit_usd: None,
-            chain_id: Some(42431),
-            unit_type: None,
-            channel_id: None,
-            challenge_id: Some("challenge-passkey-locked".into()),
-            request: None,
-            headers: BTreeMap::new(),
-            accepts: Vec::new(),
-        };
-        let request = parse_request("GET https://merchant.test/pay wallet=passkey_alice").unwrap();
+        grant_store
+            .mint(&action, now.saturating_add(120_000), now)
+            .await
+            .unwrap();
 
-        let msg = match backend
+        let execution = backend
             .prepare(
                 &challenge,
                 &request,
-                "passkey_alice",
+                "alice",
                 &Policy::default(),
-                "req_passkey_locked",
+                "req_mpp_host",
+            )
+            .await
+            .expect("MPP host signer should mint a proof credential under a live grant");
+        assert_eq!(execution.header_name, "Authorization");
+        assert!(execution.header_value.starts_with("Payment "));
+        assert_eq!(
+            execution.credential_metadata["secret_material_in_vfs"],
+            false
+        );
+
+        let err = match backend
+            .prepare(
+                &challenge,
+                &request,
+                "alice",
+                &Policy::default(),
+                "req_mpp_host",
             )
             .await
         {
-            Ok(_) => panic!("locked passkey wallet unexpectedly signed Tempo MPP credential"),
-            Err(err) => err.to_string(),
+            Ok(_) => panic!("MPP host signing unexpectedly replayed a one-shot grant"),
+            Err(err) => err,
         };
-        assert!(msg.contains("passkey wallet"), "{msg}");
-        assert!(msg.contains("Sealed Approval"), "{msg}");
-        assert!(msg.contains("PetalHost::sign_hash"), "{msg}");
+        assert!(err.contains("no live grant"), "replay error: {err}");
+    }
+
+    #[tokio::test]
+    async fn mpp_host_signing_denies_intent_outside_grant_terms() {
+        use bloom_auth_api::GrantStore as _;
+        let dir = tempfile::tempdir().unwrap();
+        let (petal_host, grant_store, address) = wired_petal_host(dir.path());
+        let now = now_ms();
+        let action = paid_http_test_sealed_action("alice", "act-mpp-wrong", &["x402.sign"], 1, now);
+        grant_store
+            .mint(&action, now.saturating_add(120_000), now)
+            .await
+            .unwrap();
+        let host_signer: Arc<dyn PaidHttpHostSigner> = Arc::new(PaidHttpPetalHostSigner {
+            petal_host,
+            wallet: "alice".into(),
+            action_id: "act-mpp-wrong".into(),
+        });
+        let backend = RealMppBackend::new(
+            reqwest::Client::new(),
+            Arc::new(FixedTempoRpcResolver),
+            address,
+            host_signer,
+            PaidHttpSigningFacts {
+                protocol: "mpp".into(),
+                request_id: "req_mpp_wrong_intent".into(),
+                policy_snapshot_digest: Some(action.petal_policy_digest.clone()),
+                ..Default::default()
+            },
+        );
+        let challenge = zero_amount_tempo_charge_challenge();
+        let request = parse_request("GET https://merchant.test/pay wallet=alice").unwrap();
+
+        let err = match backend
+            .prepare(
+                &challenge,
+                &request,
+                "alice",
+                &Policy::default(),
+                "req_mpp_wrong_intent",
+            )
+            .await
+        {
+            Ok(_) => panic!("MPP host signing unexpectedly used an x402-only grant"),
+            Err(err) => err,
+        };
+        assert!(
+            err.contains("allowed_sign_intents"),
+            "wrong MPP intent should deny: {err}"
+        );
     }
 
     #[tokio::test]

--- a/crates/bloom-vfs/src/handlers/wallets.rs
+++ b/crates/bloom-vfs/src/handlers/wallets.rs
@@ -1630,8 +1630,24 @@ impl WalletsHandler {
                 3 if self.policy_updates_dir(wallet).join(&segs[2]).is_dir() => {
                     Ok(Entry::dir(&segs[2]))
                 }
-                4 if matches!(segs[3].as_str(), "approval_challenge.json" | "status.json") => {
-                    Ok(Entry::file(&segs[3]))
+                4 if segs[3] == "status.json" => {
+                    let action_dir = self.policy_updates_dir(wallet).join(&segs[2]);
+                    if action_dir.is_dir() {
+                        Ok(Entry::file("status.json"))
+                    } else {
+                        Err(HandlerError::not_found(path.to_string_path()))
+                    }
+                }
+                4 if segs[3] == APPROVAL_CHALLENGE_FILE => {
+                    let challenge_path = self
+                        .policy_updates_dir(wallet)
+                        .join(&segs[2])
+                        .join(APPROVAL_CHALLENGE_FILE);
+                    if challenge_path.is_file() {
+                        Ok(Entry::file(APPROVAL_CHALLENGE_FILE))
+                    } else {
+                        Err(HandlerError::not_found(path.to_string_path()))
+                    }
                 }
                 _ => Err(HandlerError::not_found(path.to_string_path())),
             },
@@ -4510,6 +4526,17 @@ mod tests {
         assert!(names.contains(&"approval_challenge.json"), "{names:?}");
         assert!(names.contains(&"status.json"), "{names:?}");
 
+        for leaf in ["status.json", APPROVAL_CHALLENGE_FILE] {
+            let entry = f
+                .handler
+                .lookup(
+                    &VfsPath::parse(&format!("/alice/policy-updates/{action_id}/{leaf}")).unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(entry.name, leaf);
+        }
+
         // The raw challenge parses and carries a ceremony_url.
         let challenge_bytes = f
             .handler
@@ -4575,6 +4602,58 @@ mod tests {
                 "challenge leaked `{needle}`: {challenge_str}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn wallet_policy_update_lookup_rejects_missing_action_artifacts() {
+        let f = make_handler();
+
+        for leaf in ["status.json", APPROVAL_CHALLENGE_FILE] {
+            let path = VfsPath::parse(&format!("/alice/policy-updates/missing/{leaf}")).unwrap();
+            let result = f.handler.lookup(&path).await;
+            assert!(
+                matches!(result, Err(HandlerError::NotFound(_))),
+                "lookup should reject missing action artifact {leaf}: {result:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn wallet_policy_update_lookup_requires_challenge_file() {
+        let f = make_handler();
+        let action_id = "policy-no-challenge";
+        std::fs::create_dir_all(
+            f.handler
+                .keystore
+                .root()
+                .join("alice")
+                .join("policy-updates")
+                .join(action_id),
+        )
+        .unwrap();
+
+        let status = f
+            .handler
+            .lookup(
+                &VfsPath::parse(&format!("/alice/policy-updates/{action_id}/status.json")).unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(status.name, "status.json");
+
+        let challenge = f
+            .handler
+            .lookup(
+                &VfsPath::parse(&format!(
+                    "/alice/policy-updates/{action_id}/{APPROVAL_CHALLENGE_FILE}"
+                ))
+                .unwrap(),
+            )
+            .await;
+        assert!(
+            matches!(challenge, Err(HandlerError::NotFound(_))),
+            "lookup should reject missing challenge file: {challenge:?}"
+        );
     }
 
     /// A validly-signed on-disk policy that changes after the update is staged

--- a/crates/bloom-vfs/src/handlers/wallets.rs
+++ b/crates/bloom-vfs/src/handlers/wallets.rs
@@ -752,6 +752,11 @@ impl WalletsHandler {
                 now,
             )
             .await
+            // Project the stable local ceremony URL so the mounted flow can open
+            // the approval page without touching BLOOM_HOME. Same convention as
+            // the paid-http/outbox confirm challenges; the token derives from the
+            // (single-use) server_nonce and is not part of the signed preimage.
+            .map(|challenge| challenge.with_local_ceremony_url())
             .map_err(|e| HandlerError::backend(format!("issue wallet-policy challenge: {e}")))
     }
 
@@ -822,6 +827,100 @@ impl WalletsHandler {
         )?;
         write_atomic_file(&wallet_dir.join("policy.toml"), proposed_policy)?;
         Ok(())
+    }
+
+    /// On-disk root for staged wallet-policy update artifacts (challenges and,
+    /// once approved, the signed approval). These are *views* of a pending
+    /// Sealed Approval — the canonical proposed policy lives in the sealed
+    /// action subject, never in these side files.
+    fn policy_updates_dir(&self, wallet: &str) -> std::path::PathBuf {
+        self.keystore.root().join(wallet).join("policy-updates")
+    }
+
+    /// Sorted list of staged policy-update action ids that have on-disk
+    /// artifacts, for the `policy-updates/` VFS listing.
+    fn policy_update_action_ids(&self, wallet: &str) -> Vec<String> {
+        let mut ids = Vec::new();
+        if let Ok(rd) = std::fs::read_dir(self.policy_updates_dir(wallet)) {
+            for ent in rd.flatten() {
+                if ent.file_type().map(|t| t.is_dir()).unwrap_or(false)
+                    && let Some(name) = ent.file_name().to_str()
+                {
+                    ids.push(name.to_string());
+                }
+            }
+        }
+        ids.sort();
+        ids
+    }
+
+    /// Raw approval challenge JSON for a staged policy update, surfaced through
+    /// the mount so an agent can discover the ceremony (including `ceremony_url`)
+    /// without reading `BLOOM_HOME`. Contains only bounded challenge metadata —
+    /// no signatures, grants, or key material.
+    fn read_policy_update_challenge(
+        &self,
+        wallet: &str,
+        action_id: &str,
+    ) -> Result<Vec<u8>, HandlerError> {
+        let path = self
+            .policy_updates_dir(wallet)
+            .join(action_id)
+            .join(APPROVAL_CHALLENGE_FILE);
+        if !path.exists() {
+            return Err(HandlerError::not_found(format!(
+                "policy-updates/{action_id}/{APPROVAL_CHALLENGE_FILE}"
+            )));
+        }
+        Ok(std::fs::read(&path)?)
+    }
+
+    /// Human/agent-facing status view for a staged policy update. Derives its
+    /// `status` from which artifacts exist on disk (a challenge alone means the
+    /// ceremony is still pending; an approval means the one-shot grant can be
+    /// minted by re-writing the same proposed policy). Exposes `ceremony_url`
+    /// and the exact retry path; never exposes the signed approval itself.
+    fn policy_update_status_json(
+        &self,
+        wallet: &str,
+        action_id: &str,
+    ) -> Result<Vec<u8>, HandlerError> {
+        let action_dir = self.policy_updates_dir(wallet).join(action_id);
+        if !action_dir.is_dir() {
+            return Err(HandlerError::not_found(format!(
+                "policy-updates/{action_id}"
+            )));
+        }
+        let challenge_path = action_dir.join(APPROVAL_CHALLENGE_FILE);
+        let challenge: Option<ApprovalChallenge> = if challenge_path.exists() {
+            Some(read_json(&challenge_path)?)
+        } else {
+            None
+        };
+        let approved = action_dir.join(APPROVAL_FILE).exists();
+        let status = if approved { "approved" } else { "challenged" };
+        let next_step = if approved {
+            "re-write the same proposed policy to /wallets/<wallet>/policy.toml to install"
+        } else {
+            "open ceremony_url, approve, then re-write the same proposed policy.toml"
+        };
+        let body = serde_json::json!({
+            "schema": "bloom.wallet_policy_update_view.v1",
+            "wallet": wallet,
+            "action_id": action_id,
+            "surface": WALLET_POLICY_SURFACE,
+            "status": status,
+            "write_path": format!("/wallets/{wallet}/policy.toml"),
+            "installation_target": format!("/wallets/{wallet}/policy.toml"),
+            "challenge_path": format!("/wallets/{wallet}/policy-updates/{action_id}/{APPROVAL_CHALLENGE_FILE}"),
+            "assurance": challenge.as_ref().map(|c| c.assurance),
+            "ceremony_url": challenge.as_ref().and_then(|c| c.ceremony_url.clone()),
+            "expiry_ms": challenge.as_ref().map(|c| c.expiry_ms),
+            "next_step": next_step,
+        });
+        let mut out = serde_json::to_vec_pretty(&body).map_err(err_be)?;
+        out.push(b'\n');
+        Ok(out)
     }
 
     async fn require_sealed_evm_owner_session_approval(
@@ -913,6 +1012,7 @@ impl WalletsHandler {
             Entry::dir("chains"),
             Entry::dir("sign"),
             Entry::dir("policy-session"),
+            Entry::dir("policy-updates"),
             Entry::dir("capabilities"),
         ];
         if kind == bloom_keystore::WalletKind::PasskeyGated {
@@ -1525,6 +1625,16 @@ impl WalletsHandler {
                 4 if segs[3] == "use" => Ok(Entry::writable_file("use")),
                 _ => Err(HandlerError::not_found(path.to_string_path())),
             },
+            "policy-updates" => match segs.len() {
+                2 => Ok(Entry::dir("policy-updates")),
+                3 if self.policy_updates_dir(wallet).join(&segs[2]).is_dir() => {
+                    Ok(Entry::dir(&segs[2]))
+                }
+                4 if matches!(segs[3].as_str(), "approval_challenge.json" | "status.json") => {
+                    Ok(Entry::file(&segs[3]))
+                }
+                _ => Err(HandlerError::not_found(path.to_string_path())),
+            },
             "capabilities" => match segs.len() {
                 2 => Ok(Entry::dir("capabilities")),
                 3 if segs[2] == "active.json" => Ok(Entry::file("active.json")),
@@ -1566,6 +1676,12 @@ impl WalletsHandler {
             "chains" if segs.len() >= 4 => self.read_chain(wallet, &segs[2], &segs[3..]).await,
             "policy-session" if segs.len() == 3 && segs[2] == "active.json" => {
                 self.policy_session_active_json(wallet).await
+            }
+            "policy-updates" if segs.len() == 4 && segs[3] == "approval_challenge.json" => {
+                self.read_policy_update_challenge(wallet, &segs[2])
+            }
+            "policy-updates" if segs.len() == 4 && segs[3] == "status.json" => {
+                self.policy_update_status_json(wallet, &segs[2])
             }
             "capabilities" if segs.len() == 3 && segs[2] == "active.json" => {
                 self.capabilities_active_json(wallet)
@@ -1682,6 +1798,23 @@ impl WalletsHandler {
                 .collect()),
             2 if segs[1] == "sign" => Ok(Self::sign_dir_entries()),
             2 if segs[1] == "policy-session" => Ok(Self::policy_session_dir_entries()),
+            2 if segs[1] == "policy-updates" => Ok(self
+                .policy_update_action_ids(wallet)
+                .iter()
+                .map(|id| Entry::dir(id))
+                .collect()),
+            3 if segs[1] == "policy-updates" => {
+                let dir = self.policy_updates_dir(wallet).join(&segs[2]);
+                if !dir.is_dir() {
+                    return Err(HandlerError::not_found(path.to_string_path()));
+                }
+                let mut out = Vec::new();
+                if dir.join(APPROVAL_CHALLENGE_FILE).exists() {
+                    out.push(Entry::file("approval_challenge.json"));
+                }
+                out.push(Entry::file("status.json"));
+                Ok(out)
+            }
             n if n >= 3 && segs[1] == "chains" => {
                 self.list_chain(wallet, &segs[2], &segs[3..]).await
             }
@@ -4330,6 +4463,220 @@ mod tests {
             .unwrap();
         let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
         assert!(!names.contains(&"unlock-passkey"), "names={names:?}");
+    }
+
+    /// The staged challenge is discoverable and readable through the mount:
+    /// `policy-updates/` lists the action, its `approval_challenge.json` carries
+    /// a `ceremony_url`, `status.json` renders the retry guidance, and none of it
+    /// leaks the signed approval or any secret material.
+    #[tokio::test]
+    async fn wallet_policy_challenge_is_visible_and_secret_free_via_vfs() {
+        let mut f = make_handler();
+        let services = wallet_policy_auth_services(&f);
+        convert_wallet_to_passkey(&f, "alice");
+        f.handler = f.handler.with_auth_services(services);
+        let (old_policy, _) = f.handler.keystore.raw_policy("alice").unwrap();
+        let mut proposed: Policy = toml::from_str(&old_policy).unwrap();
+        proposed.approval.agent_autonomy = Some(bloom_proto::AgentAutonomyMode::UnderPolicy);
+        proposed.limits.max_tx_usd = Some("10".into());
+        proposed.limits.max_day_usd = Some("100".into());
+        let proposed = toml::to_string_pretty(&proposed).unwrap();
+        let action_id =
+            wallet_policy_action_id("alice", old_policy.as_bytes(), proposed.as_bytes());
+        let p = VfsPath::parse("/alice/policy.toml").unwrap();
+        assert!(matches!(
+            f.handler.write(&p, proposed.as_bytes()).await.unwrap_err(),
+            HandlerError::PermissionDenied
+        ));
+
+        // policy-updates/ lists the staged action.
+        let listed = f
+            .handler
+            .list(&VfsPath::parse("/alice/policy-updates").unwrap())
+            .await
+            .unwrap();
+        assert!(
+            listed.iter().any(|e| e.name == action_id),
+            "policy-updates listing missing action id: {listed:?}"
+        );
+
+        // The action dir advertises its readable artifacts.
+        let artifacts = f
+            .handler
+            .list(&VfsPath::parse(&format!("/alice/policy-updates/{action_id}")).unwrap())
+            .await
+            .unwrap();
+        let names: Vec<&str> = artifacts.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&"approval_challenge.json"), "{names:?}");
+        assert!(names.contains(&"status.json"), "{names:?}");
+
+        // The raw challenge parses and carries a ceremony_url.
+        let challenge_bytes = f
+            .handler
+            .read(
+                &VfsPath::parse(&format!(
+                    "/alice/policy-updates/{action_id}/approval_challenge.json"
+                ))
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        let challenge: ApprovalChallenge = serde_json::from_slice(&challenge_bytes).unwrap();
+        assert_eq!(challenge.surface, WALLET_POLICY_SURFACE);
+        assert!(
+            challenge.ceremony_url.is_some(),
+            "challenge should project a ceremony_url"
+        );
+
+        // status.json renders the retry guidance and the same ceremony_url.
+        let status_bytes = f
+            .handler
+            .read(
+                &VfsPath::parse(&format!("/alice/policy-updates/{action_id}/status.json")).unwrap(),
+            )
+            .await
+            .unwrap();
+        let status: serde_json::Value = serde_json::from_slice(&status_bytes).unwrap();
+        assert_eq!(status["status"], "challenged");
+        assert_eq!(status["write_path"], "/wallets/alice/policy.toml");
+        assert!(status["ceremony_url"].is_string());
+
+        // Approve, then confirm the signed approval is NOT reachable through the
+        // mount — only bounded challenge/status views are.
+        write_json(
+            f.handler
+                .keystore
+                .root()
+                .join("alice")
+                .join("policy-updates")
+                .join(&action_id)
+                .join(APPROVAL_FILE),
+            &signed_wallet_policy_approval(&challenge),
+        )
+        .unwrap();
+        let approval_read = f
+            .handler
+            .read(
+                &VfsPath::parse(&format!(
+                    "/alice/policy-updates/{action_id}/{APPROVAL_FILE}"
+                ))
+                .unwrap(),
+            )
+            .await;
+        assert!(
+            approval_read.is_err(),
+            "signed approval.json must not be readable via VFS"
+        );
+        // The challenge bytes carry no key/PRF/grant material.
+        let challenge_str = String::from_utf8_lossy(&challenge_bytes);
+        for needle in ["private_key", "prf", "webauthn_assertion", "signature_b64"] {
+            assert!(
+                !challenge_str.contains(needle),
+                "challenge leaked `{needle}`: {challenge_str}"
+            );
+        }
+    }
+
+    /// A validly-signed on-disk policy that changes after the update is staged
+    /// invalidates the prior approval: the approved retry re-derives a fresh
+    /// action id (bound to the new baseline), finds no matching grant/approval,
+    /// and fails closed asking for a restage — the proposed policy is not
+    /// installed.
+    #[tokio::test]
+    async fn wallet_policy_on_disk_change_after_staging_requires_restage() {
+        let mut f = make_handler();
+        let services = wallet_policy_auth_services(&f);
+        convert_wallet_to_passkey(&f, "alice");
+        f.handler = f.handler.with_auth_services(services);
+        let (old_policy, _) = f.handler.keystore.raw_policy("alice").unwrap();
+        let mut proposed: Policy = toml::from_str(&old_policy).unwrap();
+        proposed.denylists.recipients.insert("0x1234".into());
+        let proposed = toml::to_string_pretty(&proposed).unwrap();
+        let action_id =
+            wallet_policy_action_id("alice", old_policy.as_bytes(), proposed.as_bytes());
+        let p = VfsPath::parse("/alice/policy.toml").unwrap();
+
+        assert!(matches!(
+            f.handler.write(&p, proposed.as_bytes()).await.unwrap_err(),
+            HandlerError::PermissionDenied
+        ));
+        let dir = f
+            .handler
+            .keystore
+            .root()
+            .join("alice")
+            .join("policy-updates")
+            .join(&action_id);
+        let challenge: ApprovalChallenge = read_json(dir.join(APPROVAL_CHALLENGE_FILE)).unwrap();
+        write_json(
+            dir.join(APPROVAL_FILE),
+            &signed_wallet_policy_approval(&challenge),
+        )
+        .unwrap();
+
+        // Out-of-band but still validly-signed change to the current policy.
+        let mut baseline_shift: Policy = toml::from_str(&old_policy).unwrap();
+        baseline_shift.denylists.recipients.insert("0x9999".into());
+        let baseline_shift = toml::to_string_pretty(&baseline_shift).unwrap();
+        f.handler
+            .keystore
+            .write_policy("alice", baseline_shift.as_bytes())
+            .unwrap();
+
+        // Approved retry now re-baselines and must restage rather than install.
+        assert!(matches!(
+            f.handler.write(&p, proposed.as_bytes()).await.unwrap_err(),
+            HandlerError::PermissionDenied
+        ));
+        let on_disk =
+            std::fs::read_to_string(f.handler.keystore.root().join("alice/policy.toml")).unwrap();
+        assert_eq!(
+            on_disk, baseline_shift,
+            "proposed policy must not be installed"
+        );
+    }
+
+    /// A passkey wallet whose `policy.toml.sig` is already stale (out-of-band
+    /// edit outside the VFS/sandbox) fails closed on the first VFS write: the
+    /// signed-policy check in `info` rejects it and no repair/challenge is
+    /// attempted.
+    #[tokio::test]
+    async fn wallet_policy_stale_signature_fails_closed_without_repair() {
+        let mut f = make_handler();
+        let services = wallet_policy_auth_services(&f);
+        convert_wallet_to_passkey(&f, "alice");
+        f.handler = f.handler.with_auth_services(services);
+        let (old_policy, _) = f.handler.keystore.raw_policy("alice").unwrap();
+
+        // Break the signed-policy invariant out of band (as a hand edit to
+        // BLOOM_HOME would): mutate policy.toml but leave the old signature.
+        let mut tampered: Policy = toml::from_str(&old_policy).unwrap();
+        tampered.denylists.recipients.insert("0xdead".into());
+        let tampered = toml::to_string_pretty(&tampered).unwrap();
+        std::fs::write(
+            f.handler.keystore.root().join("alice/policy.toml"),
+            tampered.as_bytes(),
+        )
+        .unwrap();
+
+        let mut proposed: Policy = toml::from_str(&old_policy).unwrap();
+        proposed.limits.max_tx_usd = Some("5".into());
+        let proposed = toml::to_string_pretty(&proposed).unwrap();
+        let p = VfsPath::parse("/alice/policy.toml").unwrap();
+        let err = f.handler.write(&p, proposed.as_bytes()).await.unwrap_err();
+        assert!(
+            !matches!(err, HandlerError::PermissionDenied),
+            "stale policy must fail closed with the signed-policy error, not a challenge: {err}"
+        );
+        assert!(
+            !f.handler
+                .keystore
+                .root()
+                .join("alice")
+                .join("policy-updates")
+                .exists(),
+            "stale-signature write must not stage or repair a policy update"
+        );
     }
 
     #[tokio::test]

--- a/crates/bloom/src/main.rs
+++ b/crates/bloom/src/main.rs
@@ -23,9 +23,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use anyhow::{Context, Result, bail};
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as B64;
-use bloom_auth_api::{
-    ApprovalChallenge, AssuranceLevel, SignedApproval, SignerTransport, UnsignedApproval,
-};
+use bloom_auth_api::{ApprovalChallenge, AssuranceLevel, SignerTransport, UnsignedApproval};
 use bloom_daemon::Daemon;
 use bloom_daemon::ipc::{IpcClient, IpcServer, default_socket_path};
 use bloom_hyperliquid::{
@@ -1574,9 +1572,7 @@ async fn run(cli: Cli) -> Result<()> {
             let info = d.keystore.info(&wallet)?;
             let passkey_wallet = matches!(info.kind, bloom_keystore::WalletKind::PasskeyGated);
             match info.kind {
-                bloom_keystore::WalletKind::PasskeyGated => {
-                    bail!(PASSKEY_WRITE_UNLOCKED_DISABLED);
-                }
+                bloom_keystore::WalletKind::PasskeyGated => {}
                 _ => {
                     d.keystore
                         .unlock(&wallet, passphrase.as_deref().unwrap_or(""))?;
@@ -3151,12 +3147,16 @@ async fn sign_request_sealed_approval_if_challenged(
         None,
         review_session_id,
     );
-    let signature = d
-        .keystore
-        .sign_approval_with_passkey(wallet, &unsigned, intent)
-        .await
-        .context("sign request Sealed Approval with passkey")?;
-    let approval: SignedApproval = unsigned.into_signed(signature);
+    let (_grant, approval) = bloom_daemon::sealed_ceremony::run_sealed_approval_ceremony(
+        &d.keystore,
+        &d.auth_services,
+        unsigned,
+        intent,
+        cli_now_ms(),
+        d.signer_cache.as_ref(),
+    )
+    .await
+    .context("run request sealed approval browser ceremony")?;
     let approval_path = dir.join("approval.json");
     std::fs::write(
         &approval_path,

--- a/crates/bloom/src/main.rs
+++ b/crates/bloom/src/main.rs
@@ -1169,6 +1169,16 @@ fn is_endpoint_permission_denial(e: &std::io::Error) -> bool {
     e.kind() == std::io::ErrorKind::PermissionDenied || e.raw_os_error() == Some(1)
 }
 
+/// True when a daemon IPC call failed because the VFS *handler* returned
+/// `PermissionDenied` (JSON-RPC code `-32007`) — i.e. a Sealed Approval
+/// challenge was staged — rather than a transport/socket-level denial.
+/// [`try_ipc`] only surfaces this as a propagated `Err`, so it is safe to
+/// distinguish it here by the JSON-RPC error payload.
+fn is_ipc_handler_permission_denied(e: &std::io::Error) -> bool {
+    let s = e.to_string();
+    s.contains("-32007") || s.contains("permission denied")
+}
+
 async fn run(cli: Cli) -> Result<()> {
     let (connect, ipc_socket) = if cli.connect.is_some() {
         (cli.connect, None)
@@ -1551,23 +1561,64 @@ async fn run(cli: Cli) -> Result<()> {
             let wallet = wallet.context(
                 "could not determine paying wallet for this request; pass --wallet or --unlock-wallet",
             )?;
-            let ipc_res = try_ipc(
-                &client,
-                &client_endpoint,
-                "write_unlocked",
-                serde_json::json!({
-                    "path": path,
-                    "bytes_b64": B64.encode(&body),
-                    "wallet": &wallet,
-                }),
-            )
-            .await
-            .with_context(|| format!("ipc request confirm via {}", client_endpoint.display))?;
-            if ipc_res.is_some() {
-                debug!(endpoint = %client_endpoint.display, "cli.request.confirm.via_ipc");
-                return Ok(());
+            // Daemon-backed confirm reaches the VFS handler through a *plain*
+            // `write`, not `write_unlocked`: the requests handler stages a
+            // Sealed Approval challenge and signs the x402/Tempo MPP credential
+            // only under a grant-gated PetalHost signature. `write_unlocked` is
+            // not a passkey signing lane. On a staged-challenge PermissionDenied
+            // we run the request ceremony (writes approval.json to the shared
+            // home) and retry the same plain write so the daemon consumes it.
+            let confirm_params = serde_json::json!({
+                "path": path,
+                "bytes_b64": B64.encode(&body),
+            });
+            match try_ipc(&client, &client_endpoint, "write", confirm_params.clone()).await {
+                Ok(Some(_)) => {
+                    debug!(endpoint = %client_endpoint.display, "cli.request.confirm.via_ipc");
+                    return Ok(());
+                }
+                Ok(None) => {
+                    debug!("cli.request.confirm.via_inproc: no daemon socket present");
+                    // Fall through to the in-process fallback below.
+                }
+                Err(e) if is_ipc_handler_permission_denied(&e) => {
+                    // The daemon staged a Sealed Approval challenge on the first
+                    // plain write. Build a read-only daemon (the serving daemon
+                    // holds the home write lock) to run the request ceremony,
+                    // which writes approval.json onto the shared home, then retry
+                    // the same plain write so the daemon verifies and consumes it.
+                    let ceremony_daemon = Daemon::from_home(home.clone())
+                        .context("build daemon for request confirm ceremony")?;
+                    let approved = sign_request_sealed_approval_if_challenged(
+                        &ceremony_daemon,
+                        &wallet,
+                        &id,
+                        None,
+                    )
+                    .await
+                    .context("request confirm Sealed Approval ceremony")?;
+                    if !approved {
+                        return Err(anyhow::Error::new(e)).context(
+                            "request confirm denied but no approval challenge was staged",
+                        );
+                    }
+                    let retry = try_ipc(&client, &client_endpoint, "write", confirm_params)
+                        .await
+                        .with_context(|| {
+                            format!("ipc request confirm retry via {}", client_endpoint.display)
+                        })?;
+                    if retry.is_some() {
+                        debug!(endpoint = %client_endpoint.display, "cli.request.confirm.via_ipc.after_ceremony");
+                        return Ok(());
+                    }
+                    bail!("request confirm retry did not reach the daemon after Sealed Approval");
+                }
+                Err(e) => {
+                    return Err(anyhow::Error::new(e)).with_context(|| {
+                        format!("ipc request confirm via {}", client_endpoint.display)
+                    });
+                }
             }
-            debug!("cli.request.confirm.via_inproc: no daemon socket present");
             let (_home_permit, d) = build_write_daemon(home)?;
             let info = d.keystore.info(&wallet)?;
             let passkey_wallet = matches!(info.kind, bloom_keystore::WalletKind::PasskeyGated);

--- a/docs/architecture/Bloom Machine + Petals.md
+++ b/docs/architecture/Bloom Machine + Petals.md
@@ -27,15 +27,18 @@ to approve.
 ## The Grant Envelope
 
 A Sealed Approval grant authorizes a single Petal to use bounded signing
-authority. The Bloom Machine structurally enforces the *envelope* of that grant:
+authority for a single sealed action. The Bloom Machine structurally enforces
+the *envelope* of that grant:
 
  - the **wallet** whose key may be used;
  - the **Petal identity** allowed to consume the grant;
+ - the **sealed action** the grant is bound to;
+ - the allowed **signing intents** a request may declare;
  - the maximum **signature count**, `N`;
  - the **expiry**, `T`.
 
 Within a live grant the acting Petal may request up to `N` signatures until `T`.
-These four bounds are the guarantees the Bloom Machine makes, and that no Petal
+These bounds are the guarantees the Bloom Machine makes, and that no Petal
 can exceed.
 
 ## Trust Boundary

--- a/docs/architecture/Open-Internet Sealed Approval Ceremony.md
+++ b/docs/architecture/Open-Internet Sealed Approval Ceremony.md
@@ -12,7 +12,8 @@ The open-internet relay described here is not implemented today. The current
 mounted-VFS implementation supports Bloom Machine-owned loopback ceremony URLs on
 `http://localhost:18734`: `approval_challenge.json` carries a local
 `ceremony_url`, the token is derived from `server_nonce`, and the Bloom Machine owns
-grant minting for the mounted EVM slice. This document is the target design for
+grant minting for the mounted flows (the EVM outbox, paid-HTTP `/requests`, and
+wallet `policy.toml` updates). This document is the target design for
 making that same ceremony reachable from another device over the open internet.
 The `ceremony_url` contract itself — the field in `approval_challenge.json`,
 single-use token, `expiry_ms` bound — is defined in
@@ -124,6 +125,11 @@ at approval time:
   where the user approving from another device may not have a client available
   to retry.
 
+Execute applies only to broadcastable sealed actions (those carrying a
+`chain_name`). For non-broadcast actions — wallet-policy updates and paid-HTTP
+confirms — the two modes are equivalent: the ceremony mints the grant only, and
+the action installs when the client retries the confirm write.
+
 Auto-execution is never a silent Bloom Machine default.
 
 ## Changes From the Current Implementation
@@ -135,8 +141,9 @@ ways:
   `http://localhost:18734` with RP ID `localhost`; it does not expose that
   endpoint over the open internet.
 - Today `approval_challenge.json` carries a local loopback `ceremony_url` for
-  the mounted EVM slice. In the target relay design, the same projection points
-  at a per-install HTTPS hostname.
+  the mounted flows (EVM outbox, paid-HTTP `/requests`, and wallet
+  `policy.toml` updates). In the target relay design, the same projection
+  points at a per-install HTTPS hostname.
 - Today there is no relay, per-install hostname, internet exposure setting, or
   Bloom Machine-held public certificate for a relay hostname.
 

--- a/docs/architecture/Wallet.md
+++ b/docs/architecture/Wallet.md
@@ -320,8 +320,7 @@ a mix.
 
 ## Current Implementation Notes
 
-The current `feat/mounted-sealed-approval-demo` branch does not yet fully match
-this target layout. In particular, the current passkey keystore path still uses
+The current codebase does not yet fully match this target layout. In particular, the current passkey keystore path still uses
 one wallet-level `passkey.json` and one wallet-level `prf.salt`, with no
 `credentials/<credential_id>/wrapped_dek` directory and no wallet DEK fan-out
 across multiple credentials.

--- a/docs/architecture/Wallet.md
+++ b/docs/architecture/Wallet.md
@@ -192,6 +192,46 @@ Forbidden paths:
 - marker files such as `.confirm_approved.json` or `review_approved.json`;
 - persisting grants, PRF output, wallet DEK, or decrypted owner key bytes.
 
+## Wallet Policy Editing (mounted, Sealed Approval)
+
+For a passkey wallet, `policy.toml` is signed authorization state guarded by
+`policy.toml.sig`. The first-party edit surface is the mounted VFS path
+`/wallets/<wallet>/policy.toml`; editing it is a Sealed Approval action.
+
+Flow:
+
+1. The agent writes proposed policy bytes to `/wallets/<wallet>/policy.toml`.
+   The write first passes the standard signed-policy check (`Keystore::info`),
+   so a wallet whose current signature is already stale fails closed here and is
+   never used as a baseline for a new edit.
+2. Bloom stages a canonical `policy_update` Sealed Approval action whose subject
+   carries the wallet, VFS path, current signed policy bytes, proposed policy
+   bytes, and a normalized authority diff. The action id is bound to
+   `blake3(old_policy)` and `blake3(proposed_policy)`; authority-expanding edits
+   require hardened assurance.
+3. With no live grant, the first write issues an `approval_challenge.json` (with
+   a projected `ceremony_url`) and returns permission denied.
+4. The challenge and a `status.json` view are reachable through the mount at
+   `/wallets/<wallet>/policy-updates/<action_id>/`, so the agent never needs
+   `BLOOM_HOME` access. These are read-only views: bounded challenge metadata and
+   `ceremony_url` only — never the signed approval, grant, or key/PRF material.
+5. Approval mints a one-shot grant. The grant is keyed to the sealed action id,
+   which is bound to `blake3(proposed_policy)`, so only the exact approved
+   proposed bytes can consume it — a retry with different bytes re-derives a new
+   action id and finds no grant. On the approved retry Bloom also requires the
+   current on-disk policy to still match the sealed baseline (otherwise it
+   refuses and requires a fresh edit), signs through the host signer, writes
+   `policy.toml.sig`, then installs `policy.toml` — the wallet is never left with
+   a new policy lacking a matching signature.
+
+Local (passphrase) wallets keep immediate policy writes with no ceremony.
+
+Out of scope: direct edits to `BLOOM_HOME/keystore/<wallet>/policy.toml` are
+unsupported by this flow. If such an edit breaks `policy.toml.sig`, the wallet
+fails closed on every signed path and is not repaired here; recovery uses the
+admin helper `bloom wallet sign-policy <wallet>`. `write_unlocked` remains
+disabled as a passkey signing lane.
+
 ## Multi-Passkey Operations
 
 Credential changes are authority changes. They must be staged as Sealed Approval

--- a/docs/specs/2026-06-15-paid-http-requests.md
+++ b/docs/specs/2026-06-15-paid-http-requests.md
@@ -278,7 +278,17 @@ unpaid HTTP probe
         wait for confirm
                 │
                 ▼
-        sign/pay/open-channel/sign-voucher as required
+        if Sealed Approval is required:
+        write pending/<id>/approval_challenge.json with ceremony_url
+                │
+                ▼
+        foreground/browser ceremony mints a one-shot in-memory grant
+                │
+                ▼
+        execute from sealed subject bytes + sealed policy snapshot
+                │
+                ▼
+        host-sign exact x402/MPP digest under the live grant as required
                 │
                 ▼
         retry HTTP request with payment credential
@@ -460,13 +470,28 @@ or secret token unless it is specifically safe as a receipt/public proof.
 
 ### Wallet signing and passkey unlocks
 
-Tempo MPP confirmation always obtains the signer through Bloom's unlocked
-keystore path (`Keystore::signer(wallet)`). Passkey-gated wallets are supported
-when their foreground `unlock-passkey` / `unlock_passkey` flow has populated the
-same unlocked signer cache; they are not a separate unsupported wallet type.
-Locked local wallets fail before MPP credential creation. Locked passkey wallets
-fail with an explicit instruction to run the foreground passkey unlock flow before
-writing `confirm`.
+x402 and Tempo MPP confirmation both route wallet signatures through Bloom's
+paid-HTTP host signer. The protocol adapters construct the exact digest they
+need, attach structured public `SigningAttestation` facts, and ask the host to
+sign under a live Sealed Approval grant. The host enforces the paid-HTTP Petal
+identity, action id, intent (`x402.sign` or `paid-http.mpp.sign`), signing hash,
+and sealed policy snapshot digest before signing.
+
+For passkey-gated wallets, foreground confirmation follows the Sealed Approval
+ceremony instead of requiring a separate unlocked signer cache. The first
+confirm may write `approval_challenge.json` with `ceremony_url` and deny; the
+foreground command, user, or agent opens that URL, completes WebAuthn, mints a
+short-lived grant, and retries confirmation. The one-shot allowance is consumed
+atomically only when a host signature is produced. Failures before signing do
+not consume the grant.
+
+Confirmation reconstructs request execution from the sealed paid-HTTP subject
+bytes. `request.toml`, `challenge.json`, and `policy_check.json` are projection
+artifacts, not authority. If they differ from the sealed subject, or
+`private/request_body` no longer matches the sealed body hash, confirmation
+fails before signing or credential minting. Execution limits come from the
+sealed policy snapshot; live policy may narrow or deny as defense in depth, but
+it cannot widen the sealed payment terms.
 
 ### `receipt.json`
 
@@ -623,13 +648,10 @@ Implementation note: the Tempo MPP adapter uses the real `mpp` Rust SDK
 charge/session credential creation, and Authorization/Payment-Receipt formatting.
 Tempo MPP charges and sessions are normalized and policy-gated (including
 cumulative session-spend caps) and share the same confirm path as x402: signing
-runs only after confirmation and policy approval, x402 keeps its keystore signer
-with a staged request-id–bound EIP-3009 nonce, the paid retry is a real HTTP
-request, and a failed retry (HTTP >= 400 or a signing/settlement error)
-transitions the request to the `failed` state. Tempo MPP signing uses
-`Keystore::signer(wallet)`, so passkey-gated wallets work after the foreground
-`unlock_passkey` flow has unlocked the signer and locked passkey wallets fail
-before credential creation with an unlock-specific error.
+runs only after confirmation and Sealed Approval, host signing consumes the
+one-shot grant allowance only when the credential digest is signed, the paid
+retry is a real HTTP request, and a failed retry (HTTP >= 400 or a
+signing/settlement error) transitions the request to the `failed` state.
 
 Only redacted credential metadata, receipts, audit entries, and cumulative
 session spend are written; no raw Authorization headers, signed transactions,


### PR DESCRIPTION
## Summary

Builds on the Sealed Approval ceremony infrastructure (base branch) to bring the paid-HTTP `/requests` surface and in-VFS wallet policy editing onto the ceremony model, and closes the mount/IPC integration gaps that previously blocked those writes from reaching their handlers.

**Paid HTTP requests (x402 + MPP/Tempo)**
- Confirming a paid request is now a first-party Sealed Approval action: the first `confirm` write stages an approval challenge (with a local `ceremony_url`); the x402/Tempo credential is signed only under a grant-gated `PetalHost` signature and retried from sealed bytes. Credential material stays redacted in the VFS.
- MPP/Tempo (chainId 4217) charge flow wired end-to-end alongside x402.

**Wallet policy editing in the mounted VFS**
- Editing `wallets/<w>/policy.toml` is a Sealed Approval action that installs the updated `policy.toml` plus its matching `policy.toml.sig`; a `policy-updates/` surface exposes the challenge/status (no secrets). Ordinary read/sign/broadcast paths keep verifying `policy.toml.sig`.

**Integration-gap fixes (what makes the flows actually work over the NFS mount)**
- Removed the coarse signer-path gates that denied `policy.toml` and `requests/…/confirm` before they reached the VFS handler, in both the IPC (`do_write`) and mount adapter lanes. The handler's own Sealed Approval gate is the authority; `write_unlocked` remains disabled for passkey wallets.
- Ceremony server no longer routes non-broadcast (non-tx) actions through the tx-engine outbox — wallet-policy and paid-HTTP confirms are grant-only.
- Mount: pending request listings advertise `confirm`/`cancel`; `response` resolves as a directory via `lookup` (previously reported as a 0-byte file, which surfaced as ENOTDIR on the mount).

Manually verified end-to-end against a live daemon: staged and confirmed both an x402 and an MPP/Tempo request to `api.nansen.ai` — ceremony → grant → signed credential → `200` response, with credential material kept redacted.

## Checklist

Every item must be checked before merge (enforced by the `checklist-complete`
status check). If an item does not apply, check it and write `N/A` in place
of the link or after the item.

- [x] Tests added or updated for behavior changes
- [x] Architecture docs (`docs/architecture/`) updated if contracts or
      behavior changed
- [x] Sealed Approval invariants respected (no signing outside a grant or
      bounded capability, no PRF/grant persistence, execution from sealed
      bytes) — see `docs/architecture/Sealed Approvals.md`
- [x] Agent Documentation updated (`crates/bloom-vfs/src/docs/agent-guidance.md`
      and affected Petal READMEs) — see
      `docs/architecture/Agent-native Documentation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
