### PR TITLE
fix(daemon): enable mount support by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,18 +117,10 @@ For local development, use the package-manager-native checks:
 
 ```sh
 cargo fmt
-cargo test -p bloom --no-default-features
+cargo test -p bloom
 cargo test --workspace --lib
-```
-
-Mount support is included in the default CLI build:
-
-```sh
 cargo build -p bloom
 ```
-
-Portable builds can omit the NFS mount adapter with
-`cargo build -p bloom --no-default-features`.
 
 ## Filesystem layout
 
@@ -192,7 +184,7 @@ Bloom is a Rust Cargo workspace. The main user-facing/runtime crates are:
 | `bloom-mempool` | Optional pending-transaction indexing for configured WebSocket providers. |
 | `bloom-defi` | Enso Shortcuts client and natural-language DeFi intent support. |
 | `bloom-watch` | Subscription registry and polling executor. |
-| `bloom-mount` | NFSv4 mount adapter behind the `mount` feature. |
+| `bloom-mount` | NFSv4 adapter that mounts Bloom's VFS as an ordinary filesystem. |
 | `bloom-tools` | Pure crypto/encoding helpers. |
 | `bloom-etherscan` | Etherscan v2 multichain client and on-disk TTL cache. |
 | `bloom-ens` | ENS namehash plus forward/reverse/text/contenthash resolution. |

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ running Anvil node.
 Mount Bloom first, then interact with it like a directory:
 
 ```sh
-cargo build -p bloom --all-features
+cargo build -p bloom
 cargo run -p bloom -- init
 mkdir -p "$HOME/bloom"
 cargo run -p bloom -- serve --mount "$HOME/bloom"
@@ -121,11 +121,14 @@ cargo test -p bloom --no-default-features
 cargo test --workspace --lib
 ```
 
-Build the mount-capable CLI with:
+Mount support is included in the default CLI build:
 
 ```sh
-cargo build -p bloom --all-features
+cargo build -p bloom
 ```
+
+Portable builds can omit the NFS mount adapter with
+`cargo build -p bloom --no-default-features`.
 
 ## Filesystem layout
 

--- a/crates/bloom-daemon/Cargo.toml
+++ b/crates/bloom-daemon/Cargo.toml
@@ -9,10 +9,10 @@ description = "Daemon library wiring VFS + chain + tx + mount for bloom"
 doctest = false
 
 [features]
-default = []
+default = ["mount"]
 # Forward to bloom-mount/mount: enables `Daemon::mount(path)` and pulls
-# in the embednfs server. Off by default so the default daemon build
-# stays portable (no embednfs git dep, no kernel NFS tooling).
+# in the embednfs server. Portable builds can opt out with
+# `--no-default-features`.
 mount = ["bloom-mount/mount"]
 # Forward to bloom-revert/bytecode-decompile: appends the heimdall-rs
 # decompile fallback to the revert-decoder chain. Heavy build (heimdall

--- a/crates/bloom-tx/src/outbox.rs
+++ b/crates/bloom-tx/src/outbox.rs
@@ -1080,12 +1080,11 @@ fn parse_sent_entry(
             max_fee_per_gas,
             max_priority_fee_per_gas,
         }
-    } else if let Some(gp) = staged.gas_price.as_deref() {
+    } else {
+        let gp = staged.gas_price.as_deref()?;
         bloom_mempool::TxFees::Legacy {
             gas_price: gp.parse::<u128>().ok()?,
         }
-    } else {
-        return None;
     };
     // intent.json is written once at entry creation and never modified;
     // its mtime is therefore a stable proxy for when the tx was sent.

--- a/crates/bloom/Cargo.toml
+++ b/crates/bloom/Cargo.toml
@@ -10,8 +10,9 @@ name = "bloom"
 path = "src/main.rs"
 
 [features]
-default = []
-# Enable the embedded NFS mount adapter through the daemon crate.
+default = ["mount"]
+# Enable the embedded NFS mount adapter through the daemon crate. This remains
+# a named feature so portable builds can opt out with `--no-default-features`.
 mount = ["bloom-daemon/mount", "dep:bloom-mount"]
 # Pass-through for the heimdall-rs decompile decoder. Build with
 # `cargo build --features bytecode-decompile` to enable.


### PR DESCRIPTION
## Summary

- enable the `mount` feature by default for the Bloom CLI and daemon crates
- present mounted filesystem support as the standard README build and usage path
- apply the behavior-preserving `?` rewrite required by the current stable Clippy lane

Closes #68.

## Verification

- `cargo fmt --check`
- `cargo check -p bloom`
- `cargo test -p bloom`
- `cargo test -p bloom-daemon --lib`
- `cargo test -p bloom-tx`
- `cargo clippy --workspace --all-targets -- -D warnings`
- verified with `cargo metadata` that both `bloom` and `bloom-daemon` default to `mount`
- verified with `cargo tree -p bloom -e features` that the default graph includes `embednfs`

## Checklist

- [x] Tests added or updated for behavior changes — N/A: this is a Cargo default-feature change covered by the existing default suite
- [x] Architecture docs (`docs/architecture/`) updated if contracts or behavior changed — N/A: no architecture contract changed
- [x] Sealed Approval invariants respected (no signing outside a grant or bounded capability, no PRF/grant persistence, execution from sealed bytes) — N/A: no signing or approval code changed
- [x] Agent Documentation updated (`crates/bloom-vfs/src/docs/agent-guidance.md` and affected Petal READMEs) — N/A: mounted VFS behavior is unchanged; the top-level build instructions were updated
