### PR TITLE
defi: enable safe defaults for fresh homes

### DIFF
--- a/crates/bloom-daemon/src/lib.rs
+++ b/crates/bloom-daemon/src/lib.rs
@@ -2392,12 +2392,13 @@ impl Daemon {
                 ) as _,
             );
 
-        // DeFi: Enso's public REST works without an API key for chains
-        // they support keyless (currently quote+route on Base mainnet).
-        // Mount whenever an `[enso]` block exists in config; an empty
-        // api_key just means unauthenticated calls (rate-limited).
+        // DeFi: fresh configs mount the surface by default. Enso production
+        // routing requires a credential; an empty config key falls back to
+        // BLOOM_ENSO_KEY / ENSO_API_KEY and otherwise produces an actionable
+        // error only when a route is requested. Older/custom configs can still
+        // omit `[enso]` to disable the surface entirely.
         if let Some(enso_cfg) = &config.enso {
-            let mut enso = EnsoClient::new(&enso_cfg.api_key);
+            let mut enso = EnsoClient::new_with_env_fallback(&enso_cfg.api_key);
             match url::Url::parse(&enso_cfg.api_url) {
                 Ok(url) => {
                     debug!(api_url = %url, "daemon.enso_configured");
@@ -2407,8 +2408,10 @@ impl Daemon {
                     warn!(api_url = %enso_cfg.api_url, error = %e, "daemon.enso_url_invalid_using_default");
                 }
             }
-            if enso_cfg.api_key.is_empty() {
-                warn!("enso api_key empty; mounting defi/ for keyless access (rate-limited)");
+            if enso.api_key().is_empty() {
+                warn!(
+                    "Enso API key unavailable; defi/ is mounted for discovery but route requests require BLOOM_ENSO_KEY or ENSO_API_KEY"
+                );
             }
             debug!("daemon.defi_mounted");
             // Hyperliquid deposit goal: bridge address + deposit chain, from
@@ -3053,6 +3056,10 @@ mod tests {
         assert!(d.vfs.handler("ens").is_some());
         assert!(d.vfs.handler("petals").is_some());
         assert!(
+            d.vfs.handler("defi").is_some(),
+            "fresh homes should mount DeFi with Enso defaults"
+        );
+        assert!(
             d.vfs.handler("hyperliquid").is_some(),
             "fresh homes should mount Hyperliquid with public defaults"
         );
@@ -3632,6 +3639,19 @@ mod tests {
 
         let daemon = Daemon::from_home(home).unwrap();
         assert!(daemon.vfs.handler("hyperliquid").is_none());
+    }
+
+    #[test]
+    fn config_without_enso_keeps_surface_disabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomeDir::at(dir.path());
+        home.ensure().unwrap();
+        let mut config = Config::local_default();
+        config.enso = None;
+        config.save(&home.config_path()).unwrap();
+
+        let daemon = Daemon::from_home(home).unwrap();
+        assert!(daemon.vfs.handler("defi").is_none());
     }
 
     /// A pre-existing watch spec on disk should be loaded into the

--- a/crates/bloom-defi/src/lib.rs
+++ b/crates/bloom-defi/src/lib.rs
@@ -1,7 +1,7 @@
 //! Enso DeFi intent client.
 //!
 //! Real client against the Enso Shortcuts API
-//! (<https://api.enso.finance>). Handles single-step routes (swaps,
+//! (<https://api.enso.build>). Handles single-step routes (swaps,
 //! deposits, etc.) and multi-step bundles. Read/quote-oriented; no
 //! broadcasting concerns live here — the resulting tx is staged through
 //! the wallet outbox by the caller.
@@ -21,7 +21,7 @@ use alloy::sol_types::{SolCall, SolValue};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-const DEFAULT_BASE_URL: &str = "https://api.enso.finance";
+const DEFAULT_BASE_URL: &str = "https://api.enso.build";
 
 /// Sentinel address Enso uses for the chain's native token (ETH, MATIC, …).
 pub const NATIVE_TOKEN: &str = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
@@ -353,20 +353,27 @@ impl EnsoClient {
         }
     }
 
+    /// Construct from an optional configured key, falling back to the standard
+    /// environment variables when a fresh config intentionally leaves the key
+    /// empty. `BLOOM_ENSO_KEY` wins over Enso's generic `ENSO_API_KEY`.
+    pub fn new_with_env_fallback(api_key: impl Into<String>) -> Self {
+        let key = resolve_api_key(
+            api_key.into(),
+            std::env::var("BLOOM_ENSO_KEY").ok(),
+            std::env::var("ENSO_API_KEY").ok(),
+        );
+        Self::new(key)
+    }
+
     /// Try to construct from `BLOOM_ENSO_KEY` (preferred) or `ENSO_API_KEY`.
     pub fn from_env() -> Result<Self, EnsoError> {
-        let key = match std::env::var("BLOOM_ENSO_KEY")
-            .ok()
-            .or_else(|| std::env::var("ENSO_API_KEY").ok())
-        {
-            Some(k) => k,
-            None => {
-                tracing::debug!("enso.from_env.missing_key");
-                return Err(EnsoError::MissingKey);
-            }
-        };
+        let key = resolve_api_key(
+            String::new(),
+            std::env::var("BLOOM_ENSO_KEY").ok(),
+            std::env::var("ENSO_API_KEY").ok(),
+        );
         if key.is_empty() {
-            tracing::debug!("enso.from_env.empty_key");
+            tracing::debug!("enso.from_env.missing_key");
             return Err(EnsoError::MissingKey);
         }
         Ok(Self::new(key))
@@ -385,6 +392,15 @@ impl EnsoClient {
         &self.api_key
     }
 
+    /// Fail before doing any route preparation that could touch a chain RPC.
+    pub fn ensure_configured(&self) -> Result<(), EnsoError> {
+        if self.api_key.trim().is_empty() {
+            Err(EnsoError::MissingKey)
+        } else {
+            Ok(())
+        }
+    }
+
     fn auth(&self, rb: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
         if self.api_key.is_empty() {
             tracing::trace!("enso.auth.unconfigured");
@@ -399,6 +415,7 @@ impl EnsoClient {
     /// Enso's REST surface uses **GET** with query params for `route`
     /// (despite being mutating in spirit); we follow that.
     pub async fn route(&self, req: RouteRequest) -> Result<RouteResponse, EnsoError> {
+        self.ensure_configured()?;
         let url = self.base_url.join("/api/v1/shortcuts/route")?;
         tracing::trace!(
             chain_id = req.chain_id,
@@ -446,6 +463,7 @@ impl EnsoClient {
 
     /// `POST /api/v1/shortcuts/bundle` — multi-step.
     pub async fn bundle(&self, req: BundleRequest) -> Result<BundleResponse, EnsoError> {
+        self.ensure_configured()?;
         let url = self.base_url.join("/api/v1/shortcuts/bundle")?;
         tracing::trace!(
             chain_id = req.chain_id,
@@ -491,6 +509,7 @@ impl EnsoClient {
     /// `GET /api/v1/shortcuts/quote` — non-committal price preview.
     /// Returns `amountOut` without producing tx calldata.
     pub async fn quote(&self, req: RouteRequest) -> Result<QuoteResponse, EnsoError> {
+        self.ensure_configured()?;
         let url = self.base_url.join("/api/v1/shortcuts/quote")?;
         tracing::trace!(
             chain_id = req.chain_id,
@@ -528,6 +547,18 @@ impl EnsoClient {
         );
         Ok(v)
     }
+}
+
+fn resolve_api_key(
+    configured: String,
+    bloom_env: Option<String>,
+    enso_env: Option<String>,
+) -> String {
+    [Some(configured), bloom_env, enso_env]
+        .into_iter()
+        .flatten()
+        .find(|key| !key.trim().is_empty())
+        .unwrap_or_default()
 }
 
 // --- Enso Quoter: simulate + validate ------------------------------------
@@ -972,8 +1003,49 @@ mod tests {
     #[test]
     fn client_uses_default_base_url() {
         let c = EnsoClient::new("k");
-        assert_eq!(c.base_url().as_str(), "https://api.enso.finance/");
+        assert_eq!(c.base_url().as_str(), "https://api.enso.build/");
         assert_eq!(c.api_key(), "k");
+    }
+
+    #[test]
+    fn api_key_resolution_prefers_config_then_bloom_then_enso() {
+        assert_eq!(
+            resolve_api_key(
+                "configured".into(),
+                Some("bloom".into()),
+                Some("enso".into())
+            ),
+            "configured"
+        );
+        assert_eq!(
+            resolve_api_key(String::new(), Some("bloom".into()), Some("enso".into())),
+            "bloom"
+        );
+        assert_eq!(
+            resolve_api_key(String::new(), Some(" ".into()), Some("enso".into())),
+            "enso"
+        );
+        assert!(resolve_api_key(String::new(), None, None).is_empty());
+    }
+
+    #[tokio::test]
+    async fn route_without_api_key_fails_before_network() {
+        let client = EnsoClient::new("");
+        let request = RouteRequest {
+            from_address: Address::ZERO,
+            chain_id: 1,
+            destination_chain_id: None,
+            token_in: NATIVE_TOKEN.parse().unwrap(),
+            token_out: Address::ZERO,
+            amount_in: U256::from(1u64),
+            slippage_bps: 50,
+            routing_strategy: Some(RoutingStrategy::Router),
+            receiver: None,
+        };
+        assert!(matches!(
+            client.route(request).await,
+            Err(EnsoError::MissingKey)
+        ));
     }
 
     #[tokio::test]

--- a/crates/bloom-keystore/src/lib.rs
+++ b/crates/bloom-keystore/src/lib.rs
@@ -337,7 +337,7 @@ pub fn create_xdsa_wallet(
     write_atomic(&dir.join("pubkey"), pk_hex.as_bytes())?;
     write_atomic(&dir.join("kind"), b"local")?;
     write_atomic(&dir.join("algorithm"), b"xdsa")?;
-    let default_policy = Policy::default();
+    let default_policy = Policy::fresh_wallet_default();
     write_atomic(
         &dir.join("policy.toml"),
         toml::to_string_pretty(&default_policy)
@@ -946,7 +946,7 @@ impl Keystore {
         write_atomic(&dir.join("address"), checksum_address(&address).as_bytes())?;
         write_atomic(&dir.join("pubkey"), pub_hex.as_bytes())?;
         write_atomic(&dir.join("kind"), b"local")?;
-        let default_policy = Policy::default();
+        let default_policy = Policy::fresh_wallet_default();
         write_atomic(
             &dir.join("policy.toml"),
             toml::to_string_pretty(&default_policy)
@@ -1164,6 +1164,23 @@ mod tests {
         assert_eq!(s.address(), info.address);
         ks.lock("alice");
         assert!(!ks.is_unlocked("alice"));
+    }
+
+    #[test]
+    fn new_wallet_uses_review_gated_defi_defaults() {
+        let (_dir, ks) = temp_store();
+        let info = ks.create_local("my-wallet", "test-passphrase").unwrap();
+        assert!(info.policy.defi.enabled);
+        assert!(
+            info.policy
+                .defi
+                .allowed_receivers
+                .contains("class:wallet_eoa")
+        );
+        assert_eq!(
+            info.policy.effective_agent_autonomy(),
+            bloom_proto::AgentAutonomyMode::Disabled
+        );
     }
 
     #[test]

--- a/crates/bloom-keystore/src/passkey.rs
+++ b/crates/bloom-keystore/src/passkey.rs
@@ -1444,7 +1444,7 @@ fn unique_rebind_backup_dir(root: &std::path::Path, name: &str) -> std::path::Pa
 /// Default policy TOML for a fresh passkey registration, served to the
 /// registration page before any attempt exists.
 pub fn default_passkey_policy_toml() -> Result<String, KeystoreError> {
-    let mut default_policy = Policy::default();
+    let mut default_policy = Policy::fresh_wallet_default();
     default_policy.approval.agent_autonomy = Some(bloom_proto::AgentAutonomyMode::Disabled);
     toml::to_string_pretty(&default_policy).map_err(|e| KeystoreError::Policy(e.to_string()))
 }

--- a/crates/bloom-proto/src/config.rs
+++ b/crates/bloom-proto/src/config.rs
@@ -194,9 +194,22 @@ pub struct EtherscanConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EnsoConfig {
+    /// Enso production API credential. Fresh configs leave this empty so the
+    /// daemon can read `BLOOM_ENSO_KEY` / `ENSO_API_KEY` without requiring a
+    /// config edit.
+    #[serde(default)]
     pub api_key: String,
     #[serde(default = "default_enso_url")]
     pub api_url: String,
+}
+
+impl Default for EnsoConfig {
+    fn default() -> Self {
+        Self {
+            api_key: String::new(),
+            api_url: default_enso_url(),
+        }
+    }
 }
 
 /// Hyperliquid HyperCore API configuration. Every field has a default so a
@@ -261,7 +274,7 @@ fn default_etherscan_url() -> String {
     "https://api.etherscan.io/v2/api".to_string()
 }
 fn default_enso_url() -> String {
-    "https://api.enso.finance".to_string()
+    "https://api.enso.build".to_string()
 }
 fn default_hyperliquid_mainnet_url() -> String {
     "https://api.hyperliquid.xyz".to_string()
@@ -446,7 +459,7 @@ impl Config {
             stage_ttl: default_stage_ttl(),
             chains,
             etherscan: None,
-            enso: None,
+            enso: Some(EnsoConfig::default()),
             petals: PetalsConfig::default(),
             hyperliquid: Some(HyperliquidConfig::default()),
             mempool: BTreeMap::new(),
@@ -663,7 +676,9 @@ mod tests {
         assert_eq!(cfg.mount_path, "/bloom");
         assert_eq!(cfg.nfs_listen_addr, "127.0.0.1:12049");
         assert!(cfg.etherscan.is_none());
-        assert!(cfg.enso.is_none());
+        let enso = cfg.enso.as_ref().expect("DeFi is enabled by default");
+        assert!(enso.api_key.is_empty());
+        assert_eq!(enso.api_url, "https://api.enso.build");
         assert_eq!(cfg.petals.preinstalled, ["polymarket"]);
         let hyperliquid = cfg
             .hyperliquid
@@ -1124,7 +1139,11 @@ api_key = "ENKEY"
         assert_eq!(es.api_url, "https://api.etherscan.io/v2/api");
         let en = cfg.enso.expect("enso parsed");
         assert_eq!(en.api_key, "ENKEY");
-        assert_eq!(en.api_url, "https://api.enso.finance");
+        assert_eq!(en.api_url, "https://api.enso.build");
+
+        let en: EnsoConfig = toml::from_str("").unwrap();
+        assert!(en.api_key.is_empty());
+        assert_eq!(en.api_url, "https://api.enso.build");
     }
 
     #[test]

--- a/crates/bloom-proto/src/defi_policy.rs
+++ b/crates/bloom-proto/src/defi_policy.rs
@@ -43,7 +43,9 @@ fn default_true() -> bool {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DefiPolicy {
     /// Master gate. Defaults to **false**: the generic DeFi route surface
-    /// refuses all value-moving routes until the owner opts in.
+    /// refuses all value-moving routes until the owner opts in. Fresh wallets
+    /// use [`DefiPolicy::fresh_wallet_default`], which permits only reviewed
+    /// routes returning to the owner EOA.
     #[serde(default)]
     pub enabled: bool,
     /// Source chains a route may originate on. Empty ⇒ none allowed.
@@ -123,6 +125,64 @@ impl Default for DefiPolicy {
             denied_protocols: BTreeSet::new(),
             allow_unknown_protocols: false,
             require_calldata_verification: true,
+            max_input_usd: None,
+            max_native_value_wei: None,
+        }
+    }
+}
+
+impl DefiPolicy {
+    /// Policy installed for newly-created wallets.
+    ///
+    /// Existing policies that omit `[defi]` continue to deserialize through
+    /// [`Default`] as disabled, so upgrading Bloom never expands an existing
+    /// wallet's authority. Fresh wallets permit only routes returning to the
+    /// owner EOA on Bloom's default Enso-supported chains, through the Enso V2
+    /// routers documented at <https://docs.enso.build/pages/build/reference/deployments>.
+    ///
+    /// Router addresses are intentionally pinned as a fail-closed allowlist:
+    /// Enso recommends using `tx.to` because deployments can change, and a new
+    /// address must therefore be reviewed here before fresh wallets accept it.
+    /// Calldata verification remains warning-only for this route class because
+    /// the generic handler cannot yet prove Enso's minimum-output floor. This
+    /// does not grant autonomous signing: the default wallet approval mode is
+    /// disabled, so outbox broadcast still requires fresh Sealed Approval.
+    pub fn fresh_wallet_default() -> Self {
+        const COMMON_ROUTER: &str = "0xf75584ef6673ad213a685a1b58cc0330b8ea22cf";
+        const LINEA_ROUTER: &str = "0xa146d46823f3f594b785200102be5385cafce9b5";
+        let routers = [
+            ("ethereum", COMMON_ROUTER),
+            ("optimism", COMMON_ROUTER),
+            ("bsc", COMMON_ROUTER),
+            ("gnosis", COMMON_ROUTER),
+            ("polygon", COMMON_ROUTER),
+            ("hyperliquid", COMMON_ROUTER),
+            ("base", COMMON_ROUTER),
+            ("arbitrum", COMMON_ROUTER),
+            ("avalanche", COMMON_ROUTER),
+            ("linea", LINEA_ROUTER),
+        ];
+        let allowed_chains = routers
+            .iter()
+            .map(|(chain, _)| (*chain).to_string())
+            .collect();
+
+        Self {
+            enabled: true,
+            allowed_source_chains: allowed_chains,
+            allowed_destination_chains: routers
+                .iter()
+                .map(|(chain, _)| (*chain).to_string())
+                .collect(),
+            allowed_receivers: ["class:wallet_eoa".to_string()].into_iter().collect(),
+            denied_receivers: BTreeSet::new(),
+            allowed_routers: routers
+                .into_iter()
+                .map(|(chain, router)| format!("{chain}:{router}"))
+                .collect(),
+            denied_protocols: BTreeSet::new(),
+            allow_unknown_protocols: false,
+            require_calldata_verification: false,
             max_input_usd: None,
             max_native_value_wei: None,
         }
@@ -576,6 +636,52 @@ mod tests {
             checks
                 .iter()
                 .any(|c| c.rule == "defi.enabled" && c.outcome == PolicyOutcome::Deny)
+        );
+    }
+
+    #[test]
+    fn fresh_wallet_default_allows_reviewed_swap_to_owner_on_documented_router() {
+        let policy = DefiPolicy::fresh_wallet_default();
+        let mut ctx = clean_ctx();
+        ctx.source_chain = "ethereum".into();
+        ctx.destination_chain = "ethereum".into();
+        ctx.receiver_class = ReceiverClass::WalletEoa;
+        ctx.router = "0xf75584ef6673ad213a685a1b58cc0330b8ea22cf".into();
+        ctx.min_out_enforced = false;
+        ctx.receiver_verified = false;
+
+        let checks = evaluate_defi_route(&policy, &ctx);
+        assert!(
+            !has_deny(&checks),
+            "fresh reviewed route denied: {checks:?}"
+        );
+        assert!(has_warn(&checks), "unverified calldata must remain visible");
+        assert!(!policy.require_calldata_verification);
+        assert!(policy.allowed_receivers.contains("class:wallet_eoa"));
+    }
+
+    #[test]
+    fn fresh_wallet_default_fails_closed_on_router_or_receiver_change() {
+        let policy = DefiPolicy::fresh_wallet_default();
+        let mut ctx = clean_ctx();
+        ctx.source_chain = "base".into();
+        ctx.destination_chain = "base".into();
+        ctx.receiver_class = ReceiverClass::WalletEoa;
+        ctx.router = "0x0000000000000000000000000000000000000001".into();
+        assert!(has_deny(&evaluate_defi_route(&policy, &ctx)));
+
+        ctx.router = "0xf75584ef6673ad213a685a1b58cc0330b8ea22cf".into();
+        ctx.receiver_class = ReceiverClass::Unknown;
+        assert!(has_deny(&evaluate_defi_route(&policy, &ctx)));
+    }
+
+    #[test]
+    fn fresh_wallet_default_pins_linea_router_deployment() {
+        let policy = DefiPolicy::fresh_wallet_default();
+        assert!(
+            policy
+                .allowed_routers
+                .contains("linea:0xa146d46823f3f594b785200102be5385cafce9b5")
         );
     }
 

--- a/crates/bloom-proto/src/policy.rs
+++ b/crates/bloom-proto/src/policy.rs
@@ -55,8 +55,9 @@ pub struct Policy {
     /// wallet policy can disable it or apply exposure limits.
     #[serde(default)]
     pub polymarket: crate::polymarket_policy::PolymarketPolicy,
-    /// Generic DeFi route policy (`[defi]`). Defaults to disabled — the
-    /// open-ended `defi/intents` route surface refuses until opted in.
+    /// Generic DeFi route policy (`[defi]`). Missing sections deserialize as
+    /// disabled for backward compatibility; newly-created wallets receive the
+    /// narrower review-gated defaults from [`Policy::fresh_wallet_default`].
     #[serde(default)]
     pub defi: crate::defi_policy::DefiPolicy,
     /// Paid HTTP request policy (`[payments]`). Defaults to disabled — paid
@@ -1051,6 +1052,18 @@ pub fn has_soft_violation(checks: &[PolicyCheck]) -> bool {
 }
 
 impl Policy {
+    /// Policy written for a newly-created wallet.
+    ///
+    /// Keep [`Default`] backward-compatible and fail-closed for policy files
+    /// created before newer surfaces existed; fresh product defaults can opt a
+    /// new wallet into narrowly bounded, review-gated capabilities here.
+    pub fn fresh_wallet_default() -> Self {
+        Self {
+            defi: crate::defi_policy::DefiPolicy::fresh_wallet_default(),
+            ..Self::default()
+        }
+    }
+
     /// Default permissive policy. Useful in tests / on dev chains.
     pub fn permissive() -> Self {
         Policy::default()
@@ -1068,6 +1081,19 @@ impl Policy {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn fresh_wallet_default_enables_review_gated_defi_without_changing_legacy_default() {
+        let legacy = Policy::default();
+        assert!(!legacy.defi.enabled);
+
+        let fresh = Policy::fresh_wallet_default();
+        assert!(fresh.defi.enabled);
+        assert_eq!(
+            fresh.effective_agent_autonomy(),
+            AgentAutonomyMode::Disabled
+        );
+    }
 
     #[test]
     fn most_restrictive_picks_smaller_cap() {

--- a/crates/bloom-vfs/src/docs/README.md
+++ b/crates/bloom-vfs/src/docs/README.md
@@ -266,7 +266,8 @@ echo cancel  > /bloom/wallets/alice/chains/ethereum/outbox/pending/<id>/cancel
 ```
 
 DeFi intent (Enso shortcuts) — natural language is the canonical input;
-JSON works too. If `defi/` is present, use it directly:
+JSON works too. Fresh homes expose `/defi` by default; set `BLOOM_ENSO_KEY`
+or `ENSO_API_KEY` for Enso's production API without editing `config.toml`:
 
 ```sh
 echo 'swap 0.1 eth to USDC on base' \

--- a/crates/bloom-vfs/src/docs/agent-guidance.md
+++ b/crates/bloom-vfs/src/docs/agent-guidance.md
@@ -43,7 +43,8 @@ If the external Polymarket Petal is installed, start with
 `cat petals/polymarket/README.md`, read `petals/polymarket/AGENTS.md`, then
 inspect `petals/polymarket/meta/route-contract.json` and list its route tree
 before using its prediction-market routes.
-Read `/defi/README.md` for DeFi intents via Enso shortcuts.
+Fresh homes mount `/defi` by default; read `/defi/README.md` for Enso shortcut
+intents and the required environment credential.
 
 ## Wallets
 

--- a/crates/bloom-vfs/src/handlers/defi.rs
+++ b/crates/bloom-vfs/src/handlers/defi.rs
@@ -79,7 +79,8 @@ const README: &[u8] = br#"# DeFi Intents (Enso Shortcuts)
 
 ## Safety Model
 
-- Route discovery uses the Enso Shortcuts API (requires BLOOM_ENSO_KEY)
+- Fresh homes mount this surface by default
+- Route discovery uses the Enso Shortcuts API (set BLOOM_ENSO_KEY or ENSO_API_KEY)
 - Simulation is re-run on each read; reverts are decoded
 - Auto-approve handles ERC-20 allowances when needed
 - Broadcast requires the standard outbox confirm (owner gate)
@@ -861,6 +862,10 @@ impl DefiHandler {
             .keystore
             .info(wallet)
             .map_err(|e| HandlerError::backend(e.to_string()))?;
+        // Credential preflight must precede chain-id, token-decimal, balance,
+        // and allowance RPC reads so an unconfigured fresh home fails locally
+        // with the setup instruction instead of an unrelated RPC error.
+        self.enso.ensure_configured().map_err(map_enso_err)?;
         let chain_name = body
             .chain
             .clone()
@@ -1667,7 +1672,19 @@ fn is_session_file(s: &str) -> bool {
 fn map_enso_err(e: EnsoError) -> HandlerError {
     match e {
         EnsoError::Disabled | EnsoError::MissingKey => {
-            HandlerError::Unsupported("Enso is disabled (no API key)".into())
+            HandlerError::Unsupported(
+                "DeFi routing requires an Enso API key; set BLOOM_ENSO_KEY or ENSO_API_KEY (no config.toml edit required)"
+                    .into(),
+            )
+        }
+        EnsoError::Api {
+            status: 401 | 403,
+            ..
+        } => {
+            HandlerError::Unsupported(
+                "Enso rejected the configured API key; update BLOOM_ENSO_KEY or ENSO_API_KEY"
+                    .into(),
+            )
         }
         EnsoError::InvalidIntent(s) => HandlerError::invalid(s),
         other => HandlerError::backend(other.to_string()),
@@ -2323,12 +2340,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn confirm_refuses_on_default_deny_policy() {
-        // A wallet with default policy ([defi] disabled) must refuse to stage
-        // a route at confirm — before any TxEngine::stage.
+    async fn confirm_refuses_on_legacy_default_deny_policy() {
+        // Existing policy files that predate fresh-wallet DeFi defaults still
+        // deserialize with [defi] disabled and must refuse before staging.
         let td = tempfile::tempdir().unwrap();
         let h = test_handler(td.path());
         h.keystore.create_local("alice", "pw").unwrap();
+        let legacy = toml::to_string_pretty(&bloom_proto::Policy::default()).unwrap();
+        h.keystore.write_policy("alice", legacy.as_bytes()).unwrap();
         let mut sess = fake_session("alice", "s1");
         sess.chain = "ethereum".into();
         sess.destination_chain = None;
@@ -2339,6 +2358,33 @@ mod tests {
             msg.contains("defi.enabled") || msg.to_lowercase().contains("disabled"),
             "default-deny must cite the defi gate, got: {msg}"
         );
+    }
+
+    #[tokio::test]
+    async fn create_session_without_enso_key_fails_before_chain_rpc() {
+        let td = tempfile::tempdir().unwrap();
+        let h = test_handler(td.path());
+        h.keystore
+            .create_local("my-wallet", "test-passphrase")
+            .unwrap();
+
+        let err = h
+            .create_session(
+                "my-wallet",
+                NewIntentBody {
+                    kind: None,
+                    intent: "swap 1 usdc to eth".into(),
+                    chain: Some("ethereum".into()),
+                    destination_chain: None,
+                    receiver: None,
+                    slippage_bps: None,
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, HandlerError::Unsupported(_)));
+        assert!(err.to_string().contains("BLOOM_ENSO_KEY"));
     }
 
     #[test]

--- a/crates/bloom-vfs/src/handlers/defi.rs
+++ b/crates/bloom-vfs/src/handlers/defi.rs
@@ -915,6 +915,7 @@ impl DefiHandler {
                 "Enso route transaction input does not match the requested token and amount",
             ));
         }
+        validate_route_sender(&req, &route)?;
 
         // Build the swap (Raw) intent and, when the source token is an
         // ERC-20 with insufficient allowance to the router, a preceding
@@ -1682,13 +1683,24 @@ fn map_enso_err(e: EnsoError) -> HandlerError {
             ..
         } => {
             HandlerError::Unsupported(
-                "Enso rejected the configured API key; update BLOOM_ENSO_KEY or ENSO_API_KEY"
+                "Enso rejected the configured API key; if [enso].api_key is set in config.toml, update or remove it and restart Bloom; otherwise update BLOOM_ENSO_KEY or ENSO_API_KEY and restart Bloom"
                     .into(),
             )
         }
         EnsoError::InvalidIntent(s) => HandlerError::invalid(s),
         other => HandlerError::backend(other.to_string()),
     }
+}
+
+fn validate_route_sender(req: &RouteRequest, route: &RouteResponse) -> Result<(), HandlerError> {
+    if route.tx.from != req.from_address {
+        return Err(HandlerError::invalid(format!(
+            "Enso route sender {} does not match requested wallet {}; refusing response",
+            checksum_address(&route.tx.from),
+            checksum_address(&req.from_address),
+        )));
+    }
+    Ok(())
 }
 
 /// Recognize a Hyperliquid deposit goal: `deposit <amount> [token] to
@@ -2199,6 +2211,57 @@ mod tests {
         let defaulted =
             DefiHandler::compose_route_request(8453, Some(137), from, &nat, 6, None).unwrap();
         assert_eq!(defaulted.receiver, Some(from));
+    }
+
+    #[test]
+    fn route_sender_must_match_requested_wallet() {
+        let expected: Address = "0x0000000000000000000000000000000000000001"
+            .parse()
+            .unwrap();
+        let unexpected: Address = "0x0000000000000000000000000000000000000002"
+            .parse()
+            .unwrap();
+        let req = RouteRequest {
+            from_address: expected,
+            chain_id: 1,
+            destination_chain_id: None,
+            token_in: NATIVE_TOKEN_ADDR,
+            token_out: Address::ZERO,
+            amount_in: U256::from(1u64),
+            slippage_bps: 50,
+            routing_strategy: Some(RoutingStrategy::Router),
+            receiver: Some(expected),
+        };
+        let mut route = RouteResponse {
+            tx: bloom_defi::RouteTx {
+                from: expected,
+                to: Address::ZERO,
+                data: Default::default(),
+                value: U256::from(1u64),
+            },
+            amount_out: "1".into(),
+            gas: None,
+            route: serde_json::Value::Null,
+            price_impact: None,
+            destination_chain_id: None,
+        };
+
+        validate_route_sender(&req, &route).unwrap();
+        route.tx.from = unexpected;
+        let err = validate_route_sender(&req, &route).unwrap_err();
+        assert!(err.to_string().contains("does not match requested wallet"));
+    }
+
+    #[test]
+    fn rejected_key_error_explains_config_precedence() {
+        let err = map_enso_err(EnsoError::Api {
+            status: 401,
+            body: "unauthorized".into(),
+        });
+        let message = err.to_string();
+        assert!(message.contains("[enso].api_key"));
+        assert!(message.contains("update or remove"));
+        assert!(message.contains("restart Bloom"));
     }
 
     #[test]

--- a/docs/architecture/Wallet.md
+++ b/docs/architecture/Wallet.md
@@ -131,6 +131,14 @@ Target creation flow:
 11. Present recovery material or recovery instructions in a foreground ceremony;
     never hide a recovery secret in logs or background output.
 
+The initial policy is a product default, distinct from the backward-compatible
+serde `Policy::default()`. New wallets enable the generic DeFi route surface
+only for owner-EOA receivers on supported chains and pinned provider routers;
+unknown receivers, routers, protocols, and chains fail closed. Agent autonomy
+remains disabled, so these defaults do not authorize unattended signing or
+broadcast. Existing policy files that omit `[defi]` continue to deserialize
+with DeFi disabled and do not gain authority during an upgrade.
+
 The wallet-creation registration ceremony is distinct from Sealed Approval for
 later actions. Registration establishes wallet authority; Sealed Approval spends
 or changes that authority for a specific sealed action.


### PR DESCRIPTION
Closes #75.

## Summary

- mount `/defi` in fresh homes through a default `[enso]` block
- use the current `https://api.enso.build` endpoint and accept `BLOOM_ENSO_KEY` or `ENSO_API_KEY` without a config edit
- install review-gated DeFi policy defaults for newly created wallets, limited to the owner EOA and pinned Enso V2 router deployments
- keep existing wallets fail-closed: a missing legacy `[defi]` section still deserializes as disabled
- fail locally with actionable credential guidance before any chain RPC or Enso request

## Safety

- agent autonomy remains disabled, so fresh policy defaults do not create an autonomous broadcast lane
- unknown receivers, routers, protocols, and unsupported chains remain denied
- router addresses are pinned intentionally; an Enso router change fails closed until reviewed
- calldata verification limitations remain visible as policy warnings

Enso production routing requires an API credential per the [official authentication docs](https://docs.enso.build/pages/build/get-started/authentication), so this makes DeFi config-edit-free rather than credential-free. Router pins come from the [official deployment list](https://docs.enso.build/pages/build/reference/deployments).

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --doc --no-fail-fast`
- `cargo nextest run --workspace --all-targets --no-fail-fast` (1,563 passed; 20 skipped)
- `cargo test -p bloom-vfs` (471 passed; 1 ignored after documentation amendment)
- manual fresh-home walkthrough: `/defi` present, default Enso config present, fresh wallet policy bounded as above, and missing credentials fail immediately with environment-variable guidance

## Checklist

- [x] Tests added or updated for behavior changes
- [x] Architecture docs (`docs/architecture/`) updated if contracts or behavior changed
- [x] Sealed Approval invariants respected (no signing outside a grant or bounded capability, no PRF/grant persistence, execution from sealed bytes) — see `docs/architecture/Sealed Approvals.md`
- [x] Agent Documentation updated (`crates/bloom-vfs/src/docs/agent-guidance.md` and affected Petal READMEs) — see `docs/architecture/Agent-native Documentation.md`
