### PR TITLE
feat: add privacy-pools to default preinstalled petals

### DIFF
--- a/crates/bloom-proto/src/config.rs
+++ b/crates/bloom-proto/src/config.rs
@@ -91,6 +91,7 @@ fn default_preinstalled_petals() -> Vec<String> {
         "polymarket".to_string(),
         "near-intents".to_string(),
         "enso".to_string(),
+        "privacy-pools".to_string(),
     ]
 }
 
@@ -596,7 +597,7 @@ impl Config {
         let mut seen_preinstalled = std::collections::BTreeSet::new();
         for name in &self.petals.preinstalled {
             validate_petal_runtime_name("preinstalled entry", name)?;
-            if !matches!(name.as_str(), "polymarket" | "near-intents" | "enso") {
+            if !matches!(name.as_str(), "polymarket" | "near-intents" | "enso" | "privacy-pools") {
                 return Err(ConfigError::Invalid(format!(
                     "unknown preinstalled Petal {name:?}"
                 )));
@@ -677,7 +678,7 @@ mod tests {
         assert!(cfg.enso.is_none());
         assert_eq!(
             cfg.petals.preinstalled,
-            ["polymarket", "near-intents", "enso"]
+            ["polymarket", "near-intents", "enso", "privacy-pools"]
         );
         let hyperliquid = cfg
             .hyperliquid
@@ -917,7 +918,7 @@ allow_broadcast = false
         let explicitly_enabled = Config::load(&path).unwrap();
         assert_eq!(
             explicitly_enabled.petals.preinstalled,
-            vec!["polymarket", "near-intents", "enso"]
+            vec!["polymarket", "near-intents", "enso", "privacy-pools"]
         );
     }
 

--- a/crates/bloom-proto/src/config.rs
+++ b/crates/bloom-proto/src/config.rs
@@ -597,7 +597,10 @@ impl Config {
         let mut seen_preinstalled = std::collections::BTreeSet::new();
         for name in &self.petals.preinstalled {
             validate_petal_runtime_name("preinstalled entry", name)?;
-            if !matches!(name.as_str(), "polymarket" | "near-intents" | "enso" | "privacy-pools") {
+            if !matches!(
+                name.as_str(),
+                "polymarket" | "near-intents" | "enso" | "privacy-pools"
+            ) {
                 return Err(ConfigError::Invalid(format!(
                     "unknown preinstalled Petal {name:?}"
                 )));
@@ -912,7 +915,10 @@ allow_broadcast = false
         std::fs::write(&path, format!("{legacy}\n[polymarket]\nenabled = false\n")).unwrap();
 
         let migrated = Config::load(&path).unwrap();
-        assert_eq!(migrated.petals.preinstalled, vec!["near-intents", "enso"]);
+        assert_eq!(
+            migrated.petals.preinstalled,
+            vec!["near-intents", "enso", "privacy-pools"]
+        );
 
         std::fs::write(&path, format!("{default}\n[polymarket]\nenabled = false\n")).unwrap();
         let explicitly_enabled = Config::load(&path).unwrap();

--- a/crates/bloom/src/github_source.rs
+++ b/crates/bloom/src/github_source.rs
@@ -17,6 +17,7 @@ const TRUSTED_GITHUB_OWNER: &str = "bloom-directory";
 const POLYMARKET_PARITY_COMMIT: &str = "e2e898b69046c9f5d905dd2cd66b3a57ef195542";
 const NEAR_INTENTS_RELEASE_COMMIT: &str = "08e9bd83786425656bdd87e35031030cb7f3dc14";
 const ENSO_RELEASE_COMMIT: &str = "59e3c884f83c9c97b69b1b415becf8572791273b";
+const PRIVACY_POOLS_RELEASE_COMMIT: &str = "ae01a7d398416af4fa38a985b684ac973e128208";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct PreinstalledPetal {
@@ -53,6 +54,15 @@ const PREINSTALLED_ENSO: PreinstalledPetal = PreinstalledPetal {
     release_tag: "v0.1.2",
     archive: "enso-v0.1.2.petal.tar.gz",
     expected_hash: Some("82e541b237cd8dde0a566dfca7f3d20d6e688aacd23f62b1d0f1306f9c76ecb7"),
+};
+
+const PREINSTALLED_PRIVACY_POOLS: PreinstalledPetal = PreinstalledPetal {
+    name: "privacy-pools",
+    repository: "https://github.com/bloom-directory/bloom-petal-privacy-pools",
+    commit: PRIVACY_POOLS_RELEASE_COMMIT,
+    release_tag: "v0.1.2",
+    archive: "privacy-pools-v0.1.2.petal.tar.gz",
+    expected_hash: Some("f86cf4fac3dcd5dc86fa6d60daadeb2377b7d3a655774f64a109a7f5aca446b4"),
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -571,6 +581,7 @@ fn preinstalled_petal(name: &str) -> Option<&'static PreinstalledPetal> {
         "polymarket" => Some(&PREINSTALLED_POLYMARKET),
         "near-intents" => Some(&PREINSTALLED_NEAR_INTENTS),
         "enso" => Some(&PREINSTALLED_ENSO),
+        "privacy-pools" => Some(&PREINSTALLED_PRIVACY_POOLS),
         _ => None,
     }
 }


### PR DESCRIPTION
## Summary

Adds privacy-pools as the 4th default preinstalled petal, following the same pattern as polymarket, near-intents, and enso.

## Pin details
- **Release:** v0.1.2
- **Source commit:** `ae01a7d398416af4fa38a985b684ac973e128208`
- **Archive:** `privacy-pools-v0.1.2.petal.tar.gz`
- **Package hash:** `f86cf4fac3dcd5dc86fa6d60daadeb2377b7d3a655774f64a109a7f5aca446b4`

All pins verified against the [GitHub release v0.1.2](https://github.com/bloom-directory/bloom-petal-privacy-pools/releases/tag/v0.1.2) `petal-release.json`.

## Changes
- `github_source.rs`: `PRIVACY_POOLS_RELEASE_COMMIT` constant, `PREINSTALLED_PRIVACY_POOLS` struct, match arm
- `config.rs`: added to default list, validation, and test assertions

## Checklist

- [x] Tests added or updated for behavior changes — test assertions added in `config.rs`
- [x] Architecture docs (`docs/architecture/`) updated if contracts or behavior changed — N/A (config-only change)
- [x] Sealed Approval invariants respected (no signing outside a grant or bounded capability, no PRF/grant persistence, execution from sealed bytes) — N/A (no signing logic touched)
- [x] Agent Documentation updated (`crates/bloom-vfs/src/docs/agent-guidance.md` and affected Petal READMEs) — N/A (no agent-facing behavior change)