### PR TITLE
feat: add venice-x402 as default preinstalled petal

### DIFF
--- a/crates/bloom-proto/src/config.rs
+++ b/crates/bloom-proto/src/config.rs
@@ -91,6 +91,7 @@ fn default_preinstalled_petals() -> Vec<String> {
         "polymarket".to_string(),
         "near-intents".to_string(),
         "enso".to_string(),
+        "venice-x402".to_string(),
     ]
 }
 

--- a/crates/bloom-proto/src/config.rs
+++ b/crates/bloom-proto/src/config.rs
@@ -597,7 +597,10 @@ impl Config {
         let mut seen_preinstalled = std::collections::BTreeSet::new();
         for name in &self.petals.preinstalled {
             validate_petal_runtime_name("preinstalled entry", name)?;
-            if !matches!(name.as_str(), "polymarket" | "near-intents" | "enso") {
+            if !matches!(
+                name.as_str(),
+                "polymarket" | "near-intents" | "enso" | "venice-x402"
+            ) {
                 return Err(ConfigError::Invalid(format!(
                     "unknown preinstalled Petal {name:?}"
                 )));
@@ -678,7 +681,7 @@ mod tests {
         assert!(cfg.enso.is_none());
         assert_eq!(
             cfg.petals.preinstalled,
-            ["polymarket", "near-intents", "enso"]
+            ["polymarket", "near-intents", "enso", "venice-x402"]
         );
         let hyperliquid = cfg
             .hyperliquid
@@ -912,13 +915,16 @@ allow_broadcast = false
         std::fs::write(&path, format!("{legacy}\n[polymarket]\nenabled = false\n")).unwrap();
 
         let migrated = Config::load(&path).unwrap();
-        assert_eq!(migrated.petals.preinstalled, vec!["near-intents", "enso"]);
+        assert_eq!(
+            migrated.petals.preinstalled,
+            vec!["near-intents", "enso", "venice-x402"]
+        );
 
         std::fs::write(&path, format!("{default}\n[polymarket]\nenabled = false\n")).unwrap();
         let explicitly_enabled = Config::load(&path).unwrap();
         assert_eq!(
             explicitly_enabled.petals.preinstalled,
-            vec!["polymarket", "near-intents", "enso"]
+            vec!["polymarket", "near-intents", "enso", "venice-x402"]
         );
     }
 

--- a/crates/bloom/src/github_source.rs
+++ b/crates/bloom/src/github_source.rs
@@ -17,6 +17,7 @@ const TRUSTED_GITHUB_OWNER: &str = "bloom-directory";
 const POLYMARKET_PARITY_COMMIT: &str = "e2e898b69046c9f5d905dd2cd66b3a57ef195542";
 const NEAR_INTENTS_RELEASE_COMMIT: &str = "08e9bd83786425656bdd87e35031030cb7f3dc14";
 const ENSO_RELEASE_COMMIT: &str = "59e3c884f83c9c97b69b1b415becf8572791273b";
+const VENICE_X402_RELEASE_COMMIT: &str = "f8d6a1b287397b2c66fa11ca777fe2b762640964";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct PreinstalledPetal {
@@ -53,6 +54,15 @@ const PREINSTALLED_ENSO: PreinstalledPetal = PreinstalledPetal {
     release_tag: "v0.1.2",
     archive: "enso-v0.1.2.petal.tar.gz",
     expected_hash: Some("82e541b237cd8dde0a566dfca7f3d20d6e688aacd23f62b1d0f1306f9c76ecb7"),
+};
+
+const PREINSTALLED_VENICE_X402: PreinstalledPetal = PreinstalledPetal {
+    name: "venice-x402",
+    repository: "https://github.com/bloom-directory/bloom-petal-venice-x402",
+    commit: VENICE_X402_RELEASE_COMMIT,
+    release_tag: "v0.1.0",
+    archive: "venice-x402-v0.1.0.petal.tar.gz",
+    expected_hash: Some("473df7e6a3f948480684d4485f07836918f0e36042d1b2105dc82fdb0370bf18"),
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -571,6 +581,7 @@ fn preinstalled_petal(name: &str) -> Option<&'static PreinstalledPetal> {
         "polymarket" => Some(&PREINSTALLED_POLYMARKET),
         "near-intents" => Some(&PREINSTALLED_NEAR_INTENTS),
         "enso" => Some(&PREINSTALLED_ENSO),
+        "venice-x402" => Some(&PREINSTALLED_VENICE_X402),
         _ => None,
     }
 }


### PR DESCRIPTION
## Summary

Adds `venice-x402` (v0.1.0) as a default preinstalled petal.

### Release details
- **Repo:** bloom-directory/bloom-petal-venice-x402
- **Tag:** v0.1.0
- **Commit:** `f8d6a1b287397b2c66fa11ca777fe2b762640964`
- **Package hash:** `473df7e6a3f948480684d4485f07836918f0e36042d1b2105dc82fdb0370bf18`
- **Archive SHA256:** `d2901177b345dba3c7819406f9decb9ed0d167ca7b1f4c7b2895cf39729922be`

### What the petal does
Private AI inference via Venice's x402 payment protocol:
- SIWE authentication on Base
- USDC top-up via EIP-3009 (EIP-712 typed data signing)
- Venice chat completions API
- Balance checking and model listing
- 6 route components, 64 unit + integration tests

### Changes
- `github_source.rs`: `VENICE_X402_RELEASE_COMMIT` constant, `PREINSTALLED_VENICE_X402` struct, match arm
- `config.rs`: `"venice-x402"` added to default preinstalled list

Follows the exact pattern of polymarket, near-intents, and enso.

## Checklist

- [x] Tests added or updated for behavior changes — test assertions added in `config.rs` for the new default petal
- [x] Architecture docs (`docs/architecture/`) updated if contracts or behavior changed — N/A (config-only change)
- [x] Sealed Approval invariants respected (no signing outside a grant or bounded capability, no PRF/grant persistence, execution from sealed bytes) — N/A (no signing logic touched)
- [x] Agent Documentation updated (`crates/bloom-vfs/src/docs/agent-guidance.md` and affected Petal READMEs) — N/A (no agent-facing behavior change)