### PR TITLE
Fix release test prerequisites

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,11 @@ jobs:
       - name: Install Rust toolchain
         run: rustup show
 
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
       - name: Run workspace tests (locked)
         run: cargo test --workspace --locked
 


### PR DESCRIPTION
## Summary

- install Foundry in the tagged-release test job before running the workspace suite
- match the existing CI prerequisite used by `bloom-it` Anvil integration tests

## Root cause

The `v0.1.0` release run failed because the clean release runner executed `bloom-it` without an `anvil` binary.

## Validation

- [x] `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 -ignore 'label .* is unknown' .github/workflows/release.yml`
- [x] `git diff --check`

## PR checklist

- [x] Tests added or updated for behavior changes — N/A: installs an existing test prerequisite
- [x] Architecture docs updated if contracts or behavior changed — N/A
- [x] Sealed Approval invariants respected — N/A
- [x] Agent Documentation updated — N/A