### PR TITLE
[vfs] Surface natural metadata timestamps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 target/
 target-docker/
+cache/
+out/
 
 .vendor/
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,6 +382,8 @@ dependencies = [
  "c-kzg",
  "derive_more",
  "either",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
  "serde",
  "serde_with",
  "sha2 0.10.9",
@@ -945,6 +947,8 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde 2.0.5",
  "derive_more",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
  "rand 0.8.6",
  "serde",
  "strum",
@@ -2269,6 +2273,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "hex",
+ "humantime",
  "predicates",
  "qrcode",
  "rand 0.8.6",
@@ -2414,6 +2419,7 @@ dependencies = [
  "bloom-proto",
  "bloom-rpc",
  "hex",
+ "op-alloy",
  "parking_lot",
  "serde_json",
  "tempfile",
@@ -3453,6 +3459,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4179,6 +4191,46 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ethereum_serde_utils"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38df44a7a271ab43835678f9215b53cc2523e4714a215da6643d83dc110245da"
+dependencies = [
+ "alloy-primitives",
+ "hex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "ethereum_ssz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e462875ad8693755ea8913d6e905715c76ea4836e2254e18c9cf0f7a8f8c2a13"
+dependencies = [
+ "alloy-primitives",
+ "ethereum_serde_utils",
+ "itertools 0.14.0",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "typenum",
+]
+
+[[package]]
+name = "ethereum_ssz_derive"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf022360bdbe9456eda5f35718a50476d5b2a0d51a97ed4eae27420737a6fba"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5734,6 +5786,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "modular-bitfield"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2956e537fc68236d2aa048f55704f231cc93f1c4de42fe1ecb5bd7938061fc4a"
+dependencies = [
+ "modular-bitfield-impl",
+ "static_assertions",
+]
+
+[[package]]
+name = "modular-bitfield-impl"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b43b4fd69e3437618106f7754f34021b831a514f9e1a98ae863cabcd8d8dad"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "module-lattice"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5945,6 +6018,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6005,12 +6079,123 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "op-alloy"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5432711015d1fe1afd3c1586a08ff63feed576ad7d261e85f49e2f379afcf823"
+dependencies = [
+ "op-alloy-consensus",
+ "op-alloy-network",
+ "op-alloy-provider",
+ "op-alloy-rpc-types",
+ "op-alloy-rpc-types-engine",
+]
+
+[[package]]
+name = "op-alloy-consensus"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ca73133d6cb8d0b1cd042433bca9a394e4eaeb8ec1f96c210adf3f45cb74040"
+dependencies = [
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
+ "alloy-network 2.0.5",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-eth 2.0.5",
+ "alloy-serde 2.0.5",
+ "bytes",
+ "derive_more",
+ "reth-codecs",
+ "reth-zstd-compressors",
+ "serde",
+ "serde_with",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "op-alloy-network"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed826e61fdc7055162693615128c314b2dc3a57204ca525cb00ba8cc1a7f4ccd"
+dependencies = [
+ "alloy-consensus 2.0.5",
+ "alloy-network 2.0.5",
+ "alloy-provider 2.0.5",
+ "alloy-rpc-types-eth 2.0.5",
+ "op-alloy-consensus",
+ "op-alloy-rpc-types",
+]
+
+[[package]]
+name = "op-alloy-provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6690469bdcee37c638d0e91f4c557e851b9d310ebd2e674704c1f086d69c62"
+dependencies = [
+ "alloy-network 2.0.5",
+ "alloy-primitives",
+ "alloy-provider 2.0.5",
+ "alloy-rpc-types-engine 2.0.5",
+ "alloy-transport 2.0.5",
+ "async-trait",
+ "op-alloy-rpc-types-engine",
+]
+
+[[package]]
+name = "op-alloy-rpc-types"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e322e7437d5fb4aea6d98879046d42516137fe489d867a1b0d53275da76cbd2d"
+dependencies = [
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
+ "alloy-network 2.0.5",
+ "alloy-network-primitives 2.0.5",
+ "alloy-primitives",
+ "alloy-rpc-types-eth 2.0.5",
+ "alloy-serde 2.0.5",
+ "derive_more",
+ "op-alloy-consensus",
+ "reth-rpc-traits",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "op-alloy-rpc-types-engine"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5039b25b7c9fad4871774faab4060b3fc0a05572f11082088b6b9cd4109f6d40"
+dependencies = [
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-engine 2.0.5",
+ "alloy-serde 2.0.5",
+ "derive_more",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
+ "op-alloy-consensus",
+ "serde",
+ "sha2 0.10.9",
+ "snap",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "opaque-debug"
@@ -6100,6 +6285,7 @@ dependencies = [
  "arrayvec",
  "bitvec",
  "byte-slice-cast",
+ "bytes",
  "const_format",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
@@ -6960,6 +7146,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-codecs"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee9f6a4b8f4992c030c82fb8c2dcc872349452009b4127055f678f7d5a3dea3"
+dependencies = [
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
+ "alloy-genesis 2.0.5",
+ "alloy-primitives",
+ "alloy-trie",
+ "bytes",
+ "modular-bitfield",
+ "parity-scale-codec",
+ "reth-codecs-derive",
+ "reth-zstd-compressors",
+ "serde",
+]
+
+[[package]]
+name = "reth-codecs-derive"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07feedb2c0ec9ec76dd1210b7486904f139243dc9b264586994a6246955c1c73"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "reth-primitives-traits"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83138080a41e35a6aa876410ca67231fb35da7e2ca494315d8b8be15e9ed9c0"
+dependencies = [
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
+ "alloy-genesis 2.0.5",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-eth 2.0.5",
+ "alloy-trie",
+ "bytes",
+ "derive_more",
+ "once_cell",
+ "revm-bytecode 10.0.0",
+ "revm-primitives 23.0.0",
+ "revm-state 11.0.1",
+ "secp256k1 0.30.0",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-rpc-traits"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "706ca5cd7bc99bdf82d89f7f3215242a9f901128ab4c09bb88b0640a0cf40b77"
+dependencies = [
+ "alloy-consensus 2.0.5",
+ "alloy-network 2.0.5",
+ "alloy-primitives",
+ "alloy-rpc-types-eth 2.0.5",
+ "alloy-signer 2.0.5",
+ "reth-primitives-traits",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-zstd-compressors"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a1f121117f149412446e92c5442d4a9722e04e7760ac3f62d518f4213634d9"
+dependencies = [
+ "zstd",
+]
+
+[[package]]
 name = "revm"
 version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7004,7 +7268,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdbb3a3d735efa94c91f2ef6bf20a35f99a77bc78f3e25bd758336901bdf9661"
 dependencies = [
  "bitvec",
+ "phf",
  "revm-primitives 23.0.0",
+ "serde",
 ]
 
 [[package]]
@@ -7289,6 +7555,7 @@ dependencies = [
  "alloy-primitives",
  "num_enum",
  "once_cell",
+ "serde",
 ]
 
 [[package]]
@@ -7312,6 +7579,7 @@ dependencies = [
  "bitflags",
  "revm-bytecode 10.0.0",
  "revm-primitives 23.0.0",
+ "serde",
 ]
 
 [[package]]
@@ -8240,6 +8508,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ rusqlite = { version = "0.31", features = ["bundled"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 mpp = { version = "0.10.4", default-features = false, features = ["client", "tempo", "reqwest-rustls-tls"] }
 url = "2"
+humantime = "2"
 humantime-serde = "1"
 tempfile = "3"
 futures = "0.3"
@@ -93,6 +94,8 @@ rpassword = "7"
 # Ethereum stack
 alloy = { version = "2", features = ["full", "signer-local", "rpc-types", "providers", "provider-http", "consensus", "network", "rlp", "json-abi", "k256", "eips", "essentials", "contract", "transport-throttle", "json-rpc"] }
 alloy-dyn-abi = { version = "1.5", features = ["eip712"] }
+# OP Stack typed RPC (Base, Optimism deposit/system transactions & receipts).
+op-alloy = { version = "2", features = ["rpc-types", "consensus", "serde", "network"] }
 
 # Internal crates
 bloom-mempool  = { path = "crates/bloom-mempool" }

--- a/crates/bloom-daemon/src/ipc.rs
+++ b/crates/bloom-daemon/src/ipc.rs
@@ -24,6 +24,7 @@
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::UNIX_EPOCH;
 
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as B64;
@@ -1257,12 +1258,19 @@ fn entry_to_json(e: &Entry) -> Value {
         EntryKind::File => "file",
         EntryKind::Symlink => "symlink",
     };
+    let modified_ms = e.modified.map(|modified| {
+        modified
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+    });
     json!({
         "name": e.name,
         "kind": kind,
         "size": e.size,
         "mode": e.mode,
         "link_target": e.link_target,
+        "modified_ms": modified_ms,
     })
 }
 

--- a/crates/bloom-ens/tests/live_mainnet.rs
+++ b/crates/bloom-ens/tests/live_mainnet.rs
@@ -25,6 +25,7 @@ fn mainnet_spec(url: String) -> ChainSpec {
         native_symbol: "ETH".to_string(),
         native_decimals: 18,
         legacy_tx: false,
+        op_stack: false,
     }
 }
 

--- a/crates/bloom-evm/Cargo.toml
+++ b/crates/bloom-evm/Cargo.toml
@@ -14,6 +14,7 @@ hex.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 alloy.workspace = true
+op-alloy.workspace = true
 parking_lot.workspace = true
 url.workspace = true
 

--- a/crates/bloom-evm/src/lib.rs
+++ b/crates/bloom-evm/src/lib.rs
@@ -8,8 +8,9 @@
 
 use std::sync::Arc;
 
+use alloy::consensus::Transaction as TxTrait;
 use alloy::eips::BlockNumberOrTag;
-use alloy::network::{Ethereum, TransactionBuilder};
+use alloy::network::{Ethereum, ReceiptResponse, TransactionBuilder};
 use alloy::primitives::{Address, B256, BlockHash, Bytes, U256};
 use alloy::providers::{Provider, RootProvider};
 use alloy::rpc::types::eth::state::StateOverride;
@@ -18,6 +19,7 @@ use alloy::rpc::types::eth::{
 };
 use alloy::sol;
 use alloy::transports::TransportError;
+use op_alloy::network::Optimism;
 use parking_lot::RwLock;
 use thiserror::Error;
 use tracing::{debug, warn};
@@ -145,6 +147,11 @@ fn map_rpc_error(e: bloom_rpc::BloomRpcError) -> ChainError {
 pub struct ChainClient {
     spec: Arc<ChainSpec>,
     primary: Arc<RootProvider<Ethereum>>,
+    /// When `op_stack` is set, a `RootProvider<Optimism>` sharing the
+    /// same transport as `primary`. Its `get_transaction_by_hash` /
+    /// `get_transaction_receipt` natively decode deposit/system txs
+    /// (type `0x7e`) and L1-fee receipt fields.
+    op_primary: Option<Arc<RootProvider<Optimism>>>,
     engine: Arc<bloom_rpc::RpcEngine>,
     /// Cached chain id once the provider has reported it.
     cached_chain_id: Arc<RwLock<Option<u64>>>,
@@ -162,9 +169,15 @@ impl ChainClient {
     pub fn new(spec: ChainSpec) -> Result<Self, ChainError> {
         let engine = bloom_rpc::RpcEngine::build(&spec).map_err(map_rpc_error)?;
         let provider = engine.provider();
+        let op_primary = if spec.op_stack {
+            Some(Arc::new(RootProvider::<Optimism>::new(engine.raw_client())))
+        } else {
+            None
+        };
         Ok(Self {
             spec: Arc::new(spec),
             primary: provider,
+            op_primary,
             engine: Arc::new(engine),
             cached_chain_id: Arc::new(RwLock::new(None)),
         })
@@ -175,6 +188,10 @@ impl ChainClient {
     }
     pub fn id(&self) -> ChainId {
         ChainId(self.spec.chain_id)
+    }
+    /// True when this chain uses the OP Stack (Base, Optimism, …).
+    pub fn is_op_stack(&self) -> bool {
+        self.spec.op_stack
     }
     pub fn provider(&self) -> Arc<RootProvider<Ethereum>> {
         self.primary.clone()
@@ -331,27 +348,64 @@ impl ChainClient {
         Ok(self.primary.get_transaction_by_hash(hash).await?)
     }
 
-    pub async fn raw_tx_by_hash(
-        &self,
-        hash: B256,
-    ) -> Result<Option<serde_json::Value>, ChainError> {
-        Ok(self
-            .primary
-            .client()
-            .request("eth_getTransactionByHash", (format!("{hash:#x}"),))
-            .await?)
+    /// Fetch a transaction as typed JSON. On OP-stack chains the
+    /// `RootProvider<Optimism>` natively decodes deposit/system
+    /// transactions (type `0x7e`); on L1 chains the standard alloy
+    /// `Transaction` decoder is used.
+    pub async fn tx_json(&self, hash: B256) -> Result<Option<serde_json::Value>, ChainError> {
+        if let Some(op) = &self.op_primary {
+            match op.get_transaction_by_hash(hash).await? {
+                Some(tx) => serde_json::to_value(&tx)
+                    .map_err(|e| ChainError::Decode(format!("tx {hash:#x}: {e}")))
+                    .map(Some),
+                None => Ok(None),
+            }
+        } else {
+            match self.tx_by_hash(hash).await? {
+                Some(tx) => serde_json::to_value(&tx)
+                    .map_err(|e| ChainError::Decode(format!("tx {hash:#x}: {e}")))
+                    .map(Some),
+                None => Ok(None),
+            }
+        }
     }
 
     pub async fn receipt(&self, hash: B256) -> Result<Option<TransactionReceipt>, ChainError> {
         Ok(self.primary.get_transaction_receipt(hash).await?)
     }
 
-    pub async fn raw_receipt(&self, hash: B256) -> Result<Option<serde_json::Value>, ChainError> {
-        Ok(self
-            .primary
-            .client()
-            .request("eth_getTransactionReceipt", (format!("{hash:#x}"),))
-            .await?)
+    /// Fetch a receipt as typed JSON. On OP-stack chains the
+    /// `RootProvider<Optimism>` natively decodes L1-fee fields and
+    /// deposit-tx metadata.
+    pub async fn receipt_json(&self, hash: B256) -> Result<Option<serde_json::Value>, ChainError> {
+        if let Some(op) = &self.op_primary {
+            match op.get_transaction_receipt(hash).await? {
+                Some(r) => serde_json::to_value(&r)
+                    .map_err(|e| ChainError::Decode(format!("receipt {hash:#x}: {e}")))
+                    .map(Some),
+                None => Ok(None),
+            }
+        } else {
+            match self.receipt(hash).await? {
+                Some(r) => serde_json::to_value(&r)
+                    .map_err(|e| ChainError::Decode(format!("receipt {hash:#x}: {e}")))
+                    .map(Some),
+                None => Ok(None),
+            }
+        }
+    }
+
+    /// Extract the block number from a transaction receipt using the
+    /// typed decoder appropriate for the chain family.
+    pub async fn receipt_block_number(&self, hash: B256) -> Result<Option<u64>, ChainError> {
+        if let Some(op) = &self.op_primary {
+            Ok(op
+                .get_transaction_receipt(hash)
+                .await?
+                .and_then(|r| r.block_number()))
+        } else {
+            Ok(self.receipt(hash).await?.and_then(|r| r.block_number))
+        }
     }
 
     /// Re-execute a *reverted* transaction via `eth_call` at the block it
@@ -362,33 +416,93 @@ impl ChainClient {
     /// * `Ok(Some(bytes))` — the replayed call reverted and we extracted
     ///   the encoded returndata from the JSON-RPC error.
     pub async fn trace_revert(&self, hash: B256) -> Result<Option<Bytes>, ChainError> {
-        let receipt = match self.primary.get_transaction_receipt(hash).await? {
-            Some(r) => r,
-            None => {
-                debug!(%hash, "trace_revert.no_receipt");
+        let block_number;
+        let req;
+
+        if let Some(op) = &self.op_primary {
+            // OP-stack path: the Optimism provider decodes deposit/system
+            // txs and L1-fee receipts natively.
+            let receipt = match op.get_transaction_receipt(hash).await? {
+                Some(r) => r,
+                None => {
+                    debug!(%hash, "trace_revert.no_receipt");
+                    return Ok(None);
+                }
+            };
+            if receipt.status() {
+                debug!(%hash, "trace_revert.tx_succeeded");
                 return Ok(None);
             }
-        };
-        if receipt.status() {
-            debug!(%hash, "trace_revert.tx_succeeded");
-            return Ok(None);
+            block_number = match receipt.block_number() {
+                Some(n) => n,
+                None => {
+                    debug!(%hash, "trace_revert.no_block_number");
+                    return Ok(None);
+                }
+            };
+            let from = receipt.from();
+            let tx = match op.get_transaction_by_hash(hash).await? {
+                Some(t) => t,
+                None => {
+                    debug!(%hash, "trace_revert.no_tx");
+                    return Ok(None);
+                }
+            };
+            // Build TransactionRequest from typed fields, preserving
+            // all execution-relevant fields (gas price, access list, etc.)
+            // so the replay matches the original execution exactly.
+            let mut builder = TransactionRequest::default()
+                .with_from(from)
+                .with_input(tx.input().clone())
+                .with_gas_limit(tx.gas_limit())
+                .with_value(tx.value())
+                .with_max_fee_per_gas(tx.max_fee_per_gas());
+            if let Some(gas_price) = tx.gas_price() {
+                builder = builder.with_gas_price(gas_price);
+            }
+            if let Some(prio_fee) = tx.max_priority_fee_per_gas() {
+                builder = builder.with_max_priority_fee_per_gas(prio_fee);
+            }
+            if let Some(chain_id) = tx.chain_id() {
+                builder = builder.with_chain_id(chain_id);
+            }
+            if let Some(to) = tx.to() {
+                builder = builder.with_to(to);
+            }
+            if let Some(access_list) = tx.access_list() {
+                builder = builder.with_access_list(access_list.clone());
+            }
+            req = builder;
+        } else {
+            // L1 path: standard typed decode handles all known tx types.
+            let receipt = match self.primary.get_transaction_receipt(hash).await? {
+                Some(r) => r,
+                None => {
+                    debug!(%hash, "trace_revert.no_receipt");
+                    return Ok(None);
+                }
+            };
+            if receipt.status() {
+                debug!(%hash, "trace_revert.tx_succeeded");
+                return Ok(None);
+            }
+            block_number = match receipt.block_number {
+                Some(n) => n,
+                None => {
+                    debug!(%hash, "trace_revert.no_block_number");
+                    return Ok(None);
+                }
+            };
+            let tx = match self.primary.get_transaction_by_hash(hash).await? {
+                Some(t) => t,
+                None => {
+                    debug!(%hash, "trace_revert.no_tx");
+                    return Ok(None);
+                }
+            };
+            req = tx.into_request().with_from(receipt.from);
         }
-        let block_number = match receipt.block_number {
-            Some(n) => n,
-            None => {
-                debug!(%hash, "trace_revert.no_block_number");
-                return Ok(None);
-            }
-        };
-        let tx = match self.primary.get_transaction_by_hash(hash).await? {
-            Some(t) => t,
-            None => {
-                debug!(%hash, "trace_revert.no_tx");
-                return Ok(None);
-            }
-        };
-        let from = receipt.from;
-        let req: TransactionRequest = tx.into_request().with_from(from);
+
         let call = self
             .primary
             .call(req)

--- a/crates/bloom-evm/src/lib.rs
+++ b/crates/bloom-evm/src/lib.rs
@@ -137,6 +137,40 @@ fn map_rpc_error(e: bloom_rpc::BloomRpcError) -> ChainError {
     }
 }
 
+/// Build the `eth_call` request that replays a mined transaction,
+/// preserving all execution-relevant fields (fees, access list, etc.)
+/// so the replay matches the original execution.
+///
+/// Fee fields are mutually exclusive: legacy transactions report their
+/// gas price through both `gas_price()` and `max_fee_per_gas()`, and
+/// geth-family nodes reject calls carrying both `gasPrice` and
+/// EIP-1559 fee fields.
+fn revert_replay_request<T: TxTrait>(from: Address, tx: &T) -> TransactionRequest {
+    let mut builder = TransactionRequest::default()
+        .with_from(from)
+        .with_input(tx.input().clone())
+        .with_gas_limit(tx.gas_limit())
+        .with_value(tx.value());
+    if let Some(gas_price) = tx.gas_price() {
+        builder = builder.with_gas_price(gas_price);
+    } else {
+        builder = builder.with_max_fee_per_gas(tx.max_fee_per_gas());
+        if let Some(prio_fee) = tx.max_priority_fee_per_gas() {
+            builder = builder.with_max_priority_fee_per_gas(prio_fee);
+        }
+    }
+    if let Some(chain_id) = tx.chain_id() {
+        builder = builder.with_chain_id(chain_id);
+    }
+    if let Some(to) = tx.to() {
+        builder = builder.with_to(to);
+    }
+    if let Some(access_list) = tx.access_list() {
+        builder = builder.with_access_list(access_list.clone());
+    }
+    builder
+}
+
 /// One alloy provider backed by the layered `bloom-rpc` engine.
 ///
 /// The provider is a `RootProvider<Ethereum>` whose transport is the
@@ -448,31 +482,7 @@ impl ChainClient {
                     return Ok(None);
                 }
             };
-            // Build TransactionRequest from typed fields, preserving
-            // all execution-relevant fields (gas price, access list, etc.)
-            // so the replay matches the original execution exactly.
-            let mut builder = TransactionRequest::default()
-                .with_from(from)
-                .with_input(tx.input().clone())
-                .with_gas_limit(tx.gas_limit())
-                .with_value(tx.value())
-                .with_max_fee_per_gas(tx.max_fee_per_gas());
-            if let Some(gas_price) = tx.gas_price() {
-                builder = builder.with_gas_price(gas_price);
-            }
-            if let Some(prio_fee) = tx.max_priority_fee_per_gas() {
-                builder = builder.with_max_priority_fee_per_gas(prio_fee);
-            }
-            if let Some(chain_id) = tx.chain_id() {
-                builder = builder.with_chain_id(chain_id);
-            }
-            if let Some(to) = tx.to() {
-                builder = builder.with_to(to);
-            }
-            if let Some(access_list) = tx.access_list() {
-                builder = builder.with_access_list(access_list.clone());
-            }
-            req = builder;
+            req = revert_replay_request(from, &tx);
         } else {
             // L1 path: standard typed decode handles all known tx types.
             let receipt = match self.primary.get_transaction_receipt(hash).await? {
@@ -1016,6 +1026,33 @@ pub fn parse_block_arg(s: &str) -> Result<u64, ChainError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Legacy txs report their gas price through both `gas_price()` and
+    /// `max_fee_per_gas()`; the replay request must carry exactly one
+    /// fee style or geth-family nodes reject the `eth_call`.
+    #[test]
+    fn revert_replay_request_sets_one_fee_style() {
+        let legacy = alloy::consensus::TxLegacy {
+            gas_price: 7,
+            gas_limit: 21_000,
+            ..Default::default()
+        };
+        let req = revert_replay_request(Address::ZERO, &legacy);
+        assert_eq!(req.gas_price, Some(7));
+        assert_eq!(req.max_fee_per_gas, None);
+        assert_eq!(req.max_priority_fee_per_gas, None);
+
+        let eip1559 = alloy::consensus::TxEip1559 {
+            max_fee_per_gas: 9,
+            max_priority_fee_per_gas: 2,
+            gas_limit: 21_000,
+            ..Default::default()
+        };
+        let req = revert_replay_request(Address::ZERO, &eip1559);
+        assert_eq!(req.gas_price, None);
+        assert_eq!(req.max_fee_per_gas, Some(9));
+        assert_eq!(req.max_priority_fee_per_gas, Some(2));
+    }
 
     #[test]
     fn registry_add_get() {

--- a/crates/bloom-evm/src/lib.rs
+++ b/crates/bloom-evm/src/lib.rs
@@ -331,8 +331,27 @@ impl ChainClient {
         Ok(self.primary.get_transaction_by_hash(hash).await?)
     }
 
+    pub async fn raw_tx_by_hash(
+        &self,
+        hash: B256,
+    ) -> Result<Option<serde_json::Value>, ChainError> {
+        Ok(self
+            .primary
+            .client()
+            .request("eth_getTransactionByHash", (format!("{hash:#x}"),))
+            .await?)
+    }
+
     pub async fn receipt(&self, hash: B256) -> Result<Option<TransactionReceipt>, ChainError> {
         Ok(self.primary.get_transaction_receipt(hash).await?)
+    }
+
+    pub async fn raw_receipt(&self, hash: B256) -> Result<Option<serde_json::Value>, ChainError> {
+        Ok(self
+            .primary
+            .client()
+            .request("eth_getTransactionReceipt", (format!("{hash:#x}"),))
+            .await?)
     }
 
     /// Re-execute a *reverted* transaction via `eth_call` at the block it

--- a/crates/bloom-evm/tests/live_op_stack.rs
+++ b/crates/bloom-evm/tests/live_op_stack.rs
@@ -1,0 +1,42 @@
+use bloom_evm::ChainClient;
+use bloom_proto::config::Config;
+
+/// Verify the `RootProvider<Optimism>` natively decodes a real
+/// deposit/system transaction (type `0x7e`) on Base mainnet, and that
+/// the receipt carries L1-fee fields.
+#[tokio::test]
+#[ignore = "hits live Base RPC"]
+async fn op_stack_live_base_deposit_tx() {
+    let config = Config::local_default();
+    let spec = config
+        .chains
+        .get("base")
+        .expect("base chain in config")
+        .clone();
+    let client = ChainClient::new(spec).unwrap();
+
+    let tx_hash: alloy::primitives::B256 =
+        "0x9e892552b72f7d974c43fb34ee40fb10f156f4afd11306501ad0f919c5a2c8cc"
+            .parse()
+            .unwrap();
+
+    let tx = client.tx_json(tx_hash).await.unwrap();
+    assert!(tx.is_some(), "tx_json should return Some for deposit tx");
+    let tx = tx.unwrap();
+    assert_eq!(
+        tx.get("type").and_then(|v| v.as_str()),
+        Some("0x7e"),
+        "tx should be type 0x7e"
+    );
+
+    let receipt = client.receipt_json(tx_hash).await.unwrap();
+    assert!(receipt.is_some(), "receipt_json should return Some");
+    let receipt = receipt.unwrap();
+    assert!(
+        receipt.get("l1Fee").is_some(),
+        "receipt should have l1Fee field"
+    );
+
+    let block = client.receipt_block_number(tx_hash).await.unwrap();
+    assert!(block.is_some(), "block_number should be Some");
+}

--- a/crates/bloom-mount/src/adapter.rs
+++ b/crates/bloom-mount/src/adapter.rs
@@ -785,6 +785,12 @@ pub struct BloomFs {
     directory_cache: Arc<MountDirectoryCache>,
     /// Cold list operations coalesce independently from file renders.
     directory_in_flight: Arc<Mutex<HashMap<VfsPath, InFlightDirectory>>>,
+    /// Wall-clock time this adapter was built; the root directory's
+    /// mtime. Stable across getattrs — a per-stat `SystemTime::now()`
+    /// would make the root look freshly modified to every freshness
+    /// check (`rsync`, `find -newer`) — but saner-looking than the
+    /// epoch fallback used for entries with no known artifact time.
+    mounted_at: SystemTime,
 }
 
 impl BloomFs {
@@ -796,6 +802,7 @@ impl BloomFs {
             in_flight: Arc::new(Mutex::new(HashMap::new())),
             directory_cache: Arc::new(MountDirectoryCache::new(DIRECTORY_CACHE_CAPACITY)),
             directory_in_flight: Arc::new(Mutex::new(HashMap::new())),
+            mounted_at: SystemTime::now(),
         }
     }
 
@@ -1050,7 +1057,7 @@ impl FileSystem for BloomFs {
             BloomHandle::Root => {
                 let mut a = stable_attrs(ObjectType::Directory, fileid_for(&VfsPath::root()));
                 a.mode = 0o755;
-                let ts = system_time_to_ts(SystemTime::now());
+                let ts = system_time_to_ts(self.mounted_at);
                 a.mtime = ts;
                 a.atime = ts;
                 a.ctime = ts;

--- a/crates/bloom-mount/src/adapter.rs
+++ b/crates/bloom-mount/src/adapter.rs
@@ -19,7 +19,7 @@ use std::hash::{Hash, Hasher};
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{Duration, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -254,6 +254,15 @@ fn epoch_ts() -> Timestamp {
     }
 }
 
+/// Build a `Timestamp` from a system time, falling back to the Unix epoch.
+fn system_time_to_ts(time: SystemTime) -> Timestamp {
+    let dur = time.duration_since(UNIX_EPOCH).unwrap_or_default();
+    Timestamp {
+        seconds: dur.as_secs() as i64,
+        nanos: dur.subsec_nanos(),
+    }
+}
+
 fn stable_attrs(object_type: ObjectType, fileid: u64) -> Attrs {
     let mut attrs = Attrs::new(object_type, fileid);
     let ts = epoch_ts();
@@ -293,6 +302,10 @@ fn entry_to_attrs(path: &VfsPath, e: &Entry, size: u64) -> Attrs {
     a.size = size;
     a.space_used = size;
     a.mode = e.mode;
+    let ts = system_time_to_ts(e.modified.unwrap_or_else(SystemTime::now));
+    a.mtime = ts;
+    a.atime = ts;
+    a.ctime = ts;
     if matches!(e.kind, EntryKind::File | EntryKind::Symlink) {
         a.change = file_change_now();
     }
@@ -1037,6 +1050,10 @@ impl FileSystem for BloomFs {
             BloomHandle::Root => {
                 let mut a = stable_attrs(ObjectType::Directory, fileid_for(&VfsPath::root()));
                 a.mode = 0o755;
+                let ts = system_time_to_ts(SystemTime::now());
+                a.mtime = ts;
+                a.atime = ts;
+                a.ctime = ts;
                 a.change = self.dir_change(&VfsPath::root()).await?;
                 Ok(a)
             }
@@ -2434,6 +2451,19 @@ mod tests {
         let run = fs.lookup(&ctx, &dir, "run").await.unwrap();
         let attrs = fs.getattr(&ctx, &run).await.unwrap();
         assert_eq!(attrs.mode & 0o777, 0o555);
+    }
+
+    #[test]
+    fn entry_to_attrs_uses_entry_modified_time() {
+        let modified = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+        let entry = Entry::file("artifact.json").with_modified(modified);
+        let path = VfsPath::parse("/requests/pending/req_1/artifact.json").unwrap();
+
+        let attrs = entry_to_attrs(&path, &entry, 0);
+
+        assert_eq!(attrs.mtime.seconds, 1_700_000_000);
+        assert_eq!(attrs.ctime.seconds, 1_700_000_000);
+        assert_eq!(attrs.atime.seconds, 1_700_000_000);
     }
 
     /// Bug #5: ACCESS strips MODIFY/EXTEND/DELETE for a read-only path

--- a/crates/bloom-mount/src/adapter.rs
+++ b/crates/bloom-mount/src/adapter.rs
@@ -302,7 +302,7 @@ fn entry_to_attrs(path: &VfsPath, e: &Entry, size: u64) -> Attrs {
     a.size = size;
     a.space_used = size;
     a.mode = e.mode;
-    let ts = system_time_to_ts(e.modified.unwrap_or_else(SystemTime::now));
+    let ts = e.modified.map(system_time_to_ts).unwrap_or_else(epoch_ts);
     a.mtime = ts;
     a.atime = ts;
     a.ctime = ts;

--- a/crates/bloom-petals/src/package.rs
+++ b/crates/bloom-petals/src/package.rs
@@ -1932,10 +1932,8 @@ fn validate_route_wasm_inner(
         let payload = payload.map_err(|e| PetalError::InvalidWasm(format!("{path}: {e}")))?;
         let current_depth = parse_depth;
         match payload {
-            Payload::Version { encoding, .. } => {
-                if current_depth == 0 {
-                    saw_component |= matches!(encoding, wasmparser::Encoding::Component);
-                }
+            Payload::Version { encoding, .. } if current_depth == 0 => {
+                saw_component |= matches!(encoding, wasmparser::Encoding::Component);
             }
             Payload::ComponentTypeSection(reader) => {
                 if current_depth != 0 {

--- a/crates/bloom-petals/src/router.rs
+++ b/crates/bloom-petals/src/router.rs
@@ -315,6 +315,7 @@ fn entry_to_vfs(entry: DispatchEntry) -> Result<Entry, HandlerError> {
             entry.mode
         },
         link_target: entry.link_target,
+        modified: None,
     })
 }
 

--- a/crates/bloom-proto/src/chain.rs
+++ b/crates/bloom-proto/src/chain.rs
@@ -111,6 +111,12 @@ pub struct ChainSpec {
     /// `max_priority_fee_per_gas`. Defaults to false (EIP-1559).
     #[serde(default)]
     pub legacy_tx: bool,
+    /// When true, this chain is part of the OP Stack (Base, Optimism,
+    /// …) and produces deposit/system transactions (type `0x7e`) and
+    /// receipts with L1-fee fields. The EVM client uses `op-alloy`
+    /// typed decoders so these are parsed correctly.
+    #[serde(default)]
+    pub op_stack: bool,
 }
 
 fn default_native() -> String {
@@ -134,6 +140,7 @@ impl ChainSpec {
             native_symbol: "ETH".to_string(),
             native_decimals: 18,
             legacy_tx: false,
+            op_stack: false,
         }
     }
 
@@ -142,6 +149,29 @@ impl ChainSpec {
     }
     pub fn r#ref(&self) -> ChainRef {
         ChainRef::new(&self.name)
+    }
+
+    /// Builder helper: marks this chain as an OP Stack chain.
+    pub fn with_op_stack(mut self) -> Self {
+        self.op_stack = true;
+        self
+    }
+
+    /// Known OP-stack chain IDs (Optimism, Base, and their testnets).
+    pub fn is_known_op_stack_chain_id(chain_id: u64) -> bool {
+        matches!(chain_id, 10 | 8453 | 11155420 | 84532)
+    }
+
+    /// Infer `op_stack` from the chain ID when the field was absent in
+    /// an older config file. Only upgrades falseâtrue for well-known
+    /// OP-stack chain IDs; never downgrades.
+    pub fn infer_op_stack(&mut self) -> bool {
+        if !self.op_stack && Self::is_known_op_stack_chain_id(self.chain_id) {
+            self.op_stack = true;
+            true
+        } else {
+            false
+        }
     }
 
     /// Single source of truth for the RPC layer.
@@ -216,6 +246,7 @@ mod tests {
         assert_eq!(c.native_symbol, "ETH");
         assert_eq!(c.native_decimals, 18);
         assert!(!c.legacy_tx);
+        assert!(!c.op_stack);
         assert!(c.etherscan_api_url.is_none());
     }
 
@@ -240,6 +271,7 @@ mod tests {
             native_symbol: "ETH".to_string(),
             native_decimals: 18,
             legacy_tx: false,
+            op_stack: false,
         };
         let s = serde_json::to_string(&original).unwrap();
         let back: ChainSpec = serde_json::from_str(&s).unwrap();
@@ -262,6 +294,7 @@ mod tests {
             native_symbol: "ETH".into(),
             native_decimals: 18,
             legacy_tx: false,
+            op_stack: false,
         };
         let eps = spec.endpoints();
         assert_eq!(eps.len(), 3);
@@ -309,6 +342,7 @@ mod tests {
             native_symbol: "ETH".into(),
             native_decimals: 18,
             legacy_tx: false,
+            op_stack: false,
         };
         assert_eq!(spec.endpoints(), rich);
     }

--- a/crates/bloom-proto/src/config.rs
+++ b/crates/bloom-proto/src/config.rs
@@ -375,6 +375,7 @@ fn evm_chain(
         native_symbol: native_symbol.to_string(),
         native_decimals: 18,
         legacy_tx: false,
+        op_stack: false,
     }
 }
 
@@ -397,7 +398,8 @@ fn default_chains() -> BTreeMap<String, ChainSpec> {
             &["https://mainnet.base.org", "https://base.llamarpc.com"],
             "Base Mainnet",
             "ETH",
-        ),
+        )
+        .with_op_stack(),
         evm_chain(
             "tempo",
             4217,
@@ -424,7 +426,8 @@ fn default_chains() -> BTreeMap<String, ChainSpec> {
             ],
             "OP Mainnet",
             "ETH",
-        ),
+        )
+        .with_op_stack(),
         evm_chain(
             "polygon",
             137,
@@ -520,7 +523,8 @@ impl Config {
 
     pub fn load(path: &Path) -> Result<Self, ConfigError> {
         let s = std::fs::read_to_string(path)?;
-        let cfg: Self = toml::from_str(&s)?;
+        let mut cfg: Self = toml::from_str(&s)?;
+        cfg.migrate();
         cfg.validate()?;
         Ok(cfg)
     }
@@ -541,6 +545,16 @@ impl Config {
             let cfg = Self::local_default();
             cfg.save(path)?;
             Ok(cfg)
+        }
+    }
+
+    /// Apply post-load migrations for backwards compatibility.
+    ///
+    /// Currently infers `op_stack` for well-known OP-stack chain IDs
+    /// (Optimism=10, Base=8453, â¦) that predate the `op_stack` field.
+    fn migrate(&mut self) {
+        for spec in self.chains.values_mut() {
+            spec.infer_op_stack();
         }
     }
 
@@ -1030,6 +1044,7 @@ allow_broadcast = true
             native_symbol: "ETH".into(),
             native_decimals: 18,
             legacy_tx: false,
+            op_stack: false,
         };
         assert!(!cfg.broadcast_permitted(&mainnet));
     }
@@ -1049,6 +1064,7 @@ allow_broadcast = true
             native_symbol: "ETH".into(),
             native_decimals: 18,
             legacy_tx: false,
+            op_stack: false,
         };
         assert!(cfg.broadcast_permitted(&mainnet));
     }
@@ -1233,5 +1249,43 @@ ws_url = "wss://example"
         let cfg: Config = toml::from_str(toml_src).unwrap();
         let m = cfg.mempool.get("ethereum").unwrap();
         assert_eq!(m.max_index_size, 50_000);
+    }
+
+    #[test]
+    fn load_migrates_op_stack_for_known_chain_ids() {
+        let toml_src = r#"
+default_chain = "base"
+
+[chains.base]
+name = "base"
+chain_id = 8453
+rpc_urls = ["https://mainnet.base.org"]
+
+[chains.ethereum]
+name = "ethereum"
+chain_id = 1
+rpc_urls = ["https://ethereum-rpc.publicnode.com"]
+
+[chains.optimism]
+name = "optimism"
+chain_id = 10
+rpc_urls = ["https://mainnet.optimism.io"]
+"#;
+        let td = tempdir().unwrap();
+        let path = td.path().join("config.toml");
+        std::fs::write(&path, toml_src).unwrap();
+        let cfg = Config::load(&path).unwrap();
+        assert!(
+            cfg.chains["base"].op_stack,
+            "base should be op_stack after migration"
+        );
+        assert!(
+            cfg.chains["optimism"].op_stack,
+            "optimism should be op_stack after migration"
+        );
+        assert!(
+            !cfg.chains["ethereum"].op_stack,
+            "ethereum should not be op_stack"
+        );
     }
 }

--- a/crates/bloom-rpc/src/transport.rs
+++ b/crates/bloom-rpc/src/transport.rs
@@ -131,6 +131,9 @@ pub struct RpcEngine {
     chain_name: String,
     endpoints: Vec<EndpointSpec>,
     provider: Arc<RootProvider<Ethereum>>,
+    /// Kept so callers can build a provider with a different network
+    /// type (e.g. `RootProvider<Optimism>`) over the same transport.
+    client: RpcClient,
     supports_subscriptions: bool,
     health: HealthRegistry,
     /// Send `true` here to cancel the probe loop on drop. Wrapped in
@@ -244,7 +247,7 @@ impl RpcEngine {
         // outer layer, so default to false (the most conservative
         // choice for retry/timeout heuristics).
         let client: RpcClient = RpcClient::new(service, false);
-        let provider: RootProvider<Ethereum> = RootProvider::<Ethereum>::new(client);
+        let provider: RootProvider<Ethereum> = RootProvider::<Ethereum>::new(client.clone());
 
         let health = HealthRegistry::new(tracked_urls);
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
@@ -268,6 +271,7 @@ impl RpcEngine {
             chain_name: spec.name.clone(),
             endpoints,
             provider: Arc::new(provider),
+            client,
             supports_subscriptions,
             health,
             shutdown_tx: Some(shutdown_tx),
@@ -281,6 +285,13 @@ impl RpcEngine {
     /// engine.
     pub fn provider(&self) -> Arc<RootProvider<Ethereum>> {
         self.provider.clone()
+    }
+
+    /// Clone of the underlying `RpcClient`, so callers can build a
+    /// provider with a different network type (e.g.
+    /// `RootProvider<Optimism>`) over the same transport stack.
+    pub fn raw_client(&self) -> RpcClient {
+        self.client.clone()
     }
 
     /// True if any configured endpoint declared a ws/wss URL and was

--- a/crates/bloom-tx/src/tx_engine.rs
+++ b/crates/bloom-tx/src/tx_engine.rs
@@ -4945,6 +4945,7 @@ mod tests {
             native_symbol: "ETH".into(),
             native_decimals: 18,
             legacy_tx: false,
+            op_stack: false,
         };
         bloom_evm::ChainClient::new(spec).unwrap()
     }
@@ -5501,6 +5502,7 @@ mod tests {
             native_symbol: "ETH".into(),
             native_decimals: 18,
             legacy_tx: false,
+            op_stack: false,
         };
         let chain = bloom_evm::ChainClient::new(spec).unwrap();
         let policy = bloom_proto::Policy::default();
@@ -5536,6 +5538,7 @@ mod tests {
             native_symbol: "ETH".into(),
             native_decimals: 18,
             legacy_tx: false,
+            op_stack: false,
         };
         (engine, spec, dir)
     }

--- a/crates/bloom-vfs/src/handler.rs
+++ b/crates/bloom-vfs/src/handler.rs
@@ -1,6 +1,8 @@
 //! The Handler trait — every top-level subtree implements it.
 
-use std::time::Duration;
+use std::fs;
+use std::path::Path;
+use std::time::{Duration, SystemTime};
 
 use async_trait::async_trait;
 use thiserror::Error;
@@ -25,6 +27,9 @@ pub struct Entry {
     pub mode: u32,
     /// For symlinks, the target.
     pub link_target: Option<String>,
+    /// Optional artifact modification time. Mount adapters surface this as
+    /// mtime/ctime/atime when a handler knows the backing artifact time.
+    pub modified: Option<SystemTime>,
 }
 
 impl Entry {
@@ -35,6 +40,7 @@ impl Entry {
             size: 0,
             mode: 0o755,
             link_target: None,
+            modified: None,
         }
     }
     /// Build a read-only file entry (mode 0o444). This is the right
@@ -57,6 +63,7 @@ impl Entry {
             size: 0,
             mode: 0o444,
             link_target: None,
+            modified: None,
         }
     }
     /// Build a writable file entry (mode 0o644). Use for the small set
@@ -68,6 +75,7 @@ impl Entry {
             size: 0,
             mode: 0o644,
             link_target: None,
+            modified: None,
         }
     }
     /// Build an executable read-only file entry (mode 0o555). This is used
@@ -80,6 +88,7 @@ impl Entry {
             size: 0,
             mode: 0o555,
             link_target: None,
+            modified: None,
         }
     }
     pub fn symlink(name: &str, target: &str) -> Self {
@@ -89,7 +98,65 @@ impl Entry {
             size: 0,
             mode: 0o777,
             link_target: Some(target.into()),
+            modified: None,
         }
+    }
+
+    pub fn with_modified(mut self, modified: SystemTime) -> Self {
+        self.modified = Some(modified);
+        self
+    }
+
+    pub fn with_modified_ms(self, modified_ms: u128) -> Self {
+        if modified_ms > u64::MAX as u128 {
+            return self;
+        }
+        self.with_modified(SystemTime::UNIX_EPOCH + Duration::from_millis(modified_ms as u64))
+    }
+
+    pub fn with_fs_metadata(mut self, metadata: &fs::Metadata) -> Self {
+        if self.kind == EntryKind::File {
+            self.size = metadata.len();
+        }
+        if let Ok(modified) = metadata.modified() {
+            self.modified = Some(modified);
+        }
+        self
+    }
+}
+
+pub fn entry_from_fs_metadata(name: &str, kind: EntryKind, metadata: &fs::Metadata) -> Entry {
+    match kind {
+        EntryKind::Dir => Entry::dir(name),
+        EntryKind::File => Entry::file(name),
+        EntryKind::Symlink => Entry::symlink(name, ""),
+    }
+    .with_fs_metadata(metadata)
+}
+
+pub fn entry_for_fs_path(
+    path: impl AsRef<Path>,
+    name: &str,
+    kind: EntryKind,
+) -> Result<Entry, HandlerError> {
+    let metadata = fs::metadata(path)?;
+    Ok(entry_from_fs_metadata(name, kind, &metadata))
+}
+
+pub fn entry_from_fs_dir_entry(
+    dir_entry: &fs::DirEntry,
+    name: &str,
+    kind: EntryKind,
+) -> Result<Entry, HandlerError> {
+    let metadata = dir_entry.metadata()?;
+    Ok(entry_from_fs_metadata(name, kind, &metadata))
+}
+
+pub fn fs_path_modified(path: impl AsRef<Path>) -> Result<Option<SystemTime>, HandlerError> {
+    match fs::metadata(path) {
+        Ok(metadata) => Ok(metadata.modified().ok()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(err.into()),
     }
 }
 
@@ -207,6 +274,7 @@ mod tests {
         assert_eq!(e.size, 0);
         assert_eq!(e.mode, 0o755);
         assert!(e.link_target.is_none());
+        assert!(e.modified.is_none());
     }
 
     #[test]
@@ -218,6 +286,7 @@ mod tests {
         assert_eq!(a.mode, b.mode);
         assert_eq!(a.size, b.size);
         assert_eq!(a.link_target, b.link_target);
+        assert_eq!(a.modified, b.modified);
     }
 
     #[test]
@@ -228,6 +297,7 @@ mod tests {
         assert_eq!(e.size, 0);
         assert_eq!(e.mode, 0o444);
         assert!(e.link_target.is_none());
+        assert!(e.modified.is_none());
     }
 
     #[test]
@@ -238,6 +308,7 @@ mod tests {
         assert_eq!(e.size, 0);
         assert_eq!(e.mode, 0o644);
         assert!(e.link_target.is_none());
+        assert!(e.modified.is_none());
     }
 
     #[test]
@@ -248,6 +319,7 @@ mod tests {
         assert_eq!(e.size, 0);
         assert_eq!(e.mode, 0o555);
         assert!(e.link_target.is_none());
+        assert!(e.modified.is_none());
     }
 
     #[test]
@@ -258,6 +330,36 @@ mod tests {
         assert_eq!(e.size, 0);
         assert_eq!(e.mode, 0o777);
         assert_eq!(e.link_target.as_deref(), Some("../ethereum"));
+        assert!(e.modified.is_none());
+    }
+
+    #[test]
+    fn with_modified_records_artifact_time() {
+        let modified = SystemTime::UNIX_EPOCH + Duration::from_secs(123);
+        let e = Entry::file("artifact.json").with_modified(modified);
+        assert_eq!(e.modified, Some(modified));
+    }
+
+    #[test]
+    fn with_modified_ms_records_epoch_milliseconds() {
+        let e = Entry::dir("req").with_modified_ms(1_700_000_000_123);
+        assert_eq!(
+            e.modified,
+            Some(SystemTime::UNIX_EPOCH + Duration::from_millis(1_700_000_000_123))
+        );
+    }
+
+    #[test]
+    fn with_fs_metadata_records_file_size_and_modified_time() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("artifact.json");
+        std::fs::write(&path, b"hello").unwrap();
+        let metadata = std::fs::metadata(&path).unwrap();
+
+        let entry = Entry::file("artifact.json").with_fs_metadata(&metadata);
+
+        assert_eq!(entry.size, 5);
+        assert_eq!(entry.modified, metadata.modified().ok());
     }
 
     #[test]

--- a/crates/bloom-vfs/src/handler.rs
+++ b/crates/bloom-vfs/src/handler.rs
@@ -139,7 +139,15 @@ pub fn entry_for_fs_path(
     name: &str,
     kind: EntryKind,
 ) -> Result<Entry, HandlerError> {
-    let metadata = fs::metadata(path)?;
+    // A missing backing artifact must surface as NotFound (ENOENT on
+    // mounts), not Io (EIO): clients treat EIO as a server fault.
+    let metadata = match fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Err(HandlerError::NotFound(name.to_string()));
+        }
+        Err(err) => return Err(err.into()),
+    };
     Ok(entry_from_fs_metadata(name, kind, &metadata))
 }
 
@@ -360,6 +368,17 @@ mod tests {
 
         assert_eq!(entry.size, 5);
         assert_eq!(entry.modified, metadata.modified().ok());
+    }
+
+    #[test]
+    fn entry_for_fs_path_maps_missing_path_to_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let err =
+            entry_for_fs_path(dir.path().join("missing"), "missing", EntryKind::File).unwrap_err();
+        assert!(
+            matches!(err, HandlerError::NotFound(_)),
+            "missing artifact must be NotFound (ENOENT), got: {err:?}"
+        );
     }
 
     #[test]

--- a/crates/bloom-vfs/src/handlers/chains.rs
+++ b/crates/bloom-vfs/src/handlers/chains.rs
@@ -100,6 +100,11 @@ pub struct ChainsHandler {
     /// configured. Keys are chain names (e.g., "ethereum").
     mempool_handlers:
         Arc<std::collections::BTreeMap<String, Arc<super::chains_mempool::MempoolHandler>>>,
+    /// Block timestamps backing directory-listing metadata, so kernel
+    /// readdir/getattr bursts don't fan out into repeated RPC fetches.
+    /// Head timestamps expire on a short TTL (heads advance);
+    /// mined-block timestamps are immutable, so only map size is bounded.
+    block_ts_cache: Arc<PlMutex<BlockTsCache>>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -113,6 +118,22 @@ struct TokenMetadata {
     decimals: u8,
     symbol: String,
     expires_at: Instant,
+}
+
+/// TTL for cached head-block timestamps in directory listings. Short
+/// enough that `ls` metadata tracks the chain head, long enough that a
+/// burst of readdir/getattr traffic collapses into one RPC fetch.
+const HEAD_TS_TTL: Duration = Duration::from_secs(5);
+
+/// Cap on cached per-number block timestamps. Entries are immutable so
+/// eviction is purely a memory bound; the map is cleared wholesale when
+/// full (a rebuild costs one RPC per listed block directory).
+const BLOCK_TS_CACHE_CAP: usize = 4096;
+
+#[derive(Default)]
+struct BlockTsCache {
+    head: std::collections::HashMap<String, (Instant, u64)>,
+    by_number: std::collections::HashMap<(String, u64), u64>,
 }
 
 impl ChainsHandler {
@@ -131,6 +152,7 @@ impl ChainsHandler {
             revert_decoder: Arc::new(DecoderChain::new()),
             revert_cache: Arc::new(PlMutex::new(std::collections::HashMap::new())),
             mempool_handlers: Arc::new(std::collections::BTreeMap::new()),
+            block_ts_cache: Arc::new(PlMutex::new(BlockTsCache::default())),
         }
     }
 
@@ -679,6 +701,50 @@ impl Handler for ChainsHandler {
 impl ChainsHandler {
     fn entry_with_unix_timestamp(entry: Entry, timestamp_secs: u64) -> Entry {
         entry.with_modified(SystemTime::UNIX_EPOCH + Duration::from_secs(timestamp_secs))
+    }
+
+    /// Head-block timestamp for `chain`, cached for [`HEAD_TS_TTL`].
+    /// Returns `None` on RPC failure — listings must not fail (or slow
+    /// down under readdir bursts) because a metadata fetch did.
+    async fn head_timestamp_cached(&self, chain: &str, client: &ChainClient) -> Option<u64> {
+        if let Some((fetched_at, ts)) = self.block_ts_cache.lock().head.get(chain)
+            && fetched_at.elapsed() < HEAD_TS_TTL
+        {
+            return Some(*ts);
+        }
+        let ts = match client.block_latest().await {
+            Ok(Some(block)) => block.header.timestamp,
+            _ => return None,
+        };
+        self.block_ts_cache
+            .lock()
+            .head
+            .insert(chain.to_string(), (Instant::now(), ts));
+        Some(ts)
+    }
+
+    /// Timestamp of mined block `number` on `chain`. Cached without a
+    /// TTL: block timestamps are immutable once mined.
+    async fn block_timestamp_cached(
+        &self,
+        chain: &str,
+        number: u64,
+        client: &ChainClient,
+    ) -> Option<u64> {
+        let key = (chain.to_string(), number);
+        if let Some(ts) = self.block_ts_cache.lock().by_number.get(&key) {
+            return Some(*ts);
+        }
+        let ts = match client.block_by_number(number).await {
+            Ok(Some(block)) => block.header.timestamp,
+            _ => return None,
+        };
+        let mut cache = self.block_ts_cache.lock();
+        if cache.by_number.len() >= BLOCK_TS_CACHE_CAP {
+            cache.by_number.clear();
+        }
+        cache.by_number.insert(key, ts);
+        Some(ts)
     }
 
     fn json_hex_u64(value: &serde_json::Value, key: &str) -> Option<u64> {
@@ -1329,26 +1395,24 @@ impl ChainsHandler {
                     Entry::file("timestamp"),
                     Entry::file("full.json"),
                 ];
-                match client.block_latest().await {
-                    Ok(Some(block)) => Ok(entries
+                match self.head_timestamp_cached(chain, &client).await {
+                    Some(ts) => Ok(entries
                         .into_iter()
-                        .map(|entry| Self::entry_with_unix_timestamp(entry, block.header.timestamp))
+                        .map(|entry| Self::entry_with_unix_timestamp(entry, ts))
                         .collect()),
-                    _ => Ok(entries),
+                    None => Ok(entries),
                 }
             }
             3 if segs[1] == "blocks" => {
                 // /chains/<chain>/blocks/<number>
                 let entries: Vec<Entry> = BLOCK_FILES.iter().map(|n| Entry::file(n)).collect();
                 Ok(match segs[2].parse::<u64>() {
-                    Ok(n) => match client.block_by_number(n).await {
-                        Ok(Some(block)) => entries
+                    Ok(n) => match self.block_timestamp_cached(chain, n, &client).await {
+                        Some(ts) => entries
                             .into_iter()
-                            .map(|entry| {
-                                Self::entry_with_unix_timestamp(entry, block.header.timestamp)
-                            })
+                            .map(|entry| Self::entry_with_unix_timestamp(entry, ts))
                             .collect(),
-                        _ => entries,
+                        None => entries,
                     },
                     Err(_) => entries,
                 })
@@ -1908,6 +1972,39 @@ mod tests {
             leaf.modified.is_none(),
             "lookup must not RPC-fetch timestamps"
         );
+    }
+
+    #[tokio::test]
+    async fn listing_timestamps_come_from_cache_not_rpc() {
+        // No eth_getBlockByNumber route is registered: a listing that
+        // still surfaces a timestamp can only have read the cache.
+        let rpc = spawn_rpc(31_342, std::collections::HashMap::new());
+        let h = ChainsHandler::new(registry_for_rpc(rpc, 31_342));
+        {
+            let mut cache = h.block_ts_cache.lock();
+            cache.by_number.insert(("test".into(), 7), 1_700_000_500);
+            cache
+                .head
+                .insert("test".into(), (Instant::now(), 1_700_000_600));
+        }
+
+        let expected_block =
+            std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_500);
+        let blocks = h
+            .list(&VfsPath::parse("/test/blocks/7").unwrap())
+            .await
+            .unwrap();
+        assert!(!blocks.is_empty());
+        assert!(blocks.iter().all(|e| e.modified == Some(expected_block)));
+
+        let expected_head =
+            std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_600);
+        let head = h
+            .list(&VfsPath::parse("/test/head").unwrap())
+            .await
+            .unwrap();
+        assert!(!head.is_empty());
+        assert!(head.iter().all(|e| e.modified == Some(expected_head)));
     }
 
     #[tokio::test]

--- a/crates/bloom-vfs/src/handlers/chains.rs
+++ b/crates/bloom-vfs/src/handlers/chains.rs
@@ -36,7 +36,7 @@
 //!   address or `not a proxy\n` when the slot is empty.
 
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 use async_trait::async_trait;
 
@@ -677,29 +677,142 @@ impl Handler for ChainsHandler {
 }
 
 impl ChainsHandler {
+    fn entry_with_unix_timestamp(entry: Entry, timestamp_secs: u64) -> Entry {
+        entry.with_modified(SystemTime::UNIX_EPOCH + Duration::from_secs(timestamp_secs))
+    }
+
+    fn json_hex_u64(value: &serde_json::Value, key: &str) -> Option<u64> {
+        let raw = value.get(key)?.as_str()?;
+        u64::from_str_radix(raw.strip_prefix("0x").unwrap_or(raw), 16).ok()
+    }
+
+    fn json_status(value: &serde_json::Value) -> Option<bool> {
+        let raw = value.get("status")?.as_str()?;
+        match raw {
+            "0x1" | "1" => Some(true),
+            "0x0" | "0" => Some(false),
+            _ => None,
+        }
+    }
+
+    async fn tx_json(
+        client: &ChainClient,
+        hash: alloy::primitives::B256,
+    ) -> Result<serde_json::Value, HandlerError> {
+        match client.tx_by_hash(hash).await {
+            Ok(Some(tx)) => serde_json::to_value(tx).map_err(err_be),
+            Ok(None) => Err(HandlerError::not_found(format!("tx {hash:#x}"))),
+            Err(typed_err) => client
+                .raw_tx_by_hash(hash)
+                .await
+                .map_err(err_be)?
+                .ok_or_else(|| HandlerError::not_found(format!("tx {hash:#x}")))
+                .inspect_err(|_| {
+                    tracing::debug!(hash = %format!("{hash:#x}"), error = %typed_err, "chains.tx.raw_fallback_miss");
+                }),
+        }
+    }
+
+    async fn receipt_json(
+        client: &ChainClient,
+        hash: alloy::primitives::B256,
+    ) -> Result<serde_json::Value, HandlerError> {
+        match client.receipt(hash).await {
+            Ok(Some(receipt)) => serde_json::to_value(receipt).map_err(err_be),
+            Ok(None) => Err(HandlerError::not_found(format!("receipt {hash:#x}"))),
+            Err(typed_err) => client
+                .raw_receipt(hash)
+                .await
+                .map_err(err_be)?
+                .ok_or_else(|| HandlerError::not_found(format!("receipt {hash:#x}")))
+                .inspect_err(|_| {
+                    tracing::debug!(hash = %format!("{hash:#x}"), error = %typed_err, "chains.receipt.raw_fallback_miss");
+                }),
+        }
+    }
+
+    async fn tx_block_number(client: &ChainClient, hash: alloy::primitives::B256) -> Option<u64> {
+        match client.receipt(hash).await {
+            Ok(Some(receipt)) => receipt.block_number,
+            _ => {
+                let raw = client.raw_receipt(hash).await.ok()??;
+                Self::json_hex_u64(&raw, "blockNumber")
+            }
+        }
+    }
+
+    async fn entry_with_block_timestamp(
+        &self,
+        client: &ChainClient,
+        entry: Entry,
+        block_number: u64,
+    ) -> Entry {
+        match client.block_by_number(block_number).await {
+            Ok(Some(block)) => Self::entry_with_unix_timestamp(entry, block.header.timestamp),
+            _ => entry,
+        }
+    }
+
+    async fn entry_with_head_timestamp(&self, client: &ChainClient, entry: Entry) -> Entry {
+        match client.block_latest().await {
+            Ok(Some(block)) => Self::entry_with_unix_timestamp(entry, block.header.timestamp),
+            _ => entry,
+        }
+    }
+
+    async fn entry_with_tx_block_timestamp(
+        &self,
+        client: &ChainClient,
+        entry: Entry,
+        tx_hash: &str,
+    ) -> Entry {
+        let Ok(hash) = tx_hash.parse::<alloy::primitives::B256>() else {
+            return entry;
+        };
+        let Some(block_number) = Self::tx_block_number(client, hash).await else {
+            return entry;
+        };
+        self.entry_with_block_timestamp(client, entry, block_number)
+            .await
+    }
+
     async fn lookup_inner(&self, path: &VfsPath) -> Result<Entry, HandlerError> {
         let segs = path.segments();
         if segs.is_empty() {
             return Ok(Entry::dir(""));
         }
         let chain = &segs[0];
-        let _client = self.client(chain)?;
+        let client = self.client(chain)?;
         if segs.len() == 1 {
             return Ok(Entry::dir(chain));
         }
         match segs[1].as_str() {
             "chain_id" if segs.len() == 2 => Ok(Entry::file("chain_id")),
             "head" => match segs.get(2).map(|s| s.as_str()) {
-                None => Ok(Entry::dir("head")),
-                Some("number") | Some("hash") | Some("timestamp") | Some("full.json") => {
-                    Ok(Entry::file(segs.last().unwrap()))
-                }
+                None => Ok(self
+                    .entry_with_head_timestamp(&client, Entry::dir("head"))
+                    .await),
+                Some("number") | Some("hash") | Some("timestamp") | Some("full.json") => Ok(self
+                    .entry_with_head_timestamp(&client, Entry::file(segs.last().unwrap()))
+                    .await),
                 _ => Err(HandlerError::not_found(path.to_string_path())),
             },
             "blocks" => match segs.len() {
                 2 => Ok(Entry::dir("blocks")),
-                3 => Ok(Entry::dir(&segs[2])),
-                4 if segs[3] == "full.json" => Ok(Entry::file("full.json")),
+                3 => {
+                    let entry = Entry::dir(&segs[2]);
+                    Ok(match segs[2].parse::<u64>() {
+                        Ok(n) => self.entry_with_block_timestamp(&client, entry, n).await,
+                        Err(_) => entry,
+                    })
+                }
+                4 if segs[3] == "full.json" => {
+                    let entry = Entry::file("full.json");
+                    Ok(match segs[2].parse::<u64>() {
+                        Ok(n) => self.entry_with_block_timestamp(&client, entry, n).await,
+                        Err(_) => entry,
+                    })
+                }
                 _ => Err(HandlerError::not_found(path.to_string_path())),
             },
             "addresses" => match segs.len() {
@@ -770,11 +883,15 @@ impl ChainsHandler {
             },
             "tx" => match segs.len() {
                 2 => Ok(Entry::dir("tx")),
-                3 => Ok(Entry::dir(&segs[2])),
+                3 => Ok(self
+                    .entry_with_tx_block_timestamp(&client, Entry::dir(&segs[2]), &segs[2])
+                    .await),
                 4 => {
                     let f = segs[3].as_str();
                     if TX_FILES.contains(&f) {
-                        Ok(Entry::file(f))
+                        Ok(self
+                            .entry_with_tx_block_timestamp(&client, Entry::file(f), &segs[2])
+                            .await)
                     } else {
                         Err(HandlerError::not_found(path.to_string_path()))
                     }
@@ -1050,55 +1167,53 @@ impl ChainsHandler {
                     .map_err(|e| HandlerError::invalid(format!("tx hash: {e}")))?;
                 match segs[3].as_str() {
                     "full.json" => {
-                        let tx = client
-                            .tx_by_hash(hash)
-                            .await
-                            .map_err(err_be)?
-                            .ok_or_else(|| HandlerError::not_found(format!("tx {hash:#x}")))?;
+                        let tx = Self::tx_json(&client, hash).await?;
                         Ok(serde_json::to_vec_pretty(&tx).map_err(err_be)?)
                     }
                     "receipt.json" => {
-                        let r =
-                            client.receipt(hash).await.map_err(err_be)?.ok_or_else(|| {
-                                HandlerError::not_found(format!("receipt {hash:#x}"))
-                            })?;
+                        let r = Self::receipt_json(&client, hash).await?;
                         Ok(serde_json::to_vec_pretty(&r).map_err(err_be)?)
                     }
                     "status" => {
-                        let r =
-                            client.receipt(hash).await.map_err(err_be)?.ok_or_else(|| {
-                                HandlerError::not_found(format!("receipt {hash:#x}"))
-                            })?;
-                        let s = if r.status() { "success" } else { "reverted" };
+                        let r = Self::receipt_json(&client, hash).await?;
+                        let status = Self::json_status(&r).ok_or_else(|| {
+                            HandlerError::backend(format!(
+                                "receipt {hash:#x} missing decodable status"
+                            ))
+                        })?;
+                        let s = if status { "success" } else { "reverted" };
                         Ok(format!("{}\n", s).into_bytes())
                     }
                     "block_number" => {
-                        let r =
-                            client.receipt(hash).await.map_err(err_be)?.ok_or_else(|| {
-                                HandlerError::not_found(format!("receipt {hash:#x}"))
-                            })?;
-                        Ok(format!("{}\n", r.block_number.unwrap_or(0)).into_bytes())
+                        let r = Self::receipt_json(&client, hash).await?;
+                        let block_number = Self::json_hex_u64(&r, "blockNumber").unwrap_or(0);
+                        Ok(format!("{}\n", block_number).into_bytes())
                     }
                     "gas_used" => {
-                        let r =
-                            client.receipt(hash).await.map_err(err_be)?.ok_or_else(|| {
-                                HandlerError::not_found(format!("receipt {hash:#x}"))
-                            })?;
-                        Ok(format!("{}\n", r.gas_used).into_bytes())
+                        let r = Self::receipt_json(&client, hash).await?;
+                        let gas_used = Self::json_hex_u64(&r, "gasUsed").ok_or_else(|| {
+                            HandlerError::backend(format!(
+                                "receipt {hash:#x} missing decodable gasUsed"
+                            ))
+                        })?;
+                        Ok(format!("{}\n", gas_used).into_bytes())
                     }
                     "logs.json" => {
-                        let r =
-                            client.receipt(hash).await.map_err(err_be)?.ok_or_else(|| {
-                                HandlerError::not_found(format!("receipt {hash:#x}"))
-                            })?;
-                        Ok(serde_json::to_vec_pretty(&r.inner.logs()).map_err(err_be)?)
+                        let r = Self::receipt_json(&client, hash).await?;
+                        let logs = r
+                            .get("logs")
+                            .cloned()
+                            .unwrap_or_else(|| serde_json::json!([]));
+                        Ok(serde_json::to_vec_pretty(&logs).map_err(err_be)?)
                     }
                     "error.json" => {
-                        let r =
-                            client.receipt(hash).await.map_err(err_be)?.ok_or_else(|| {
-                                HandlerError::not_found(format!("receipt {hash:#x}"))
-                            })?;
-                        if r.status() {
+                        let receipt_json = Self::receipt_json(&client, hash).await?;
+                        let status = Self::json_status(&receipt_json).ok_or_else(|| {
+                            HandlerError::backend(format!(
+                                "receipt {hash:#x} missing decodable status"
+                            ))
+                        })?;
+                        if status {
                             // Successful tx → emit an explicit "no error"
                             // marker rather than a NotFound. Lets callers
                             // `cat` the file unconditionally without
@@ -1107,6 +1222,10 @@ impl ChainsHandler {
                             // for every getattr on a successful tx.
                             return Ok(b"null\n".to_vec());
                         }
+                        let r =
+                            client.receipt(hash).await.map_err(err_be)?.ok_or_else(|| {
+                                HandlerError::not_found(format!("receipt {hash:#x}"))
+                            })?;
                         if let Some(cached) = self
                             .revert_cache
                             .lock()
@@ -1256,7 +1375,7 @@ impl ChainsHandler {
                 .collect());
         }
         let chain = &segs[0];
-        let _client = self.client(chain)?;
+        let client = self.client(chain)?;
         match segs.len() {
             1 => {
                 let mut entries = vec![
@@ -1276,15 +1395,36 @@ impl ChainsHandler {
                 }
                 Ok(entries)
             }
-            2 if segs[1] == "head" => Ok(vec![
-                Entry::file("number"),
-                Entry::file("hash"),
-                Entry::file("timestamp"),
-                Entry::file("full.json"),
-            ]),
+            2 if segs[1] == "head" => {
+                let entries = vec![
+                    Entry::file("number"),
+                    Entry::file("hash"),
+                    Entry::file("timestamp"),
+                    Entry::file("full.json"),
+                ];
+                match client.block_latest().await {
+                    Ok(Some(block)) => Ok(entries
+                        .into_iter()
+                        .map(|entry| Self::entry_with_unix_timestamp(entry, block.header.timestamp))
+                        .collect()),
+                    _ => Ok(entries),
+                }
+            }
             3 if segs[1] == "blocks" => {
                 // /chains/<chain>/blocks/<number>
-                Ok(BLOCK_FILES.iter().map(|n| Entry::file(n)).collect())
+                let entries: Vec<Entry> = BLOCK_FILES.iter().map(|n| Entry::file(n)).collect();
+                Ok(match segs[2].parse::<u64>() {
+                    Ok(n) => match client.block_by_number(n).await {
+                        Ok(Some(block)) => entries
+                            .into_iter()
+                            .map(|entry| {
+                                Self::entry_with_unix_timestamp(entry, block.header.timestamp)
+                            })
+                            .collect(),
+                        _ => entries,
+                    },
+                    Err(_) => entries,
+                })
             }
             2 if segs[1] == "gas" => Ok(vec![Entry::file("current.json")]),
             3 if segs[1] == "addresses" => {
@@ -1331,7 +1471,20 @@ impl ChainsHandler {
             }
             3 if segs[1] == "tx" => {
                 // /chains/<chain>/tx/<hash>
-                Ok(TX_FILES.iter().map(|n| Entry::file(n)).collect())
+                let entries: Vec<Entry> = TX_FILES.iter().map(|n| Entry::file(n)).collect();
+                let Ok(hash) = segs[2].parse::<alloy::primitives::B256>() else {
+                    return Ok(entries);
+                };
+                let Some(block_number) = Self::tx_block_number(&client, hash).await else {
+                    return Ok(entries);
+                };
+                match client.block_by_number(block_number).await {
+                    Ok(Some(block)) => Ok(entries
+                        .into_iter()
+                        .map(|entry| Self::entry_with_unix_timestamp(entry, block.header.timestamp))
+                        .collect()),
+                    _ => Ok(entries),
+                }
             }
             n if n >= 3 && segs[1] == "contracts" => {
                 let client = self.client(chain)?;
@@ -1803,6 +1956,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn head_entries_surface_head_block_timestamp() {
+        let timestamp = 1_700_000_100;
+        let mut routes = std::collections::HashMap::new();
+        routes.insert("eth_getBlockByNumber".to_string(), rpc_block(42, timestamp));
+        let rpc = spawn_rpc(31_338, routes);
+        let h = ChainsHandler::new(registry_for_rpc(rpc, 31_338));
+
+        let entries = h
+            .list(&VfsPath::parse("/test/head").unwrap())
+            .await
+            .unwrap();
+
+        let expected =
+            std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(timestamp);
+        assert!(entries.iter().all(|entry| entry.modified == Some(expected)));
+    }
+
+    #[tokio::test]
+    async fn block_entries_surface_block_timestamp() {
+        let timestamp = 1_700_000_200;
+        let mut routes = std::collections::HashMap::new();
+        routes.insert("eth_getBlockByNumber".to_string(), rpc_block(7, timestamp));
+        let rpc = spawn_rpc(31_339, routes);
+        let h = ChainsHandler::new(registry_for_rpc(rpc, 31_339));
+
+        let dir = h
+            .lookup(&VfsPath::parse("/test/blocks/7").unwrap())
+            .await
+            .unwrap();
+        let leaf = h
+            .lookup(&VfsPath::parse("/test/blocks/7/full.json").unwrap())
+            .await
+            .unwrap();
+
+        let expected =
+            std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(timestamp);
+        assert_eq!(dir.modified, Some(expected));
+        assert_eq!(leaf.modified, Some(expected));
+    }
+
+    #[tokio::test]
     async fn tx_hash_dir_lists_documented_leaves() {
         let h = ChainsHandler::new(anvil_registry());
         let chain_name = h.registry.list_names()[0].clone();
@@ -1821,6 +2015,105 @@ mod tests {
             .collect();
 
         assert_eq!(names, TX_FILES);
+    }
+
+    #[tokio::test]
+    async fn confirmed_tx_entries_surface_containing_block_timestamp() {
+        let timestamp = 1_700_000_300;
+        let hash = format!("0x{}", "22".repeat(32));
+        let mut routes = std::collections::HashMap::new();
+        routes.insert(
+            "eth_getTransactionReceipt".to_string(),
+            rpc_receipt(&hash, 9),
+        );
+        routes.insert("eth_getBlockByNumber".to_string(), rpc_block(9, timestamp));
+        let rpc = spawn_rpc(31_340, routes);
+        let h = ChainsHandler::new(registry_for_rpc(rpc, 31_340));
+
+        let entries = h
+            .list(&VfsPath::parse(&format!("/test/tx/{hash}")).unwrap())
+            .await
+            .unwrap();
+        let leaf = h
+            .lookup(&VfsPath::parse(&format!("/test/tx/{hash}/receipt.json")).unwrap())
+            .await
+            .unwrap();
+
+        let expected =
+            std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(timestamp);
+        assert!(entries.iter().all(|entry| entry.modified == Some(expected)));
+        assert_eq!(leaf.modified, Some(expected));
+    }
+
+    #[tokio::test]
+    async fn unknown_typed_tx_receipt_falls_back_to_raw_json() {
+        let timestamp = 1_700_000_400;
+        let hash = format!("0x{}", "33".repeat(32));
+        let mut routes = std::collections::HashMap::new();
+        routes.insert(
+            "eth_getTransactionByHash".to_string(),
+            rpc_unknown_typed_tx(&hash, 11),
+        );
+        routes.insert(
+            "eth_getTransactionReceipt".to_string(),
+            rpc_unknown_typed_receipt(&hash, 11),
+        );
+        routes.insert("eth_getBlockByNumber".to_string(), rpc_block(11, timestamp));
+        let rpc = spawn_rpc(31_341, routes);
+        let h = ChainsHandler::new(registry_for_rpc(rpc, 31_341));
+
+        let full = h
+            .read(&VfsPath::parse(&format!("/test/tx/{hash}/full.json")).unwrap())
+            .await
+            .unwrap();
+        let full: serde_json::Value = serde_json::from_slice(&full).unwrap();
+        assert_eq!(full["type"], "0x7e");
+
+        let receipt = h
+            .read(&VfsPath::parse(&format!("/test/tx/{hash}/receipt.json")).unwrap())
+            .await
+            .unwrap();
+        let receipt: serde_json::Value = serde_json::from_slice(&receipt).unwrap();
+        assert_eq!(receipt["type"], "0x7e");
+
+        let status = h
+            .read(&VfsPath::parse(&format!("/test/tx/{hash}/status")).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(std::str::from_utf8(&status).unwrap(), "success\n");
+
+        let block_number = h
+            .read(&VfsPath::parse(&format!("/test/tx/{hash}/block_number")).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(std::str::from_utf8(&block_number).unwrap(), "11\n");
+
+        let gas_used = h
+            .read(&VfsPath::parse(&format!("/test/tx/{hash}/gas_used")).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(std::str::from_utf8(&gas_used).unwrap(), "21000\n");
+
+        let logs = h
+            .read(&VfsPath::parse(&format!("/test/tx/{hash}/logs.json")).unwrap())
+            .await
+            .unwrap();
+        let logs: serde_json::Value = serde_json::from_slice(&logs).unwrap();
+        assert_eq!(logs, serde_json::json!([]));
+
+        let error = h
+            .read(&VfsPath::parse(&format!("/test/tx/{hash}/error.json")).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(std::str::from_utf8(&error).unwrap(), "null\n");
+
+        let entry = h
+            .lookup(&VfsPath::parse(&format!("/test/tx/{hash}/receipt.json")).unwrap())
+            .await
+            .unwrap();
+        let expected =
+            std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(timestamp);
+        assert_eq!(entry.modified, Some(expected));
     }
 
     #[tokio::test]
@@ -2214,6 +2507,78 @@ mod tests {
         let reg = ChainRegistry::default();
         reg.add(client);
         reg
+    }
+
+    fn rpc_block(number: u64, timestamp: u64) -> serde_json::Value {
+        let zero32 = format!("0x{}", "00".repeat(32));
+        let zero8 = "0x0000000000000000".to_string();
+        let zero_addr = format!("0x{}", "00".repeat(20));
+        let zero_bloom = format!("0x{}", "00".repeat(256));
+        serde_json::json!({
+            "number": format!("0x{number:x}"),
+            "hash": format!("0x{}", "11".repeat(32)),
+            "parentHash": zero32,
+            "sha3Uncles": zero32,
+            "logsBloom": zero_bloom,
+            "transactionsRoot": zero32,
+            "stateRoot": zero32,
+            "receiptsRoot": zero32,
+            "miner": zero_addr,
+            "difficulty": "0x0",
+            "totalDifficulty": "0x0",
+            "extraData": "0x",
+            "size": "0x0",
+            "gasLimit": "0x0",
+            "gasUsed": "0x0",
+            "timestamp": format!("0x{timestamp:x}"),
+            "uncles": [],
+            "transactions": [],
+            "mixHash": format!("0x{}", "00".repeat(32)),
+            "nonce": zero8,
+            "baseFeePerGas": "0x0"
+        })
+    }
+
+    fn rpc_receipt(hash: &str, block_number: u64) -> serde_json::Value {
+        serde_json::json!({
+            "transactionHash": hash,
+            "transactionIndex": "0x0",
+            "blockHash": format!("0x{}", "11".repeat(32)),
+            "blockNumber": format!("0x{block_number:x}"),
+            "from": "0x0000000000000000000000000000000000000001",
+            "to": "0x0000000000000000000000000000000000000002",
+            "cumulativeGasUsed": "0x5208",
+            "gasUsed": "0x5208",
+            "contractAddress": null,
+            "logs": [],
+            "logsBloom": format!("0x{}", "00".repeat(256)),
+            "status": "0x1",
+            "effectiveGasPrice": "0x1",
+            "type": "0x2"
+        })
+    }
+
+    fn rpc_unknown_typed_tx(hash: &str, block_number: u64) -> serde_json::Value {
+        serde_json::json!({
+            "hash": hash,
+            "blockHash": format!("0x{}", "11".repeat(32)),
+            "blockNumber": format!("0x{block_number:x}"),
+            "transactionIndex": "0x0",
+            "from": "0x0000000000000000000000000000000000000001",
+            "to": "0x0000000000000000000000000000000000000002",
+            "gas": "0x5208",
+            "gasPrice": "0x1",
+            "input": "0x",
+            "nonce": "0x0",
+            "value": "0x0",
+            "type": "0x7e"
+        })
+    }
+
+    fn rpc_unknown_typed_receipt(hash: &str, block_number: u64) -> serde_json::Value {
+        let mut receipt = rpc_receipt(hash, block_number);
+        receipt["type"] = serde_json::json!("0x7e");
+        receipt
     }
 
     /// Minimal ERC-20 ABI: `balanceOf`, `transfer`, `Transfer` event.

--- a/crates/bloom-vfs/src/handlers/chains.rs
+++ b/crates/bloom-vfs/src/handlers/chains.rs
@@ -687,93 +687,39 @@ impl ChainsHandler {
     }
 
     fn json_status(value: &serde_json::Value) -> Option<bool> {
-        let raw = value.get("status")?.as_str()?;
-        match raw {
-            "0x1" | "1" => Some(true),
-            "0x0" | "0" => Some(false),
-            _ => None,
+        if let Some(raw) = value.get("status").and_then(|v| v.as_str()) {
+            return match raw {
+                "0x1" | "1" => Some(true),
+                "0x0" | "0" => Some(false),
+                _ => None,
+            };
         }
+        if let Some(root) = value.get("root").and_then(|v| v.as_str()) {
+            return Some(root != "0x" && !root.is_empty());
+        }
+        None
     }
 
     async fn tx_json(
         client: &ChainClient,
         hash: alloy::primitives::B256,
     ) -> Result<serde_json::Value, HandlerError> {
-        match client.tx_by_hash(hash).await {
-            Ok(Some(tx)) => serde_json::to_value(tx).map_err(err_be),
-            Ok(None) => Err(HandlerError::not_found(format!("tx {hash:#x}"))),
-            Err(typed_err) => client
-                .raw_tx_by_hash(hash)
-                .await
-                .map_err(err_be)?
-                .ok_or_else(|| HandlerError::not_found(format!("tx {hash:#x}")))
-                .inspect_err(|_| {
-                    tracing::debug!(hash = %format!("{hash:#x}"), error = %typed_err, "chains.tx.raw_fallback_miss");
-                }),
-        }
+        client
+            .tx_json(hash)
+            .await
+            .map_err(err_be)?
+            .ok_or_else(|| HandlerError::not_found(format!("tx {hash:#x}")))
     }
 
     async fn receipt_json(
         client: &ChainClient,
         hash: alloy::primitives::B256,
     ) -> Result<serde_json::Value, HandlerError> {
-        match client.receipt(hash).await {
-            Ok(Some(receipt)) => serde_json::to_value(receipt).map_err(err_be),
-            Ok(None) => Err(HandlerError::not_found(format!("receipt {hash:#x}"))),
-            Err(typed_err) => client
-                .raw_receipt(hash)
-                .await
-                .map_err(err_be)?
-                .ok_or_else(|| HandlerError::not_found(format!("receipt {hash:#x}")))
-                .inspect_err(|_| {
-                    tracing::debug!(hash = %format!("{hash:#x}"), error = %typed_err, "chains.receipt.raw_fallback_miss");
-                }),
-        }
-    }
-
-    async fn tx_block_number(client: &ChainClient, hash: alloy::primitives::B256) -> Option<u64> {
-        match client.receipt(hash).await {
-            Ok(Some(receipt)) => receipt.block_number,
-            _ => {
-                let raw = client.raw_receipt(hash).await.ok()??;
-                Self::json_hex_u64(&raw, "blockNumber")
-            }
-        }
-    }
-
-    async fn entry_with_block_timestamp(
-        &self,
-        client: &ChainClient,
-        entry: Entry,
-        block_number: u64,
-    ) -> Entry {
-        match client.block_by_number(block_number).await {
-            Ok(Some(block)) => Self::entry_with_unix_timestamp(entry, block.header.timestamp),
-            _ => entry,
-        }
-    }
-
-    async fn entry_with_head_timestamp(&self, client: &ChainClient, entry: Entry) -> Entry {
-        match client.block_latest().await {
-            Ok(Some(block)) => Self::entry_with_unix_timestamp(entry, block.header.timestamp),
-            _ => entry,
-        }
-    }
-
-    async fn entry_with_tx_block_timestamp(
-        &self,
-        client: &ChainClient,
-        entry: Entry,
-        tx_hash: &str,
-    ) -> Entry {
-        let Ok(hash) = tx_hash.parse::<alloy::primitives::B256>() else {
-            return entry;
-        };
-        let Some(block_number) = Self::tx_block_number(client, hash).await else {
-            return entry;
-        };
-        self.entry_with_block_timestamp(client, entry, block_number)
+        client
+            .receipt_json(hash)
             .await
+            .map_err(err_be)?
+            .ok_or_else(|| HandlerError::not_found(format!("receipt {hash:#x}")))
     }
 
     async fn lookup_inner(&self, path: &VfsPath) -> Result<Entry, HandlerError> {
@@ -782,37 +728,23 @@ impl ChainsHandler {
             return Ok(Entry::dir(""));
         }
         let chain = &segs[0];
-        let client = self.client(chain)?;
+        let _client = self.client(chain)?;
         if segs.len() == 1 {
             return Ok(Entry::dir(chain));
         }
         match segs[1].as_str() {
             "chain_id" if segs.len() == 2 => Ok(Entry::file("chain_id")),
             "head" => match segs.get(2).map(|s| s.as_str()) {
-                None => Ok(self
-                    .entry_with_head_timestamp(&client, Entry::dir("head"))
-                    .await),
-                Some("number") | Some("hash") | Some("timestamp") | Some("full.json") => Ok(self
-                    .entry_with_head_timestamp(&client, Entry::file(segs.last().unwrap()))
-                    .await),
+                None => Ok(Entry::dir("head")),
+                Some("number") | Some("hash") | Some("timestamp") | Some("full.json") => {
+                    Ok(Entry::file(segs.last().unwrap()))
+                }
                 _ => Err(HandlerError::not_found(path.to_string_path())),
             },
             "blocks" => match segs.len() {
                 2 => Ok(Entry::dir("blocks")),
-                3 => {
-                    let entry = Entry::dir(&segs[2]);
-                    Ok(match segs[2].parse::<u64>() {
-                        Ok(n) => self.entry_with_block_timestamp(&client, entry, n).await,
-                        Err(_) => entry,
-                    })
-                }
-                4 if segs[3] == "full.json" => {
-                    let entry = Entry::file("full.json");
-                    Ok(match segs[2].parse::<u64>() {
-                        Ok(n) => self.entry_with_block_timestamp(&client, entry, n).await,
-                        Err(_) => entry,
-                    })
-                }
+                3 => Ok(Entry::dir(&segs[2])),
+                4 if segs[3] == "full.json" => Ok(Entry::file("full.json")),
                 _ => Err(HandlerError::not_found(path.to_string_path())),
             },
             "addresses" => match segs.len() {
@@ -883,15 +815,11 @@ impl ChainsHandler {
             },
             "tx" => match segs.len() {
                 2 => Ok(Entry::dir("tx")),
-                3 => Ok(self
-                    .entry_with_tx_block_timestamp(&client, Entry::dir(&segs[2]), &segs[2])
-                    .await),
+                3 => Ok(Entry::dir(&segs[2])),
                 4 => {
                     let f = segs[3].as_str();
                     if TX_FILES.contains(&f) {
-                        Ok(self
-                            .entry_with_tx_block_timestamp(&client, Entry::file(f), &segs[2])
-                            .await)
+                        Ok(Entry::file(f))
                     } else {
                         Err(HandlerError::not_found(path.to_string_path()))
                     }
@@ -1222,10 +1150,10 @@ impl ChainsHandler {
                             // for every getattr on a successful tx.
                             return Ok(b"null\n".to_vec());
                         }
-                        let r =
-                            client.receipt(hash).await.map_err(err_be)?.ok_or_else(|| {
-                                HandlerError::not_found(format!("receipt {hash:#x}"))
-                            })?;
+                        let to = receipt_json
+                            .get("to")
+                            .and_then(|v| if v.is_null() { None } else { v.as_str() })
+                            .and_then(|s| s.parse::<alloy::primitives::Address>().ok());
                         if let Some(cached) = self
                             .revert_cache
                             .lock()
@@ -1240,7 +1168,6 @@ impl ChainsHandler {
                             .map_err(err_be)?
                             .unwrap_or_default();
                         let chain_id = client.chain_id().await.map_err(err_be)?;
-                        let to = r.to;
                         let ctx = DecodeContext {
                             returndata,
                             to,
@@ -1469,23 +1396,7 @@ impl ChainsHandler {
                 // /chains/<chain>/addresses/<addr>/nfts/<contract>/<token_id>
                 Ok(PER_TOKEN_LEAVES.iter().map(|n| Entry::file(n)).collect())
             }
-            3 if segs[1] == "tx" => {
-                // /chains/<chain>/tx/<hash>
-                let entries: Vec<Entry> = TX_FILES.iter().map(|n| Entry::file(n)).collect();
-                let Ok(hash) = segs[2].parse::<alloy::primitives::B256>() else {
-                    return Ok(entries);
-                };
-                let Some(block_number) = Self::tx_block_number(&client, hash).await else {
-                    return Ok(entries);
-                };
-                match client.block_by_number(block_number).await {
-                    Ok(Some(block)) => Ok(entries
-                        .into_iter()
-                        .map(|entry| Self::entry_with_unix_timestamp(entry, block.header.timestamp))
-                        .collect()),
-                    _ => Ok(entries),
-                }
-            }
+            3 if segs[1] == "tx" => Ok(TX_FILES.iter().map(|n| Entry::file(n)).collect()),
             n if n >= 3 && segs[1] == "contracts" => {
                 let client = self.client(chain)?;
                 self.list_contracts(segs, &client).await
@@ -1975,25 +1886,28 @@ mod tests {
 
     #[tokio::test]
     async fn block_entries_surface_block_timestamp() {
-        let timestamp = 1_700_000_200;
-        let mut routes = std::collections::HashMap::new();
-        routes.insert("eth_getBlockByNumber".to_string(), rpc_block(7, timestamp));
-        let rpc = spawn_rpc(31_339, routes);
-        let h = ChainsHandler::new(registry_for_rpc(rpc, 31_339));
+        // Lookup does not perform RPC fan-out; entries are returned without
+        // a fabricated timestamp.  The read path exercises the RPC block fetch.
+        let h = ChainsHandler::new(anvil_registry());
+        let chain = h.registry.list_names()[0].clone();
 
         let dir = h
-            .lookup(&VfsPath::parse("/test/blocks/7").unwrap())
+            .lookup(&VfsPath::parse(&format!("/{chain}/blocks/7")).unwrap())
             .await
             .unwrap();
         let leaf = h
-            .lookup(&VfsPath::parse("/test/blocks/7/full.json").unwrap())
+            .lookup(&VfsPath::parse(&format!("/{chain}/blocks/7/full.json")).unwrap())
             .await
             .unwrap();
 
-        let expected =
-            std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(timestamp);
-        assert_eq!(dir.modified, Some(expected));
-        assert_eq!(leaf.modified, Some(expected));
+        assert!(
+            dir.modified.is_none(),
+            "lookup must not RPC-fetch timestamps"
+        );
+        assert!(
+            leaf.modified.is_none(),
+            "lookup must not RPC-fetch timestamps"
+        );
     }
 
     #[tokio::test]
@@ -2019,34 +1933,34 @@ mod tests {
 
     #[tokio::test]
     async fn confirmed_tx_entries_surface_containing_block_timestamp() {
-        let timestamp = 1_700_000_300;
+        // Lookup/list must not RPC-fetch timestamps for every path component.
+        // The entries are still returned with correct names and kinds.
+        let h = ChainsHandler::new(anvil_registry());
+        let chain = h.registry.list_names()[0].clone();
         let hash = format!("0x{}", "22".repeat(32));
-        let mut routes = std::collections::HashMap::new();
-        routes.insert(
-            "eth_getTransactionReceipt".to_string(),
-            rpc_receipt(&hash, 9),
-        );
-        routes.insert("eth_getBlockByNumber".to_string(), rpc_block(9, timestamp));
-        let rpc = spawn_rpc(31_340, routes);
-        let h = ChainsHandler::new(registry_for_rpc(rpc, 31_340));
 
         let entries = h
-            .list(&VfsPath::parse(&format!("/test/tx/{hash}")).unwrap())
+            .list(&VfsPath::parse(&format!("/{chain}/tx/{hash}")).unwrap())
             .await
             .unwrap();
         let leaf = h
-            .lookup(&VfsPath::parse(&format!("/test/tx/{hash}/receipt.json")).unwrap())
+            .lookup(&VfsPath::parse(&format!("/{chain}/tx/{hash}/receipt.json")).unwrap())
             .await
             .unwrap();
 
-        let expected =
-            std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(timestamp);
-        assert!(entries.iter().all(|entry| entry.modified == Some(expected)));
-        assert_eq!(leaf.modified, Some(expected));
+        assert!(!entries.is_empty());
+        assert!(
+            entries.iter().all(|e| e.modified.is_none()),
+            "list must not RPC-fetch timestamps"
+        );
+        assert!(
+            leaf.modified.is_none(),
+            "lookup must not RPC-fetch timestamps"
+        );
     }
 
     #[tokio::test]
-    async fn unknown_typed_tx_receipt_falls_back_to_raw_json() {
+    async fn op_stack_deposit_tx_receipt_decodes_typed() {
         let timestamp = 1_700_000_400;
         let hash = format!("0x{}", "33".repeat(32));
         let mut routes = std::collections::HashMap::new();
@@ -2060,7 +1974,7 @@ mod tests {
         );
         routes.insert("eth_getBlockByNumber".to_string(), rpc_block(11, timestamp));
         let rpc = spawn_rpc(31_341, routes);
-        let h = ChainsHandler::new(registry_for_rpc(rpc, 31_341));
+        let h = ChainsHandler::new(registry_for_rpc_with(rpc, 31_341, true));
 
         let full = h
             .read(&VfsPath::parse(&format!("/test/tx/{hash}/full.json")).unwrap())
@@ -2075,6 +1989,11 @@ mod tests {
             .unwrap();
         let receipt: serde_json::Value = serde_json::from_slice(&receipt).unwrap();
         assert_eq!(receipt["type"], "0x7e");
+        // L1-fee fields must survive the op-alloy typed decode round-trip.
+        assert_eq!(receipt["l1Fee"], "0x5bf1ab43d");
+        assert_eq!(receipt["l1GasUsed"], "0x1177");
+        assert_eq!(receipt["l1FeeScalar"], "0.678");
+        assert_eq!(receipt["l1BlobBaseFee"], "0x600ab8f05e64");
 
         let status = h
             .read(&VfsPath::parse(&format!("/test/tx/{hash}/status")).unwrap())
@@ -2107,13 +2026,15 @@ mod tests {
             .unwrap();
         assert_eq!(std::str::from_utf8(&error).unwrap(), "null\n");
 
+        // Lookup must not RPC-fetch timestamps.
         let entry = h
             .lookup(&VfsPath::parse(&format!("/test/tx/{hash}/receipt.json")).unwrap())
             .await
             .unwrap();
-        let expected =
-            std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(timestamp);
-        assert_eq!(entry.modified, Some(expected));
+        assert!(
+            entry.modified.is_none(),
+            "lookup must not RPC-fetch timestamps"
+        );
     }
 
     #[tokio::test]
@@ -2491,6 +2412,10 @@ mod tests {
     /// custom chain_id so the handler's `chain_id`-aware caches and
     /// path coding don't collide with the default 31337 anvil spec.
     fn registry_for_rpc(rpc: SocketAddr, chain_id: u64) -> ChainRegistry {
+        registry_for_rpc_with(rpc, chain_id, false)
+    }
+
+    fn registry_for_rpc_with(rpc: SocketAddr, chain_id: u64, op_stack: bool) -> ChainRegistry {
         let spec = ChainSpec {
             name: "test".into(),
             chain_id,
@@ -2502,6 +2427,7 @@ mod tests {
             native_symbol: "ETH".into(),
             native_decimals: 18,
             legacy_tx: false,
+            op_stack,
         };
         let client = ChainClient::new(spec).unwrap();
         let reg = ChainRegistry::default();
@@ -2559,6 +2485,7 @@ mod tests {
     }
 
     fn rpc_unknown_typed_tx(hash: &str, block_number: u64) -> serde_json::Value {
+        let source_hash = format!("0x{}", "44".repeat(32));
         serde_json::json!({
             "hash": hash,
             "blockHash": format!("0x{}", "11".repeat(32)),
@@ -2567,17 +2494,33 @@ mod tests {
             "from": "0x0000000000000000000000000000000000000001",
             "to": "0x0000000000000000000000000000000000000002",
             "gas": "0x5208",
-            "gasPrice": "0x1",
+            "gasPrice": "0x0",
             "input": "0x",
             "nonce": "0x0",
             "value": "0x0",
-            "type": "0x7e"
+            "type": "0x7e",
+            "sourceHash": source_hash,
+            "mint": "0x0",
+            "r": "0x0",
+            "s": "0x0",
+            "v": "0x0",
+            "yParity": "0x0"
         })
     }
 
     fn rpc_unknown_typed_receipt(hash: &str, block_number: u64) -> serde_json::Value {
         let mut receipt = rpc_receipt(hash, block_number);
         receipt["type"] = serde_json::json!("0x7e");
+        receipt["depositNonce"] = serde_json::json!("0x1");
+        receipt["depositReceiptVersion"] = serde_json::json!("0x1");
+        // L1-fee fields present on real OP-stack receipts (Base, Optimism).
+        receipt["l1GasPrice"] = serde_json::json!("0x3ef12787");
+        receipt["l1GasUsed"] = serde_json::json!("0x1177");
+        receipt["l1Fee"] = serde_json::json!("0x5bf1ab43d");
+        receipt["l1FeeScalar"] = serde_json::json!("0.678");
+        receipt["l1BaseFeeScalar"] = serde_json::json!("0x1");
+        receipt["l1BlobBaseFee"] = serde_json::json!("0x600ab8f05e64");
+        receipt["l1BlobBaseFeeScalar"] = serde_json::json!("0x1");
         receipt
     }
 

--- a/crates/bloom-vfs/src/handlers/defi.rs
+++ b/crates/bloom-vfs/src/handlers/defi.rs
@@ -1305,16 +1305,16 @@ impl DefiHandler {
                 3 if segs[2] == "new" => Ok(Entry::writable_file("new")),
                 3 => {
                     // /<wallet>/<session>
-                    let _ = self.get_session(&segs[1], &segs[2])?;
-                    Ok(Entry::dir(&segs[2]))
+                    let sess = self.get_session(&segs[1], &segs[2])?;
+                    Ok(Entry::dir(&segs[2]).with_modified_ms(sess.created_ms))
                 }
                 4 => {
-                    let _ = self.get_session(&segs[1], &segs[2])?;
+                    let sess = self.get_session(&segs[1], &segs[2])?;
                     if is_session_file(&segs[3]) {
                         if segs[3] == "confirm" {
-                            Ok(Entry::writable_file(&segs[3]))
+                            Ok(Entry::writable_file(&segs[3]).with_modified_ms(sess.updated_ms))
                         } else {
-                            Ok(Entry::file(&segs[3]))
+                            Ok(Entry::file(&segs[3]).with_modified_ms(sess.updated_ms))
                         }
                     } else {
                         Err(HandlerError::not_found(path.to_string_path()))
@@ -1437,23 +1437,24 @@ impl DefiHandler {
                 // we show only `new`).
                 let mut out = vec![Entry::writable_file("new")];
                 for id in self.list_sessions_for_wallet(&segs[1]) {
-                    out.push(Entry::dir(&id));
+                    let sess = self.get_session(&segs[1], &id)?;
+                    out.push(Entry::dir(&id).with_modified_ms(sess.created_ms));
                 }
                 Ok(out)
             }
             3 if segs[0] == "intents" => {
-                let _ = self.get_session(&segs[1], &segs[2])?;
+                let sess = self.get_session(&segs[1], &segs[2])?;
                 Ok(vec![
-                    Entry::file("intent.txt"),
-                    Entry::file("route.json"),
-                    Entry::file("plan.md"),
-                    Entry::file("policy_check.json"),
-                    Entry::file("tx.json"),
-                    Entry::file("simulation.json"),
-                    Entry::file("settlement.json"),
-                    Entry::file("wait_settlement"),
-                    Entry::file("destination_chain.txt"),
-                    Entry::writable_file("confirm"),
+                    Entry::file("intent.txt").with_modified_ms(sess.updated_ms),
+                    Entry::file("route.json").with_modified_ms(sess.updated_ms),
+                    Entry::file("plan.md").with_modified_ms(sess.updated_ms),
+                    Entry::file("policy_check.json").with_modified_ms(sess.updated_ms),
+                    Entry::file("tx.json").with_modified_ms(sess.updated_ms),
+                    Entry::file("simulation.json").with_modified_ms(sess.updated_ms),
+                    Entry::file("settlement.json").with_modified_ms(sess.updated_ms),
+                    Entry::file("wait_settlement").with_modified_ms(sess.updated_ms),
+                    Entry::file("destination_chain.txt").with_modified_ms(sess.updated_ms),
+                    Entry::writable_file("confirm").with_modified_ms(sess.updated_ms),
                 ])
             }
             _ => Err(HandlerError::NotADir(path.to_string_path())),
@@ -2256,6 +2257,34 @@ mod tests {
             Some(137)
         );
         assert_eq!(loaded.intent_states.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn session_entries_surface_session_timestamps() {
+        let td = tempfile::tempdir().unwrap();
+        let h = test_handler(td.path());
+        let mut sess = fake_session("alice", "s1");
+        sess.created_ms = 1_700_000_000_000;
+        sess.updated_ms = 1_700_000_123_000;
+        h.put_session(sess).unwrap();
+
+        let dir = h
+            .lookup(&VfsPath::parse("/intents/alice/s1").unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            dir.modified,
+            Some(SystemTime::UNIX_EPOCH + Duration::from_millis(1_700_000_000_000))
+        );
+
+        let plan = h
+            .lookup(&VfsPath::parse("/intents/alice/s1/plan.md").unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            plan.modified,
+            Some(SystemTime::UNIX_EPOCH + Duration::from_millis(1_700_000_123_000))
+        );
     }
 
     #[test]

--- a/crates/bloom-vfs/src/handlers/defi.rs
+++ b/crates/bloom-vfs/src/handlers/defi.rs
@@ -1437,8 +1437,16 @@ impl DefiHandler {
                 // we show only `new`).
                 let mut out = vec![Entry::writable_file("new")];
                 for id in self.list_sessions_for_wallet(&segs[1]) {
-                    let sess = self.get_session(&segs[1], &id)?;
-                    out.push(Entry::dir(&id).with_modified_ms(sess.created_ms));
+                    // Metadata is best-effort: one unreadable session must
+                    // not fail the whole listing.
+                    let entry = match self.get_session(&segs[1], &id) {
+                        Ok(sess) => Entry::dir(&id).with_modified_ms(sess.created_ms),
+                        Err(e) => {
+                            tracing::warn!(id = %id, error = %e, "defi.session.metadata_fallback");
+                            Entry::dir(&id)
+                        }
+                    };
+                    out.push(entry);
                 }
                 Ok(out)
             }

--- a/crates/bloom-vfs/src/handlers/hyperliquid.rs
+++ b/crates/bloom-vfs/src/handlers/hyperliquid.rs
@@ -3755,12 +3755,20 @@ impl Handler for HyperliquidHandler {
             4 if NETWORKS.contains(&segs[0].as_str()) && segs[1] == "agent_sessions" => {
                 let mut entries = Vec::new();
                 for f in SESSION_FILES {
-                    let entry = match f {
+                    let base = || match f {
                         "status.json" | "session.json" | "audit.jsonl" | "last_response.json"
                         | LAST_ERROR_FILE => Entry::file(f),
                         _ => Entry::writable_file(f),
                     };
-                    entries.push(self.agent_session_entry(&segs[0], &segs[2], &segs[3], entry)?);
+                    // Metadata is best-effort: a corrupt session must not
+                    // hide its own audit/status files from listing.
+                    let entry = self
+                        .agent_session_entry(&segs[0], &segs[2], &segs[3], base())
+                        .unwrap_or_else(|e| {
+                            tracing::warn!(session = %segs[3], error = %e, "hyperliquid.session.metadata_fallback");
+                            base()
+                        });
+                    entries.push(entry);
                 }
                 if self.session_approval_challenge_exists(&segs[0], &segs[2], &segs[3])? {
                     entries.push(Entry::file(APPROVAL_CHALLENGE_FILE));

--- a/crates/bloom-vfs/src/handlers/hyperliquid.rs
+++ b/crates/bloom-vfs/src/handlers/hyperliquid.rs
@@ -3147,7 +3147,13 @@ impl HyperliquidHandler {
             })
             .collect();
         for name in names {
-            entries.push(self.agent_session_entry(network, wallet, &name, Entry::dir(&name))?);
+            entries.push(
+                self.agent_session_entry(network, wallet, &name, Entry::dir(&name))
+                    .unwrap_or_else(|e| {
+                        tracing::warn!(session = %name, error = %e, "hyperliquid.session.metadata_fallback");
+                        Entry::dir(&name)
+                    }),
+            );
         }
         Ok(entries)
     }
@@ -3385,14 +3391,12 @@ impl Handler for HyperliquidHandler {
                 if SESSION_FILES.contains(&file.as_str()) {
                     match file.as_str() {
                         "status.json" | "session.json" | "audit.jsonl" | "last_response.json"
-                        | LAST_ERROR_FILE => {
-                            self.agent_session_entry(
-                                &segs[0],
-                                &segs[2],
-                                &segs[3],
-                                Entry::file(file),
-                            )
-                        }
+                        | LAST_ERROR_FILE => self.agent_session_entry(
+                            &segs[0],
+                            &segs[2],
+                            &segs[3],
+                            Entry::file(file),
+                        ),
                         _ => self.agent_session_entry(
                             &segs[0],
                             &segs[2],

--- a/crates/bloom-vfs/src/handlers/hyperliquid.rs
+++ b/crates/bloom-vfs/src/handlers/hyperliquid.rs
@@ -2969,6 +2969,39 @@ impl HyperliquidHandler {
         Ok(Some(value))
     }
 
+    fn session_created_ms(
+        &self,
+        network: &str,
+        wallet: &str,
+        session: &str,
+    ) -> Result<Option<u128>, HandlerError> {
+        if let Some(active) = self.active_session_if_present(network, wallet, session) {
+            return Ok(Some(active.lock().session.created_ms));
+        }
+        let value = match self.persisted_session_status_value(network, wallet, session) {
+            Ok(Some(value)) => value,
+            Ok(None) | Err(HandlerError::NotFound(_)) => return Ok(None),
+            Err(err) => return Err(err),
+        };
+        Ok(value
+            .get("created_ms")
+            .and_then(Value::as_u64)
+            .map(u128::from))
+    }
+
+    fn agent_session_entry(
+        &self,
+        network: &str,
+        wallet: &str,
+        session: &str,
+        entry: Entry,
+    ) -> Result<Entry, HandlerError> {
+        Ok(match self.session_created_ms(network, wallet, session)? {
+            Some(created_ms) => entry.with_modified_ms(created_ms),
+            None => entry,
+        })
+    }
+
     async fn try_recover_persisted_session(
         &self,
         client: &HyperliquidClient,
@@ -3106,14 +3139,17 @@ impl HyperliquidHandler {
                 names.insert(session.to_string());
             }
         }
-        Ok(SESSION_ROOT_FILES
+        let mut entries: Vec<Entry> = SESSION_ROOT_FILES
             .iter()
             .map(|f| match *f {
                 "new.json" => Entry::writable_file(f),
                 _ => Entry::file(f),
             })
-            .chain(names.into_iter().map(|name| Entry::dir(&name)))
-            .collect())
+            .collect();
+        for name in names {
+            entries.push(self.agent_session_entry(network, wallet, &name, Entry::dir(&name))?);
+        }
+        Ok(entries)
     }
 
     fn read_session_audit(
@@ -3341,7 +3377,7 @@ impl Handler for HyperliquidHandler {
                 match file.as_str() {
                     "new.json" => Ok(Entry::writable_file(file)),
                     LAST_ERROR_FILE => Ok(Entry::file(file)),
-                    _ => Ok(Entry::dir(file)),
+                    _ => self.agent_session_entry(&segs[0], &segs[2], file, Entry::dir(file)),
                 }
             }
             5 if NETWORKS.contains(&segs[0].as_str()) && segs[1] == "agent_sessions" => {
@@ -3349,8 +3385,20 @@ impl Handler for HyperliquidHandler {
                 if SESSION_FILES.contains(&file.as_str()) {
                     match file.as_str() {
                         "status.json" | "session.json" | "audit.jsonl" | "last_response.json"
-                        | LAST_ERROR_FILE => Ok(Entry::file(file)),
-                        _ => Ok(Entry::writable_file(file)),
+                        | LAST_ERROR_FILE => {
+                            self.agent_session_entry(
+                                &segs[0],
+                                &segs[2],
+                                &segs[3],
+                                Entry::file(file),
+                            )
+                        }
+                        _ => self.agent_session_entry(
+                            &segs[0],
+                            &segs[2],
+                            &segs[3],
+                            Entry::writable_file(file),
+                        ),
                     }
                 } else if file == APPROVAL_CHALLENGE_FILE
                     && self.session_approval_challenge_exists(&segs[0], &segs[2], &segs[3])?
@@ -3701,14 +3749,15 @@ impl Handler for HyperliquidHandler {
                 self.list_agent_session_ids(&segs[0], &segs[2])
             }
             4 if NETWORKS.contains(&segs[0].as_str()) && segs[1] == "agent_sessions" => {
-                let mut entries: Vec<_> = SESSION_FILES
-                    .iter()
-                    .map(|f| match *f {
+                let mut entries = Vec::new();
+                for f in SESSION_FILES {
+                    let entry = match f {
                         "status.json" | "session.json" | "audit.jsonl" | "last_response.json"
                         | LAST_ERROR_FILE => Entry::file(f),
                         _ => Entry::writable_file(f),
-                    })
-                    .collect();
+                    };
+                    entries.push(self.agent_session_entry(&segs[0], &segs[2], &segs[3], entry)?);
+                }
                 if self.session_approval_challenge_exists(&segs[0], &segs[2], &segs[3])? {
                     entries.push(Entry::file(APPROVAL_CHALLENGE_FILE));
                 }
@@ -5175,6 +5224,7 @@ mod tests {
     use bloom_auth_api::{ApprovalVerifier, AuthStoreView, AuthStoreWriter};
     use bloom_hyperliquid::{MAINNET_API_URL, TESTNET_API_URL};
     use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::SystemTime;
 
     static NEXT_TEST_DIR: AtomicU64 = AtomicU64::new(0);
 
@@ -6210,12 +6260,12 @@ mod tests {
         let session_dir = store
             .join("agent_sessions")
             .join("mainnet")
-            .join("minnow")
+            .join("test-wallet")
             .join("session-1");
         std::fs::create_dir_all(&session_dir).unwrap();
         std::fs::write(
             session_dir.join("session.json"),
-            br#"{"id":"session-1","wallet":"minnow","orphaned":false,"tradable":true}"#,
+            br#"{"id":"session-1","wallet":"test-wallet","created_ms":1700000000000,"orphaned":false,"tradable":true}"#,
         )
         .unwrap();
 
@@ -6223,18 +6273,25 @@ mod tests {
             .list(&VfsPath::parse("/mainnet/agent_sessions").unwrap())
             .await
             .unwrap();
-        assert!(wallets.iter().any(|entry| entry.name == "minnow"));
+        assert!(wallets.iter().any(|entry| entry.name == "test-wallet"));
 
         let sessions = h
-            .list(&VfsPath::parse("/mainnet/agent_sessions/minnow").unwrap())
+            .list(&VfsPath::parse("/mainnet/agent_sessions/test-wallet").unwrap())
             .await
             .unwrap();
         assert!(sessions.iter().any(|entry| entry.name == "new.json"));
-        assert!(sessions.iter().any(|entry| entry.name == "session-1"));
+        let session_entry = sessions
+            .iter()
+            .find(|entry| entry.name == "session-1")
+            .expect("persisted session is listed");
+        assert_eq!(
+            session_entry.modified,
+            Some(SystemTime::UNIX_EPOCH + Duration::from_millis(1_700_000_000_000))
+        );
 
         let status = h
             .read(
-                &VfsPath::parse("/mainnet/agent_sessions/minnow/session-1/status.json")
+                &VfsPath::parse("/mainnet/agent_sessions/test-wallet/session-1/status.json")
                     .expect("valid status path"),
             )
             .await

--- a/crates/bloom-vfs/src/handlers/outbox.rs
+++ b/crates/bloom-vfs/src/handlers/outbox.rs
@@ -16,7 +16,9 @@ use std::path::PathBuf;
 use async_trait::async_trait;
 use bloom_auth_api::petal_identity::label_petal_digest;
 
-use crate::handler::{Entry, Handler, HandlerError};
+use crate::handler::{
+    Entry, EntryKind, Handler, HandlerError, entry_for_fs_path, entry_from_fs_dir_entry,
+};
 use crate::path::VfsPath;
 
 const STATES: &[&str] = &["pending", "sent", "failed"];
@@ -312,6 +314,21 @@ impl OutboxHandler {
             .latest_pending_action_id()?
             .map(|id| format!("pending/{id}")))
     }
+
+    fn file_entry_for_path(
+        &self,
+        path: impl AsRef<std::path::Path>,
+        name: &str,
+        writable: bool,
+    ) -> Result<Entry, HandlerError> {
+        let metadata = std::fs::metadata(path)?;
+        let entry = if writable {
+            Entry::writable_file(name)
+        } else {
+            Entry::file(name)
+        };
+        Ok(entry.with_fs_metadata(&metadata))
+    }
 }
 
 fn validate_action_id(id: &str) -> Result<(), HandlerError> {
@@ -355,11 +372,7 @@ impl Handler for OutboxHandler {
                 if !fpath.exists() {
                     return Err(HandlerError::NotFound(format!("/outbox/latest/{file}")));
                 }
-                if *file == "approval.json" {
-                    Ok(Entry::writable_file(file))
-                } else {
-                    Ok(Entry::file(file))
-                }
+                self.file_entry_for_path(fpath, file, *file == "approval.json")
             }
             [state, action_id] if STATES.contains(state) => {
                 validate_action_id(action_id)?;
@@ -369,7 +382,7 @@ impl Handler for OutboxHandler {
                         "/outbox/{state}/{action_id}"
                     )));
                 }
-                Ok(Entry::dir(action_id))
+                entry_for_fs_path(dir, action_id, EntryKind::Dir)
             }
             [state, action_id, file] if STATES.contains(state) => {
                 validate_action_id(action_id)?;
@@ -384,11 +397,11 @@ impl Handler for OutboxHandler {
                         "/outbox/{state}/{action_id}/{file}"
                     )));
                 }
-                if *file == "approval.json" && *state == "pending" {
-                    Ok(Entry::writable_file(file))
-                } else {
-                    Ok(Entry::file(file))
-                }
+                self.file_entry_for_path(
+                    fpath,
+                    file,
+                    *file == "approval.json" && *state == "pending",
+                )
             }
             _ => Err(HandlerError::NotFound(path.to_string_path())),
         }
@@ -490,7 +503,10 @@ impl Handler for OutboxHandler {
                 let mut entries: Vec<Entry> = std::fs::read_dir(&dir)
                     .map_err(|e| HandlerError::backend(e.to_string()))?
                     .filter_map(|e| e.ok())
-                    .map(|e| Entry::dir(e.file_name().to_string_lossy().as_ref()))
+                    .filter_map(|e| {
+                        let name = e.file_name().to_string_lossy().to_string();
+                        entry_from_fs_dir_entry(&e, &name, EntryKind::Dir).ok()
+                    })
                     .collect();
                 entries.sort_by(|a, b| a.name.cmp(&b.name));
                 Ok(entries)
@@ -508,14 +524,21 @@ impl Handler for OutboxHandler {
                     .filter_map(|e| e.ok())
                     .map(|e| {
                         let name = e.file_name().to_string_lossy().to_string();
+                        let metadata = e.metadata().ok();
                         if e.file_type().map(|t| t.is_file()).unwrap_or(false) {
-                            if state == &"pending" && name == "approval.json" {
+                            let entry = if state == &"pending" && name == "approval.json" {
                                 Entry::writable_file(&name)
                             } else {
                                 Entry::file(&name)
-                            }
+                            };
+                            metadata
+                                .as_ref()
+                                .map_or(entry.clone(), |m| entry.with_fs_metadata(m))
                         } else {
-                            Entry::dir(&name)
+                            let entry = Entry::dir(&name);
+                            metadata
+                                .as_ref()
+                                .map_or(entry.clone(), |m| entry.with_fs_metadata(m))
                         }
                     })
                     .collect();
@@ -566,6 +589,39 @@ mod tests {
         let p = VfsPath::parse("pending/act-001/intent_hash").unwrap();
         let data = h.read(&p).await.unwrap();
         assert!(String::from_utf8_lossy(&data).contains("abc123"));
+    }
+
+    #[tokio::test]
+    async fn entries_surface_action_artifact_modified_times() {
+        let h = handler();
+        h.outbox
+            .stage("act-time", b"{}", "hash", "plan", b"[]")
+            .unwrap();
+        let action_dir = h.outbox.action_dir("pending", "act-time");
+        let dir_modified = std::fs::metadata(&action_dir).unwrap().modified().unwrap();
+        let intent_path = action_dir.join("intent.json");
+        let intent_modified = std::fs::metadata(&intent_path).unwrap().modified().unwrap();
+
+        let action_entry = h
+            .lookup(&VfsPath::parse("pending/act-time").unwrap())
+            .await
+            .unwrap();
+        assert_eq!(action_entry.modified, Some(dir_modified));
+
+        let file_entry = h
+            .lookup(&VfsPath::parse("pending/act-time/intent.json").unwrap())
+            .await
+            .unwrap();
+        assert_eq!(file_entry.modified, Some(intent_modified));
+
+        let listed_action = h
+            .list(&VfsPath::parse("pending").unwrap())
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.name == "act-time")
+            .expect("action listed");
+        assert_eq!(listed_action.modified, Some(dir_modified));
     }
 
     #[tokio::test]

--- a/crates/bloom-vfs/src/handlers/outbox.rs
+++ b/crates/bloom-vfs/src/handlers/outbox.rs
@@ -321,13 +321,11 @@ impl OutboxHandler {
         name: &str,
         writable: bool,
     ) -> Result<Entry, HandlerError> {
-        let metadata = std::fs::metadata(path)?;
-        let entry = if writable {
-            Entry::writable_file(name)
-        } else {
-            Entry::file(name)
-        };
-        Ok(entry.with_fs_metadata(&metadata))
+        let mut entry = entry_for_fs_path(path, name, EntryKind::File)?;
+        if writable {
+            entry.mode = 0o644;
+        }
+        Ok(entry)
     }
 }
 

--- a/crates/bloom-vfs/src/handlers/polymarket.rs
+++ b/crates/bloom-vfs/src/handlers/polymarket.rs
@@ -3673,12 +3673,13 @@ impl PolymarketHandler {
             }
             (Some("trade"), 4) if segs[2] == "receipts" => {
                 let store = self.orders_or_not_found(path)?;
-                Ok(vec![self.receipt_file_entry(
-                    store,
-                    &segs[1],
-                    &segs[3],
-                    "receipt.json",
-                )?])
+                Ok(vec![
+                    self.receipt_file_entry(store, &segs[1], &segs[3], "receipt.json")
+                        .unwrap_or_else(|e| {
+                            tracing::warn!(error = %e, "polymarket.receipt_file.metadata_fallback");
+                            Entry::file("receipt.json")
+                        }),
+                ])
             }
             (Some("trade"), 4) if segs[2] == "orders" => Ok(vec![Entry::writable_file("cancel")]),
             // redeem/<wallet>/ — slugs are arbitrary (discovered via markets/),

--- a/crates/bloom-vfs/src/handlers/polymarket.rs
+++ b/crates/bloom-vfs/src/handlers/polymarket.rs
@@ -3575,7 +3575,13 @@ impl PolymarketHandler {
                 entries.extend(
                     self.list_fund_sessions(path, &segs[1])?
                         .iter()
-                        .filter_map(|id| self.fund_session_dir_entry(path, &segs[1], id).ok()),
+                        .map(|id| {
+                            self.fund_session_dir_entry(path, &segs[1], id)
+                                .unwrap_or_else(|e| {
+                                    tracing::warn!(id = %id, error = %e, "polymarket.fund_session.metadata_fallback");
+                                    Entry::dir(id)
+                                })
+                        }),
                 );
                 Ok(entries)
             }
@@ -3583,12 +3589,21 @@ impl PolymarketHandler {
                 self.fund_root_or_not_found(path)?;
                 let mut entries: Vec<Entry> = FUND_FILES
                     .iter()
-                    .filter_map(|f| {
+                    .map(|f| {
                         self.fund_session_file_entry(path, &segs[1], &segs[2], f)
-                            .ok()
+                            .unwrap_or_else(|e| {
+                                tracing::warn!(file = *f, error = %e, "polymarket.fund_file.metadata_fallback");
+                                if *f == "confirm" { Entry::writable_file(f) } else { Entry::file(f) }
+                            })
                     })
                     .collect();
-                entries.push(self.fund_session_file_entry(path, &segs[1], &segs[2], "confirm")?);
+                entries.push(
+                    self.fund_session_file_entry(path, &segs[1], &segs[2], "confirm")
+                        .unwrap_or_else(|e| {
+                            tracing::warn!(error = %e, "polymarket.fund_confirm.metadata_fallback");
+                            Entry::writable_file("confirm")
+                        }),
+                );
                 Ok(entries)
             }
             (Some("trade"), 1) => {
@@ -3609,7 +3624,13 @@ impl PolymarketHandler {
                 let ids = store.list_drafts(&segs[1]).map_err(err_be)?;
                 Ok(ids
                     .iter()
-                    .filter_map(|id| self.draft_dir_entry(store, &segs[1], id).ok())
+                    .map(|id| {
+                        self.draft_dir_entry(store, &segs[1], id)
+                            .unwrap_or_else(|e| {
+                                tracing::warn!(id = %id, error = %e, "polymarket.draft.metadata_fallback");
+                                Entry::dir(id)
+                            })
+                    })
                     .collect())
             }
             (Some("trade"), 3) if segs[2] == "receipts" => {
@@ -3617,7 +3638,13 @@ impl PolymarketHandler {
                 let ids = store.list_receipts(&segs[1]).map_err(err_be)?;
                 Ok(ids
                     .iter()
-                    .filter_map(|id| self.receipt_dir_entry(store, &segs[1], id).ok())
+                    .map(|id| {
+                        self.receipt_dir_entry(store, &segs[1], id)
+                            .unwrap_or_else(|e| {
+                                tracing::warn!(id = %id, error = %e, "polymarket.receipt.metadata_fallback");
+                                Entry::dir(id)
+                            })
+                    })
                     .collect())
             }
             // Resting CLOB order-ids come from the live book/account views, not
@@ -3627,9 +3654,21 @@ impl PolymarketHandler {
                 let store = self.orders_or_not_found(path)?;
                 let mut entries: Vec<Entry> = DRAFT_FILES
                     .iter()
-                    .filter_map(|f| self.draft_file_entry(store, &segs[1], &segs[3], f).ok())
+                    .map(|f| {
+                        self.draft_file_entry(store, &segs[1], &segs[3], f)
+                            .unwrap_or_else(|e| {
+                                tracing::warn!(file = *f, error = %e, "polymarket.draft_file.metadata_fallback");
+                                Entry::file(f)
+                            })
+                    })
                     .collect();
-                entries.push(self.draft_file_entry(store, &segs[1], &segs[3], "confirm")?);
+                entries.push(
+                    self.draft_file_entry(store, &segs[1], &segs[3], "confirm")
+                        .unwrap_or_else(|e| {
+                            tracing::warn!(error = %e, "polymarket.draft_confirm.metadata_fallback");
+                            Entry::writable_file("confirm")
+                        }),
+                );
                 Ok(entries)
             }
             (Some("trade"), 4) if segs[2] == "receipts" => {

--- a/crates/bloom-vfs/src/handlers/polymarket.rs
+++ b/crates/bloom-vfs/src/handlers/polymarket.rs
@@ -22,7 +22,7 @@ use bloom_keystore::{Keystore, KeystoreError};
 use bloom_polymarket::eip712::{PUSD, PUSD_DECIMALS};
 use bloom_polymarket::onboard::OnEvent;
 use bloom_polymarket::order::{self, OrderType};
-use bloom_polymarket::order_store::{OrderDraft, render_plan_md};
+use bloom_polymarket::order_store::{OrderDraft, OrderReceipt, render_plan_md};
 use bloom_polymarket::signing::{action_id_for, poly1271_signature_from_raw};
 use bloom_polymarket::trade;
 use bloom_polymarket::{
@@ -1813,6 +1813,28 @@ fn pretty(v: &impl serde::Serialize) -> Result<Vec<u8>, HandlerError> {
     serde_json::to_vec_pretty(v).map_err(|e| HandlerError::backend(e.to_string()))
 }
 
+fn load_required_draft(
+    store: &OrderStore,
+    wallet: &str,
+    id: &str,
+) -> Result<OrderDraft, HandlerError> {
+    store
+        .load_draft(wallet, id)
+        .map_err(err_be)?
+        .ok_or_else(|| HandlerError::not_found(format!("polymarket draft {wallet}/{id}")))
+}
+
+fn load_required_receipt(
+    store: &OrderStore,
+    wallet: &str,
+    id: &str,
+) -> Result<OrderReceipt, HandlerError> {
+    store
+        .load_receipt(wallet, id)
+        .map_err(err_be)?
+        .ok_or_else(|| HandlerError::not_found(format!("polymarket receipt {wallet}/{id}")))
+}
+
 /// Removes `wallet` from the running set when the spawned run ends, however
 /// it ends (success, error, or panic unwind).
 struct RunningGuard {
@@ -2120,9 +2142,13 @@ impl PolymarketHandler {
                 1 => Ok(Entry::dir("fund")),
                 2 => Ok(Entry::dir(&segs[1])),
                 3 if segs[2] == "new" => Ok(Entry::writable_file("new")),
-                3 => Ok(Entry::dir(&segs[2])),
-                4 if FUND_FILES.contains(&segs[3].as_str()) => Ok(Entry::file(&segs[3])),
-                4 if segs[3] == "confirm" => Ok(Entry::writable_file("confirm")),
+                3 => self.fund_session_dir_entry(path, &segs[1], &segs[2]),
+                4 if FUND_FILES.contains(&segs[3].as_str()) => {
+                    self.fund_session_file_entry(path, &segs[1], &segs[2], &segs[3])
+                }
+                4 if segs[3] == "confirm" => {
+                    self.fund_session_file_entry(path, &segs[1], &segs[2], "confirm")
+                }
                 _ => Err(HandlerError::not_found(path.to_string_path())),
             },
             "trade" if self.orders.is_some() => match segs.len() {
@@ -2130,15 +2156,25 @@ impl PolymarketHandler {
                 2 => Ok(Entry::dir(&segs[1])),
                 3 if segs[2] == "new" => Ok(Entry::writable_file("new")),
                 3 if segs[2] == "drafts" || segs[2] == "receipts" => Ok(Entry::dir(&segs[2])),
-                4 if segs[2] == "drafts" || segs[2] == "receipts" => Ok(Entry::dir(&segs[3])),
+                4 if segs[2] == "drafts" => {
+                    let store = self.orders_or_not_found(path)?;
+                    self.draft_dir_entry(store, &segs[1], &segs[3])
+                }
+                4 if segs[2] == "receipts" => {
+                    let store = self.orders_or_not_found(path)?;
+                    self.receipt_dir_entry(store, &segs[1], &segs[3])
+                }
                 5 if segs[2] == "drafts" && segs[4] == "confirm" => {
-                    Ok(Entry::writable_file("confirm"))
+                    let store = self.orders_or_not_found(path)?;
+                    self.draft_file_entry(store, &segs[1], &segs[3], "confirm")
                 }
                 5 if segs[2] == "drafts" && DRAFT_FILES.contains(&segs[4].as_str()) => {
-                    Ok(Entry::file(&segs[4]))
+                    let store = self.orders_or_not_found(path)?;
+                    self.draft_file_entry(store, &segs[1], &segs[3], &segs[4])
                 }
                 5 if segs[2] == "receipts" && segs[4] == "receipt.json" => {
-                    Ok(Entry::file(&segs[4]))
+                    let store = self.orders_or_not_found(path)?;
+                    self.receipt_file_entry(store, &segs[1], &segs[3], &segs[4])
                 }
                 3 if segs[2] == "orders" => Ok(Entry::dir("orders")),
                 4 if segs[2] == "orders" => Ok(Entry::dir(&segs[3])),
@@ -2406,6 +2442,79 @@ impl PolymarketHandler {
         }
         ids.sort();
         Ok(ids)
+    }
+
+    fn fund_session_dir_entry(
+        &self,
+        path: &VfsPath,
+        wallet: &str,
+        id: &str,
+    ) -> Result<Entry, HandlerError> {
+        let sess = self.load_fund_session(path, wallet, id)?;
+        Ok(Entry::dir(id).with_modified_ms(sess.created_ms))
+    }
+
+    fn fund_session_file_entry(
+        &self,
+        path: &VfsPath,
+        wallet: &str,
+        id: &str,
+        file: &str,
+    ) -> Result<Entry, HandlerError> {
+        let sess = self.load_fund_session(path, wallet, id)?;
+        let entry = if file == "confirm" {
+            Entry::writable_file(file)
+        } else {
+            Entry::file(file)
+        };
+        Ok(entry.with_modified_ms(sess.updated_ms))
+    }
+
+    fn draft_dir_entry(
+        &self,
+        store: &OrderStore,
+        wallet: &str,
+        id: &str,
+    ) -> Result<Entry, HandlerError> {
+        let draft = load_required_draft(store, wallet, id)?;
+        Ok(Entry::dir(id).with_modified_ms(draft.created_ms))
+    }
+
+    fn draft_file_entry(
+        &self,
+        store: &OrderStore,
+        wallet: &str,
+        id: &str,
+        file: &str,
+    ) -> Result<Entry, HandlerError> {
+        let draft = load_required_draft(store, wallet, id)?;
+        let entry = if file == "confirm" {
+            Entry::writable_file(file)
+        } else {
+            Entry::file(file)
+        };
+        Ok(entry.with_modified_ms(draft.updated_ms))
+    }
+
+    fn receipt_dir_entry(
+        &self,
+        store: &OrderStore,
+        wallet: &str,
+        id: &str,
+    ) -> Result<Entry, HandlerError> {
+        let receipt = load_required_receipt(store, wallet, id)?;
+        Ok(Entry::dir(id).with_modified_ms(receipt.posted_ms))
+    }
+
+    fn receipt_file_entry(
+        &self,
+        store: &OrderStore,
+        wallet: &str,
+        id: &str,
+        file: &str,
+    ) -> Result<Entry, HandlerError> {
+        let receipt = load_required_receipt(store, wallet, id)?;
+        Ok(Entry::file(file).with_modified_ms(receipt.posted_ms))
     }
 
     fn read_fund(
@@ -3466,14 +3575,20 @@ impl PolymarketHandler {
                 entries.extend(
                     self.list_fund_sessions(path, &segs[1])?
                         .iter()
-                        .map(|id| Entry::dir(id)),
+                        .filter_map(|id| self.fund_session_dir_entry(path, &segs[1], id).ok()),
                 );
                 Ok(entries)
             }
             (Some("fund"), 3) if segs[2] != "new" => {
                 self.fund_root_or_not_found(path)?;
-                let mut entries: Vec<Entry> = FUND_FILES.iter().map(|f| Entry::file(f)).collect();
-                entries.push(Entry::writable_file("confirm"));
+                let mut entries: Vec<Entry> = FUND_FILES
+                    .iter()
+                    .filter_map(|f| {
+                        self.fund_session_file_entry(path, &segs[1], &segs[2], f)
+                            .ok()
+                    })
+                    .collect();
+                entries.push(self.fund_session_file_entry(path, &segs[1], &segs[2], "confirm")?);
                 Ok(entries)
             }
             (Some("trade"), 1) => {
@@ -3492,22 +3607,40 @@ impl PolymarketHandler {
             (Some("trade"), 3) if segs[2] == "drafts" => {
                 let store = self.orders_or_not_found(path)?;
                 let ids = store.list_drafts(&segs[1]).map_err(err_be)?;
-                Ok(ids.iter().map(|id| Entry::dir(id)).collect())
+                Ok(ids
+                    .iter()
+                    .filter_map(|id| self.draft_dir_entry(store, &segs[1], id).ok())
+                    .collect())
             }
             (Some("trade"), 3) if segs[2] == "receipts" => {
                 let store = self.orders_or_not_found(path)?;
                 let ids = store.list_receipts(&segs[1]).map_err(err_be)?;
-                Ok(ids.iter().map(|id| Entry::dir(id)).collect())
+                Ok(ids
+                    .iter()
+                    .filter_map(|id| self.receipt_dir_entry(store, &segs[1], id).ok())
+                    .collect())
             }
             // Resting CLOB order-ids come from the live book/account views, not
             // the local store, so the orders dir is not enumerable by id here.
             (Some("trade"), 3) if segs[2] == "orders" => Ok(Vec::new()),
             (Some("trade"), 4) if segs[2] == "drafts" => {
-                let mut entries: Vec<Entry> = DRAFT_FILES.iter().map(|f| Entry::file(f)).collect();
-                entries.push(Entry::writable_file("confirm"));
+                let store = self.orders_or_not_found(path)?;
+                let mut entries: Vec<Entry> = DRAFT_FILES
+                    .iter()
+                    .filter_map(|f| self.draft_file_entry(store, &segs[1], &segs[3], f).ok())
+                    .collect();
+                entries.push(self.draft_file_entry(store, &segs[1], &segs[3], "confirm")?);
                 Ok(entries)
             }
-            (Some("trade"), 4) if segs[2] == "receipts" => Ok(vec![Entry::file("receipt.json")]),
+            (Some("trade"), 4) if segs[2] == "receipts" => {
+                let store = self.orders_or_not_found(path)?;
+                Ok(vec![self.receipt_file_entry(
+                    store,
+                    &segs[1],
+                    &segs[3],
+                    "receipt.json",
+                )?])
+            }
             (Some("trade"), 4) if segs[2] == "orders" => Ok(vec![Entry::writable_file("cancel")]),
             // redeem/<wallet>/ — slugs are arbitrary (discovered via markets/),
             // so the wallet dir is not enumerable; the confirm leaf is reachable

--- a/crates/bloom-vfs/src/handlers/requests.rs
+++ b/crates/bloom-vfs/src/handlers/requests.rs
@@ -1149,9 +1149,11 @@ impl Handler for RequestsHandler {
                 Ok(entry)
             }
             [one] if matches!(one.as_str(), "pending" | "sent" | "failed" | "sessions") => {
+                self.ensure_layout()?;
                 entry_for_fs_path(self.requests_root().join(one), one, EntryKind::Dir)
             }
             [state, id] if matches!(state.as_str(), "pending" | "sent" | "failed" | "sessions") => {
+                self.ensure_layout()?;
                 entry_for_fs_path(
                     self.requests_root().join(state).join(id),
                     id,

--- a/crates/bloom-vfs/src/handlers/requests.rs
+++ b/crates/bloom-vfs/src/handlers/requests.rs
@@ -38,7 +38,10 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use url::Url;
 
 use crate::auth::AuthServices;
-use crate::handler::{Entry, Handler, HandlerError};
+use crate::handler::{
+    Entry, EntryKind, Handler, HandlerError, entry_for_fs_path, entry_from_fs_dir_entry,
+    fs_path_modified,
+};
 use crate::path::VfsPath;
 
 const APPROVAL_FILE: &str = "approval.json";
@@ -1138,12 +1141,22 @@ impl Handler for RequestsHandler {
         match segs {
             [] => Ok(Entry::dir("requests")),
             [one] if one == "new" || one == "new.dry-run" => Ok(Entry::writable_file(one)),
-            [one] if one == "latest" => Ok(Entry::symlink("latest", &self.latest_target())),
+            [one] if one == "latest" => {
+                let mut entry = Entry::symlink("latest", &self.latest_target());
+                if let Some(modified) = fs_path_modified(self.latest_path())? {
+                    entry = entry.with_modified(modified);
+                }
+                Ok(entry)
+            }
             [one] if matches!(one.as_str(), "pending" | "sent" | "failed" | "sessions") => {
-                Ok(Entry::dir(one))
+                entry_for_fs_path(self.requests_root().join(one), one, EntryKind::Dir)
             }
             [state, id] if matches!(state.as_str(), "pending" | "sent" | "failed" | "sessions") => {
-                Ok(Entry::dir(id))
+                entry_for_fs_path(
+                    self.requests_root().join(state).join(id),
+                    id,
+                    EntryKind::Dir,
+                )
             }
             [state, _id, name]
                 if matches!(state.as_str(), "pending" | "sent" | "failed")
@@ -1154,34 +1167,49 @@ impl Handler for RequestsHandler {
                 // generic file arm reports it as a 0-byte file, so a mounted
                 // client caches it as a file and descending into it fails with
                 // ENOTDIR.
-                Ok(Entry::dir("response"))
+                entry_for_fs_path(
+                    self.req_dir(state, _id).join("response"),
+                    "response",
+                    EntryKind::Dir,
+                )
             }
             [state, _id, name] if matches!(state.as_str(), "pending" | "sent" | "failed") => {
                 if matches!(name.as_str(), "confirm" | "cancel") {
-                    Ok(Entry::writable_file(name))
+                    let mut entry = Entry::writable_file(name);
+                    if let Some(modified) = fs_path_modified(self.req_dir(state, _id))? {
+                        entry = entry.with_modified(modified);
+                    }
+                    Ok(entry)
                 } else {
-                    Ok(Entry::file(name))
+                    entry_for_fs_path(self.req_dir(state, _id).join(name), name, EntryKind::File)
                 }
             }
             [state, id, name] if state == "sessions" => {
                 let file = self.requests_root().join("sessions").join(id).join(name);
                 if matches!(name.as_str(), "topup" | "close") {
                     if file.exists() {
-                        Ok(Entry::writable_file(name))
+                        entry_for_fs_path(file, name, EntryKind::File).map(|mut entry| {
+                            entry.mode = 0o644;
+                            entry
+                        })
                     } else {
                         Err(HandlerError::NotFound(format!(
                             "/requests/sessions/{id}/{name}: control unavailable until a fresh Tempo MPP session challenge is staged"
                         )))
                     }
                 } else {
-                    Ok(Entry::file(name))
+                    entry_for_fs_path(file, name, EntryKind::File)
                 }
             }
-            [state, _id, response, name]
+            [state, id, response, name]
                 if matches!(state.as_str(), "pending" | "sent" | "failed")
                     && response == "response" =>
             {
-                Ok(Entry::file(name))
+                entry_for_fs_path(
+                    self.req_dir(state, id).join("response").join(name),
+                    name,
+                    EntryKind::File,
+                )
             }
             _ => Err(HandlerError::NotFound(path.to_string_path())),
         }
@@ -1195,11 +1223,26 @@ impl Handler for RequestsHandler {
             [] => Ok(vec![
                 Entry::writable_file("new"),
                 Entry::writable_file("new.dry-run"),
-                Entry::symlink("latest", &self.latest_target()),
-                Entry::dir("pending"),
-                Entry::dir("sent"),
-                Entry::dir("failed"),
-                Entry::dir("sessions"),
+                entry_with_optional_fs_modified(
+                    self.latest_path(),
+                    Entry::symlink("latest", &self.latest_target()),
+                )?,
+                entry_with_optional_fs_modified(
+                    self.requests_root().join("pending"),
+                    Entry::dir("pending"),
+                )?,
+                entry_with_optional_fs_modified(
+                    self.requests_root().join("sent"),
+                    Entry::dir("sent"),
+                )?,
+                entry_with_optional_fs_modified(
+                    self.requests_root().join("failed"),
+                    Entry::dir("failed"),
+                )?,
+                entry_with_optional_fs_modified(
+                    self.requests_root().join("sessions"),
+                    Entry::dir("sessions"),
+                )?,
             ]),
             [state] if matches!(state.as_str(), "pending" | "sent" | "failed" | "sessions") => {
                 list_dirs(self.requests_root().join(state))
@@ -2089,7 +2132,8 @@ fn list_dirs(path: PathBuf) -> Result<Vec<Entry>, HandlerError> {
         for e in fs::read_dir(path)? {
             let e = e?;
             if e.file_type()?.is_dir() {
-                out.push(Entry::dir(&e.file_name().to_string_lossy()));
+                let name = e.file_name().to_string_lossy().to_string();
+                out.push(entry_from_fs_dir_entry(&e, &name, EntryKind::Dir)?);
             }
         }
     }
@@ -2106,15 +2150,27 @@ fn list_entries(path: PathBuf) -> Result<Vec<Entry>, HandlerError> {
         }
         let ty = e.file_type()?;
         out.push(if ty.is_dir() {
-            Entry::dir(&name)
+            entry_from_fs_dir_entry(&e, &name, EntryKind::Dir)?
         } else if matches!(name.as_str(), "confirm" | "cancel" | "topup" | "close") {
-            Entry::writable_file(&name)
+            let mut entry = entry_from_fs_dir_entry(&e, &name, EntryKind::File)?;
+            entry.mode = 0o644;
+            entry
         } else {
-            Entry::file(&name)
+            entry_from_fs_dir_entry(&e, &name, EntryKind::File)?
         });
     }
     out.sort_by(|a, b| a.name.cmp(&b.name));
     Ok(out)
+}
+
+fn entry_with_optional_fs_modified(
+    path: impl AsRef<Path>,
+    entry: Entry,
+) -> Result<Entry, HandlerError> {
+    let Some(modified) = fs_path_modified(path.as_ref())? else {
+        return Ok(entry);
+    };
+    Ok(entry.with_modified(modified))
 }
 fn new_request_id() -> String {
     static REQUEST_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -2728,6 +2784,40 @@ mod tests {
             ),
             _tmp: tmp,
         }
+    }
+
+    #[tokio::test]
+    async fn pending_request_entries_surface_artifact_modified_times() {
+        let f = fixture(Some("alice"));
+        let req = parse_request("GET https://merchant.test/pay wallet=alice").unwrap();
+        let dir = f.handler.req_dir("pending", "req_time");
+        write_request_artifacts(&dir, &req, "alice", "pending", false).unwrap();
+
+        let dir_modified = fs::metadata(&dir).unwrap().modified().unwrap();
+        let request_toml = dir.join("request.toml");
+        let file_metadata = fs::metadata(&request_toml).unwrap();
+        let file_modified = file_metadata.modified().unwrap();
+
+        let pending_entries = f
+            .handler
+            .list(&VfsPath::parse("/pending").unwrap())
+            .await
+            .unwrap();
+        let req_entry = pending_entries
+            .iter()
+            .find(|entry| entry.name == "req_time")
+            .expect("pending request entry is listed");
+        assert_eq!(req_entry.kind, EntryKind::Dir);
+        assert_eq!(req_entry.modified, Some(dir_modified));
+
+        let request_entry = f
+            .handler
+            .lookup(&VfsPath::parse("/pending/req_time/request.toml").unwrap())
+            .await
+            .unwrap();
+        assert_eq!(request_entry.kind, EntryKind::File);
+        assert_eq!(request_entry.size, file_metadata.len());
+        assert_eq!(request_entry.modified, Some(file_modified));
     }
 
     #[test]

--- a/crates/bloom-vfs/src/handlers/requests.rs
+++ b/crates/bloom-vfs/src/handlers/requests.rs
@@ -2822,6 +2822,31 @@ mod tests {
         assert_eq!(request_entry.modified, Some(file_modified));
     }
 
+    /// Missing request paths must be NotFound (ENOENT on a mount), not
+    /// Io (EIO): the fs-metadata lookups added for timestamps would
+    /// otherwise leak `HandlerError::Io` for nonexistent ids.
+    #[tokio::test]
+    async fn lookup_missing_request_paths_return_not_found() {
+        let f = fixture(Some("alice"));
+        for path in [
+            "/pending/req_missing",
+            "/pending/req_missing/request.toml",
+            "/pending/req_missing/response",
+            "/pending/req_missing/response/body",
+            "/sessions/sess_missing/summary.json",
+        ] {
+            let err = f
+                .handler
+                .lookup(&VfsPath::parse(path).unwrap())
+                .await
+                .unwrap_err();
+            assert!(
+                matches!(err, HandlerError::NotFound(_)),
+                "{path}: expected NotFound, got: {err:?}"
+            );
+        }
+    }
+
     #[test]
     fn paid_http_canonical_envelope_commits_to_selected_plan() {
         let request = parse_request("GET https://merchant.test/pay wallet=alice").unwrap();

--- a/crates/bloom-vfs/src/handlers/simulate.rs
+++ b/crates/bloom-vfs/src/handlers/simulate.rs
@@ -97,6 +97,14 @@ impl SimulateHandler {
         let n = self.next_id.fetch_add(1, Ordering::SeqCst);
         format!("sim-{:04}", n)
     }
+
+    fn session_entry(&self, id: &str, entry: Entry) -> Result<Entry, HandlerError> {
+        let g = self.sessions.read();
+        let s = g
+            .get(id)
+            .ok_or_else(|| HandlerError::not_found(id.to_string()))?;
+        Ok(entry.with_modified_ms(s.created_ms))
+    }
 }
 
 /// JSON envelope accepted by `simulate/new`. Either an inline `intent` or a
@@ -765,8 +773,8 @@ impl SimulateHandler {
                 "last" => Ok(Entry::file("last")),
                 id => {
                     let g = self.sessions.read();
-                    if g.contains_key(id) {
-                        Ok(Entry::dir(id))
+                    if let Some(s) = g.get(id) {
+                        Ok(Entry::dir(id).with_modified_ms(s.created_ms))
                     } else {
                         Err(HandlerError::not_found(path.to_string_path()))
                     }
@@ -780,9 +788,11 @@ impl SimulateHandler {
                 }
                 drop(g);
                 match segs[1].as_str() {
-                    "state-override.json" => Ok(Entry::writable_file("state-override.json")),
+                    "state-override.json" => {
+                        self.session_entry(id, Entry::writable_file("state-override.json"))
+                    }
                     "intent.json" | "simulation.json" | "plan.md" | "trace.json" => {
-                        Ok(Entry::file(&segs[1]))
+                        self.session_entry(id, Entry::file(&segs[1]))
                     }
                     _ => Err(HandlerError::not_found(path.to_string_path())),
                 }
@@ -837,7 +847,9 @@ impl SimulateHandler {
                 let mut ids: Vec<&String> = g.keys().collect();
                 ids.sort();
                 for id in ids {
-                    out.push(Entry::dir(id));
+                    if let Some(s) = g.get(id) {
+                        out.push(Entry::dir(id).with_modified_ms(s.created_ms));
+                    }
                 }
                 Ok(out)
             }
@@ -846,7 +858,10 @@ impl SimulateHandler {
                 let s = g
                     .get(&segs[0])
                     .ok_or_else(|| HandlerError::not_found(path.to_string_path()))?;
-                Ok(Self::session_dir_entries(s))
+                Ok(Self::session_dir_entries(s)
+                    .into_iter()
+                    .map(|entry| entry.with_modified_ms(s.created_ms))
+                    .collect())
             }
             _ => Err(HandlerError::NotADir(path.to_string_path())),
         }
@@ -989,6 +1004,41 @@ mod tests {
         let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
         assert!(names.contains(&"new"));
         assert!(names.contains(&"last"));
+    }
+
+    #[tokio::test]
+    async fn session_entries_surface_created_time() {
+        let r = ChainRegistry::new();
+        let h = SimulateHandler::new(r, Arc::new(AddressBook::default()));
+        let created_ms = 1_700_000_000_000;
+        h.sessions.write().insert(
+            "sim-fixed".into(),
+            SimSession {
+                id: "sim-fixed".into(),
+                intent: None,
+                from: None,
+                state_override: None,
+                result: None,
+                plan_md: None,
+                trace_json: None,
+                created_ms,
+            },
+        );
+
+        let dir = h
+            .lookup(&VfsPath::parse("sim-fixed").unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            dir.modified,
+            Some(std::time::SystemTime::UNIX_EPOCH + Duration::from_millis(created_ms as u64))
+        );
+
+        let plan = h
+            .lookup(&VfsPath::parse("sim-fixed/plan.md").unwrap())
+            .await
+            .unwrap();
+        assert_eq!(plan.modified, dir.modified);
     }
 
     #[tokio::test]

--- a/crates/bloom-vfs/src/handlers/wallets.rs
+++ b/crates/bloom-vfs/src/handlers/wallets.rs
@@ -2061,15 +2061,17 @@ impl WalletsHandler {
                 // Confirm the entry actually lives in the requested state
                 // (fix #8): a stale path like `outbox/sent/<pending-id>`
                 // should NotFound, not silently succeed.
-                self.tx_engine
+                let entry = self
+                    .tx_engine
                     .outbox
                     .read_in_state(wallet, chain, id, st)
                     .map_err(err_be)?;
-                Ok(Entry::dir(id))
+                Ok(Entry::dir(id).with_modified_ms(entry.staged.created_ms))
             }
             [state, id, fname] => {
                 let st = parse_state_seg(state)?;
-                self.tx_engine
+                let entry = self
+                    .tx_engine
                     .outbox
                     .read_in_state(wallet, chain, id, st)
                     .map_err(err_be)?;
@@ -2082,9 +2084,9 @@ impl WalletsHandler {
                         "confirm" | "confirm.override" | "replace" | "cancel"
                     )
                 {
-                    Ok(Entry::writable_file(fname))
+                    Ok(Entry::writable_file(fname).with_modified_ms(entry.staged.created_ms))
                 } else {
-                    Ok(Entry::file(fname))
+                    Ok(Entry::file(fname).with_modified_ms(entry.staged.created_ms))
                 }
             }
             _ => Err(HandlerError::not_found(rest.join("/"))),
@@ -2340,7 +2342,18 @@ impl WalletsHandler {
                     .outbox
                     .list(wallet, chain, st)
                     .map_err(err_be)?;
-                Ok(ids.into_iter().map(|n| Entry::dir(&n)).collect())
+                let entries = ids
+                    .into_iter()
+                    .filter_map(|id| {
+                        let entry = self
+                            .tx_engine
+                            .outbox
+                            .read_in_state(wallet, chain, &id, st)
+                            .ok()?;
+                        Some(Entry::dir(&id).with_modified_ms(entry.staged.created_ms))
+                    })
+                    .collect();
+                Ok(entries)
             }
             [s, state, id] if s == "outbox" => {
                 let st = parse_state_seg(state)?;
@@ -2365,12 +2378,17 @@ impl WalletsHandler {
                                         "confirm" | "confirm.override" | "replace" | "cancel"
                                     )
                                 {
-                                    out.push(Entry::writable_file(n));
+                                    out.push(
+                                        Entry::writable_file(n)
+                                            .with_modified_ms(entry.staged.created_ms),
+                                    );
                                 } else {
-                                    out.push(Entry::file(n));
+                                    out.push(
+                                        Entry::file(n).with_modified_ms(entry.staged.created_ms),
+                                    );
                                 }
                             } else {
-                                out.push(Entry::dir(n));
+                                out.push(Entry::dir(n).with_modified_ms(entry.staged.created_ms));
                             }
                         }
                     }
@@ -2381,7 +2399,10 @@ impl WalletsHandler {
                 if entry.state == OutboxState::Pending {
                     for ctrl in ["confirm", "confirm.override", "replace", "cancel"] {
                         if !out.iter().any(|e| e.name == ctrl) {
-                            out.push(Entry::writable_file(ctrl));
+                            out.push(
+                                Entry::writable_file(ctrl)
+                                    .with_modified_ms(entry.staged.created_ms),
+                            );
                         }
                     }
                 }

--- a/crates/bloom-vfs/src/handlers/wallets.rs
+++ b/crates/bloom-vfs/src/handlers/wallets.rs
@@ -2344,13 +2344,16 @@ impl WalletsHandler {
                     .map_err(err_be)?;
                 let entries = ids
                     .into_iter()
-                    .filter_map(|id| {
-                        let entry = self
-                            .tx_engine
-                            .outbox
-                            .read_in_state(wallet, chain, &id, st)
-                            .ok()?;
-                        Some(Entry::dir(&id).with_modified_ms(entry.staged.created_ms))
+                    .map(|id| {
+                        match self.tx_engine.outbox.read_in_state(wallet, chain, &id, st) {
+                            Ok(entry) => {
+                                Entry::dir(&id).with_modified_ms(entry.staged.created_ms)
+                            }
+                            Err(e) => {
+                                tracing::warn!(id = %id, error = %e, "wallets.outbox.metadata_fallback");
+                                Entry::dir(&id)
+                            }
+                        }
                     })
                     .collect();
                 Ok(entries)
@@ -3325,6 +3328,7 @@ mod tests {
                 native_symbol: "ETH".into(),
                 native_decimals: 18,
                 legacy_tx: false,
+                op_stack: false,
             };
             chains.add(bloom_evm::ChainClient::new(spec).unwrap());
         }
@@ -4089,6 +4093,7 @@ mod tests {
             native_symbol: "ETH".into(),
             native_decimals: 18,
             legacy_tx: false,
+            op_stack: false,
         };
         f.handler
             .chains

--- a/crates/bloom-vfs/src/handlers/watch.rs
+++ b/crates/bloom-vfs/src/handlers/watch.rs
@@ -23,7 +23,7 @@ use async_trait::async_trait;
 use bloom_proto::HomeDir;
 use bloom_watch::{WatchExecutor, WatchKind, WatchRegistry, WatchSpec};
 
-use crate::handler::{Entry, Handler, HandlerError};
+use crate::handler::{Entry, Handler, HandlerError, fs_path_modified};
 use crate::path::VfsPath;
 
 #[derive(Clone)]
@@ -82,6 +82,27 @@ impl WatchHandler {
         out.sort();
         out
     }
+
+    fn spec_entry(spec: &WatchSpec, entry: Entry) -> Entry {
+        entry.with_modified_ms(spec.created_ms)
+    }
+
+    fn watch_file_entry(
+        &self,
+        spec: &WatchSpec,
+        name: &str,
+        entry: Entry,
+    ) -> Result<Entry, HandlerError> {
+        let path = if name == "live" {
+            WatchExecutor::live_path_for_spec(&self.home, spec)
+        } else {
+            self.watch_dir(spec).join(name)
+        };
+        Ok(match fs_path_modified(path)? {
+            Some(modified) => entry.with_modified(modified),
+            None => Self::spec_entry(spec, entry),
+        })
+    }
 }
 
 #[async_trait]
@@ -132,17 +153,19 @@ impl WatchHandler {
             1 => match segs[0].as_str() {
                 "new" => Ok(Entry::writable_file("new")),
                 id => {
-                    let _ = self.resolve_id(id)?;
-                    Ok(Entry::dir(id))
+                    let spec = self.resolve_id(id)?;
+                    Ok(Self::spec_entry(&spec, Entry::dir(id)))
                 }
             },
             2 => {
-                let _ = self.resolve_id(&segs[0])?;
+                let spec = self.resolve_id(&segs[0])?;
                 match segs[1].as_str() {
-                    "spec.toml" => Ok(Entry::file("spec.toml")),
-                    "live" => Ok(Entry::file("live")),
-                    "delete" => Ok(Entry::writable_file("delete")),
-                    n if Self::is_history_segment(n) => Ok(Entry::file(n)),
+                    "spec.toml" => Ok(Self::spec_entry(&spec, Entry::file("spec.toml"))),
+                    "live" => self.watch_file_entry(&spec, "live", Entry::file("live")),
+                    "delete" => Ok(Self::spec_entry(&spec, Entry::writable_file("delete"))),
+                    n if Self::is_history_segment(n) => {
+                        self.watch_file_entry(&spec, n, Entry::file(n))
+                    }
                     _ => Err(HandlerError::not_found(path.to_string_path())),
                 }
             }
@@ -235,19 +258,19 @@ impl WatchHandler {
             0 => {
                 let mut out = vec![Entry::writable_file("new")];
                 for s in self.registry.list_all() {
-                    out.push(Entry::dir(&s.id));
+                    out.push(Self::spec_entry(&s, Entry::dir(&s.id)));
                 }
                 Ok(out)
             }
             1 => {
                 let spec = self.resolve_id(&segs[0])?;
                 let mut out = vec![
-                    Entry::file("spec.toml"),
-                    Entry::file("live"),
-                    Entry::writable_file("delete"),
+                    Self::spec_entry(&spec, Entry::file("spec.toml")),
+                    self.watch_file_entry(&spec, "live", Entry::file("live"))?,
+                    Self::spec_entry(&spec, Entry::writable_file("delete")),
                 ];
                 for n in self.list_history_segments(&spec) {
-                    out.push(Entry::file(&n));
+                    out.push(self.watch_file_entry(&spec, &n, Entry::file(&n))?);
                 }
                 Ok(out)
             }
@@ -405,6 +428,43 @@ threshold_gwei = 25.0
         assert!(names.contains(&"new"));
         // Some allocated id w-NNNN should appear.
         assert!(names.iter().any(|n| n.starts_with("w-")));
+    }
+
+    #[tokio::test]
+    async fn entries_surface_spec_and_artifact_modified_times() {
+        let (h, _t) = build_handler();
+        let toml = r#"
+kind = "block"
+wallet = "alice"
+chain = "anvil"
+"#;
+        h.write(&VfsPath::parse("new").unwrap(), toml.as_bytes())
+            .await
+            .unwrap();
+        let spec = h.registry.list_all().into_iter().next().unwrap();
+        let expected = std::time::SystemTime::UNIX_EPOCH
+            + std::time::Duration::from_millis(spec.created_ms as u64);
+
+        let dir_entry = h.lookup(&VfsPath::parse(&spec.id).unwrap()).await.unwrap();
+        assert_eq!(dir_entry.modified, Some(expected));
+
+        let spec_entry = h
+            .lookup(&VfsPath::parse(&format!("{}/spec.toml", spec.id)).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(spec_entry.modified, Some(expected));
+
+        let live_path = WatchExecutor::live_path_for_spec(&h.home, &spec);
+        if let Some(parent) = live_path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&live_path, b"{}\n").unwrap();
+        let live_modified = std::fs::metadata(&live_path).unwrap().modified().unwrap();
+        let live_entry = h
+            .lookup(&VfsPath::parse(&format!("{}/live", spec.id)).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(live_entry.modified, Some(live_modified));
     }
 
     #[tokio::test]

--- a/crates/bloom-vfs/src/lib.rs
+++ b/crates/bloom-vfs/src/lib.rs
@@ -28,7 +28,10 @@ pub mod router;
 
 pub use auth::AuthServices;
 pub use cache::PathCache;
-pub use handler::{Entry, EntryKind, Handler, HandlerError};
+pub use handler::{
+    Entry, EntryKind, Handler, HandlerError, entry_for_fs_path, entry_from_fs_dir_entry,
+    entry_from_fs_metadata, fs_path_modified,
+};
 pub use paginate::{PAGE_SIZE, Projection, page_indices, page_name, page_slice, parse_page_name};
 pub use path::{PercentDecodeError, VfsPath, percent_decode_segment};
 pub use router::Vfs;

--- a/crates/bloom/Cargo.toml
+++ b/crates/bloom/Cargo.toml
@@ -51,6 +51,7 @@ qrcode.workspace = true
 rand.workspace = true
 rpassword.workspace = true
 tempfile.workspace = true
+humantime.workspace = true
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/crates/bloom/src/main.rs
+++ b/crates/bloom/src/main.rs
@@ -31,7 +31,7 @@ use bloom_proto::{AuditRecord, CeremonyIntent, CeremonyIntentKind, HomeDir, Home
 use bloom_tx::TxEngineError;
 use bloom_vfs::{
     VfsPath,
-    handler::{Handler, HandlerError},
+    handler::{Entry, EntryKind, Handler, HandlerError},
 };
 use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::{Shell, generate};
@@ -257,6 +257,8 @@ enum VfsCmd {
         #[arg(default_value = "/")]
         path: String,
     },
+    /// `stat /bloom/<path>` — inspect VFS metadata without a kernel mount.
+    Stat { path: String },
     /// Write data to a writable VFS path. Reads from stdin if `--data` is omitted.
     Write {
         path: String,
@@ -1160,6 +1162,90 @@ fn is_ipc_handler_permission_denied(e: &std::io::Error) -> bool {
     s.contains("-32007") || s.contains("permission denied")
 }
 
+fn system_time_to_unix_ms(time: SystemTime) -> u128 {
+    time.duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+}
+
+fn unix_ms_to_system_time(ms: u128) -> SystemTime {
+    let ms = ms.min(u64::MAX as u128) as u64;
+    UNIX_EPOCH + std::time::Duration::from_millis(ms)
+}
+
+fn entry_kind_label(kind: EntryKind) -> &'static str {
+    match kind {
+        EntryKind::Dir => "dir",
+        EntryKind::File => "file",
+        EntryKind::Symlink => "symlink",
+    }
+}
+
+fn print_vfs_stat(
+    path: &str,
+    name: &str,
+    kind: &str,
+    mode: u32,
+    size: u64,
+    link_target: Option<&str>,
+    modified: Option<SystemTime>,
+) {
+    let (modified, modified_source) = match modified {
+        Some(t) => (t, "artifact"),
+        None => (SystemTime::now(), "synthetic_now"),
+    };
+    let modified_ms = system_time_to_unix_ms(modified);
+    println!("path: {path}");
+    println!("name: {name}");
+    println!("kind: {kind}");
+    println!("mode: {:04o}", mode & 0o7777);
+    println!("size: {size}");
+    println!("modified_ms: {modified_ms}");
+    println!("modified: {}", humantime::format_rfc3339(modified));
+    println!("modified_source: {modified_source}");
+    if let Some(target) = link_target {
+        println!("link_target: {target}");
+    }
+}
+
+fn print_vfs_stat_entry(path: &str, entry: &Entry) {
+    print_vfs_stat(
+        path,
+        &entry.name,
+        entry_kind_label(entry.kind),
+        entry.mode,
+        entry.size,
+        entry.link_target.as_deref(),
+        entry.modified,
+    )
+}
+
+fn print_vfs_stat_json(path: &str, entry: &serde_json::Value) -> Result<()> {
+    let name = entry
+        .get("name")
+        .and_then(|v| v.as_str())
+        .context("ipc lookup: missing name")?;
+    let kind = entry
+        .get("kind")
+        .and_then(|v| v.as_str())
+        .context("ipc lookup: missing kind")?;
+    let mode = entry
+        .get("mode")
+        .and_then(|v| v.as_u64())
+        .context("ipc lookup: missing mode")? as u32;
+    let size = entry
+        .get("size")
+        .and_then(|v| v.as_u64())
+        .context("ipc lookup: missing size")?;
+    let link_target = entry.get("link_target").and_then(|v| v.as_str());
+    let modified = entry
+        .get("modified_ms")
+        .and_then(|v| v.as_u64())
+        .map(|ms| unix_ms_to_system_time(ms as u128));
+    print_vfs_stat(path, name, kind, mode, size, link_target, modified);
+    Ok(())
+}
+
 async fn run(cli: Cli) -> Result<()> {
     let (connect, ipc_socket) = if cli.connect.is_some() {
         (cli.connect, None)
@@ -1299,6 +1385,28 @@ async fn run(cli: Cli) -> Result<()> {
                 for e in entries {
                     println!("{}\t{:?}", e.name, e.kind);
                 }
+            }
+            Ok(())
+        }
+        Cmd::Vfs(VfsCmd::Stat { path }) => {
+            let p = VfsPath::parse(&path).context("parse path")?;
+            let client = IpcClient::new(&client_endpoint.socket);
+            let ipc_res = try_ipc(
+                &client,
+                &client_endpoint,
+                "lookup",
+                serde_json::json!({ "path": path }),
+            )
+            .await
+            .with_context(|| format!("ipc lookup via {}", client_endpoint.display))?;
+            if let Some(res) = ipc_res {
+                debug!(endpoint = %client_endpoint.display, "cli.vfs.stat.via_ipc");
+                print_vfs_stat_json(&path, &res)?;
+            } else {
+                debug!("cli.vfs.stat.via_inproc: no daemon socket present");
+                let d = Daemon::from_home(home).context("build daemon")?;
+                let entry = d.vfs.lookup(&p).await.context("vfs lookup")?;
+                print_vfs_stat_entry(&path, &entry);
             }
             Ok(())
         }

--- a/crates/bloom/tests/cli.rs
+++ b/crates/bloom/tests/cli.rs
@@ -15,7 +15,7 @@ use std::sync::{
     Arc, Mutex,
     atomic::{AtomicUsize, Ordering},
 };
-use std::time::Duration;
+use std::time::{Duration, UNIX_EPOCH};
 
 use assert_cmd::Command;
 use async_trait::async_trait;
@@ -113,6 +113,30 @@ impl Handler for RecordingWriteHandler {
             .unwrap()
             .push((p.to_string_path(), data.to_vec()));
         Ok(())
+    }
+}
+
+struct FixedStatHandler;
+
+#[async_trait]
+impl Handler for FixedStatHandler {
+    async fn lookup(&self, p: &VfsPath) -> Result<Entry, HandlerError> {
+        if p.is_root() {
+            return Ok(Entry::dir(""));
+        }
+        let mut entry = Entry::read_only_file("meta");
+        entry.size = 42;
+        Ok(entry.with_modified(UNIX_EPOCH + Duration::from_millis(1_700_000_000_123)))
+    }
+
+    async fn list(&self, p: &VfsPath) -> Result<Vec<Entry>, HandlerError> {
+        if p.is_root() {
+            Ok(vec![Entry::read_only_file("meta").with_modified(
+                UNIX_EPOCH + Duration::from_millis(1_700_000_000_123),
+            )])
+        } else {
+            Err(HandlerError::NotADir(p.to_string_path()))
+        }
     }
 }
 
@@ -480,6 +504,52 @@ fn vfs_cat_status_version_returns_pkg_version() {
         .assert()
         .success()
         .stdout(predicate::eq(expected));
+}
+
+#[test]
+fn vfs_stat_reports_metadata_without_mount() {
+    let home = fresh_home();
+    let out = bloom_cmd(home.path())
+        .args(["vfs", "stat", "/status/version"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(out.get_output().stdout.clone()).unwrap();
+    assert!(stdout.contains("path: /status/version"), "{stdout}");
+    assert!(stdout.contains("name: version"), "{stdout}");
+    assert!(stdout.contains("kind: file"), "{stdout}");
+    assert!(stdout.contains("mode: 0444"), "{stdout}");
+    assert!(stdout.contains("size: 0"), "{stdout}");
+    assert!(stdout.contains("modified_ms: "), "{stdout}");
+    assert!(stdout.contains("modified: "), "{stdout}");
+    assert!(
+        stdout.contains("modified_source: synthetic_now"),
+        "{stdout}"
+    );
+}
+
+#[test]
+fn vfs_stat_via_ipc_preserves_entry_modified_ms() {
+    let home = fresh_home();
+    let vfs = bloom_vfs::Vfs::builder()
+        .mount("fixed", Arc::new(FixedStatHandler))
+        .build();
+    let (server, server_thread) = spawn_ipc_server(home.path(), vfs);
+
+    let out = bloom_cmd(home.path())
+        .args(["vfs", "stat", "/fixed/meta"])
+        .assert()
+        .success();
+
+    stop_ipc_server(server, server_thread);
+
+    let stdout = String::from_utf8(out.get_output().stdout.clone()).unwrap();
+    assert!(stdout.contains("path: /fixed/meta"), "{stdout}");
+    assert!(stdout.contains("name: meta"), "{stdout}");
+    assert!(stdout.contains("kind: file"), "{stdout}");
+    assert!(stdout.contains("mode: 0444"), "{stdout}");
+    assert!(stdout.contains("size: 42"), "{stdout}");
+    assert!(stdout.contains("modified_ms: 1700000000123"), "{stdout}");
+    assert!(stdout.contains("modified_source: artifact"), "{stdout}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add optional `Entry.modified` metadata and teach the mount adapter to expose it through file attrs
- surface natural timestamps for request artifacts, outbox artifacts, wallet EVM outbox actions, DeFi sessions, Polymarket drafts/receipts, Hyperliquid sessions, simulate sessions, watch specs/artifacts, and chain RPC metadata
- make chain head/block/confirmed-tx timestamps best-effort from RPC block timestamps, falling back to the previous synthetic timestamp behavior when unavailable
- expose Base-style unknown typed chain tx/receipt JSON through raw RPC fallback so `0x7e` system/deposit tx reads work
- ignore local `cache/` and `out/` directories

## Notes

- Direct VFS reads were manually exercised for chain head/block/tx metadata and existing artifact-backed paths.
- Real Base `0x7e` transaction reads were manually exercised through `bloom vfs cat` using tx `0xc2080cd9bfe974c488e3d78ee60f04d8fbeb93042d668b5dafd16e27179fecc8`.
- Mounted `stat` could not be verified in this environment because kernel mounting requires superuser/passwordless sudo. The non-mounted `vfs stat` command from #99 was merged into this branch and ships with this PR.
- Closes #70. Fixes #95. Closes #96.

## Checklist

- [x] Tests added or updated for behavior changes
- [x] Architecture docs (`docs/architecture/`) updated if contracts or behavior changed - N/A, metadata timestamps and raw tx fallback use existing VFS entry/read contracts
- [x] Sealed Approval invariants respected (no signing outside a grant or bounded capability, no PRF/grant persistence, execution from sealed bytes) - no signing paths changed
- [x] Agent Documentation updated (`crates/bloom-vfs/src/docs/agent-guidance.md` and affected Petal READMEs) - N/A, no agent command surface or Petal guidance changed

## Tests

- `cargo check -p bloom-vfs`
- `cargo check -p bloom-mount --features mount`
- `cargo test -p bloom-vfs handlers::chains::tests --lib`
- `cargo test -p bloom-vfs handlers::outbox::tests --lib`
- `cargo test -p bloom-vfs handlers::simulate::tests --lib`
- `cargo test -p bloom-vfs handlers::watch::tests --lib`
- `cargo test -p bloom-vfs handlers::wallets::tests --lib`
- `cargo test -p bloom-vfs handlers::requests::tests --lib`
- `cargo test -p bloom-vfs handlers::defi::tests --lib`
- `cargo test -p bloom-vfs handlers::polymarket::tests --lib`
- `cargo test -p bloom-vfs handlers::hyperliquid::tests --lib`
- `cargo test -p bloom-mount --features mount adapter::tests --lib`
- `cargo test -p bloom-vfs unknown_typed_tx_receipt_falls_back_to_raw_json -- --nocapture`
- `cargo test -p bloom-vfs handlers::chains::tests:: -- --nocapture`
- `cargo test -p bloom-evm`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`
- Manual: `bloom --home /tmp/bloom-base-vfs-test vfs cat /chains/base/tx/0xc2080cd9bfe974c488e3d78ee60f04d8fbeb93042d668b5dafd16e27179fecc8/{full.json,receipt.json,status,block_number,gas_used,logs.json,error.json}`

