### PR TITLE
fix: remove agent-guidance.md surfacing in VFS, clarify protocol selection for paid http requests

### DIFF
--- a/crates/bloom-tx/src/outbox.rs
+++ b/crates/bloom-tx/src/outbox.rs
@@ -1080,12 +1080,11 @@ fn parse_sent_entry(
             max_fee_per_gas,
             max_priority_fee_per_gas,
         }
-    } else if let Some(gp) = staged.gas_price.as_deref() {
+    } else {
+        let gp = staged.gas_price.as_deref()?;
         bloom_mempool::TxFees::Legacy {
             gas_price: gp.parse::<u128>().ok()?,
         }
-    } else {
-        return None;
     };
     // intent.json is written once at entry creation and never modified;
     // its mtime is therefore a stable proxy for when the tx was sent.

--- a/crates/bloom-vfs/src/docs/agent-guidance.md
+++ b/crates/bloom-vfs/src/docs/agent-guidance.md
@@ -134,12 +134,24 @@ VFS policy write) with the signed-policy error; the mounted flow does not repair
 it. Recovering an externally-broken policy needs the admin helper
 `bloom wallet sign-policy <wallet>`, not this edit surface.
 
-## Paid HTTP
+## Paid HTTP (x402 and MPP)
 
 Paid HTTP requests live under `requests`. Agents should stage the request,
 read `plan.md`, and confirm only when the quoted cost, network, asset, and
-merchant match the task. Bloom handles x402 and Tempo MPP internally; agents
-should not look for separate `/x402` or `/mpp` paths.
+merchant match the task. Bloom handles both x402 and MPP internally.
+
+### Selecting the payment protocol
+
+Bloom handles credentials and settlement internally, but the merchant may use
+request headers to select its payment rail.
+
+For a merchant supporting both x402 and MPP:
+
+- No negotiation header may default to x402.
+- To request MPP, include the negotiation header
+  `authorization: Payment` in the staged request.
+
+### Approval
 
 If paid confirmation needs passkey approval, the first confirm write may return
 permission denied after writing
@@ -163,7 +175,7 @@ the sealed subject, or `private/request_body` no longer matches the sealed body
 hash, confirmation fails before signing or minting credentials. Live policy may
 narrow or deny, but it cannot widen the already sealed payment terms.
 
