### PR TITLE
Fix wallet confirm under serve for passkey sealed approvals

### DIFF
--- a/crates/bloom/src/main.rs
+++ b/crates/bloom/src/main.rs
@@ -2123,23 +2123,61 @@ async fn run(cli: Cli) -> Result<()> {
             let path = format!("/wallets/{wallet}/chains/{chain}/outbox/pending/{id}/confirm");
             let body = text.into_bytes();
             let client = IpcClient::new(&client_endpoint.socket);
-            let ipc_res = try_ipc(
-                &client,
-                &client_endpoint,
-                "write_unlocked",
-                serde_json::json!({
-                    "path": path,
-                    "bytes_b64": B64.encode(&body),
-                    "wallet": &wallet,
-                }),
-            )
-            .await
-            .with_context(|| format!("ipc wallet confirm via {}", client_endpoint.display))?;
-            if ipc_res.is_some() {
-                debug!(endpoint = %client_endpoint.display, "cli.wallet.confirm.via_ipc");
-                return Ok(());
+            // Daemon-backed confirm must use the plain VFS write lane. The
+            // wallets handler/tx engine stages Sealed Approval challenges and
+            // later consumes approval.json; `write_unlocked` is intentionally
+            // not a passkey signing lane.
+            let confirm_params = serde_json::json!({
+                "path": path,
+                "bytes_b64": B64.encode(&body),
+            });
+            match try_ipc(&client, &client_endpoint, "write", confirm_params.clone()).await {
+                Ok(Some(_)) => {
+                    debug!(endpoint = %client_endpoint.display, "cli.wallet.confirm.via_ipc");
+                    return Ok(());
+                }
+                Ok(None) => {
+                    debug!("cli.wallet.confirm.via_inproc: no daemon socket present");
+                    // Fall through to the in-process fallback below.
+                }
+                Err(e) if is_ipc_handler_permission_denied(&e) => {
+                    // The serving daemon staged approval_challenge.json on the
+                    // first plain write. Build a read-only daemon in this
+                    // process to run the foreground ceremony against the shared
+                    // home, write approval.json, then retry the same write so
+                    // the serving daemon verifies and broadcasts.
+                    let ceremony_daemon = Daemon::from_home(home.clone())
+                        .context("build daemon for wallet confirm ceremony")?;
+                    let approved = sign_outbox_sealed_approval_if_challenged(
+                        &ceremony_daemon,
+                        &wallet,
+                        &chain,
+                        &id,
+                        None,
+                    )
+                    .await
+                    .context("wallet confirm Sealed Approval ceremony")?;
+                    if !approved {
+                        return Err(anyhow::Error::new(e))
+                            .context("wallet confirm denied but no approval challenge was staged");
+                    }
+                    let retry = try_ipc(&client, &client_endpoint, "write", confirm_params)
+                        .await
+                        .with_context(|| {
+                            format!("ipc wallet confirm retry via {}", client_endpoint.display)
+                        })?;
+                    if retry.is_some() {
+                        debug!(endpoint = %client_endpoint.display, "cli.wallet.confirm.via_ipc.after_ceremony");
+                        return Ok(());
+                    }
+                    bail!("wallet confirm retry did not reach the daemon after Sealed Approval");
+                }
+                Err(e) => {
+                    return Err(anyhow::Error::new(e)).with_context(|| {
+                        format!("ipc wallet confirm via {}", client_endpoint.display)
+                    });
+                }
             }
-            debug!("cli.wallet.confirm.via_inproc: no daemon socket present");
             let text = String::from_utf8(body).expect("wallet confirm text originated as UTF-8");
             let (home_permit, d) = build_write_daemon(home)?;
             let info = d.keystore.info(&wallet)?;

--- a/crates/bloom/tests/cli.rs
+++ b/crates/bloom/tests/cli.rs
@@ -1129,6 +1129,39 @@ fn vfs_routes_via_ipc_when_socket_exists() {
     server_thread.join().expect("ipc server thread panicked");
 }
 
+#[test]
+fn wallet_confirm_uses_plain_ipc_write_when_socket_exists() {
+    let home = fresh_home();
+    let handler = RecordingWriteHandler::new();
+    let vfs = bloom_vfs::Vfs::builder()
+        .mount("wallets", handler.clone())
+        .build();
+    let (server, server_thread) = spawn_ipc_server(home.path(), vfs);
+
+    bloom_cmd(home.path())
+        .args([
+            "wallet",
+            "confirm",
+            "alice",
+            "base",
+            "0001-deadbeef",
+            "--text",
+            "y",
+        ])
+        .assert()
+        .success();
+
+    stop_ipc_server(server, server_thread);
+
+    let writes = handler.writes();
+    assert_eq!(writes.len(), 1, "expected one VFS write, got {writes:?}");
+    assert_eq!(
+        writes[0].0,
+        "/alice/chains/base/outbox/pending/0001-deadbeef/confirm"
+    );
+    assert_eq!(writes[0].1, b"y");
+}
+
 /// End-to-end petals smoke test: install a WAT module from a file,
 /// confirm `petals ls` shows it under both its hash and its petname, then
 /// `petals run` it and check that WASI stdout reaches the parent process.


### PR DESCRIPTION
## Summary

- route daemon-backed `bloom wallet confirm` through plain IPC `write` instead of `write_unlocked`
- on daemon `PermissionDenied`, run the foreground Sealed Approval ceremony, write `approval.json`, and retry the same write
- add a socket-present CLI regression proving wallet confirm uses the VFS write lane

## Checklist

- [x] Tests added or updated for behavior changes
- [x] Architecture docs (`docs/architecture/`) updated if contracts or behavior changed - N/A, this preserves the existing Sealed Approval/VFS contract and fixes the CLI route
- [x] Sealed Approval invariants respected (no signing outside a grant or bounded capability, no PRF/grant persistence, execution from sealed bytes)
- [x] Agent Documentation updated (`crates/bloom-vfs/src/docs/agent-guidance.md` and affected Petal READMEs) - N/A, no agent-facing VFS surface or Petal guidance changed

## Verification

- `cargo fmt`
- `cargo test -p bloom wallet_confirm_uses_plain_ipc_write_when_socket_exists -- --nocapture`
- `cargo test -p bloom-daemon passkey_write_unlocked_is_hard_disabled -- --nocapture`
- `cargo test -p bloom-vfs approval_challenge_is_visible_and_read_only -- --nocapture`
- `cargo check -p bloom`
- `git diff --check`

Closes #90
