### PR TITLE
release: v0.1.1

### DIFF
--- a/.github/workflows/propose-release.yml
+++ b/.github/workflows/propose-release.yml
@@ -3,10 +3,11 @@ name: Propose Release
 # This workflow prepares a reviewed version-bump PR. It never writes to the
 # default branch, creates a stable tag, or publishes a GitHub release.
 #
-# RELEASE_PR_TOKEN must be a repository secret backed by a GitHub App token or
-# fine-grained token with Contents: read/write and Pull requests: read/write.
-# A token other than GITHUB_TOKEN is required so the generated PR receives the
-# normal pull_request CI checks.
+# RELEASE_PR_TOKEN must be a repository secret containing a fine-grained PAT
+# with Contents: read/write and Pull requests: read/write. A separate token lets
+# the generated PR receive normal pull_request CI without manual approval.
+# Using a GitHub App instead requires minting its short-lived installation token
+# in this workflow rather than storing an installation token as this secret.
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to create or retry (e.g. v0.1.1).'
+        description: 'Existing tag to retry (e.g. v0.1.1).'
         required: true
         type: string
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2256,7 +2256,7 @@ dependencies = [
 
 [[package]]
 name = "bloom"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy 2.0.5",
  "anyhow",
@@ -2299,7 +2299,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-auth"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-auth-api"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-daemon"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy 2.0.5",
  "anyhow",
@@ -2376,7 +2376,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-defi"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy 2.0.5",
  "bloom-proto",
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-ens"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy 2.0.5",
  "bloom-evm",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-etherscan"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy 2.0.5",
  "async-trait",
@@ -2425,7 +2425,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-evm"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy 2.0.5",
  "bloom-proto",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-hyperliquid"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy 2.0.5",
  "alloy-dyn-abi",
@@ -2460,7 +2460,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-it"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy 2.0.5",
  "anyhow",
@@ -2486,7 +2486,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-keystore"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy 2.0.5",
  "argon2",
@@ -2520,7 +2520,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-mempool"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy 2.0.5",
  "anyhow",
@@ -2542,7 +2542,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-mount"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "bloom-vfs",
@@ -2558,7 +2558,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-paid-http"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2573,7 +2573,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-paid-mpp"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy 2.0.5",
  "async-trait",
@@ -2589,7 +2589,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-paid-x402"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy 2.0.5",
  "async-trait",
@@ -2612,7 +2612,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-petals"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2644,7 +2644,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-prices"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "parking_lot",
  "reqwest 0.12.28",
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-proto"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy 2.0.5",
  "blake3",
@@ -2678,7 +2678,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-revert"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy 2.0.5",
  "alloy-dyn-abi",
@@ -2700,7 +2700,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-rpc"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy 2.0.5",
  "bloom-proto",
@@ -2716,7 +2716,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-tools"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy 2.0.5",
  "alloy-dyn-abi",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-tx"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy 2.0.5",
  "anyhow",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-update"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "parking_lot",
  "reqwest 0.12.28",
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-vfs"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy 2.0.5",
  "async-trait",
@@ -2817,7 +2817,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-watch"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy 2.0.5",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -23,8 +23,8 @@ The `prepare` job enforces these hard gates
 4. The workspace `version` in `Cargo.toml` at that commit equals the tag
    (`X.Y.Z`).
 
-**Nothing else is checked by the publish workflow.** In particular, `release.yml`
-does **not** verify that:
+**No other release-eligibility policy is checked by the workflow.** In
+particular, `release.yml` does **not** verify that:
 
 - the bump arrived via a pull request,
 - the new version is greater than the previous one (monotonicity),
@@ -38,6 +38,12 @@ Direct pushes to `master` are not permitted.
 
 The version bump must land on `master` via a merged PR, then the merge commit is
 tagged.
+
+The repository's `v*` tag rules must allow new tag creation while preventing
+updates, deletion, and non-fast-forward changes. This permits each release tag
+to be created once and keeps it immutable afterward. If **Restrict creations**
+is enabled for `v*`, a repository administrator must disable it before the tag
+can be pushed.
 
 ```sh
 # 1. Branch off latest master and bump the workspace version.
@@ -73,10 +79,14 @@ version.)
 Actions UI (workflow_dispatch) with the next version, and it opens the bump PR
 for you. Two caveats:
 
-- It requires the `RELEASE_PR_TOKEN` repository secret (a GitHub App or
-  fine-grained PAT). PRs opened with the default `GITHUB_TOKEN` do not run CI on
-  themselves, so a separate token is used; without it the workflow hard-fails
-  (`.github/workflows/propose-release.yml:42-46`).
+- It requires the `RELEASE_PR_TOKEN` repository secret containing a
+  fine-grained PAT with **Contents: read/write** and **Pull requests:
+  read/write** access to this repository. PRs opened with the default
+  `GITHUB_TOKEN` receive approval-required CI runs; the separate token lets CI
+  run normally. Without it the workflow hard-fails
+  (`.github/workflows/propose-release.yml:43-47`). A GitHub App requires a
+  workflow change to mint a short-lived installation token rather than storing
+  an installation token directly as this secret.
 - Unlike the publish workflow, the **propose** workflow does enforce two extra
   rules:
   - the proposed version must be strictly greater than the current one
@@ -108,9 +118,10 @@ The publish workflow will not catch it.
   `Release` workflow for the same tag. Do not delete or move a public release
   tag. If the failure requires a code change, merge the fix and cut a new
   version. To de-risk, let CI pass on the bump PR before tagging.
-- **`Cargo.toml` has two `version = "0.x.y"` lines.** Only the one under
-  `[workspace.package]` is the release version (line 33). The other is a
-  dependency pin and must not be changed.
+- **The release version has one source of truth.** Edit only the `version` under
+  `[workspace.package]` in `Cargo.toml` (line 33). Dependency version
+  constraints elsewhere in the file are unrelated to the bloom release
+  version.
 - **Versioning scheme.** This project follows semver. While `0.x`, a bump in the
   second component (`0.1.0` → `0.2.0`) is a minor/breaking-ish release; a bump
   in the third (`0.1.0` → `0.1.1`) is a patch. The propose workflow enforces

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,17 +6,21 @@ two disagree, the contract wins — it is what runs in CI.
 
 ## TL;DR — the contract
 
-A release is published when, and only when, a `vX.Y.Z` tag is pushed to the
-repository. That tag push triggers the `Release` workflow
-(`.github/workflows/release.yml:23`), which then runs `prepare`, `test`,
-`build` (4 native binaries), and `publish`.
+A `vX.Y.Z` tag push starts the initial `Release` workflow run. An existing tag
+can also be retried with the workflow's manual `workflow_dispatch` trigger by
+entering the tag name in the Actions UI (`.github/workflows/release.yml:23-32`).
+Both triggers run the complete `prepare`, `test`, `build` (4 native binaries),
+and `publish` pipeline.
 
-The `prepare` job enforces exactly two hard gates
-(`.github/workflows/release.yml:80-92`):
+The `prepare` job enforces these hard gates
+(`.github/workflows/release.yml:65-92`):
 
-1. The tagged commit is reachable from `master` (i.e. it is an ancestor of
+1. The tag name strictly matches `vX.Y.Z`, with numeric SemVer components.
+2. The tag already exists in the repository and resolves to a commit. Manual
+   dispatch does not create a missing tag.
+3. The tagged commit is reachable from `master` (i.e. it is an ancestor of
    `origin/master`).
-2. The workspace `version` in `Cargo.toml` at that commit equals the tag
+4. The workspace `version` in `Cargo.toml` at that commit equals the tag
    (`X.Y.Z`).
 
 **Nothing else is checked by the publish workflow.** In particular, `release.yml`
@@ -56,10 +60,12 @@ git tag v0.1.1 <merge-sha>               # pin the exact SHA, do not tag a movin
 git push origin v0.1.1                   # this triggers the Release workflow
 ```
 
-Prefer tagging an explicit `<merge-sha>` over `origin/master`. If you tag
-`origin/master` and another commit lands between your `fetch` and your `git tag`,
-you will tag the wrong commit and `prepare` will reject it (the `Cargo.toml`
-version at that SHA will not match the tag).
+Prefer tagging an explicit `<merge-sha>` over `origin/master`. The
+remote-tracking ref does not move between `git fetch` and `git tag`, but a fetch
+can advance it past the release PR if other changes have already landed. Pinning
+the reviewed merge SHA avoids accidentally tagging a later commit. (`prepare`
+may not catch that mistake if the later commit retains the same workspace
+version.)
 
 ## Alternative: the Propose Release workflow
 
@@ -97,8 +103,11 @@ The publish workflow will not catch it.
 
 - **Tests run only after the tag is public.** The `test` job
   (`.github/workflows/release.yml:105`) runs on the tagged commit. If it fails,
-  a public `vX.Y.Z` tag already exists with no (or partial) release, and the tag
-  must be deleted/moved. To de-risk, let CI pass on the bump PR before tagging.
+  a public `vX.Y.Z` tag already exists with no (or partial) release. For a
+  transient failure, rerun the failed Actions jobs or manually dispatch the
+  `Release` workflow for the same tag. Do not delete or move a public release
+  tag. If the failure requires a code change, merge the fix and cut a new
+  version. To de-risk, let CI pass on the bump PR before tagging.
 - **`Cargo.toml` has two `version = "0.x.y"` lines.** Only the one under
   `[workspace.package]` is the release version (line 33). The other is a
   dependency pin and must not be changed.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,108 @@
+# Releasing bloom
+
+How to cut a release. This document describes what the release machinery
+**actually enforces** (the contract) and the **procedure** to follow. When the
+two disagree, the contract wins — it is what runs in CI.
+
+## TL;DR — the contract
+
+A release is published when, and only when, a `vX.Y.Z` tag is pushed to the
+repository. That tag push triggers the `Release` workflow
+(`.github/workflows/release.yml:23`), which then runs `prepare`, `test`,
+`build` (4 native binaries), and `publish`.
+
+The `prepare` job enforces exactly two hard gates
+(`.github/workflows/release.yml:80-92`):
+
+1. The tagged commit is reachable from `master` (i.e. it is an ancestor of
+   `origin/master`).
+2. The workspace `version` in `Cargo.toml` at that commit equals the tag
+   (`X.Y.Z`).
+
+**Nothing else is checked by the publish workflow.** In particular, `release.yml`
+does **not** verify that:
+
+- the bump arrived via a pull request,
+- the new version is greater than the previous one (monotonicity),
+- the release notes are non-empty.
+
+Branch protection on `master` is what forces the version-bump to land via a
+merged pull request — that requirement comes from GitHub, not from the workflow.
+Direct pushes to `master` are not permitted.
+
+## Procedure (only path)
+
+The version bump must land on `master` via a merged PR, then the merge commit is
+tagged.
+
+```sh
+# 1. Branch off latest master and bump the workspace version.
+git checkout master && git pull
+git checkout -b release/v0.1.1          # use the version you are cutting
+$EDITOR Cargo.toml                       # edit the single line under [workspace.package]
+cargo check --workspace                  # refresh Cargo.lock so it matches
+git add Cargo.toml Cargo.lock
+git commit -m "release: v0.1.1"
+
+# 2. Open the PR (branch protection requires a PR to land on master).
+git push -u origin release/v0.1.1
+gh pr create --title "release: v0.1.1" --body "Version bump for release."
+
+# 3. Get the PR reviewed and merged.
+
+# 4. After merge, tag the merge commit and push the tag.
+git fetch origin
+git tag v0.1.1 <merge-sha>               # pin the exact SHA, do not tag a moving ref
+git push origin v0.1.1                   # this triggers the Release workflow
+```
+
+Prefer tagging an explicit `<merge-sha>` over `origin/master`. If you tag
+`origin/master` and another commit lands between your `fetch` and your `git tag`,
+you will tag the wrong commit and `prepare` will reject it (the `Cargo.toml`
+version at that SHA will not match the tag).
+
+## Alternative: the Propose Release workflow
+
+`.github/workflows/propose-release.yml` automates step 1–2. Run it from the
+Actions UI (workflow_dispatch) with the next version, and it opens the bump PR
+for you. Two caveats:
+
+- It requires the `RELEASE_PR_TOKEN` repository secret (a GitHub App or
+  fine-grained PAT). PRs opened with the default `GITHUB_TOKEN` do not run CI on
+  themselves, so a separate token is used; without it the workflow hard-fails
+  (`.github/workflows/propose-release.yml:42-46`).
+- Unlike the publish workflow, the **propose** workflow does enforce two extra
+  rules:
+  - the proposed version must be strictly greater than the current one
+    (`.github/workflows/propose-release.yml:84-87`), and
+  - the PR may change only `Cargo.toml` and `Cargo.lock`
+    (`.github/workflows/propose-release.yml:118-123`).
+
+Because these rules live only in the propose workflow, anyone who bypasses it
+(e.g. by opening the bump PR by hand) can ship a version that is not monotonic.
+The publish workflow will not catch it.
+
+## Watching the release
+
+- Actions → **Release**, or `gh run watch`.
+- `prepare` prints the resolved tag, version, SHA, and workspace version.
+- `build` asserts `bloom --version` matches the tag before staging artifacts
+  (`.github/workflows/release.yml:169-179`).
+- `publish` generates `SHA256SUMS` and marks the release `latest` only if its
+  version is `>=` the current latest (`.github/workflows/release.yml:283-291`).
+  The floating `latest` git tag in this repo is legacy and is **not** managed by
+  the workflow.
+
+## Gotchas
+
+- **Tests run only after the tag is public.** The `test` job
+  (`.github/workflows/release.yml:105`) runs on the tagged commit. If it fails,
+  a public `vX.Y.Z` tag already exists with no (or partial) release, and the tag
+  must be deleted/moved. To de-risk, let CI pass on the bump PR before tagging.
+- **`Cargo.toml` has two `version = "0.x.y"` lines.** Only the one under
+  `[workspace.package]` is the release version (line 33). The other is a
+  dependency pin and must not be changed.
+- **Versioning scheme.** This project follows semver. While `0.x`, a bump in the
+  second component (`0.1.0` → `0.2.0`) is a minor/breaking-ish release; a bump
+  in the third (`0.1.0` → `0.1.1`) is a patch. The propose workflow enforces
+  strict increase; the publish workflow does not enforce monotonicity at all.


### PR DESCRIPTION
## Summary

Bumps the workspace version (`0.1.0` → `0.1.1`) and adds `RELEASING.md`, the developer-facing release docs. Both ship together so future release-makers (human or agent) have an accurate reference from the moment the version lands.

### What's in here

- **`Cargo.toml`** — single-line bump under `[workspace.package]`. The `version = "..."` on the `ml-dsa` dependency line is untouched.
- **`Cargo.lock`** — regenerated by `cargo check --workspace`; the diff is purely version-string changes across the 26 workspace members that inherit the workspace version (verified: no other lines changed).
- **`RELEASING.md`** — contract-first release documentation. States what `release.yml` actually enforces vs. what is enforced only by convention / the propose workflow, and documents the branch-protection requirement that forces the bump through a merged PR.

### Why docs in the same PR

An agent preparing a release earlier got confused because the workflow *comments* describe intent ("reviewed version-bump PR") while the *bash* enforces something narrower (commit-on-master + `Cargo.toml` version == tag). `RELEASING.md` separates the contract from the procedure with `file:line` references so that doesn't recur.

### After merge — cut the release

This PR does **not** create a tag. Once merged, a maintainer pushes the matching tag, which triggers the `Release` workflow (`.github/workflows/release.yml:23`):

```sh
git fetch origin
git tag v0.1.1 <merge-sha>     # pin the exact SHA, not a moving ref
git push origin v0.1.1
```

`prepare` (`release.yml:80-92`) rejects the tag unless the merge commit is on `master` and the `Cargo.toml` version at that SHA is `0.1.1` — both satisfied by merging this PR.

## Checklist

Every item must be checked before merge (enforced by the `checklist-complete`
status check). If an item does not apply, check it and write `N/A` in place
of the link or after the item.

- [x] Tests added or updated for behavior changes — N/A (no behavior change; pure version bump + dev docs)
- [x] Architecture docs (`docs/architecture/`) updated if contracts or behavior changed — N/A (no contract/behavior change; `RELEASING.md` is a top-level dev doc, not under `docs/architecture/`)
- [x] Sealed Approval invariants respected (no signing outside a grant or bounded capability, no PRF/grant persistence, execution from sealed bytes) — see `docs/architecture/Sealed Approvals.md` — N/A (no auth/signing code touched)
- [x] Agent Documentation updated (`crates/bloom-vfs/src/docs/agent-guidance.md` and affected Petal READMEs) — see `docs/architecture/Agent-native Documentation.md` — N/A (no VFS/Petal changes)
