### PR TITLE
fix(polymarket): preserve explicit integration opt-out

### DIFF
--- a/crates/bloom-daemon/src/lib.rs
+++ b/crates/bloom-daemon/src/lib.rs
@@ -2374,9 +2374,10 @@ impl Daemon {
         // Polymarket: public read surface (Gamma/Data/CLOB) plus, when a
         // `[chains]` entry matches the Polymarket chain id (Polygon 137), the
         // onboarding state machine and L2 account views. Polymarket is enabled
-        // by default with public endpoints; a config block can override them.
+        // by default with public endpoints; `[polymarket] enabled = false`
+        // provides a persistent opt-out and other fields override the defaults.
         // Signing never leaves the daemon (Keystore::signer → KeystoreSigner).
-        if let Some(pm_cfg) = &config.polymarket {
+        if let Some(pm_cfg) = config.polymarket.as_ref().filter(|cfg| cfg.enabled) {
             let pm_url = |raw: &str| match url::Url::parse(raw) {
                 Ok(u) => Some(u),
                 Err(e) => {
@@ -2441,7 +2442,7 @@ impl Daemon {
             debug!(chain_id = pm_cfg.chain_id, "daemon.polymarket_mounted");
             vfs_builder = vfs_builder.mount("polymarket", Arc::new(handler) as _);
         } else {
-            debug!("daemon.polymarket_skipped: disabled programmatically");
+            debug!("daemon.polymarket_skipped: disabled by config");
         }
 
         // /next.md — brutally-scoped next-action aggregator for agents.
@@ -3024,6 +3025,23 @@ mod tests {
             d.vfs.handler("hyperliquid").is_some(),
             "fresh homes should mount Hyperliquid with public defaults"
         );
+        assert!(
+            d.vfs.handler("polymarket").is_some(),
+            "fresh homes should mount Polymarket with public defaults"
+        );
+    }
+
+    #[test]
+    fn explicit_polymarket_opt_out_skips_vfs_mount() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomeDir::at(dir.path());
+        let mut config = Config::local_default();
+        config.polymarket.as_mut().unwrap().enabled = false;
+        config.save(&home.config_path()).unwrap();
+
+        let d = Daemon::from_home(home).unwrap();
+        assert!(!d.config.polymarket.as_ref().unwrap().enabled);
+        assert!(d.vfs.handler("polymarket").is_none());
     }
 
     #[tokio::test]

--- a/crates/bloom-proto/src/config.rs
+++ b/crates/bloom-proto/src/config.rs
@@ -190,6 +190,10 @@ pub struct EnsoConfig {
 /// `[polymarket]` TOML table parses to the public-endpoint defaults on Polygon.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PolymarketConfig {
+    /// Mount the Polymarket VFS integration. Defaults to true; set false for a
+    /// serialization-safe opt-out.
+    #[serde(default = "default_polymarket_enabled")]
+    pub enabled: bool,
     #[serde(default = "default_gamma_url")]
     pub gamma_url: String,
     #[serde(default = "default_data_url")]
@@ -239,6 +243,7 @@ pub struct PolymarketConfig {
 impl Default for PolymarketConfig {
     fn default() -> Self {
         Self {
+            enabled: default_polymarket_enabled(),
             gamma_url: default_gamma_url(),
             data_url: default_data_url(),
             clob_url: default_clob_url(),
@@ -255,6 +260,10 @@ impl Default for PolymarketConfig {
 
 fn default_polymarket_config() -> Option<PolymarketConfig> {
     Some(PolymarketConfig::default())
+}
+
+fn default_polymarket_enabled() -> bool {
+    true
 }
 
 fn default_builder_key_mode() -> String {
@@ -818,6 +827,7 @@ mod tests {
     #[test]
     fn bare_polymarket_block_parses_to_public_defaults() {
         let pm: PolymarketConfig = toml::from_str("").unwrap();
+        assert!(pm.enabled);
         assert_eq!(pm.gamma_url, "https://gamma-api.polymarket.com");
         assert_eq!(pm.data_url, "https://data-api.polymarket.com");
         assert_eq!(pm.clob_url, "https://clob.polymarket.com");
@@ -849,8 +859,20 @@ mod tests {
         let pm = cfg
             .polymarket
             .expect("Polymarket should be enabled when the block is omitted");
+        assert!(pm.enabled);
         assert_eq!(pm.chain_id, 137);
         assert_eq!(pm.gamma_url, "https://gamma-api.polymarket.com");
+    }
+
+    #[test]
+    fn polymarket_disabled_setting_survives_toml_round_trip() {
+        let cfg: Config = toml::from_str("[polymarket]\nenabled = false\n").unwrap();
+        assert!(!cfg.polymarket.as_ref().unwrap().enabled);
+
+        let serialized = toml::to_string_pretty(&cfg).unwrap();
+        assert!(serialized.contains("enabled = false"));
+        let reloaded: Config = toml::from_str(&serialized).unwrap();
+        assert!(!reloaded.polymarket.unwrap().enabled);
     }
 
     #[test]

--- a/docs/polymarket-integration.md
+++ b/docs/polymarket-integration.md
@@ -36,8 +36,12 @@ instruction to trade.
 - Prefer self-contained blocking commands for agent flows:
   `onboard`, `fund`, `order --dry-run`, `confirm`, `sell`, `cancel`,
   `obligations`, `redeem`, `withdraw-pusd`, and `revoke-approvals`.
-- Wallet policy enables trading by default. Set `[polymarket] enabled = false`
-  to disable it, or add caps and allow/deny lists to constrain it.
+- The runtime integration is mounted by default. Set `enabled = false` in the
+  runtime configuration's `[polymarket]` table to disable the entire VFS
+  surface.
+- Separately, wallet policy enables trading by default. Set `enabled = false`
+  in the wallet policy's `[polymarket]` table to disable trading, or add caps
+  and allow/deny lists to constrain it.
 - Funding requests staged under `polymarket/fund/<wallet>/new` can be executed
   with `bloom vfs write /polymarket/fund/<wallet>/<id>/confirm --unlock-wallet
   <wallet> --data confirm`; this dispatches to the same funding engine as


### PR DESCRIPTION
## Summary

Follow-on to #116 addressing [the persistent Polymarket opt-out review comment](https://github.com/bloom-directory/bloom/pull/116#discussion_r3606740060).

- add an explicit, default-true `PolymarketConfig.enabled` runtime setting
- skip mounting the Polymarket VFS subtree when `[polymarket] enabled = false`
- preserve the disabled state across TOML serialization and reload
- distinguish the runtime integration gate from the wallet trading-policy gate in the integration guide
- cover both fresh/default mounting and explicit opt-out behavior

## Testing

- `cargo fmt --check`
- `cargo test -q -p bloom-proto -p bloom-daemon`
- `cargo check -q --workspace`
- `cargo test -q --workspace`
- `git diff --check`

## Checklist

- [x] Tests added or updated for behavior changes
- [x] Architecture docs (`docs/architecture/`) updated if contracts or behavior changed — N/A: no architecture contract changed; `docs/polymarket-integration.md` documents the runtime opt-out.
- [x] Sealed Approval invariants respected (no signing outside a grant or bounded capability, no PRF/grant persistence, execution from sealed bytes) — N/A: mounting/configuration only; signing and approval flows are unchanged.
- [x] Agent Documentation updated (`crates/bloom-vfs/src/docs/agent-guidance.md` and affected Petal READMEs) — N/A: this is a host runtime configuration setting outside the mounted VFS; the integration guide is updated instead.
