### PR TITLE
Preinstall Enso v0.1.2 and add dynamic Petal discovery

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1030,12 +1030,12 @@ timestamp on each `live` / `history` record.
 
 ## 9. Enso Petal
 
-Enso swaps are supplied by the optional
+Enso swaps are supplied by the pre-installed
 [bloom-petal-enso](https://github.com/bloom-directory/bloom-petal-enso)
-package, not a native Bloom core handler. Install it and provision the API key:
+package, not a native Bloom core handler. `bloom init` provisions the pinned
+release. Provision the API key:
 
 ```sh
-bloom petals install https://github.com/bloom-directory/bloom-petal-enso
 bloom vfs write /petals/enso/settings/api-key --data 'your-enso-api-key'
 ```
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -208,9 +208,9 @@ it expire after the configured TTL) cancels the stage.
 - **ENS** — recipient names like `vitalik.eth` resolve in tx intents
   via the canonical mainnet registry; forward resolution is also
   exposed at `ens/<name>.eth`.
-- **DeFi intents** — install the
-  [Enso Petal](https://github.com/bloom-directory/bloom-petal-enso), then use
-  `petals/enso/intents/<wallet>/...`. Store the API key through
+- **DeFi intents** — `bloom init` provisions the pinned
+  [Enso Petal](https://github.com/bloom-directory/bloom-petal-enso). Use
+  `petals/enso/intents/<wallet>/...` and store the API key through
   `petals/enso/settings/api-key`; review the route and simulation before the
   Petal confirmation stages anything into the wallet outbox.
 - **Prices** — keyless DefiLlama at `prices/spot/<coin>(.usd)` and

--- a/README.md
+++ b/README.md
@@ -144,10 +144,11 @@ A fresh Bloom VFS root exposes these default entries:
 - `prices/{spot,change_24h}/<coin>` — DefiLlama keyless price oracle.
 - `addressbook/<alias>` — local petname directory.
 - `ens/<name>.eth` — ENS forward resolution as a read surface.
-- `petals/` — installed local Petal app surfaces. The default pre-installed
-  Polymarket package is available at `petals/polymarket/`; the optional
-  [Enso Petal](https://github.com/bloom-directory/bloom-petal-enso) is
-  available at `petals/enso/` after installation.
+- `petals/` — installed local Petal app surfaces. `bloom init` provisions the
+  pinned Polymarket, Near Intents, and
+  [Enso](https://github.com/bloom-directory/bloom-petal-enso) packages.
+  Read `docs/petals.md` in the VFS for the exact installed set, mount
+  directories, summaries, and declared capabilities.
 - `requests/` — free and paid HTTP requests. Paid HTTP 402 challenges are
   staged under `pending/`, exposed as `plan.md`, and only signed after a
   confirm write.

--- a/crates/bloom-daemon/src/lib.rs
+++ b/crates/bloom-daemon/src/lib.rs
@@ -2270,6 +2270,9 @@ impl Daemon {
         };
         let petal_app_host = Arc::new(petal_app_host);
         debug!(root = %petals_root.display(), "daemon.petals_initialised");
+        let petals_for_docs = petals.clone();
+        let petals_doc_renderer: Arc<dyn Fn() -> Vec<u8> + Send + Sync> =
+            Arc::new(move || render_installed_petals_doc(&petals_for_docs));
 
         let mut vfs_builder = Vfs::builder()
             .mount(
@@ -2359,7 +2362,10 @@ impl Daemon {
                 ) as _,
             )
             .mount("status", status_handler.clone() as _)
-            .mount("docs", Arc::new(DocsHandler::new()) as _)
+            .mount(
+                "docs",
+                Arc::new(DocsHandler::new().with_petals_renderer(petals_doc_renderer)) as _,
+            )
             .mount(
                 "simulate",
                 Arc::new(SimulateHandler::new(
@@ -2390,9 +2396,6 @@ impl Daemon {
                         .map_err(|e| DaemonError::Audit(e.to_string()))?,
                 ) as _,
             );
-
-        // DeFi (Enso) is now served by the `enso` Petal at `petals/enso/`.
-        // The native DefiHandler and bloom-defi crate have been removed.
 
         // /next.md — brutally-scoped next-action aggregator for agents.
         // Answers: what wallets need attention, what confirms are pending,
@@ -2704,7 +2707,6 @@ impl Daemon {
             home = %home.root().display(),
             chains = ?config.chains.keys().collect::<Vec<_>>(),
             etherscan = etherscan_arc.is_some(),
-            enso = true, // now served via petal, always available
             ens_resolver = ens_client.is_some(),
             heimdall = cfg!(feature = "bytecode-decompile"),
             "daemon.built"
@@ -2957,6 +2959,61 @@ fn pick_ens_client(chains: &ChainRegistry) -> Option<EnsClient> {
     None
 }
 
+fn render_installed_petals_doc(petals: &PetalRunner) -> Vec<u8> {
+    match petals.installed_petal_discovery() {
+        Ok(installed) => render_petal_discovery_markdown(&installed),
+        Err(error) => {
+            warn!(error = %error, "daemon.petals_docs_render_failed");
+            format!(
+                "# Installed Petals\n\n\
+                 Bloom could not read the installed Petal manifests: `{error}`\n"
+            )
+            .into_bytes()
+        }
+    }
+}
+
+fn render_petal_discovery_markdown(installed: &[bloom_petals::package::PetalDiscovery]) -> Vec<u8> {
+    let mut markdown = String::from(
+        "# Installed Petals\n\n\
+         This file is generated from the immutable `petal.toml` manifests of \
+         the Petals installed in this Bloom home.\n\n",
+    );
+    if installed.is_empty() {
+        markdown.push_str("No Petals are currently installed.\n");
+        return markdown.into_bytes();
+    }
+
+    for petal in installed {
+        let summary = petal
+            .summary
+            .as_deref()
+            .map(|summary| summary.split_whitespace().collect::<Vec<_>>().join(" "))
+            .filter(|summary| !summary.is_empty())
+            .unwrap_or_else(|| "No consent summary was declared.".to_string());
+        let capabilities = if petal.capabilities.is_empty() {
+            "none".to_string()
+        } else {
+            petal
+                .capabilities
+                .iter()
+                .map(|capability| format!("`{capability}`"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        markdown.push_str(&format!(
+            "## `{name}`\n\n\
+             - Directory: `petals/{name}/`\n\
+             - Summary: {summary}\n\
+             - Declared capabilities: {capabilities}\n\
+             - Package documentation: `petals/{name}/README.md`, \
+             `petals/{name}/AGENTS.md`\n\n",
+            name = petal.name,
+        ));
+    }
+    markdown.into_bytes()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2983,6 +3040,21 @@ mod tests {
             bloom_tx::TxEngineError::ApprovalRequired(requirement),
             bloom_tx::TxEngineError::ApprovalRequired(_)
         ));
+    }
+
+    #[test]
+    fn installed_petal_markdown_exposes_mount_summary_and_capabilities() {
+        let markdown = render_petal_discovery_markdown(&[bloom_petals::package::PetalDiscovery {
+            name: "enso".into(),
+            summary: Some("Request routes,\n simulate, and stage swap transactions.".into()),
+            capabilities: vec!["bloom:chain".into(), "bloom:tx.outbox".into()],
+        }]);
+        let markdown = String::from_utf8(markdown).unwrap();
+        assert!(markdown.contains("## `enso`"));
+        assert!(markdown.contains("`petals/enso/`"));
+        assert!(markdown.contains("Request routes, simulate, and stage swap transactions."));
+        assert!(markdown.contains("`bloom:chain`, `bloom:tx.outbox`"));
+        assert!(markdown.contains("`petals/enso/README.md`"));
     }
 
     #[test]

--- a/crates/bloom-petals/src/package.rs
+++ b/crates/bloom-petals/src/package.rs
@@ -256,6 +256,15 @@ pub struct PetalConsentSummary {
     pub routes: Vec<PetalConsentRoute>,
 }
 
+/// Agent-facing identity and capability metadata retained in an installed
+/// package's `source/petal.toml`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PetalDiscovery {
+    pub name: String,
+    pub summary: Option<String>,
+    pub capabilities: Vec<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PetalConsentNetRule {
     pub binding: Option<String>,
@@ -1016,6 +1025,23 @@ pub fn petal_consent_summary(
         sign_intents,
         store_namespaces,
         routes,
+    })
+}
+
+/// Read the discovery fields agents need directly from an installed package
+/// manifest. Installed packages retain the validated source `petal.toml`, so
+/// this remains the single source of truth for both consent and documentation.
+pub fn petal_discovery_from_manifest_toml(bytes: &[u8]) -> Result<PetalDiscovery, PetalError> {
+    let manifest_toml = std::str::from_utf8(bytes)
+        .map_err(|_| PetalError::InvalidWasm("petal.toml is not utf-8".into()))?;
+    let manifest: PetalToml = toml::from_str(manifest_toml)?;
+    let mut capabilities = manifest.caps.allowed;
+    capabilities.sort();
+    capabilities.dedup();
+    Ok(PetalDiscovery {
+        name: manifest.name,
+        summary: manifest.consent.summary,
+        capabilities,
     })
 }
 

--- a/crates/bloom-petals/src/runner.rs
+++ b/crates/bloom-petals/src/runner.rs
@@ -19,9 +19,9 @@ use crate::error::PetalError;
 use crate::host::{DenyHost, HostError, HostVfsEntry, HostVfsEntryKind, PetalHost};
 use crate::meta::Capability;
 use crate::package::{
-    InstallRouteMetadata, RouteAbi, RouteEntryKind, RouteIndex, RouteIndexRecord, RouteOp,
-    narrow_runtime_route_metadata, sign_intents_from_manifest_toml,
-    store_policy_from_manifest_toml,
+    InstallRouteMetadata, PetalDiscovery, RouteAbi, RouteEntryKind, RouteIndex, RouteIndexRecord,
+    RouteOp, narrow_runtime_route_metadata, petal_discovery_from_manifest_toml,
+    sign_intents_from_manifest_toml, store_policy_from_manifest_toml,
 };
 use crate::policy::NetPolicy;
 use crate::registry::NameRegistry;
@@ -321,6 +321,25 @@ impl PetalRunner {
 
     pub fn local_petal_mounts(&self) -> Result<Vec<(String, String)>, PetalError> {
         self.store.list_petal_owners()
+    }
+
+    /// Return installed Petals as agent-facing discovery records sourced from
+    /// each immutable installed package's retained `petal.toml`.
+    pub fn installed_petal_discovery(&self) -> Result<Vec<PetalDiscovery>, PetalError> {
+        let mut installed = Vec::new();
+        for (mount, hash) in self.store.list_petal_owners()? {
+            let manifest =
+                std::fs::read(self.store.package_path(&hash)?.join("source/petal.toml"))?;
+            let discovery = petal_discovery_from_manifest_toml(&manifest)?;
+            if discovery.name != mount {
+                return Err(PetalError::InvalidWasm(format!(
+                    "installed Petal mount {mount:?} does not match manifest name {:?}",
+                    discovery.name
+                )));
+            }
+            installed.push(discovery);
+        }
+        Ok(installed)
     }
 
     pub fn resolve_petal_mount(&self, mount: &str) -> Result<String, PetalError> {
@@ -807,6 +826,12 @@ mod tests {
             "petal.toml",
             br#"schema = "bloom.petal.package.v1"
 name = "echo"
+
+[consent]
+summary = "Echo values for discovery tests."
+
+[caps]
+allowed = ["bloom:vfs.read"]
 "#,
         );
         write_package_file(&package, "README.md", b"# echo");
@@ -843,6 +868,22 @@ name = "echo"
 
         assert_eq!(r.resolve(&hash).unwrap(), hash);
         assert_eq!(r.resolve("echo").unwrap(), hash);
+    }
+
+    #[test]
+    fn installed_petal_discovery_reads_retained_manifest_metadata() {
+        let (dir, r) = runner();
+        install_echo_app(&dir, &r);
+
+        let installed = r.installed_petal_discovery().unwrap();
+        assert_eq!(
+            installed,
+            vec![PetalDiscovery {
+                name: "echo".into(),
+                summary: Some("Echo values for discovery tests.".into()),
+                capabilities: vec!["bloom:vfs.read".into()],
+            }]
+        );
     }
 
     #[test]

--- a/crates/bloom-proto/src/config.rs
+++ b/crates/bloom-proto/src/config.rs
@@ -87,7 +87,11 @@ impl Default for PetalsConfig {
 }
 
 fn default_preinstalled_petals() -> Vec<String> {
-    vec!["polymarket".to_string(), "near-intents".to_string()]
+    vec![
+        "polymarket".to_string(),
+        "near-intents".to_string(),
+        "enso".to_string(),
+    ]
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -585,7 +589,7 @@ impl Config {
         let mut seen_preinstalled = std::collections::BTreeSet::new();
         for name in &self.petals.preinstalled {
             validate_petal_runtime_name("preinstalled entry", name)?;
-            if !matches!(name.as_str(), "polymarket" | "near-intents") {
+            if !matches!(name.as_str(), "polymarket" | "near-intents" | "enso") {
                 return Err(ConfigError::Invalid(format!(
                     "unknown preinstalled Petal {name:?}"
                 )));
@@ -664,7 +668,10 @@ mod tests {
         assert_eq!(cfg.nfs_listen_addr, "127.0.0.1:12049");
         assert!(cfg.etherscan.is_none());
         assert!(cfg.enso.is_none());
-        assert_eq!(cfg.petals.preinstalled, ["polymarket", "near-intents"]);
+        assert_eq!(
+            cfg.petals.preinstalled,
+            ["polymarket", "near-intents", "enso"]
+        );
         let hyperliquid = cfg
             .hyperliquid
             .as_ref()
@@ -889,13 +896,13 @@ allow_broadcast = false
         std::fs::write(&path, format!("{legacy}\n[polymarket]\nenabled = false\n")).unwrap();
 
         let migrated = Config::load(&path).unwrap();
-        assert_eq!(migrated.petals.preinstalled, vec!["near-intents"]);
+        assert_eq!(migrated.petals.preinstalled, vec!["near-intents", "enso"]);
 
         std::fs::write(&path, format!("{default}\n[polymarket]\nenabled = false\n")).unwrap();
         let explicitly_enabled = Config::load(&path).unwrap();
         assert_eq!(
             explicitly_enabled.petals.preinstalled,
-            vec!["polymarket", "near-intents"]
+            vec!["polymarket", "near-intents", "enso"]
         );
     }
 

--- a/crates/bloom-vfs/src/docs/README.md
+++ b/crates/bloom-vfs/src/docs/README.md
@@ -16,8 +16,9 @@ All paths below are relative to the Bloom VFS root.
 - `defi/intents/` — Enso-mediated DeFi intents (write `quote` / `execute`).
 - `hyperliquid/` — HyperCore reads plus signed exchange and agent-session
   writes; read `hyperliquid/README.md` for the mounted workflow documentation.
-- `petals/<name>/` — installed external Petal surfaces. Polymarket is provided
-  by the default pre-installed package at `petals/polymarket/`, not built in.
+- `petals/<name>/` — installed wallet extensions. Read `docs/petals.md` for
+  the exact installed names, mount directories, consent summaries, and
+  declared capabilities.
 - `watch/` — long-running subscriptions (head, addr, log) executed by the
   daemon and persisted to JSONL.
 - `simulate/` — out-of-band tx simulation with state overrides
@@ -265,8 +266,8 @@ echo replace > /bloom/wallets/alice/chains/ethereum/outbox/pending/<id>/replace
 echo cancel  > /bloom/wallets/alice/chains/ethereum/outbox/pending/<id>/cancel
 ```
 
-The optional Enso Petal accepts natural-language or JSON swap intents at its
-own application mount:
+The pre-installed Enso Petal accepts natural-language or JSON swap intents at
+its own application mount:
 
 ```sh
 echo 'swap 0.1 eth to USDC on base' \

--- a/crates/bloom-vfs/src/docs/agent-guidance.md
+++ b/crates/bloom-vfs/src/docs/agent-guidance.md
@@ -10,6 +10,7 @@ Useful commands:
 - `ls docs` lists the embedded documentation.
 - `cat docs/README.md` reads the VFS overview.
 - `cat docs/examples.md` reads workflow examples.
+- `cat docs/petals.md` discovers the Petals installed in this Bloom home.
 
 For more information, start in the `docs` folder. It contains the canonical
 VFS usage notes and examples exposed by the mounted tree.
@@ -39,12 +40,10 @@ aggregator expose the current capability and next-action view when the daemon
 has the relevant handlers mounted.
 
 Read `/hyperliquid/README.md` for Hyperliquid trading (session-first).
-If the external Polymarket Petal is installed, start with
-`cat petals/polymarket/README.md`, read `petals/polymarket/AGENTS.md`, then
-inspect `petals/polymarket/meta/route-contract.json` and list its route tree
-before using its prediction-market routes.
-When the Enso Petal is installed, read `/petals/enso/README.md` and use its
-documented intent, review, simulation, and confirmation lifecycle.
+For wallet extensions, read `docs/petals.md` to discover the Petals installed
+in this Bloom home, their mount directories, summaries, and declared
+capabilities. Then read the selected Petal's immutable `README.md` and
+`AGENTS.md` before using its routes.
 
 ## Wallets
 
@@ -285,16 +284,24 @@ Hyperliquid trading uses Sealed Approval for owner authority:
   Generic owner-signed order/cancel/update-leverage writes are disabled; use
   agent sessions.
 
-## Polymarket Petal
+## Petals
 
-Polymarket is not built into Bloom. `bloom init` provisions the pinned default
-`bloom-directory/bloom-petal-polymarket` package at `/petals/polymarket/`.
-Start with `cat petals/polymarket/README.md`; also read
-`petals/polymarket/AGENTS.md` and inspect
-`petals/polymarket/meta/route-contract.json` for the current onboarding, policy,
-approval, and trading workflow. The README and AGENTS files are immutable
-documents from the installed package. Do not use the removed `/polymarket`
-paths or `bloom polymarket` commands.
+Petals are installed wallet extensions. They add application-specific routes
+under `petals/<name>/` while using Bloom's wallet, policy, approval, network,
+storage, and transaction capabilities.
+
+Installed Petals vary by Bloom home; do not assume a particular extension is
+present. Read `docs/petals.md` first. It is generated from the immutable
+`petal.toml` manifests of the currently installed packages and lists:
+
+- the installed Petal name and its `petals/<name>/` directory;
+- the package's `[consent].summary`; and
+- the capabilities declared by that package.
+
+After choosing a Petal, read `petals/<name>/README.md` and
+`petals/<name>/AGENTS.md`, then list its directory to discover the current
+route tree. Treat those package documents as authoritative for its workflows
+and review requirements.
 
 ## Passkey policy mode
 

--- a/crates/bloom-vfs/src/docs/agent-guidance.md
+++ b/crates/bloom-vfs/src/docs/agent-guidance.md
@@ -40,10 +40,6 @@ aggregator expose the current capability and next-action view when the daemon
 has the relevant handlers mounted.
 
 Read `/hyperliquid/README.md` for Hyperliquid trading (session-first).
-For wallet extensions, read `docs/petals.md` to discover the Petals installed
-in this Bloom home, their mount directories, summaries, and declared
-capabilities. Then read the selected Petal's immutable `README.md` and
-`AGENTS.md` before using its routes.
 
 ## Wallets
 

--- a/crates/bloom-vfs/src/handlers/docs.rs
+++ b/crates/bloom-vfs/src/handlers/docs.rs
@@ -1,6 +1,7 @@
 //! `docs/` — vendored markdown docs about how to use the FS.
 
 use async_trait::async_trait;
+use std::sync::Arc;
 
 use crate::handler::{Entry, Handler, HandlerError};
 use crate::path::VfsPath;
@@ -9,6 +10,7 @@ use crate::path::VfsPath;
 pub struct DocsHandler {
     readme: String,
     examples: String,
+    petals: Arc<dyn Fn() -> Vec<u8> + Send + Sync>,
 }
 
 impl Default for DocsHandler {
@@ -16,6 +18,9 @@ impl Default for DocsHandler {
         Self {
             readme: include_str!("../docs/README.md").to_string(),
             examples: include_str!("../docs/examples.md").to_string(),
+            petals: Arc::new(|| {
+                b"# Installed Petals\n\nNo Petals are currently installed.\n".to_vec()
+            }),
         }
     }
 }
@@ -23,6 +28,14 @@ impl Default for DocsHandler {
 impl DocsHandler {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn with_petals_renderer(
+        mut self,
+        renderer: Arc<dyn Fn() -> Vec<u8> + Send + Sync>,
+    ) -> Self {
+        self.petals = renderer;
+        self
     }
 }
 
@@ -59,6 +72,7 @@ impl DocsHandler {
             [] => Ok(Entry::dir("")),
             [s] if s == "README.md" => Ok(Entry::file("README.md")),
             [s] if s == "examples.md" => Ok(Entry::file("examples.md")),
+            [s] if s == "petals.md" => Ok(Entry::file("petals.md")),
             _ => Err(HandlerError::not_found(path.to_string_path())),
         }
     }
@@ -67,13 +81,18 @@ impl DocsHandler {
         match path.segments() {
             [s] if s == "README.md" => Ok(self.readme.as_bytes().to_vec()),
             [s] if s == "examples.md" => Ok(self.examples.as_bytes().to_vec()),
+            [s] if s == "petals.md" => Ok((self.petals)()),
             _ => Err(HandlerError::NotAFile(path.to_string_path())),
         }
     }
 
     async fn list_inner(&self, path: &VfsPath) -> Result<Vec<Entry>, HandlerError> {
         if path.is_root() {
-            Ok(vec![Entry::file("README.md"), Entry::file("examples.md")])
+            Ok(vec![
+                Entry::file("README.md"),
+                Entry::file("examples.md"),
+                Entry::file("petals.md"),
+            ])
         } else {
             Err(HandlerError::NotADir(path.to_string_path()))
         }
@@ -86,11 +105,11 @@ mod tests {
     use crate::handler::EntryKind;
 
     #[tokio::test]
-    async fn root_lists_only_readme_and_examples() {
+    async fn root_lists_embedded_and_dynamic_docs() {
         let h = DocsHandler::new();
         let entries = h.list(&VfsPath::root()).await.unwrap();
         let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
-        assert_eq!(names, ["README.md", "examples.md"]);
+        assert_eq!(names, ["README.md", "examples.md", "petals.md"]);
         for e in &entries {
             assert_eq!(e.kind, EntryKind::File);
             // Entry::file => read-only mode.
@@ -119,7 +138,7 @@ mod tests {
     #[tokio::test]
     async fn lookup_known_files_are_files() {
         let h = DocsHandler::new();
-        for name in ["README.md", "examples.md"] {
+        for name in ["README.md", "examples.md", "petals.md"] {
             let p = VfsPath::parse(&format!("/{name}")).unwrap();
             let e = h.lookup(&p).await.unwrap();
             assert_eq!(e.kind, EntryKind::File);
@@ -175,6 +194,22 @@ mod tests {
             .unwrap();
         assert!(!examples.is_empty(), "examples.md must have content");
         assert!(std::str::from_utf8(&examples).is_ok());
+    }
+
+    #[tokio::test]
+    async fn petals_doc_is_rendered_at_read_time() {
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let renderer_calls = calls.clone();
+        let h = DocsHandler::new().with_petals_renderer(Arc::new(move || {
+            let call = renderer_calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+            format!("# Installed Petals\n\nrender {call}\n").into_bytes()
+        }));
+        let path = VfsPath::parse("/petals.md").unwrap();
+
+        let first = String::from_utf8(h.read(&path).await.unwrap()).unwrap();
+        let second = String::from_utf8(h.read(&path).await.unwrap()).unwrap();
+        assert!(first.contains("render 1"));
+        assert!(second.contains("render 2"));
     }
 
     #[tokio::test]

--- a/crates/bloom/src/github_source.rs
+++ b/crates/bloom/src/github_source.rs
@@ -16,6 +16,7 @@ use url::Url;
 const TRUSTED_GITHUB_OWNER: &str = "bloom-directory";
 const POLYMARKET_PARITY_COMMIT: &str = "e2e898b69046c9f5d905dd2cd66b3a57ef195542";
 const NEAR_INTENTS_RELEASE_COMMIT: &str = "08e9bd83786425656bdd87e35031030cb7f3dc14";
+const ENSO_RELEASE_COMMIT: &str = "59e3c884f83c9c97b69b1b415becf8572791273b";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct PreinstalledPetal {
@@ -43,6 +44,15 @@ const PREINSTALLED_NEAR_INTENTS: PreinstalledPetal = PreinstalledPetal {
     release_tag: "v0.1.1",
     archive: "near-intents-v0.1.1.petal.tar.gz",
     expected_hash: Some("c3f714c01e17f642b8add45b7501d6675c851a13210ce9e834fd16d23330f166"),
+};
+
+const PREINSTALLED_ENSO: PreinstalledPetal = PreinstalledPetal {
+    name: "enso",
+    repository: "https://github.com/bloom-directory/bloom-petal-enso",
+    commit: ENSO_RELEASE_COMMIT,
+    release_tag: "v0.1.2",
+    archive: "enso-v0.1.2.petal.tar.gz",
+    expected_hash: Some("82e541b237cd8dde0a566dfca7f3d20d6e688aacd23f62b1d0f1306f9c76ecb7"),
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -560,6 +570,7 @@ fn preinstalled_petal(name: &str) -> Option<&'static PreinstalledPetal> {
     match name {
         "polymarket" => Some(&PREINSTALLED_POLYMARKET),
         "near-intents" => Some(&PREINSTALLED_NEAR_INTENTS),
+        "enso" => Some(&PREINSTALLED_ENSO),
         _ => None,
     }
 }
@@ -1021,6 +1032,11 @@ mod tests {
         assert_eq!(near.commit.len(), 40);
         assert_eq!(near.archive, "near-intents-v0.1.1.petal.tar.gz");
         assert!(near.repository.ends_with("/bloom-petal-near"));
+        let enso = preinstalled_petal("enso").unwrap();
+        assert_eq!(enso.release_tag, "v0.1.2");
+        assert_eq!(enso.commit, ENSO_RELEASE_COMMIT);
+        assert_eq!(enso.archive, "enso-v0.1.2.petal.tar.gz");
+        assert!(enso.repository.ends_with("/bloom-petal-enso"));
         assert!(preinstalled_petal("unknown").is_none());
     }
 

--- a/crates/bloom/tests/cli.rs
+++ b/crates/bloom/tests/cli.rs
@@ -366,6 +366,27 @@ fn vfs_cat_root_agent_guidance_returns_identical_content() {
 }
 
 #[test]
+fn docs_petals_discovers_installed_package_from_manifest() {
+    let home = fresh_home();
+    let package = home.path().join("demo-petal");
+    write_demo_petal_package(&package);
+    bloom_cmd(home.path())
+        .args(["petals", "install", package.to_str().unwrap()])
+        .assert()
+        .success();
+
+    bloom_cmd(home.path())
+        .args(["vfs", "cat", "/docs/petals.md"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("## `demo`"))
+        .stdout(predicate::str::contains("`petals/demo/`"))
+        .stdout(predicate::str::contains("Demo app used by CLI tests."))
+        .stdout(predicate::str::contains("Declared capabilities: none"))
+        .stdout(predicate::str::contains("`petals/demo/README.md`"));
+}
+
+#[test]
 fn vfs_ls_status_lists_known_files() {
     let home = fresh_home();
     let assert = bloom_cmd(home.path())

--- a/docs/examples-domain/05-defi.md
+++ b/docs/examples-domain/05-defi.md
@@ -1,20 +1,16 @@
 # Enso Petal
 
-Enso route discovery and swap execution are provided by the optional
+Enso route discovery and swap execution are provided by the pre-installed
 [bloom-petal-enso](https://github.com/bloom-directory/bloom-petal-enso)
-package. Bloom core no longer exposes a native `/defi` subtree. Install the
-Petal, inspect its consent summary, and confirm that it appears at
-`/petals/enso/`:
+package. Bloom core no longer exposes a native `/defi` subtree. `bloom init`
+provisions the pinned release. Inspect the installed Petal discovery document
+and confirm that it appears at `/petals/enso/`:
 
 ```sh
-bloom petals install https://github.com/bloom-directory/bloom-petal-enso
+bloom vfs cat /docs/petals.md
 bloom petals ls
 bloom vfs ls /petals/enso
 ```
-
-Source installs execute the package's declared build command as the current
-OS user. Pin an explicit release tag or commit with `--ref` when
-reproducibility matters.
 
 ## Configure the API key
 


### PR DESCRIPTION
## Summary

- add `bloom-petal-enso` v0.1.2 to the pinned preinstalled Petal catalog, bound to commit `59e3c884f83c9c97b69b1b415becf8572791273b` and package hash `82e541b237cd8dde0a566dfca7f3d20d6e688aacd23f62b1d0f1306f9c76ecb7`
- remove the stale hard-coded `enso = true` daemon build telemetry and its obsolete cutover comment
- expose installed Petal discovery metadata from each immutable retained `source/petal.toml`
- add dynamically rendered `/docs/petals.md` with installed names, mount directories, `[consent].summary` values, declared capabilities, and package documentation paths
- replace hard-coded Polymarket/Enso guidance in the projected `AGENTS.md` and `CLAUDE.md` with generic Petal discovery instructions
- update user documentation to describe Enso as a pinned `bloom init` preinstall

## Why

The Enso core-to-Petal cutover left Enso optional even though the daemon described it as always available. Agent guidance also hard-coded specific Petals, so it could drift from the packages actually installed in a Bloom home. This change makes Enso provisioning match Polymarket and Near Intents, and makes Petal documentation derive from installed package manifests at read time.

## User and agent impact

`bloom init` now provisions Enso v0.1.2 alongside the existing default Petals. Agents can read `/docs/petals.md` to discover the exact installed set and understand each extension before reading its package-specific `README.md` and `AGENTS.md`.

## Checklist

- [x] Tests added or updated for behavior changes — added manifest-retention discovery coverage, dynamic docs rendering tests, catalog assertions, and a CLI end-to-end test for `/docs/petals.md`.
- [x] Architecture docs (`docs/architecture/`) updated if contracts or behavior changed — N/A: this uses the existing pinned preinstall, immutable package-manifest, and VFS documentation architecture; product and agent-facing documentation was updated where behavior changed.
- [x] Sealed Approval invariants respected (no signing outside a grant or bounded capability, no PRF/grant persistence, execution from sealed bytes) — no signing, grant, PRF, approval, or execution path changed; `/docs/petals.md` is a read-only projection of validated immutable package manifests.
- [x] Agent Documentation updated (`crates/bloom-vfs/src/docs/agent-guidance.md` and affected Petal READMEs) — updated `agent-guidance.md`, the projected core VFS documentation, README, Quickstart, examples, and Enso domain guide; Petal READMEs are N/A because no Petal package behavior changed.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p bloom-proto -p bloom-petals -p bloom-vfs -p bloom-daemon -p bloom --all-targets -- -D warnings`
- `cargo test -p bloom-proto -p bloom-petals -p bloom-vfs -p bloom-daemon --lib` (862 tests passed)
- `cargo test -p bloom --test cli docs_petals_discovers_installed_package_from_manifest`
- `cargo test -p bloom built_in_polymarket_entry_is_immutable_and_catalogued`
- isolated real `bloom init` downloaded and verified all pinned releases, installed Enso v0.1.2 at `/petals/enso/`, and rendered all three manifest summaries and capability sets through `/docs/petals.md`
- `git diff --check`