### PR TITLE
Enable Hyperliquid by default

### DIFF
--- a/crates/bloom-daemon/src/lib.rs
+++ b/crates/bloom-daemon/src/lib.rs
@@ -1385,6 +1385,23 @@ mod tests {
         assert!(d.vfs.handler("addressbook").is_some());
         assert!(d.vfs.handler("ens").is_some());
         assert!(d.vfs.handler("public").is_some());
+        assert!(
+            d.vfs.handler("hyperliquid").is_some(),
+            "fresh homes should mount Hyperliquid with public defaults"
+        );
+    }
+
+    #[test]
+    fn config_without_hyperliquid_keeps_surface_disabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomeDir::at(dir.path());
+        home.ensure().unwrap();
+        let mut config = Config::local_default();
+        config.hyperliquid = None;
+        config.save(&home.config_path()).unwrap();
+
+        let daemon = Daemon::from_home(home).unwrap();
+        assert!(daemon.vfs.handler("hyperliquid").is_none());
     }
 
     /// A pre-existing watch spec on disk should be loaded into the

--- a/crates/bloom-proto/src/config.rs
+++ b/crates/bloom-proto/src/config.rs
@@ -469,7 +469,8 @@ fn default_chains() -> BTreeMap<String, ChainSpec> {
 }
 
 impl Config {
-    /// A safe agentic-wallet default: ten read-ready public EVM networks plus Anvil.
+    /// A safe agentic-wallet default: read-ready public EVM networks, Anvil,
+    /// and the Hyperliquid HyperCore VFS using its official public endpoints.
     ///
     /// Live networks default to read-only (`allow_broadcast = false`) and the
     /// global mainnet broadcast kill-switch stays enabled. Users can inspect
@@ -487,7 +488,7 @@ impl Config {
             etherscan: None,
             enso: None,
             polymarket: None,
-            hyperliquid: None,
+            hyperliquid: Some(HyperliquidConfig::default()),
             mempool: BTreeMap::new(),
             private_rpc: BTreeMap::new(),
             block_mainnet_broadcast: true,
@@ -604,7 +605,15 @@ mod tests {
         assert!(cfg.block_mainnet_broadcast);
         assert!(cfg.etherscan.is_none());
         assert!(cfg.enso.is_none());
-        assert!(cfg.hyperliquid.is_none());
+        let hyperliquid = cfg
+            .hyperliquid
+            .as_ref()
+            .expect("Hyperliquid is enabled by default");
+        assert_eq!(hyperliquid.mainnet_url, "https://api.hyperliquid.xyz");
+        assert_eq!(
+            hyperliquid.testnet_url,
+            "https://api.hyperliquid-testnet.xyz"
+        );
         assert_eq!(cfg.chains.len(), 12);
         let ethereum = cfg.chains.get("ethereum").expect("ethereum entry");
         assert_eq!(ethereum.chain_id, 1);


### PR DESCRIPTION
## Summary
- enable the Hyperliquid VFS in fresh Bloom configs using the existing official public endpoint defaults
- verify fresh daemons mount /hyperliquid
- preserve explicit opt-out: configs that omit the hyperliquid section still leave the surface disabled
- leave wallet policy, signing, agent-session, and Sealed Approval behavior unchanged

## Manual verification
With a disposable fresh home:
- bloom init wrote the hyperliquid block with official mainnet/testnet endpoints
- bloom status reported hyperliquid_vfs: enabled
- bloom vfs ls / included hyperliquid
- bloom vfs ls /hyperliquid listed README.md, asset_ids.md, mainnet, and testnet

## Verification
- cargo test -p bloom-proto -p bloom-daemon
- cargo test -p bloom
- cargo clippy -p bloom-proto -p bloom-daemon --all-targets -- -D warnings
- cargo check --workspace
- cargo fmt --all -- --check
- git diff --check

## Checklist
- [x] Tests added or updated for default and explicit opt-out behavior
- [x] Architecture docs unchanged: existing Hyperliquid handler and authorization boundaries are reused
- [x] Sealed Approval invariants preserved: no signing or policy behavior changed
- [x] Agent documentation unchanged: the existing /hyperliquid surface and paths are unchanged

Closes #78