### PR TITLE
feat: add hyperliquid to default preinstalled petals

### DIFF
--- a/crates/bloom-proto/src/config.rs
+++ b/crates/bloom-proto/src/config.rs
@@ -91,6 +91,7 @@ fn default_preinstalled_petals() -> Vec<String> {
         "polymarket".to_string(),
         "near-intents".to_string(),
         "enso".to_string(),
+        "hyperliquid".to_string(),
     ]
 }
 
@@ -596,7 +597,7 @@ impl Config {
         let mut seen_preinstalled = std::collections::BTreeSet::new();
         for name in &self.petals.preinstalled {
             validate_petal_runtime_name("preinstalled entry", name)?;
-            if !matches!(name.as_str(), "polymarket" | "near-intents" | "enso") {
+            if !matches!(name.as_str(), "polymarket" | "near-intents" | "enso" | "hyperliquid") {
                 return Err(ConfigError::Invalid(format!(
                     "unknown preinstalled Petal {name:?}"
                 )));
@@ -677,7 +678,7 @@ mod tests {
         assert!(cfg.enso.is_none());
         assert_eq!(
             cfg.petals.preinstalled,
-            ["polymarket", "near-intents", "enso"]
+            ["polymarket", "near-intents", "enso", "hyperliquid"]
         );
         let hyperliquid = cfg
             .hyperliquid
@@ -917,7 +918,7 @@ allow_broadcast = false
         let explicitly_enabled = Config::load(&path).unwrap();
         assert_eq!(
             explicitly_enabled.petals.preinstalled,
-            vec!["polymarket", "near-intents", "enso"]
+            vec!["polymarket", "near-intents", "enso", "hyperliquid"]
         );
     }
 

--- a/crates/bloom/src/github_source.rs
+++ b/crates/bloom/src/github_source.rs
@@ -17,6 +17,7 @@ const TRUSTED_GITHUB_OWNER: &str = "bloom-directory";
 const POLYMARKET_PARITY_COMMIT: &str = "e2e898b69046c9f5d905dd2cd66b3a57ef195542";
 const NEAR_INTENTS_RELEASE_COMMIT: &str = "08e9bd83786425656bdd87e35031030cb7f3dc14";
 const ENSO_RELEASE_COMMIT: &str = "59e3c884f83c9c97b69b1b415becf8572791273b";
+const HYPERLIQUID_RELEASE_COMMIT: &str = "fa722a986c2a0a23977e9e00df54ebd291a686db";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct PreinstalledPetal {
@@ -53,6 +54,15 @@ const PREINSTALLED_ENSO: PreinstalledPetal = PreinstalledPetal {
     release_tag: "v0.1.2",
     archive: "enso-v0.1.2.petal.tar.gz",
     expected_hash: Some("82e541b237cd8dde0a566dfca7f3d20d6e688aacd23f62b1d0f1306f9c76ecb7"),
+};
+
+const PREINSTALLED_HYPERLIQUID: PreinstalledPetal = PreinstalledPetal {
+    name: "hyperliquid",
+    repository: "https://github.com/bloom-directory/bloom-petal-hyperliquid",
+    commit: HYPERLIQUID_RELEASE_COMMIT,
+    release_tag: "v0.1.4",
+    archive: "hyperliquid-v0.1.4.petal.tar.gz",
+    expected_hash: Some("1de2eb50b7ce0f0da03d3ef1ae6554c6f1b89393096d50183fe4f2dbca6b2af7"),
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -571,6 +581,7 @@ fn preinstalled_petal(name: &str) -> Option<&'static PreinstalledPetal> {
         "polymarket" => Some(&PREINSTALLED_POLYMARKET),
         "near-intents" => Some(&PREINSTALLED_NEAR_INTENTS),
         "enso" => Some(&PREINSTALLED_ENSO),
+        "hyperliquid" => Some(&PREINSTALLED_HYPERLIQUID),
         _ => None,
     }
 }


### PR DESCRIPTION
## Summary

Adds hyperliquid as the 4th default preinstalled petal, following the same pattern as polymarket, near-intents, and enso.

## Pin details
- **Release:** v0.1.4
- **Source commit:** `fa722a986c2a0a23977e9e00df54ebd291a686db`
- **Archive:** `hyperliquid-v0.1.4.petal.tar.gz`
- **Package hash:** `1de2eb50b7ce0f0da03d3ef1ae6554c6f1b89393096d50183fe4f2dbca6b2af7`

All pins verified against the [GitHub release v0.1.4](https://github.com/bloom-directory/bloom-petal-hyperliquid/releases/tag/v0.1.4) `petal-release.json`.

## Changes
- `github_source.rs`: `HYPERLIQUID_RELEASE_COMMIT` constant, `PREINSTALLED_HYPERLIQUID` struct, match arm
- `config.rs`: added to default list, validation, and test assertions