### PR TITLE
Add VFS stat metadata command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2265,6 +2265,7 @@ dependencies = [
  "clap_complete",
  "dirs 5.0.1",
  "hex",
+ "humantime",
  "predicates",
  "qrcode",
  "rand 0.8.6",

--- a/crates/bloom-daemon/src/ipc.rs
+++ b/crates/bloom-daemon/src/ipc.rs
@@ -24,6 +24,7 @@
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::UNIX_EPOCH;
 
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as B64;
@@ -1334,12 +1335,19 @@ fn entry_to_json(e: &Entry) -> Value {
         EntryKind::File => "file",
         EntryKind::Symlink => "symlink",
     };
+    let modified_ms = e.modified.map(|modified| {
+        modified
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+    });
     json!({
         "name": e.name,
         "kind": kind,
         "size": e.size,
         "mode": e.mode,
         "link_target": e.link_target,
+        "modified_ms": modified_ms,
     })
 }
 

--- a/crates/bloom/Cargo.toml
+++ b/crates/bloom/Cargo.toml
@@ -51,6 +51,7 @@ base64.workspace = true
 qrcode.workspace = true
 rand.workspace = true
 rpassword.workspace = true
+humantime.workspace = true
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/crates/bloom/src/main.rs
+++ b/crates/bloom/src/main.rs
@@ -30,7 +30,7 @@ use bloom_proto::{AuditRecord, CeremonyIntent, CeremonyIntentKind, HomeDir, Home
 use bloom_tx::TxEngineError;
 use bloom_vfs::{
     VfsPath,
-    handler::{Handler, HandlerError},
+    handler::{Entry, EntryKind, Handler, HandlerError},
 };
 use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::{Shell, generate};
@@ -256,6 +256,8 @@ enum VfsCmd {
         #[arg(default_value = "/")]
         path: String,
     },
+    /// `stat /bloom/<path>` — inspect VFS metadata without a kernel mount.
+    Stat { path: String },
     /// Write data to a writable VFS path. Reads from stdin if `--data` is omitted.
     Write {
         path: String,
@@ -1150,6 +1152,90 @@ fn is_ipc_handler_permission_denied(e: &std::io::Error) -> bool {
     s.contains("-32007") || s.contains("permission denied")
 }
 
+fn system_time_to_unix_ms(time: SystemTime) -> u128 {
+    time.duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+}
+
+fn unix_ms_to_system_time(ms: u128) -> SystemTime {
+    let ms = ms.min(u64::MAX as u128) as u64;
+    UNIX_EPOCH + std::time::Duration::from_millis(ms)
+}
+
+fn entry_kind_label(kind: EntryKind) -> &'static str {
+    match kind {
+        EntryKind::Dir => "dir",
+        EntryKind::File => "file",
+        EntryKind::Symlink => "symlink",
+    }
+}
+
+fn print_vfs_stat(
+    path: &str,
+    name: &str,
+    kind: &str,
+    mode: u32,
+    size: u64,
+    link_target: Option<&str>,
+    modified: Option<SystemTime>,
+) {
+    let (modified, modified_source) = match modified {
+        Some(t) => (t, "artifact"),
+        None => (SystemTime::now(), "synthetic_now"),
+    };
+    let modified_ms = system_time_to_unix_ms(modified);
+    println!("path: {path}");
+    println!("name: {name}");
+    println!("kind: {kind}");
+    println!("mode: {:04o}", mode & 0o7777);
+    println!("size: {size}");
+    println!("modified_ms: {modified_ms}");
+    println!("modified: {}", humantime::format_rfc3339(modified));
+    println!("modified_source: {modified_source}");
+    if let Some(target) = link_target {
+        println!("link_target: {target}");
+    }
+}
+
+fn print_vfs_stat_entry(path: &str, entry: &Entry) {
+    print_vfs_stat(
+        path,
+        &entry.name,
+        entry_kind_label(entry.kind),
+        entry.mode,
+        entry.size,
+        entry.link_target.as_deref(),
+        entry.modified,
+    )
+}
+
+fn print_vfs_stat_json(path: &str, entry: &serde_json::Value) -> Result<()> {
+    let name = entry
+        .get("name")
+        .and_then(|v| v.as_str())
+        .context("ipc lookup: missing name")?;
+    let kind = entry
+        .get("kind")
+        .and_then(|v| v.as_str())
+        .context("ipc lookup: missing kind")?;
+    let mode = entry
+        .get("mode")
+        .and_then(|v| v.as_u64())
+        .context("ipc lookup: missing mode")? as u32;
+    let size = entry
+        .get("size")
+        .and_then(|v| v.as_u64())
+        .context("ipc lookup: missing size")?;
+    let link_target = entry.get("link_target").and_then(|v| v.as_str());
+    let modified = entry
+        .get("modified_ms")
+        .and_then(|v| v.as_u64())
+        .map(|ms| unix_ms_to_system_time(ms as u128));
+    print_vfs_stat(path, name, kind, mode, size, link_target, modified);
+    Ok(())
+}
+
 async fn run(cli: Cli) -> Result<()> {
     let (connect, ipc_socket) = if cli.connect.is_some() {
         (cli.connect, None)
@@ -1289,6 +1375,28 @@ async fn run(cli: Cli) -> Result<()> {
                 for e in entries {
                     println!("{}\t{:?}", e.name, e.kind);
                 }
+            }
+            Ok(())
+        }
+        Cmd::Vfs(VfsCmd::Stat { path }) => {
+            let p = VfsPath::parse(&path).context("parse path")?;
+            let client = IpcClient::new(&client_endpoint.socket);
+            let ipc_res = try_ipc(
+                &client,
+                &client_endpoint,
+                "lookup",
+                serde_json::json!({ "path": path }),
+            )
+            .await
+            .with_context(|| format!("ipc lookup via {}", client_endpoint.display))?;
+            if let Some(res) = ipc_res {
+                debug!(endpoint = %client_endpoint.display, "cli.vfs.stat.via_ipc");
+                print_vfs_stat_json(&path, &res)?;
+            } else {
+                debug!("cli.vfs.stat.via_inproc: no daemon socket present");
+                let d = Daemon::from_home(home).context("build daemon")?;
+                let entry = d.vfs.lookup(&p).await.context("vfs lookup")?;
+                print_vfs_stat_entry(&path, &entry);
             }
             Ok(())
         }

--- a/crates/bloom/tests/cli.rs
+++ b/crates/bloom/tests/cli.rs
@@ -15,7 +15,7 @@ use std::sync::{
     Arc, Mutex,
     atomic::{AtomicUsize, Ordering},
 };
-use std::time::Duration;
+use std::time::{Duration, UNIX_EPOCH};
 
 use assert_cmd::Command;
 use async_trait::async_trait;
@@ -87,6 +87,30 @@ impl Handler for RecordingWriteHandler {
             .unwrap()
             .push((p.to_string_path(), data.to_vec()));
         Ok(())
+    }
+}
+
+struct FixedStatHandler;
+
+#[async_trait]
+impl Handler for FixedStatHandler {
+    async fn lookup(&self, p: &VfsPath) -> Result<Entry, HandlerError> {
+        if p.is_root() {
+            return Ok(Entry::dir(""));
+        }
+        let mut entry = Entry::read_only_file("meta");
+        entry.size = 42;
+        Ok(entry.with_modified(UNIX_EPOCH + Duration::from_millis(1_700_000_000_123)))
+    }
+
+    async fn list(&self, p: &VfsPath) -> Result<Vec<Entry>, HandlerError> {
+        if p.is_root() {
+            Ok(vec![Entry::read_only_file("meta").with_modified(
+                UNIX_EPOCH + Duration::from_millis(1_700_000_000_123),
+            )])
+        } else {
+            Err(HandlerError::NotADir(p.to_string_path()))
+        }
     }
 }
 
@@ -451,6 +475,52 @@ fn vfs_cat_status_version_returns_pkg_version() {
         .assert()
         .success()
         .stdout(predicate::eq(expected));
+}
+
+#[test]
+fn vfs_stat_reports_metadata_without_mount() {
+    let home = fresh_home();
+    let out = bloom_cmd(home.path())
+        .args(["vfs", "stat", "/status/version"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(out.get_output().stdout.clone()).unwrap();
+    assert!(stdout.contains("path: /status/version"), "{stdout}");
+    assert!(stdout.contains("name: version"), "{stdout}");
+    assert!(stdout.contains("kind: file"), "{stdout}");
+    assert!(stdout.contains("mode: 0444"), "{stdout}");
+    assert!(stdout.contains("size: 0"), "{stdout}");
+    assert!(stdout.contains("modified_ms: "), "{stdout}");
+    assert!(stdout.contains("modified: "), "{stdout}");
+    assert!(
+        stdout.contains("modified_source: synthetic_now"),
+        "{stdout}"
+    );
+}
+
+#[test]
+fn vfs_stat_via_ipc_preserves_entry_modified_ms() {
+    let home = fresh_home();
+    let vfs = bloom_vfs::Vfs::builder()
+        .mount("fixed", Arc::new(FixedStatHandler))
+        .build();
+    let (server, server_thread) = spawn_ipc_server(home.path(), vfs);
+
+    let out = bloom_cmd(home.path())
+        .args(["vfs", "stat", "/fixed/meta"])
+        .assert()
+        .success();
+
+    stop_ipc_server(server, server_thread);
+
+    let stdout = String::from_utf8(out.get_output().stdout.clone()).unwrap();
+    assert!(stdout.contains("path: /fixed/meta"), "{stdout}");
+    assert!(stdout.contains("name: meta"), "{stdout}");
+    assert!(stdout.contains("kind: file"), "{stdout}");
+    assert!(stdout.contains("mode: 0444"), "{stdout}");
+    assert!(stdout.contains("size: 42"), "{stdout}");
+    assert!(stdout.contains("modified_ms: 1700000000123"), "{stdout}");
+    assert!(stdout.contains("modified_source: artifact"), "{stdout}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `bloom vfs stat <path>` so agents can inspect VFS metadata without a privileged kernel mount
- expose `modified_ms` through daemon IPC `lookup` / `list` entry JSON
- print path, name, kind, mode, size, modified time, source, and symlink target when present
- add CLI coverage for in-process stat and daemon-routed stat preserving artifact timestamps

## Stacking
- Stacked on #97 (`vfs_artifact_timestamps`) because this command consumes the new `Entry.modified` metadata.
- Base branch: `vfs_artifact_timestamps`
- Implements #96. Because this PR targets a non-default stacked branch, GitHub will not auto-close #96 until this PR is retargeted/merged through `master`.

## Verification
- `cargo fmt`
- `cargo test -p bloom vfs_stat -- --nocapture`
- `cargo test -p bloom-daemon ipc --lib`
- `cargo check -p bloom`
- `git diff --check`

## Checklist

- [x] Tests added or updated for behavior changes
- [x] Architecture docs (`docs/architecture/`) updated if contracts or behavior changed — N/A: CLI metadata inspection command only
- [x] Sealed Approval invariants respected (no signing outside a grant or bounded capability, no PRF/grant persistence, execution from sealed bytes) — N/A: read-only metadata lookup
- [x] Agent Documentation updated (`crates/bloom-vfs/src/docs/agent-guidance.md` and affected Petal READMEs) — N/A: no VFS path semantics changed; command is discoverable via `bloom vfs --help`
