### PR TITLE
release: v0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2256,7 +2256,7 @@ dependencies = [
 
 [[package]]
 name = "bloom"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "alloy 2.0.5",
  "anyhow",
@@ -2298,7 +2298,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-auth"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2315,7 +2315,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-auth-api"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2328,7 +2328,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-daemon"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "alloy 2.0.5",
  "anyhow",
@@ -2374,7 +2374,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-ens"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "alloy 2.0.5",
  "bloom-evm",
@@ -2389,7 +2389,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-etherscan"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "alloy 2.0.5",
  "async-trait",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-evm"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "alloy 2.0.5",
  "bloom-proto",
@@ -2425,7 +2425,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-hyperliquid"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "alloy 2.0.5",
  "alloy-dyn-abi",
@@ -2442,7 +2442,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-it"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "alloy 2.0.5",
  "anyhow",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-keystore"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "alloy 2.0.5",
  "argon2",
@@ -2502,7 +2502,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-mempool"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "alloy 2.0.5",
  "anyhow",
@@ -2524,7 +2524,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-mount"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "bloom-vfs",
@@ -2540,7 +2540,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-paid-http"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2555,7 +2555,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-paid-mpp"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "alloy 2.0.5",
  "async-trait",
@@ -2571,7 +2571,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-paid-x402"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "alloy 2.0.5",
  "async-trait",
@@ -2594,7 +2594,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-petals"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-prices"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "parking_lot",
  "reqwest 0.12.28",
@@ -2639,7 +2639,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-proto"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "alloy 2.0.5",
  "blake3",
@@ -2660,7 +2660,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-revert"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "alloy 2.0.5",
  "alloy-dyn-abi",
@@ -2682,7 +2682,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-rpc"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "alloy 2.0.5",
  "bloom-proto",
@@ -2698,7 +2698,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-tools"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "alloy 2.0.5",
  "alloy-dyn-abi",
@@ -2712,7 +2712,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-tx"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "alloy 2.0.5",
  "anyhow",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-update"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "parking_lot",
  "reqwest 0.12.28",
@@ -2754,7 +2754,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-vfs"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "alloy 2.0.5",
  "async-trait",
@@ -2798,7 +2798,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-watch"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "alloy 2.0.5",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"


### PR DESCRIPTION
## Proposed release: v0.1.3

Bump the Bloom workspace version from `0.1.2` to `0.1.3`. All workspace crates inherit this version, and `Cargo.lock` was regenerated without changing external dependency resolution.

This PR intentionally changes only `Cargo.toml` and `Cargo.lock`.

After merge, tag the merge commit and push the tag to start the release workflow:

```sh
git tag v0.1.3 <merge-commit>
git push origin v0.1.3
```

## Checklist

- [x] Tests added or updated for behavior changes — N/A: version metadata only; validated with workspace check, locked metadata, and a locked Bloom build.
- [x] Architecture docs (`docs/architecture/`) updated if contracts or behavior changed — N/A: no architecture, contract, or runtime behavior changed.
- [x] Sealed Approval invariants respected (no signing outside a grant or bounded capability, no PRF/grant persistence, execution from sealed bytes) — N/A: no signing, approval, grant, PRF, or execution code changed.
- [x] Agent Documentation updated (`crates/bloom-vfs/src/docs/agent-guidance.md` and affected Petal READMEs) — N/A: no agent workflow or Petal behavior changed.

## Validation

- `cargo check --workspace`
- `cargo metadata --locked --format-version 1 --no-deps`
- `cargo fmt --all -- --check`
- `cargo build --locked -p bloom`
- `target/debug/bloom --version` → `bloom 0.1.3`
- `git diff --check`
- verified the diff is limited to `Cargo.toml` and `Cargo.lock`; lockfile changes only update the 25 workspace packages from `0.1.2` to `0.1.3`