### PR TITLE
feat(config): add Robinhood Chain to default networks

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -42,11 +42,12 @@ BLOOM_HOME=/tmp/bloom-demo cargo run -p bloom -- init
 ```
 
 This prints the home dir, config path, and configured chains. The
-default config registers eleven read-ready public EVM chains (Ethereum,
-Base, Tempo, Arbitrum, Optimism, Polygon, BNB Smart Chain, Avalanche,
-Gnosis, Linea, HyperEVM) plus `anvil` at `http://127.0.0.1:8545`. Per-chain
-`allow_broadcast` defaults to `true`. Value-moving actions still require the
-applicable signing, policy, and confirmation gates.
+default config registers twelve read-ready public EVM chains (Ethereum,
+Base, Tempo, Robinhood Chain, Arbitrum, Optimism, Polygon, BNB Smart Chain,
+Avalanche, Gnosis, Linea, HyperEVM) plus `anvil` at
+`http://127.0.0.1:8545`. Per-chain `allow_broadcast` defaults to `true`.
+Value-moving actions still require the applicable signing, policy, and
+confirmation gates.
 
 ## 2. Start a local devnet
 
@@ -225,10 +226,9 @@ it expire after the configured TTL) cancels the stage.
   `bloom-petal-polymarket` package. It appears at `/petals/polymarket/`; inspect
   `meta/route-contract.json` and list the route tree for the exact installed
   workflow.
-- **Zero-config chain reads** — Ethereum, Base, Arbitrum, Optimism,
-  Polygon, BNB Smart Chain, Avalanche, Gnosis, Linea, HyperEVM, and
-  Anvil are present after `bloom init`; live-network broadcasts remain
-  opt-in.
+- **Zero-config chain reads** — Ethereum, Base, Tempo, Robinhood Chain,
+  Arbitrum, Optimism, Polygon, BNB Smart Chain, Avalanche, Gnosis, Linea,
+  HyperEVM, and Anvil are present after `bloom init`.
 - **Address book** — `addressbook/<alias>` round-trips via FS.
 - **EIP-712 / personal_sign / raw-hash signing** — write to
   `wallets/<w>/sign/{message,hash,typed_data}`; the signature lands at

--- a/README.md
+++ b/README.md
@@ -61,9 +61,10 @@ Bloom gives an agent a safe wallet workspace:
   private orderflow settings, and hash-chained audit logging.
 
 Bloom ships read-ready RPC defaults for major EVM networks — Ethereum,
-Base, Tempo, Arbitrum, Optimism, Polygon, BNB Smart Chain, Avalanche,
-Gnosis, Linea, and HyperEVM — plus local Anvil. Per-chain broadcasting is
-enabled by default; set `allow_broadcast = false` on a chain to disable it.
+Base, Tempo, Robinhood Chain, Arbitrum, Optimism, Polygon, BNB Smart Chain,
+Avalanche, Gnosis, Linea, and HyperEVM — plus local Anvil. Per-chain
+broadcasting is enabled by default; set `allow_broadcast = false` on a chain to
+disable it.
 Public reads, simulations, and planning work without adding API keys;
 local devnet sends require a running Anvil node.
 

