### PR TITLE
ci: add commit-based release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,10 +233,25 @@ jobs:
             exit 1
           fi
 
+          version_at_least() {
+            local left right lpart rpart
+            IFS=. read -r -a left <<< "${1#v}"
+            IFS=. read -r -a right <<< "${2#v}"
+            for i in 0 1 2; do
+              lpart=$((10#${left[$i]}))
+              rpart=$((10#${right[$i]}))
+              if (( lpart > rpart )); then return 0; fi
+              if (( lpart < rpart )); then return 1; fi
+            done
+            return 0
+          }
+
           PREVIOUS_TAG=""
           while IFS= read -r CANDIDATE; do
             if [[ "$CANDIDATE" != "$TAG" \
-              && "$CANDIDATE" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              && "$CANDIDATE" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+              && ! version_at_least "$CANDIDATE" "$TAG"
+            then
               PREVIOUS_TAG="$CANDIDATE"
               break
             fi
@@ -302,18 +317,6 @@ jobs:
               exit "$GH_STATUS"
             fi
           fi
-          version_at_least() {
-            local left right lpart rpart
-            IFS=. read -r -a left <<< "${1#v}"
-            IFS=. read -r -a right <<< "${2#v}"
-            for i in 0 1 2; do
-              lpart=$((10#${left[$i]}))
-              rpart=$((10#${right[$i]}))
-              if (( lpart > rpart )); then return 0; fi
-              if (( lpart < rpart )); then return 1; fi
-            done
-            return 0
-          }
           MARK_LATEST=false
           if [[ -z "$CURRENT_LATEST" || "$CURRENT_LATEST" == "latest" ]]; then
             MARK_LATEST=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,9 @@ name: Release
 #      on each of the four native runners. A verify step asserts that
 #      `bloom --version` matches the tag.
 #   4. `publish` verifies the tag still resolves to the built SHA,
-#      downloads the four tarballs, generates SHA256SUMS, and creates
-#      or updates the GitHub release for that existing tag.
+#      downloads the four tarballs, generates SHA256SUMS and release notes
+#      from commits since the previous version tag, then creates or updates
+#      the GitHub release for that existing tag.
 #
 # The floating `latest` git tag is intentionally NOT touched here.
 # GitHub's `/releases/latest/download/<file>` route follows whichever
@@ -219,6 +220,7 @@ jobs:
       - name: Create or update GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
           TAG: ${{ needs.prepare.outputs.release_tag }}
           VERSION: ${{ needs.prepare.outputs.release_version }}
           SHA: ${{ needs.prepare.outputs.release_sha }}
@@ -230,25 +232,57 @@ jobs:
             echo "::error::refusing to publish: tag $TAG resolves to $TAG_SHA, built SHA is $SHA"
             exit 1
           fi
+
+          PREVIOUS_TAG=""
+          while IFS= read -r CANDIDATE; do
+            if [[ "$CANDIDATE" != "$TAG" \
+              && "$CANDIDATE" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              PREVIOUS_TAG="$CANDIDATE"
+              break
+            fi
+          done < <(git tag --merged "$SHA" --sort=-version:refname)
+
+          RANGE="$SHA"
+          CHANGE_HEADING="### Changes"
+          if [[ -n "$PREVIOUS_TAG" ]]; then
+            RANGE="$PREVIOUS_TAG..$SHA"
+            CHANGE_HEADING="### Changes since \`$PREVIOUS_TAG\`"
+          fi
+
           NOTES="$(mktemp)"
           cat > "$NOTES" <<EOF
           ## bloom v$VERSION
 
           Automated release for tag \`$TAG\`.
 
+          $CHANGE_HEADING
+
+          EOF
+          while IFS=$'\t' read -r COMMIT SHORT_SHA SUBJECT; do
+            printf -- '- %s ([`%s`](https://github.com/%s/commit/%s))\n' \
+              "$SUBJECT" "$SHORT_SHA" "$REPOSITORY" "$COMMIT" >> "$NOTES"
+          done < <(git log --first-parent --format='%H%x09%h%x09%s' "$RANGE")
+
+          if [[ -n "$PREVIOUS_TAG" ]]; then
+            printf '\n**Full Changelog**: https://github.com/%s/compare/%s...%s\n' \
+              "$REPOSITORY" "$PREVIOUS_TAG" "$TAG" >> "$NOTES"
+          fi
+
+          cat >> "$NOTES" <<EOF
+
           ### Downloads
 
           Stable per-version URLs — pick the one for your platform:
           \`\`\`
-          https://github.com/${{ github.repository }}/releases/download/$TAG/bloom-linux-x86_64.tar.gz
-          https://github.com/${{ github.repository }}/releases/download/$TAG/bloom-linux-aarch64.tar.gz
-          https://github.com/${{ github.repository }}/releases/download/$TAG/bloom-macos-x86_64.tar.gz
-          https://github.com/${{ github.repository }}/releases/download/$TAG/bloom-macos-aarch64.tar.gz
+          https://github.com/$REPOSITORY/releases/download/$TAG/bloom-linux-x86_64.tar.gz
+          https://github.com/$REPOSITORY/releases/download/$TAG/bloom-linux-aarch64.tar.gz
+          https://github.com/$REPOSITORY/releases/download/$TAG/bloom-macos-x86_64.tar.gz
+          https://github.com/$REPOSITORY/releases/download/$TAG/bloom-macos-aarch64.tar.gz
           \`\`\`
 
           Latest-alias URL (resolves to the release marked latest):
           \`\`\`
-          https://github.com/${{ github.repository }}/releases/latest/download/bloom-linux-x86_64.tar.gz
+          https://github.com/$REPOSITORY/releases/latest/download/bloom-linux-x86_64.tar.gz
           \`\`\`
 
           Verify your download with \`SHA256SUMS\`.


### PR DESCRIPTION
## Summary

- generate each release body from the first-parent commit diff since the previous reachable `vX.Y.Z` tag
- link every listed commit and add a GitHub compare URL for the full changelog
- preserve the existing download instructions and create/update retry behavior

## Verification

- `git diff --check`
- `actionlint -color -ignore 'label "macos-26(-intel)?" is unknown' .github/workflows/release.yml`
- executed the extracted release-note generation block for `v0.1.3` and `v0.1.2`; both selected the preceding version tag and rendered the expected commits, links, compare URL, and downloads

## Checklist

- [x] Tests added or updated for behavior changes — N/A: workflow-only change; validated with `actionlint` and release-note generation simulations
- [x] Architecture docs (`docs/architecture/`) updated if contracts or behavior changed — N/A: no architecture contract changed
- [x] Sealed Approval invariants respected (no signing outside a grant or bounded capability, no PRF/grant persistence, execution from sealed bytes) — see `docs/architecture/Sealed Approvals.md` — N/A: release workflow only
- [x] Agent Documentation updated (`crates/bloom-vfs/src/docs/agent-guidance.md` and affected Petal READMEs) — see `docs/architecture/Agent-native Documentation.md` — N/A: no agent-facing behavior changed