-Example paid search:
+### Examples
 
 ```sh
 cat > requests/new <<'REQUEST'
@@ -192,6 +204,17 @@ content-type: application/json
 
 {"user":"0x..."}
 REQUEST
+
+# MPP forced based on presence of `authorization: Payment` header
+cat > requests/new <<'REQUEST'
+POST https://api.nansen.ai/api/v1/smart-money/netflow wallet=<wallet>max_amount_usd=0.10
+content-type: application/json
+accept: application/json
+authorization: Payment
+
+{"chains":["ethereum"],"filters":{"token_sectors":["DeFi"],"include_stablecoins":false},"pagination":{"page":1,"per_page":10},"order_by":[{"field":"net_flow_7d_usd","direction":"ASC"}]}
+REQUEST
+
 
 # Polymarket ghost-fill risk.
 cat > requests/new <<'REQUEST'

--- a/crates/bloom-vfs/src/handlers/docs.rs
+++ b/crates/bloom-vfs/src/handlers/docs.rs
@@ -9,7 +9,6 @@ use crate::path::VfsPath;
 pub struct DocsHandler {
     readme: String,
     examples: String,
-    agent_guidance: String,
 }
 
 impl Default for DocsHandler {
@@ -17,7 +16,6 @@ impl Default for DocsHandler {
         Self {
             readme: include_str!("../docs/README.md").to_string(),
             examples: include_str!("../docs/examples.md").to_string(),
-            agent_guidance: include_str!("../docs/agent-guidance.md").to_string(),
         }
     }
 }
@@ -61,7 +59,6 @@ impl DocsHandler {
             [] => Ok(Entry::dir("")),
             [s] if s == "README.md" => Ok(Entry::file("README.md")),
             [s] if s == "examples.md" => Ok(Entry::file("examples.md")),
-            [s] if s == "agent-guidance.md" => Ok(Entry::file("agent-guidance.md")),
             _ => Err(HandlerError::not_found(path.to_string_path())),
         }
     }
@@ -70,18 +67,13 @@ impl DocsHandler {
         match path.segments() {
             [s] if s == "README.md" => Ok(self.readme.as_bytes().to_vec()),
             [s] if s == "examples.md" => Ok(self.examples.as_bytes().to_vec()),
-            [s] if s == "agent-guidance.md" => Ok(self.agent_guidance.as_bytes().to_vec()),
             _ => Err(HandlerError::NotAFile(path.to_string_path())),
         }
     }
 
     async fn list_inner(&self, path: &VfsPath) -> Result<Vec<Entry>, HandlerError> {
         if path.is_root() {
-            Ok(vec![
-                Entry::file("README.md"),
-                Entry::file("examples.md"),
-                Entry::file("agent-guidance.md"),
-            ])
+            Ok(vec![Entry::file("README.md"), Entry::file("examples.md")])
         } else {
             Err(HandlerError::NotADir(path.to_string_path()))
         }
@@ -94,13 +86,11 @@ mod tests {
     use crate::handler::EntryKind;
 
     #[tokio::test]
-    async fn root_lists_readme_and_examples() {
+    async fn root_lists_only_readme_and_examples() {
         let h = DocsHandler::new();
         let entries = h.list(&VfsPath::root()).await.unwrap();
         let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
-        assert!(names.contains(&"README.md"), "names={names:?}");
-        assert!(names.contains(&"examples.md"), "names={names:?}");
-        assert!(names.contains(&"agent-guidance.md"), "names={names:?}");
+        assert_eq!(names, ["README.md", "examples.md"]);
         for e in &entries {
             assert_eq!(e.kind, EntryKind::File);
             // Entry::file => read-only mode.
@@ -129,12 +119,27 @@ mod tests {
     #[tokio::test]
     async fn lookup_known_files_are_files() {
         let h = DocsHandler::new();
-        for name in ["README.md", "examples.md", "agent-guidance.md"] {
+        for name in ["README.md", "examples.md"] {
             let p = VfsPath::parse(&format!("/{name}")).unwrap();
             let e = h.lookup(&p).await.unwrap();
             assert_eq!(e.kind, EntryKind::File);
             assert_eq!(e.name, name);
         }
+    }
+
+    #[tokio::test]
+    async fn agent_guidance_is_not_exposed_under_docs() {
+        let h = DocsHandler::new();
+        let path = VfsPath::parse("/agent-guidance.md").unwrap();
+
+        assert!(matches!(
+            h.lookup(&path).await,
+            Err(HandlerError::NotFound(_))
+        ));
+        assert!(matches!(
+            h.read(&path).await,
+            Err(HandlerError::NotAFile(_))
+        ));
     }
 
     #[tokio::test]

--- a/crates/bloom-vfs/src/router.rs
+++ b/crates/bloom-vfs/src/router.rs
@@ -22,6 +22,7 @@ use crate::cache::PathCache;
 use crate::handler::{Entry, EntryKind, Handler, HandlerError};
 use crate::path::VfsPath;
 
+// This source document is exposed only through the two mount-root aliases below.
 const AGENT_GUIDANCE: &[u8] = include_bytes!("docs/agent-guidance.md");
 const AGENT_GUIDANCE_FILES: [&str; 2] = ["AGENTS.md", "CLAUDE.md"];
 

--- a/docs/architecture/Agent-native Documentation.md
+++ b/docs/architecture/Agent-native Documentation.md
@@ -25,8 +25,8 @@ How it works today:
   listings include both filenames, lookups return a read-only file entry
   (mode `0o444`), and reads return the embedded bytes verbatim. Writes are
   not routable to these paths.
-- The same content is also readable at `/docs/agent-guidance.md` through the
-  docs handler, alongside `/docs/README.md` and `/docs/examples.md`.
+- The source filename is not exposed through `/docs`; the guidance is only
+  readable through the root `AGENTS.md` and `CLAUDE.md` aliases.
 
 Because the content is compiled into the Bloom Machine, the documentation an agent
 reads is always the documentation of the exact binary serving the mount.


### PR DESCRIPTION
## Summary

- Stop `docs/agent-guidance.md` surfacing in VFS (already surfaced in `AGENTS.md` and `CLAUDE.md`).
- Clarify Paid HTTP usage.

## Checklist

Every item must be checked before merge (enforced by the `checklist-complete`
status check). If an item does not apply, check it and write `N/A` in place
of the link or after the item.

- [x] Tests added or updated for behavior changes
- [x] Architecture docs (`docs/architecture/`) updated if contracts or
      behavior changed
- [x] Sealed Approval invariants respected (no signing outside a grant or
      bounded capability, no PRF/grant persistence, execution from sealed
      bytes) — see `docs/architecture/Sealed Approvals.md`
- [x] Agent Documentation updated (`crates/bloom-vfs/src/docs/agent-guidance.md`
      and affected Petal READMEs) — see
      `docs/architecture/Agent-native Documentation.md`