--- a/crates/bloom-proto/src/config.rs
+++ b/crates/bloom-proto/src/config.rs
@@ -349,6 +349,13 @@ fn default_chains() -> BTreeMap<String, ChainSpec> {
             "ETH",
         ),
         evm_chain(
+            "robinhood",
+            4663,
+            &["https://rpc.mainnet.chain.robinhood.com"],
+            "Robinhood Chain",
+            "ETH",
+        ),
+        evm_chain(
             "arbitrum",
             42161,
             &[
@@ -681,7 +688,7 @@ mod tests {
             hyperliquid.testnet_url,
             "https://api.hyperliquid-testnet.xyz"
         );
-        assert_eq!(cfg.chains.len(), 12);
+        assert_eq!(cfg.chains.len(), 13);
         let ethereum = cfg.chains.get("ethereum").expect("ethereum entry");
         assert_eq!(ethereum.chain_id, 1);
         assert!(ethereum.allow_broadcast);
@@ -691,6 +698,14 @@ mod tests {
         let tempo = cfg.chains.get("tempo").expect("tempo entry");
         assert_eq!(tempo.chain_id, 4217);
         assert_eq!(tempo.rpc_urls, vec!["https://rpc.tempo.xyz"]);
+        let robinhood = cfg.chains.get("robinhood").expect("robinhood entry");
+        assert_eq!(robinhood.chain_id, 4663);
+        assert_eq!(
+            robinhood.rpc_urls,
+            vec!["https://rpc.mainnet.chain.robinhood.com"]
+        );
+        assert_eq!(robinhood.display_name.as_deref(), Some("Robinhood Chain"));
+        assert_eq!(robinhood.native_symbol, "ETH");
         let hyperliquid = cfg.chains.get("hyperliquid").expect("hyperliquid entry");
         assert_eq!(hyperliquid.chain_id, 999);
         let anvil = cfg.chains.get("anvil").expect("anvil entry");

--- a/crates/bloom-vfs/src/docs/README.md
+++ b/crates/bloom-vfs/src/docs/README.md
@@ -32,10 +32,10 @@ All paths below are relative to the Bloom VFS root.
 - `prices/` — DefiLlama price oracle (current / historical).
 - `addressbook/` — local petname directory.
 
-Default config includes read-ready RPCs for Ethereum, Base, Arbitrum,
-Optimism, Polygon, BNB Smart Chain, Avalanche, Gnosis, Linea, HyperEVM,
-and local Anvil. Live-network broadcasts remain disabled until the user
-opts in via config.
+Default config includes read-ready RPCs for Ethereum, Base, Tempo, Robinhood
+Chain, Arbitrum, Optimism, Polygon, BNB Smart Chain, Avalanche, Gnosis, Linea,
+HyperEVM, and local Anvil. Per-chain broadcasting is enabled by default;
+value-moving actions still require the applicable approval gates.
 
 ## Reading
 

--- a/crates/bloom-vfs/src/docs/agent-guidance.md
+++ b/crates/bloom-vfs/src/docs/agent-guidance.md
@@ -11,6 +11,8 @@ Useful commands:
 - `cat docs/README.md` reads the VFS overview.
 - `cat docs/examples.md` reads workflow examples.
 - `cat docs/petals.md` discovers the Petals installed in this Bloom home.
+- `ls chains` lists configured networks; fresh homes include Robinhood Chain as
+  `chains/robinhood` (chain ID `4663`).
 
 For more information, start in the `docs` folder. It contains the canonical
 VFS usage notes and examples exposed by the mounted tree.

--- a/crates/bloom-vfs/src/docs/agent-guidance.md
+++ b/crates/bloom-vfs/src/docs/agent-guidance.md
@@ -11,8 +11,7 @@ Useful commands:
 - `cat docs/README.md` reads the VFS overview.
 - `cat docs/examples.md` reads workflow examples.
 - `cat docs/petals.md` discovers the Petals installed in this Bloom home.
-- `ls chains` lists configured networks; fresh homes include Robinhood Chain as
-  `chains/robinhood` (chain ID `4663`).
+- `ls chains` lists configured networks.
 
 For more information, start in the `docs` folder. It contains the canonical
 VFS usage notes and examples exposed by the mounted tree.

--- a/docs/AGENTIC_WALLET.md
+++ b/docs/AGENTIC_WALLET.md
@@ -36,7 +36,7 @@ An agent using Bloom can:
   challenges staged for review before any x402 or Tempo MPP credential is
   signed;
 - enforce wallet policy: spend caps, allow/deny lists, contract-call gates, private orderflow preferences, and audit logging;
-- use ten major read-ready EVM networks immediately after `bloom init`: Ethereum, Base, Arbitrum, Optimism, Polygon, BNB Smart Chain, Avalanche, Gnosis, Linea, and HyperEVM, plus local Anvil.
+- use twelve read-ready public EVM networks immediately after `bloom init`: Ethereum, Base, Tempo, Robinhood Chain, Arbitrum, Optimism, Polygon, BNB Smart Chain, Avalanche, Gnosis, Linea, and HyperEVM, plus local Anvil.
 
 Mainnet and L2 broadcast routing is enabled by default. Live sends still require the applicable signing, policy, confirmation, and Sealed Approval gates.
 


### PR DESCRIPTION
## Summary

- add Robinhood Chain mainnet to Bloom's default EVM network registry as `robinhood`
- configure chain ID `4663`, native symbol `ETH`, and the official public RPC endpoint
- update user-facing and mounted agent documentation to include the new default network

Reference: https://docs.robinhood.com/chain/connecting/#public-endpoints

## Verification

- `cargo test -p bloom-proto` — 177 passed
- `cargo test -p bloom-vfs root_agent_guidance_files_are_identical_to_markdown_source` — passed
- `cargo clippy -p bloom-proto --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- live `eth_chainId` call to `https://rpc.mainnet.chain.robinhood.com` returned `0x1237` (`4663`)

## Checklist

- [x] Tests added or updated for behavior changes
- [x] Architecture docs (`docs/architecture/`) updated if contracts or behavior changed — N/A: this adds a default network entry without changing an architecture contract
- [x] Sealed Approval invariants respected (no signing outside a grant or bounded capability, no PRF/grant persistence, execution from sealed bytes) — N/A: no signing or approval behavior changed
- [x] Agent Documentation updated (`crates/bloom-vfs/src/docs/agent-guidance.md` and affected Petal READMEs) — agent guidance and embedded VFS README updated; no Petal is affected
