### PR TITLE
Restore VFS ergonomics and require daemon-only CLI IPC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,7 +172,7 @@ jobs:
           VERSION: ${{ needs.prepare.outputs.release_version }}
         run: |
           set -euo pipefail
-          ACTUAL="$(./target/release/${{ matrix.binary }} --version | awk '{print $2}')"
+          ACTUAL="$(./target/release/${{ matrix.binary }} --version | head -n 1 | awk '{print $2}')"
           if [[ "$ACTUAL" != "$VERSION" ]]; then
             echo "::error::binary version '$ACTUAL' does not match tag '$VERSION'"
             exit 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2222,6 +2222,7 @@ dependencies = [
  "bloom-update",
  "bloom-vfs",
  "bloom-watch",
+ "fs2",
  "futures",
  "hex",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2704,6 +2704,7 @@ dependencies = [
  "qrcode",
  "rand 0.8.6",
  "reqwest 0.12.28",
+ "rustix 1.1.4",
  "serde",
  "serde_jcs",
  "serde_json",

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -34,15 +34,24 @@ Wallet paths are authenticated public projections, not key storage.
 ## Register a wallet
 
 ```sh
+BEFORE_REGISTRATIONS="$(mktemp)"
+ls /bloom/wallets/registrations > "$BEFORE_REGISTRATIONS"
 printf 'alice\n' > /bloom/wallets/new
-cat /bloom/wallets/registrations/alice/status.json
-cat /bloom/wallets/registrations/alice/ceremony_url
+AFTER_REGISTRATIONS="$(mktemp)"
+ls /bloom/wallets/registrations > "$AFTER_REGISTRATIONS"
+comm -13 "$BEFORE_REGISTRATIONS" "$AFTER_REGISTRATIONS"
+REGISTRATION_ID='<candidate-operation-id>'
+cat /bloom/wallets/registrations/"$REGISTRATION_ID"/status.json
 ```
 
-Broker originates the custody ceremony and Signer creates the key after owner
+Compare the before and after listings. Verify that each candidate's
+`requested_name` is `alice` before opening its `ceremony_url`, polling it, or
+cancelling it. Concurrent registrations for the same requested name remain
+ambiguous through this write-only sink, so serialize same-name writes. Broker
+originates the custody ceremony and Signer creates the key after owner
 authentication. Machine exposes only the resulting public projection. Import,
-recovery, rebind, credential changes, and deletion use the same custody
-boundary and never accept secret material through the mount.
+recovery, rebind, credential changes, and deletion use the same custody boundary
+and never accept secret material through the mount.
 
 ## Stage, review, and confirm
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -49,13 +49,22 @@ Registration is a Broker custody operation completed by Signer. The write
 projects a browser ceremony; it does not create custody inside Machine.
 
 ```sh
+BEFORE_REGISTRATIONS="$(mktemp)"
+ls wallets/registrations > "$BEFORE_REGISTRATIONS"
 printf 'alice\n' > wallets/new
-cat wallets/registrations/alice/status.json
-cat wallets/registrations/alice/ceremony_url
+AFTER_REGISTRATIONS="$(mktemp)"
+ls wallets/registrations > "$AFTER_REGISTRATIONS"
+comm -13 "$BEFORE_REGISTRATIONS" "$AFTER_REGISTRATIONS"
+REGISTRATION_ID='<candidate-operation-id>'
+cat wallets/registrations/"$REGISTRATION_ID"/status.json
 ```
 
-Complete the passkey ceremony, wait for completed status, then inspect the
-public wallet projection:
+Compare the before and after listings. Verify that each candidate's
+`requested_name` is `alice` before opening its `ceremony_url`, polling it, or
+cancelling it. Concurrent registrations for the same requested name remain
+ambiguous through this write-only sink, so serialize same-name writes. Complete
+the passkey ceremony and wait for `ceremony_state` to become `COMPLETED`, then
+inspect the public wallet projection:
 
 ```sh
 cat wallets/alice/address

--- a/crates/bloom-daemon/Cargo.toml
+++ b/crates/bloom-daemon/Cargo.toml
@@ -58,10 +58,11 @@ url.workspace = true
 base64.workspace = true
 blake3.workspace = true
 futures.workspace = true
+fs2.workspace = true
 hex.workspace = true
 reqwest = { workspace = true, features = ["stream"] }
 rustix.workspace = true
+tempfile.workspace = true
 
 [dev-dependencies]
 bloom-proto = { workspace = true, features = ["audit-test-seam"] }
-tempfile.workspace = true

--- a/crates/bloom-daemon/src/ipc.rs
+++ b/crates/bloom-daemon/src/ipc.rs
@@ -11,14 +11,16 @@
 //! | `lookup`   | `{ "path": "/..." }`                  | `{ "name", "kind", ... }` |
 //! | `read`     | `{ "path": "/..." }`                  | `{ "bytes_b64": "..." }`  |
 //! | `write`    | `{ "path": "/...", "bytes_b64": "" }` | `null`                    |
+//! | `write_with_lookup` | write params plus `projection_path` | identity entry           |
 //! | `list`     | `{ "path": "/..." }`                  | `[ entry, ... ]`          |
 //! | `version`  | `null`                                | `"x.y.z"`                 |
 //! | `chains`   | `null`                                | `[ "ethereum", ... ]`     |
 //! | `confirm_batch` | `{ "wallet", "txs", "text" }` | batch result              |
-//! | `petals.install` | `{ "path", "ref"? }`             | package metadata          |
-//! | `petals.build` | `{ "package_dir", "out"? }`       | package metadata          |
+//! | `petals.install` | remote source or package transport | package metadata          |
+//! | `petals.build` | `{ "package_dir", "out"? }`           | package metadata       |
 //! | `petals.list` | `null`                              | `[ package, ... ]`        |
 //! | `petals.uninstall` | `{ "hash" }`                   | `{ "removed" }`          |
+//! | `machine.execute` | tagged [`MachineCommand`]        | [`MachineCommandOutput`] |
 //! | `shutdown` | `null`                                | `null`                    |
 //!
 //! Wire framing is one JSON document per line. Encoding/decoding errors
@@ -27,6 +29,7 @@
 
 use std::collections::BTreeMap;
 use std::future::Future;
+use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
@@ -50,6 +53,10 @@ pub enum IpcError {
     Io(#[from] std::io::Error),
     #[error("home dir does not exist: {0}")]
     NoHome(PathBuf),
+    #[error("refusing insecure IPC socket {path}: {reason}")]
+    InsecureSocket { path: PathBuf, reason: String },
+    #[error("IPC endpoint is already served: {0}")]
+    EndpointBusy(PathBuf),
 }
 
 /// Default socket path under `<home>/run/bloom.sock`.
@@ -57,13 +64,17 @@ pub fn default_socket_path(home_root: &Path) -> PathBuf {
     home_root.join("run").join("bloom.sock")
 }
 
-/// RAII guard that removes the socket file on drop, covering normal exit
-/// and panics during [`IpcServer::serve`].
-struct SocketGuard(PathBuf);
-impl Drop for SocketGuard {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.0);
-    }
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct SocketIdentity {
+    device: u64,
+    inode: u64,
+}
+
+/// Keeps the persistent endpoint ownership record locked for the listener's
+/// full lifetime. The record is deliberately not removed on drop: unlinking a
+/// lock path would let a raced publisher lock a different inode.
+struct EndpointLock {
+    _file: std::fs::File,
 }
 
 #[derive(Debug, Deserialize)]
@@ -87,12 +98,56 @@ struct Response {
     error: Option<RpcError>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 struct RpcError {
     code: i32,
     message: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     data: Option<Value>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MachineErrorKind {
+    InvalidParams,
+    PermissionDenied,
+    Unavailable,
+    Conflict,
+    NotFound,
+    Internal,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Error, PartialEq, Serialize)]
+#[error("{message}")]
+pub struct MachineError {
+    pub kind: MachineErrorKind,
+    pub code: String,
+    pub message: String,
+}
+
+impl MachineError {
+    pub fn new(
+        kind: MachineErrorKind,
+        code: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            kind,
+            code: code.into(),
+            message: message.into(),
+        }
+    }
+
+    fn rpc_code(&self) -> i32 {
+        match self.kind {
+            MachineErrorKind::InvalidParams => -32602,
+            MachineErrorKind::PermissionDenied => -32007,
+            MachineErrorKind::Unavailable => -32003,
+            MachineErrorKind::Conflict => -32009,
+            MachineErrorKind::NotFound => -32004,
+            MachineErrorKind::Internal => -32603,
+        }
+    }
 }
 
 impl Response {
@@ -113,6 +168,19 @@ impl Response {
                 code,
                 message: message.into(),
                 data: None,
+            }),
+        }
+    }
+
+    fn machine_err(id: Value, error: MachineError) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            id,
+            result: None,
+            error: Some(RpcError {
+                code: error.rpc_code(),
+                message: error.message.clone(),
+                data: Some(serde_json::to_value(error).expect("Machine error serializes")),
             }),
         }
     }
@@ -143,6 +211,125 @@ pub trait PetalSourceInstallService: Send + Sync {
     fn install_source(&self, params: Value) -> Result<Value, String>;
 }
 
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MachineCustodyKind {
+    New,
+    Import,
+    Rebind,
+    Delete,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MachineCeremonyAction {
+    Status,
+    Cancel,
+    Result,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MachineOperationAction {
+    Status,
+    Cancel,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MachineLegacyMigrationReceipt {
+    pub schema: String,
+    pub operation_id: bloom_broker_api::OperationId,
+    pub wallet_name: bloom_broker_api::Token,
+    pub address: String,
+    pub public_key_fingerprint: bloom_broker_api::Digest32,
+    pub credential_id_fingerprint: bloom_broker_api::Digest32,
+    pub legacy_format_version: u8,
+    pub bundle_digest: bloom_broker_api::Digest32,
+    pub policy_mode: String,
+    pub exact_terms_digest: bloom_broker_api::Digest32,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "command", rename_all = "snake_case", deny_unknown_fields)]
+pub enum MachineCommand {
+    Status,
+    AuditStatus,
+    AuditReconcile {
+        correlation_id: String,
+        outcome: String,
+        confirm: String,
+    },
+    WalletList,
+    WalletProjection {
+        name: String,
+    },
+    WalletAddress {
+        name: String,
+    },
+    WalletUnlock {
+        name: String,
+    },
+    WalletCustody {
+        name: String,
+        kind: MachineCustodyKind,
+    },
+    WalletMigrate {
+        receipt: MachineLegacyMigrationReceipt,
+    },
+    WalletPolicyPrepare {
+        name: String,
+        policy: Vec<u8>,
+        assurance_level: String,
+    },
+    WalletPolicyCommit {
+        operation_id: String,
+    },
+    WalletOutboxCancel {
+        wallet: String,
+        chain: String,
+        id: String,
+        text: String,
+    },
+    WalletOutboxReplace {
+        wallet: String,
+        chain: String,
+        id: String,
+        intent: String,
+    },
+    Ceremony {
+        action: MachineCeremonyAction,
+        operation_id: String,
+    },
+    Operation {
+        action: MachineOperationAction,
+        operation_id: String,
+    },
+    UpdateStatus,
+    UpdateCheck,
+    Completions {
+        shell: String,
+    },
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MachineCommandOutput {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
+}
+
+pub type MachineCommandFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<MachineCommandOutput, MachineError>> + Send + 'a>>;
+
+/// Daemon-owned service seam for Machine command families that are not VFS
+/// operations. The CLI transports the closed [`MachineCommand`] contract;
+/// authority access and durable state remain in `bloom serve`.
+pub trait MachineCommandService: Send + Sync {
+    fn execute(&self, command: MachineCommand) -> MachineCommandFuture<'_>;
+}
+
 /// Server context. Cloning is cheap (Arc-shared).
 #[derive(Clone)]
 pub struct IpcServer {
@@ -154,6 +341,7 @@ pub struct IpcServer {
     petal_source_installer: Option<Arc<dyn PetalSourceInstallService>>,
     petal_mutation: Arc<tokio::sync::Mutex<()>>,
     batch_confirmation: Option<Arc<dyn BatchConfirmationService>>,
+    machine_commands: Option<Arc<dyn MachineCommandService>>,
     shutdown: Arc<Notify>,
 }
 
@@ -168,6 +356,7 @@ impl IpcServer {
             petal_source_installer: None,
             petal_mutation: Arc::new(tokio::sync::Mutex::new(())),
             batch_confirmation: None,
+            machine_commands: None,
             shutdown: Arc::new(Notify::new()),
         }
     }
@@ -200,6 +389,11 @@ impl IpcServer {
         self
     }
 
+    pub fn with_machine_commands(mut self, service: Arc<dyn MachineCommandService>) -> Self {
+        self.machine_commands = Some(service);
+        self
+    }
+
     /// Trigger graceful shutdown of the running [`serve`] loop.
     pub fn trigger_shutdown(&self) {
         self.shutdown.notify_waiters();
@@ -209,26 +403,32 @@ impl IpcServer {
     /// is triggered (either via the `shutdown` RPC method or
     /// [`IpcServer::trigger_shutdown`]).
     pub async fn serve(&self, socket_path: &Path) -> Result<(), IpcError> {
-        if let Some(parent) = socket_path.parent() {
-            std::fs::create_dir_all(parent)?;
+        let target = canonical_socket_target(socket_path)?;
+        let _endpoint_lock = acquire_endpoint_lock(&target)?;
+        let staging = private_socket_staging_dir(&target)?;
+        // Keep the unpublished path no longer than a typical endpoint name;
+        // sockaddr_un has a small fixed path limit on macOS.
+        let staged_socket = staging.path().join("s");
+        let listener = std::os::unix::net::UnixListener::bind(&staged_socket)?;
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(&staged_socket, std::fs::Permissions::from_mode(0o600))?;
+        let identity = verify_socket_security(&staged_socket, rustix::process::geteuid().as_raw())?;
+        let replacing_stale = validate_stale_socket(&target)?;
+        std::fs::rename(&staged_socket, &target)?;
+        if replacing_stale {
+            debug!(socket = %target.display(), "ipc.stale_socket_replaced");
         }
-        // Stale socket files survive non-graceful shutdowns; remove first.
-        if socket_path.exists() {
-            debug!(socket = %socket_path.display(), "ipc.stale_socket_removed");
-            let _ = std::fs::remove_file(socket_path);
+        drop(staging);
+        let published_identity =
+            verify_socket_security(&target, rustix::process::geteuid().as_raw())?;
+        if published_identity != identity {
+            return Err(IpcError::InsecureSocket {
+                path: target,
+                reason: "published socket inode does not match the staged listener".to_owned(),
+            });
         }
-        let listener = UnixListener::bind(socket_path)?;
-        let _guard = SocketGuard(socket_path.to_owned());
-        // Best-effort restrict permissions to user.
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = std::fs::metadata(socket_path)?.permissions();
-            perms.set_mode(0o600);
-            if let Err(e) = std::fs::set_permissions(socket_path, perms) {
-                debug!(socket = %socket_path.display(), error = %e, "ipc.chmod_failed");
-            }
-        }
+        listener.set_nonblocking(true)?;
+        let listener = UnixListener::from_std(listener)?;
         info!(socket = %socket_path.display(), "ipc.listening");
 
         loop {
@@ -240,6 +440,20 @@ impl IpcServer {
                 accepted = listener.accept() => {
                     match accepted {
                         Ok((stream, _addr)) => {
+                            let observed_uid = match stream.peer_cred() {
+                                Ok(credential) => credential.uid(),
+                                Err(error) => {
+                                    warn!(%error, "ipc.peer_credentials_failed");
+                                    continue;
+                                }
+                            };
+                            if !peer_uid_allowed(
+                                rustix::process::geteuid().as_raw(),
+                                observed_uid,
+                            ) {
+                                warn!(observed_uid, "ipc.peer_rejected");
+                                continue;
+                            }
                             trace!("ipc.conn_accepted");
                             let me = self.clone();
                             tokio::spawn(async move {
@@ -326,6 +540,10 @@ impl IpcServer {
                 Ok(()) => Response::ok(id, Value::Null),
                 Err(e) => map_handler_err(id, e),
             },
+            "write_with_lookup" => match self.do_write_with_lookup(&req.params).await {
+                Ok(value) => Response::ok(id, value),
+                Err(error) => map_handler_err(id, error),
+            },
             "confirm_batch" => {
                 let Some(service) = self.batch_confirmation.as_ref() else {
                     return Response::err(id, -32601, "method not found: confirm_batch");
@@ -382,6 +600,31 @@ impl IpcServer {
                 Ok(v) => Response::ok(id, v),
                 Err(e) => map_petal_err(id, e),
             },
+            "machine.execute" => {
+                let Some(service) = self.machine_commands.as_ref() else {
+                    return Response::err(id, -32601, "method not found: machine.execute");
+                };
+                let command = match serde_json::from_value::<MachineCommand>(req.params.clone()) {
+                    Ok(command) => command,
+                    Err(error) => {
+                        return Response::err(id, -32602, format!("invalid params: {error}"));
+                    }
+                };
+                if serde_json::to_value(&command).expect("Machine command serializes") != req.params
+                {
+                    return Response::err(id, -32602, "invalid params: unknown fields");
+                }
+                match service.execute(command).await {
+                    Ok(value) => Response::ok(
+                        id,
+                        serde_json::to_value(value).expect("Machine command output serializes"),
+                    ),
+                    Err(error) => Response::machine_err(id, error),
+                }
+            }
+            operation if operation.starts_with("machine.") => {
+                Response::err(id, -32601, format!("method not found: {operation}"))
+            }
             other => {
                 debug!(method = %other, "ipc.dispatch.method_not_found");
                 Response::err(id, -32601, format!("method not found: {other}"))
@@ -410,6 +653,28 @@ impl IpcServer {
         self.vfs.write(&path, &bytes).await
     }
 
+    /// Serialize a VFS mutation with lookup of the identity projection it
+    /// creates. This avoids the historical client-side write-then-`latest`
+    /// race while preserving the existing VFS protocol.
+    async fn do_write_with_lookup(&self, params: &Value) -> Result<Value, HandlerError> {
+        let path = parse_path(params)?;
+        if write_path_uses_wallet_signer(&path) {
+            return Err(HandlerError::PermissionDenied);
+        }
+        let bytes = parse_write_bytes(params)?;
+        let projection_path = params
+            .get("projection_path")
+            .and_then(Value::as_str)
+            .ok_or_else(|| HandlerError::invalid("missing projection_path"))?;
+        let projection = VfsPath::parse(projection_path)
+            .map_err(|error| HandlerError::invalid(error.to_string()))?;
+        let entry = self
+            .vfs
+            .write_then_lookup(&path, &bytes, &projection)
+            .await?;
+        Ok(entry_to_json(&entry))
+    }
+
     async fn do_list(&self, params: &Value) -> Result<Value, HandlerError> {
         let path = parse_path(params)?;
         let entries = self.vfs.list(&path).await?;
@@ -425,15 +690,23 @@ impl IpcServer {
     /// `params`: `{ path, ref? }` where path is a package directory,
     /// `.petal.tar`, or trusted remote source URL.
     async fn do_petals_install(&self, params: &Value) -> Result<Value, PetalError> {
-        let path = params
-            .get("path")
-            .and_then(Value::as_str)
-            .ok_or_else(|| PetalError::vm("missing 'path'"))?;
-        if path.contains("://") || path.starts_with("git@github.com:") {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct InstallRequest {
+            path: String,
+            #[serde(rename = "ref")]
+            requested_ref: Option<String>,
+        }
+        let request: InstallRequest = serde_json::from_value(params.clone())
+            .map_err(|error| PetalError::vm(format!("invalid petals.install request: {error}")))?;
+        let remote_path = Some(request.path.as_str());
+        if remote_path
+            .is_some_and(|path| path.contains("://") || path.starts_with("git@github.com:"))
+        {
             let installer = self.petal_source_installer.clone().ok_or_else(|| {
                 PetalError::vm("trusted remote Petal installs are not enabled on this daemon")
             })?;
-            let params = params.clone();
+            let params = json!({"path": request.path, "ref": request.requested_ref});
             let mutation = self.petal_mutation.clone().lock_owned().await;
             return tokio::task::spawn_blocking(move || {
                 let _mutation = mutation;
@@ -445,25 +718,22 @@ impl IpcServer {
             })?
             .map_err(PetalError::vm);
         }
-        if params.get("ref").is_some_and(|value| !value.is_null()) {
+        if request.requested_ref.is_some() {
             return Err(PetalError::vm(
                 "--ref is only supported for trusted GitHub source installs",
             ));
         }
 
         let runner = self.petals()?.clone();
-        let path = path.to_owned();
+        let path = PathBuf::from(request.path);
+        if !path.is_absolute() {
+            return Err(PetalError::vm("local Petal install path must be absolute"));
+        }
         let bindings_by_name = self.petal_runtime_endpoints.clone();
         let mutation = self.petal_mutation.clone().lock_owned().await;
         tokio::task::spawn_blocking(move || {
             let _mutation = mutation;
-            let metadata = std::fs::metadata(&path)?;
-            let is_dir = metadata.is_dir();
-            if !is_dir && !path.ends_with(".petal.tar") {
-                return Err(PetalError::vm(
-                    "petals install only accepts Petal package directories, .petal.tar archives, or trusted GitHub source repositories",
-                ));
-            }
+            let is_dir = std::fs::metadata(&path)?.is_dir();
             let package = if is_dir {
                 bloom_petals::package::PreparedPetalPackage::from_dir(&path)?
             } else {
@@ -474,10 +744,7 @@ impl IpcServer {
                 .get(&consent.name)
                 .cloned()
                 .unwrap_or_default();
-            bloom_petals::package::apply_petal_consent_endpoint_bindings(
-                &mut consent,
-                &bindings,
-            )?;
+            bloom_petals::package::apply_petal_consent_endpoint_bindings(&mut consent, &bindings)?;
             let (result, meta, index) = if is_dir {
                 runner.store().install_petal_package_dir(&path)?
             } else {
@@ -500,22 +767,44 @@ impl IpcServer {
     /// `params`: `{ package_dir, out? }`.
     async fn do_petals_build(&self, params: &Value) -> Result<Value, PetalError> {
         self.petals()?;
-        let package_dir = params
-            .get("package_dir")
-            .and_then(Value::as_str)
-            .ok_or_else(|| PetalError::vm("missing 'package_dir'"))?;
-        let package_dir = package_dir.to_owned();
-        let out = params.get("out").and_then(Value::as_str).map(str::to_owned);
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct BuildRequest {
+            package_dir: PathBuf,
+            out: Option<PathBuf>,
+        }
+        let request: BuildRequest = serde_json::from_value(params.clone())
+            .map_err(|error| PetalError::vm(format!("invalid petals.build request: {error}")))?;
+        if !request.package_dir.is_absolute()
+            || request.out.as_ref().is_some_and(|path| !path.is_absolute())
+        {
+            return Err(PetalError::vm(
+                "Petal build package and output paths must be absolute",
+            ));
+        }
+        let package_dir = std::fs::canonicalize(&request.package_dir).map_err(|error| {
+            PetalError::vm(format!(
+                "resolve Petal package directory {}: {error}",
+                request.package_dir.display()
+            ))
+        })?;
+        let output = request
+            .out
+            .as_deref()
+            .map(|path| validated_petal_archive_output(&package_dir, path))
+            .transpose()?;
         let mutation = self.petal_mutation.clone().lock_owned().await;
         tokio::task::spawn_blocking(move || {
             let _mutation = mutation;
-            if let Some(out) = out.as_deref() {
-                reject_archive_output_inside_package(&package_dir, out)?;
-            }
             let package = bloom_petals::package::build_petal_package_dir(&package_dir)?;
             let consent = bloom_petals::package::petal_consent_summary(&package)?;
-            if let Some(out) = out.as_deref() {
-                package.write_petal_tar(std::fs::File::create(out)?)?;
+            if let Some(out) = output.as_ref() {
+                let parent = out.parent().expect("validated archive has a parent");
+                let mut archive = tempfile::NamedTempFile::new_in(parent)?;
+                package.write_petal_tar(&mut archive)?;
+                archive.flush()?;
+                archive.as_file().sync_all()?;
+                archive.persist(out).map_err(|error| error.error)?;
             }
             Ok(json!({
                 "hash": package.hash,
@@ -523,8 +812,6 @@ impl IpcServer {
                 "wit_digest": bloom_petals::package::contract_wit_digest(),
                 "petal_mount": format!("petals/{}/", package.name),
                 "routes": package.route_index.routes.len(),
-                "artifacts": format!("{package_dir}/artifacts"),
-                "archive": out,
                 "consent_lines": petal_consent_lines(&consent),
             }))
         })
@@ -644,6 +931,190 @@ impl IpcServer {
     }
 }
 
+fn peer_uid_allowed(effective_uid: u32, observed_uid: u32) -> bool {
+    effective_uid == observed_uid
+}
+
+fn canonical_socket_target(socket_path: &Path) -> Result<PathBuf, IpcError> {
+    let parent = socket_path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .ok_or_else(|| IpcError::InsecureSocket {
+            path: socket_path.to_owned(),
+            reason: "socket path has no parent directory".to_owned(),
+        })?;
+    let file_name = socket_path
+        .file_name()
+        .ok_or_else(|| IpcError::InsecureSocket {
+            path: socket_path.to_owned(),
+            reason: "socket path has no file name".to_owned(),
+        })?;
+    std::fs::create_dir_all(parent)?;
+    let canonical_parent = std::fs::canonicalize(parent)?;
+    if !std::fs::metadata(&canonical_parent)?.is_dir() {
+        return Err(IpcError::InsecureSocket {
+            path: socket_path.to_owned(),
+            reason: format!("socket parent {} is not a directory", parent.display()),
+        });
+    }
+    Ok(canonical_parent.join(file_name))
+}
+
+fn private_socket_staging_dir(socket_path: &Path) -> Result<tempfile::TempDir, IpcError> {
+    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+    let parent = socket_path
+        .parent()
+        .ok_or_else(|| IpcError::InsecureSocket {
+            path: socket_path.to_owned(),
+            reason: "socket path has no parent directory".to_owned(),
+        })?;
+    let staging = tempfile::Builder::new()
+        .prefix(".b-")
+        .permissions(std::fs::Permissions::from_mode(0o700))
+        .tempdir_in(parent)?;
+    let metadata = std::fs::symlink_metadata(staging.path())?;
+    let mode = metadata.permissions().mode() & 0o777;
+    let effective_uid = rustix::process::geteuid().as_raw();
+    if !metadata.file_type().is_dir() || metadata.uid() != effective_uid || mode != 0o700 {
+        return Err(IpcError::InsecureSocket {
+            path: socket_path.to_owned(),
+            reason: format!(
+                "private socket staging directory must have uid={effective_uid} mode=0700; observed uid={} mode={mode:04o}",
+                metadata.uid()
+            ),
+        });
+    }
+    Ok(staging)
+}
+
+fn acquire_endpoint_lock(socket_path: &Path) -> Result<EndpointLock, IpcError> {
+    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+    let lock_path = endpoint_lock_path(socket_path)?;
+    let fd = rustix::fs::open(
+        &lock_path,
+        rustix::fs::OFlags::RDWR
+            | rustix::fs::OFlags::CREATE
+            | rustix::fs::OFlags::CLOEXEC
+            | rustix::fs::OFlags::NOFOLLOW,
+        rustix::fs::Mode::RUSR | rustix::fs::Mode::WUSR,
+    )
+    .map_err(|error| std::io::Error::from_raw_os_error(error.raw_os_error()))?;
+    let file = std::fs::File::from(fd);
+    let metadata = file.metadata()?;
+    let mode = metadata.permissions().mode() & 0o777;
+    let effective_uid = rustix::process::geteuid().as_raw();
+    if !metadata.file_type().is_file() || metadata.uid() != effective_uid || mode & 0o077 != 0 {
+        return Err(IpcError::InsecureSocket {
+            path: lock_path,
+            reason: format!(
+                "endpoint lock must be a regular owner-only file with uid={effective_uid}; observed uid={} mode={mode:04o}",
+                metadata.uid()
+            ),
+        });
+    }
+    match fs2::FileExt::try_lock_exclusive(&file) {
+        Ok(()) => Ok(EndpointLock { _file: file }),
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+            Err(IpcError::EndpointBusy(socket_path.to_owned()))
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn endpoint_lock_path(socket_path: &Path) -> Result<PathBuf, IpcError> {
+    use std::os::unix::ffi::OsStringExt as _;
+
+    let file_name = socket_path
+        .file_name()
+        .ok_or_else(|| IpcError::InsecureSocket {
+            path: socket_path.to_owned(),
+            reason: "socket path has no file name".to_owned(),
+        })?;
+    let mut lock_name = file_name.as_encoded_bytes().to_vec();
+    lock_name.extend_from_slice(b".lock");
+    Ok(socket_path.with_file_name(std::ffi::OsString::from_vec(lock_name)))
+}
+
+fn validate_stale_socket(socket_path: &Path) -> Result<bool, IpcError> {
+    use std::os::unix::fs::{FileTypeExt as _, MetadataExt as _};
+
+    let metadata = match std::fs::symlink_metadata(socket_path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error.into()),
+    };
+    let effective_uid = rustix::process::geteuid().as_raw();
+    if !metadata.file_type().is_socket() || metadata.uid() != effective_uid {
+        return Err(IpcError::InsecureSocket {
+            path: socket_path.to_owned(),
+            reason: "pre-existing path is not a socket owned by the daemon user".to_owned(),
+        });
+    }
+    Ok(true)
+}
+
+fn verify_socket_security(
+    socket_path: &Path,
+    effective_uid: u32,
+) -> Result<SocketIdentity, IpcError> {
+    use std::os::unix::fs::{FileTypeExt as _, MetadataExt as _};
+
+    let metadata = std::fs::symlink_metadata(socket_path)?;
+    let mode = metadata.mode() & 0o777;
+    if !metadata.file_type().is_socket() || metadata.uid() != effective_uid || mode != 0o600 {
+        return Err(IpcError::InsecureSocket {
+            path: socket_path.to_owned(),
+            reason: format!(
+                "expected socket uid={effective_uid} mode=0600, observed uid={} mode={mode:04o}",
+                metadata.uid()
+            ),
+        });
+    }
+    Ok(SocketIdentity {
+        device: metadata.dev(),
+        inode: metadata.ino(),
+    })
+}
+
+fn validated_petal_archive_output(
+    package_dir: &Path,
+    output: &Path,
+) -> Result<PathBuf, PetalError> {
+    let parent = output
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .ok_or_else(|| PetalError::vm("Petal archive path has no parent"))?;
+    let parent = std::fs::canonicalize(parent).map_err(|error| {
+        PetalError::vm(format!(
+            "resolve Petal archive parent {}: {error}",
+            parent.display()
+        ))
+    })?;
+    let file_name = output
+        .file_name()
+        .ok_or_else(|| PetalError::vm("Petal archive path has no file name"))?;
+    let output = parent.join(file_name);
+    if output.starts_with(package_dir) {
+        return Err(PetalError::vm(
+            "--out must be outside the package directory so archives are not packaged into future builds",
+        ));
+    }
+    match std::fs::symlink_metadata(&output) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+            return Err(PetalError::vm(format!(
+                "Petal archive output {} must be a regular file and not a symlink",
+                output.display()
+            )));
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    Ok(output)
+}
+
 fn write_path_uses_wallet_signer(path: &VfsPath) -> bool {
     let segs = path.segments();
     match segs {
@@ -697,22 +1168,6 @@ fn parse_write_bytes(params: &Value) -> Result<Vec<u8>, HandlerError> {
     } else {
         Err(HandlerError::invalid("write needs bytes_b64 or text"))
     }
-}
-
-fn reject_archive_output_inside_package(package_dir: &str, out: &str) -> Result<(), PetalError> {
-    let package_dir = std::fs::canonicalize(package_dir)?;
-    let out_path = Path::new(out);
-    let out_parent = out_path
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-        .unwrap_or_else(|| Path::new("."));
-    let out_abs = std::fs::canonicalize(out_parent)?.join(out_path.file_name().unwrap_or_default());
-    if out_abs.starts_with(package_dir) {
-        return Err(PetalError::vm(
-            "--out must be outside the package directory so archives are not packaged into future builds",
-        ));
-    }
-    Ok(())
 }
 
 fn petal_consent_lines(summary: &bloom_petals::package::PetalConsentSummary) -> Vec<String> {
@@ -886,6 +1341,24 @@ pub struct IpcClient {
     socket_path: PathBuf,
 }
 
+#[derive(Debug, Error)]
+pub enum IpcClientError {
+    #[error(transparent)]
+    Transport(#[from] std::io::Error),
+    #[error("{0}")]
+    Rpc(RpcCallError),
+    #[error("invalid IPC response: {0}")]
+    Protocol(String),
+}
+
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+#[error("{message}")]
+pub struct RpcCallError {
+    pub rpc_code: i32,
+    pub message: String,
+    pub machine: Option<MachineError>,
+}
+
 impl IpcClient {
     pub fn new(socket_path: impl Into<PathBuf>) -> Self {
         Self {
@@ -897,7 +1370,7 @@ impl IpcClient {
         &self.socket_path
     }
 
-    pub async fn call(&self, method: &str, params: Value) -> std::io::Result<Value> {
+    pub async fn call(&self, method: &str, params: Value) -> Result<Value, IpcClientError> {
         trace!(socket = %self.socket_path.display(), %method, "ipc.client.call");
         let stream = UnixStream::connect(&self.socket_path).await?;
         let (rd, mut wr) = stream.into_split();
@@ -915,10 +1388,19 @@ impl IpcClient {
         let mut line = String::new();
         rd.read_line(&mut line).await?;
         let v: Value = serde_json::from_str(line.trim())
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-        if let Some(err) = v.get("error") {
-            debug!(%method, error = %err, "ipc.client.rpc_error");
-            return Err(std::io::Error::other(err.to_string()));
+            .map_err(|error| IpcClientError::Protocol(error.to_string()))?;
+        if let Some(error) = v.get("error") {
+            debug!(%method, error = %error, "ipc.client.rpc_error");
+            let error: RpcError = serde_json::from_value(error.clone())
+                .map_err(|error| IpcClientError::Protocol(error.to_string()))?;
+            let machine = error
+                .data
+                .and_then(|data| serde_json::from_value::<MachineError>(data).ok());
+            return Err(IpcClientError::Rpc(RpcCallError {
+                rpc_code: error.code,
+                message: error.message,
+                machine,
+            }));
         }
         Ok(v.get("result").cloned().unwrap_or(Value::Null))
     }
@@ -933,6 +1415,29 @@ mod tests {
     };
 
     struct MockBatchConfirmation;
+
+    struct MockMachineCommands;
+
+    struct FailingMachineCommands(MachineError);
+
+    impl MachineCommandService for MockMachineCommands {
+        fn execute(&self, command: MachineCommand) -> MachineCommandFuture<'_> {
+            Box::pin(async move {
+                Ok(MachineCommandOutput {
+                    stdout: serde_json::to_string(&command).unwrap(),
+                    stderr: String::new(),
+                    exit_code: 0,
+                })
+            })
+        }
+    }
+
+    impl MachineCommandService for FailingMachineCommands {
+        fn execute(&self, _command: MachineCommand) -> MachineCommandFuture<'_> {
+            let error = self.0.clone();
+            Box::pin(async move { Err(error) })
+        }
+    }
 
     struct TrackingSourceInstaller {
         active: AtomicUsize,
@@ -966,6 +1471,84 @@ mod tests {
     struct SingleFileHandler {
         name: String,
         body: Vec<u8>,
+    }
+
+    struct AtomicProjectionHandler {
+        latest: tokio::sync::Mutex<String>,
+        lookup_started: Notify,
+        release_lookup: Notify,
+    }
+
+    #[async_trait::async_trait]
+    impl Handler for AtomicProjectionHandler {
+        async fn lookup(&self, path: &VfsPath) -> Result<Entry, HandlerError> {
+            if path.to_string_path() != "/latest" {
+                return Err(HandlerError::NotFound(path.to_string_path()));
+            }
+            self.lookup_started.notify_one();
+            self.release_lookup.notified().await;
+            Ok(Entry::symlink("latest", &self.latest.lock().await))
+        }
+
+        async fn write(&self, _path: &VfsPath, data: &[u8]) -> Result<(), HandlerError> {
+            *self.latest.lock().await = String::from_utf8(data.to_vec()).unwrap();
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn write_with_lookup_excludes_concurrent_ordinary_ipc_write() {
+        let handler = Arc::new(AtomicProjectionHandler {
+            latest: tokio::sync::Mutex::new(String::new()),
+            lookup_started: Notify::new(),
+            release_lookup: Notify::new(),
+        });
+        let server = IpcServer::new(
+            Vfs::builder().mount("ids", handler.clone()).build(),
+            "0",
+            vec![],
+        );
+        let atomic_server = server.clone();
+        let atomic = tokio::spawn(async move {
+            atomic_server
+                .dispatch(Request {
+                    jsonrpc: "2.0".into(),
+                    id: json!(1),
+                    method: "write_with_lookup".into(),
+                    params: json!({
+                        "path": "/ids/new",
+                        "bytes_b64": B64.encode(b"atomic"),
+                        "projection_path": "/ids/latest",
+                    }),
+                })
+                .await
+        });
+        handler.lookup_started.notified().await;
+        let ordinary_server = server.clone();
+        let ordinary = tokio::spawn(async move {
+            ordinary_server
+                .dispatch(Request {
+                    jsonrpc: "2.0".into(),
+                    id: json!(2),
+                    method: "write".into(),
+                    params: json!({
+                        "path": "/ids/new",
+                        "bytes_b64": B64.encode(b"ordinary"),
+                    }),
+                })
+                .await
+        });
+        tokio::task::yield_now().await;
+        handler.release_lookup.notify_one();
+
+        let atomic_response = atomic.await.unwrap();
+        assert!(atomic_response.error.is_none());
+        assert_eq!(
+            atomic_response.result.unwrap()["link_target"],
+            json!("atomic")
+        );
+        assert!(ordinary.await.unwrap().error.is_none());
+        assert_eq!(&*handler.latest.lock().await, "ordinary");
     }
 
     impl SingleFileHandler {
@@ -1023,6 +1606,460 @@ mod tests {
                 Arc::new(SingleFileHandler::new("greet", b"hi\n".to_vec())),
             )
             .build()
+    }
+
+    #[tokio::test]
+    async fn machine_commands_are_dispatched_only_through_the_configured_daemon_service() {
+        let server =
+            IpcServer::new(vfs(), "0", vec![]).with_machine_commands(Arc::new(MockMachineCommands));
+        let response = server
+            .dispatch(Request {
+                jsonrpc: "2.0".into(),
+                id: json!(1),
+                method: "machine.execute".into(),
+                params: json!({ "command": "status" }),
+            })
+            .await;
+        assert!(response.error.is_none());
+        assert_eq!(
+            response.result.unwrap()["stdout"],
+            r#"{"command":"status"}"#
+        );
+    }
+
+    #[tokio::test]
+    async fn machine_command_contract_rejects_unknown_fields_and_method_skew() {
+        let server =
+            IpcServer::new(vfs(), "0", vec![]).with_machine_commands(Arc::new(MockMachineCommands));
+        let unknown_field = server
+            .dispatch(Request {
+                jsonrpc: "2.0".into(),
+                id: json!(1),
+                method: "machine.execute".into(),
+                params: json!({ "command": "status", "extra": true }),
+            })
+            .await;
+        assert_eq!(unknown_field.error.unwrap().code, -32602);
+
+        let retired_method = server
+            .dispatch(Request {
+                jsonrpc: "2.0".into(),
+                id: json!(2),
+                method: "machine.status".into(),
+                params: Value::Null,
+            })
+            .await;
+        assert_eq!(retired_method.error.unwrap().code, -32601);
+
+        let unknown_command = server
+            .dispatch(Request {
+                jsonrpc: "2.0".into(),
+                id: json!(3),
+                method: "machine.execute".into(),
+                params: json!({ "command": "future_command" }),
+            })
+            .await;
+        assert_eq!(unknown_command.error.unwrap().code, -32602);
+
+        let valid_outbox_action = server
+            .dispatch(Request {
+                jsonrpc: "2.0".into(),
+                id: json!(4),
+                method: "machine.execute".into(),
+                params: json!({
+                    "command": "wallet_outbox_cancel",
+                    "wallet": "minnow",
+                    "chain": "base",
+                    "id": "tx-1",
+                    "text": "approve",
+                }),
+            })
+            .await;
+        assert!(valid_outbox_action.error.is_none());
+
+        let outbox_action_with_unknown_field = server
+            .dispatch(Request {
+                jsonrpc: "2.0".into(),
+                id: json!(5),
+                method: "machine.execute".into(),
+                params: json!({
+                    "command": "wallet_outbox_replace",
+                    "wallet": "minnow",
+                    "chain": "base",
+                    "id": "tx-1",
+                    "intent": "replacement intent",
+                    "bytes_b64": "must-not-be-accepted",
+                }),
+            })
+            .await;
+        assert_eq!(outbox_action_with_unknown_field.error.unwrap().code, -32602);
+    }
+
+    #[tokio::test]
+    async fn machine_errors_preserve_typed_contract_and_rpc_code() {
+        let expected = MachineError::new(
+            MachineErrorKind::Unavailable,
+            "UNAVAILABLE",
+            "Broker is unavailable",
+        );
+        let server = IpcServer::new(vfs(), "0", vec![])
+            .with_machine_commands(Arc::new(FailingMachineCommands(expected.clone())));
+        let response = server
+            .dispatch(Request {
+                jsonrpc: "2.0".into(),
+                id: json!(1),
+                method: "machine.execute".into(),
+                params: json!({ "command": "status" }),
+            })
+            .await;
+        let error = response.error.unwrap();
+        assert_eq!(error.code, -32003);
+        assert_eq!(error.message, "Broker is unavailable");
+        assert_eq!(
+            serde_json::from_value::<MachineError>(error.data.unwrap()).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn peer_uid_policy_accepts_only_the_effective_uid() {
+        assert!(peer_uid_allowed(501, 501));
+        assert!(!peer_uid_allowed(501, 0));
+        assert!(!peer_uid_allowed(501, 502));
+    }
+
+    #[tokio::test]
+    async fn server_refuses_to_replace_a_non_socket_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("private-run");
+        std::fs::create_dir(&parent).unwrap();
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let socket = parent.join("bloom.sock");
+        std::fs::write(&socket, b"do not remove").unwrap();
+        let error = IpcServer::new(vfs(), "0", vec![])
+            .serve(&socket)
+            .await
+            .unwrap_err();
+        assert!(matches!(error, IpcError::InsecureSocket { .. }));
+        assert_eq!(std::fs::read(&socket).unwrap(), b"do not remove");
+    }
+
+    #[tokio::test]
+    async fn server_creates_a_missing_socket_parent_and_accepts_connections() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("private-run");
+        let socket = parent.join("bloom.sock");
+        let server = IpcServer::new(vfs(), "0", vec![]);
+        let serving = server.clone();
+        let serving_socket = socket.clone();
+        let handle = tokio::spawn(async move { serving.serve(&serving_socket).await.unwrap() });
+        for _ in 0..50 {
+            if socket.exists() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert_eq!(
+            IpcClient::new(&socket)
+                .call("version", Value::Null)
+                .await
+                .unwrap(),
+            "0"
+        );
+        IpcClient::new(&socket)
+            .call("shutdown", Value::Null)
+            .await
+            .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(2), handle)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            socket.exists(),
+            "shutdown leaves an inert socket for restart"
+        );
+    }
+
+    #[tokio::test]
+    async fn server_accepts_an_existing_0755_socket_parent_without_chmod() {
+        use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("shared-run");
+        std::fs::create_dir(&parent).unwrap();
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let socket = parent.join("bloom.sock");
+        let server = IpcServer::new(vfs(), "0", vec![]);
+        let serving = server.clone();
+        let serving_socket = socket.clone();
+        let handle = tokio::spawn(async move { serving.serve(&serving_socket).await.unwrap() });
+        for _ in 0..50 {
+            if socket.exists() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert_eq!(
+            IpcClient::new(&socket)
+                .call("version", Value::Null)
+                .await
+                .unwrap(),
+            "0"
+        );
+        assert_eq!(
+            std::fs::metadata(&parent).unwrap().permissions().mode() & 0o777,
+            0o755
+        );
+        let lock_metadata =
+            std::fs::symlink_metadata(endpoint_lock_path(&socket).unwrap()).unwrap();
+        assert!(lock_metadata.file_type().is_file());
+        assert_eq!(lock_metadata.uid(), rustix::process::geteuid().as_raw());
+        assert_eq!(lock_metadata.permissions().mode() & 0o077, 0);
+        assert!(
+            std::fs::read_dir(&parent).unwrap().all(|entry| !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".b-")),
+            "private staging directory must be removed after publication"
+        );
+        IpcClient::new(&socket)
+            .call("shutdown", Value::Null)
+            .await
+            .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(2), handle)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            socket.exists(),
+            "shutdown leaves an inert socket for restart"
+        );
+        std::fs::remove_file(endpoint_lock_path(&socket).unwrap()).unwrap();
+        std::fs::remove_file(&socket).unwrap();
+    }
+
+    #[tokio::test]
+    async fn atomically_published_listener_accepts_connections_in_tmp() {
+        let reserved = tempfile::Builder::new()
+            .prefix("bloom-ipc-")
+            .tempfile_in("/tmp")
+            .unwrap();
+        let socket = reserved.path().to_owned();
+        reserved.close().unwrap();
+
+        let server = IpcServer::new(vfs(), "0", vec![]);
+        let serving = server.clone();
+        let serving_socket = socket.clone();
+        let handle = tokio::spawn(async move { serving.serve(&serving_socket).await.unwrap() });
+        for _ in 0..50 {
+            if socket.exists() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert_eq!(
+            IpcClient::new(&socket)
+                .call("version", Value::Null)
+                .await
+                .unwrap(),
+            "0"
+        );
+        IpcClient::new(&socket)
+            .call("shutdown", Value::Null)
+            .await
+            .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(2), handle)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            socket.exists(),
+            "shutdown leaves an inert socket for restart"
+        );
+        std::fs::remove_file(endpoint_lock_path(&socket).unwrap()).unwrap();
+        std::fs::remove_file(&socket).unwrap();
+    }
+
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn atomically_published_listener_accepts_connections_in_nested_private_tmp() {
+        let home = tempfile::Builder::new()
+            .prefix("bloom-ipc-home-")
+            .tempdir_in("/private/tmp")
+            .unwrap();
+        let socket = home.path().join("run/bloom.sock");
+        let server = IpcServer::new(vfs(), "0", vec![]);
+        let serving = server.clone();
+        let serving_socket = socket.clone();
+        let handle = tokio::spawn(async move { serving.serve(&serving_socket).await.unwrap() });
+        for _ in 0..50 {
+            if socket.exists() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert_eq!(
+            IpcClient::new(&socket)
+                .call("version", Value::Null)
+                .await
+                .unwrap(),
+            "0"
+        );
+        IpcClient::new(&socket)
+            .call("shutdown", Value::Null)
+            .await
+            .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(2), handle)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            socket.exists(),
+            "shutdown leaves an inert socket for restart"
+        );
+    }
+
+    #[tokio::test]
+    async fn restart_atomically_replaces_the_stale_socket_and_accepts_connections() {
+        use std::os::unix::fs::MetadataExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("bloom.sock");
+        let first = IpcServer::new(vfs(), "first", vec![]);
+        let serving = first.clone();
+        let serving_socket = socket.clone();
+        let first_handle =
+            tokio::spawn(async move { serving.serve(&serving_socket).await.unwrap() });
+        for _ in 0..50 {
+            if socket.exists() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        let first_inode = std::fs::symlink_metadata(&socket).unwrap().ino();
+        IpcClient::new(&socket)
+            .call("shutdown", Value::Null)
+            .await
+            .unwrap();
+        first_handle.await.unwrap();
+        assert_eq!(
+            std::fs::symlink_metadata(&socket).unwrap().ino(),
+            first_inode
+        );
+
+        let second = IpcServer::new(vfs(), "second", vec![]);
+        let serving = second.clone();
+        let serving_socket = socket.clone();
+        let second_handle =
+            tokio::spawn(async move { serving.serve(&serving_socket).await.unwrap() });
+        for _ in 0..50 {
+            if std::fs::symlink_metadata(&socket)
+                .map(|metadata| metadata.ino() != first_inode)
+                .unwrap_or(false)
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert_ne!(
+            std::fs::symlink_metadata(&socket).unwrap().ino(),
+            first_inode
+        );
+        assert_eq!(
+            IpcClient::new(&socket)
+                .call("version", Value::Null)
+                .await
+                .unwrap(),
+            "second"
+        );
+        IpcClient::new(&socket)
+            .call("shutdown", Value::Null)
+            .await
+            .unwrap();
+        second_handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn concurrent_server_cannot_replace_the_live_endpoint() {
+        use std::os::unix::fs::MetadataExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("bloom.sock");
+        let first = IpcServer::new(vfs(), "first", vec![]);
+        let serving = first.clone();
+        let serving_socket = socket.clone();
+        let first_handle =
+            tokio::spawn(async move { serving.serve(&serving_socket).await.unwrap() });
+        for _ in 0..50 {
+            if socket.exists() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        let first_inode = std::fs::symlink_metadata(&socket).unwrap().ino();
+
+        let second = IpcServer::new(vfs(), "second", vec![]);
+        let serving = second.clone();
+        let serving_socket = socket.clone();
+        let second_handle = tokio::spawn(async move { serving.serve(&serving_socket).await });
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert!(
+            second_handle.is_finished(),
+            "lock conflict must fail promptly"
+        );
+        let second_result = second_handle.await.unwrap();
+        assert!(
+            matches!(&second_result, Err(IpcError::EndpointBusy(_))),
+            "unexpected second server result: {second_result:?}"
+        );
+        assert_eq!(
+            std::fs::symlink_metadata(&socket).unwrap().ino(),
+            first_inode
+        );
+        assert_eq!(
+            IpcClient::new(&socket)
+                .call("version", Value::Null)
+                .await
+                .unwrap(),
+            "first"
+        );
+        IpcClient::new(&socket)
+            .call("shutdown", Value::Null)
+            .await
+            .unwrap();
+        first_handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn shutdown_never_unlinks_a_replacement_endpoint_inode() {
+        use std::os::unix::fs::MetadataExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("bloom.sock");
+        let server = IpcServer::new(vfs(), "old", vec![]);
+        let serving = server.clone();
+        let serving_socket = socket.clone();
+        let handle = tokio::spawn(async move { serving.serve(&serving_socket).await.unwrap() });
+        for _ in 0..50 {
+            if socket.exists() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+
+        let replacement_path = dir.path().join("replacement.sock");
+        let replacement = std::os::unix::net::UnixListener::bind(&replacement_path).unwrap();
+        let replacement_inode = std::fs::symlink_metadata(&replacement_path).unwrap().ino();
+        std::fs::rename(&replacement_path, &socket).unwrap();
+        server.trigger_shutdown();
+        handle.await.unwrap();
+        assert_eq!(
+            std::fs::symlink_metadata(&socket).unwrap().ino(),
+            replacement_inode
+        );
+        drop(replacement);
     }
 
     fn write_demo_petal_package(root: &Path) {
@@ -1084,6 +2121,27 @@ summary = "Demo app used by IPC tests."
         ] {
             let p = VfsPath::parse(path).unwrap();
             assert!(write_path_uses_wallet_signer(&p), "{path}");
+        }
+    }
+
+    #[tokio::test]
+    async fn raw_ipc_write_cannot_invoke_wallet_cancel_or_replace() {
+        let server = IpcServer::new(vfs(), "0", vec![]);
+        for (id, action) in ["cancel", "replace"].into_iter().enumerate() {
+            let response = server
+                .dispatch(Request {
+                    jsonrpc: "2.0".into(),
+                    id: json!(id),
+                    method: "write".into(),
+                    params: json!({
+                        "path": format!(
+                            "/wallets/minnow/chains/base/outbox/pending/tx-1/{action}"
+                        ),
+                        "bytes_b64": B64.encode(b"body"),
+                    }),
+                })
+                .await;
+            assert_eq!(response.error.unwrap().code, -32007, "{action}");
         }
     }
 
@@ -1158,7 +2216,8 @@ summary = "Demo app used by IPC tests."
         let package = dir.path().join("demo-package");
         let archive = dir.path().join("demo.petal.tar");
         write_demo_petal_package(&package);
-
+        std::fs::create_dir(package.join("artifacts")).unwrap();
+        std::fs::write(package.join("artifacts/keep.txt"), b"preserve").unwrap();
         let store = bloom_petals::PetalStore::open(dir.path().join("store")).unwrap();
         let registry =
             Arc::new(bloom_petals::NameRegistry::open(dir.path().join("registry")).unwrap());
@@ -1171,21 +2230,26 @@ summary = "Demo app used by IPC tests."
                 id: json!(1),
                 method: "petals.build".into(),
                 params: json!({
-                    "package_dir": package,
-                    "out": archive,
+                    "package_dir": package.display().to_string(),
+                    "out": archive.display().to_string(),
                 }),
             })
             .await;
         assert!(build.error.is_none());
-        assert_eq!(build.result.unwrap()["routes"], 1);
+        let build = build.result.unwrap();
+        assert_eq!(build["routes"], 1);
         assert!(archive.is_file());
+        assert_eq!(
+            std::fs::read(package.join("artifacts/keep.txt")).unwrap(),
+            b"preserve"
+        );
 
         let install = server
             .dispatch(Request {
                 jsonrpc: "2.0".into(),
                 id: json!(2),
                 method: "petals.install".into(),
-                params: json!({ "path": archive }),
+                params: json!({ "path": archive.display().to_string() }),
             })
             .await;
         assert!(install.error.is_none());
@@ -1193,6 +2257,126 @@ summary = "Demo app used by IPC tests."
         assert_eq!(result["mode"], "petal");
         assert_eq!(result["petal_mount"], "petals/demo/");
         assert_eq!(result["routes"], 1);
+    }
+
+    #[tokio::test]
+    async fn petals_build_rpc_rejects_archive_inside_package() {
+        let dir = tempfile::tempdir().unwrap();
+        let package = dir.path().join("demo-package");
+        write_demo_petal_package(&package);
+        let store = bloom_petals::PetalStore::open(dir.path().join("store")).unwrap();
+        let registry =
+            Arc::new(bloom_petals::NameRegistry::open(dir.path().join("registry")).unwrap());
+        let runner = PetalRunner::new(store, registry, bloom_petals::PetalVm::new().unwrap());
+        let response = IpcServer::new(vfs(), "0", vec![])
+            .with_petals(runner)
+            .dispatch(Request {
+                jsonrpc: "2.0".into(),
+                id: json!(1),
+                method: "petals.build".into(),
+                params: json!({
+                    "package_dir": package.display().to_string(),
+                    "out": package.join("archive.petal.tar").display().to_string(),
+                }),
+            })
+            .await;
+        let error = response.error.unwrap();
+        assert!(error.message.contains("outside the package directory"));
+        assert!(!package.join("archive.petal.tar").exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn petals_build_rpc_rejects_symlink_archive_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let package = dir.path().join("demo-package");
+        let target = dir.path().join("target.petal.tar");
+        let output = dir.path().join("output.petal.tar");
+        write_demo_petal_package(&package);
+        std::fs::write(&target, b"sentinel").unwrap();
+        std::os::unix::fs::symlink(&target, &output).unwrap();
+        let store = bloom_petals::PetalStore::open(dir.path().join("store")).unwrap();
+        let registry =
+            Arc::new(bloom_petals::NameRegistry::open(dir.path().join("registry")).unwrap());
+        let runner = PetalRunner::new(store, registry, bloom_petals::PetalVm::new().unwrap());
+        let response = IpcServer::new(vfs(), "0", vec![])
+            .with_petals(runner)
+            .dispatch(Request {
+                jsonrpc: "2.0".into(),
+                id: json!(1),
+                method: "petals.build".into(),
+                params: json!({
+                    "package_dir": package.display().to_string(),
+                    "out": output.display().to_string(),
+                }),
+            })
+            .await;
+        assert!(response.error.unwrap().message.contains("not a symlink"));
+        assert_eq!(std::fs::read(target).unwrap(), b"sentinel");
+    }
+
+    #[tokio::test]
+    async fn petals_build_rpc_rejects_non_regular_archive_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let package = dir.path().join("demo-package");
+        let output = dir.path().join("archive-directory");
+        write_demo_petal_package(&package);
+        std::fs::create_dir(&output).unwrap();
+        let store = bloom_petals::PetalStore::open(dir.path().join("store")).unwrap();
+        let registry =
+            Arc::new(bloom_petals::NameRegistry::open(dir.path().join("registry")).unwrap());
+        let runner = PetalRunner::new(store, registry, bloom_petals::PetalVm::new().unwrap());
+        let response = IpcServer::new(vfs(), "0", vec![])
+            .with_petals(runner)
+            .dispatch(Request {
+                jsonrpc: "2.0".into(),
+                id: json!(1),
+                method: "petals.build".into(),
+                params: json!({
+                    "package_dir": package.display().to_string(),
+                    "out": output.display().to_string(),
+                }),
+            })
+            .await;
+        assert!(
+            response
+                .error
+                .unwrap()
+                .message
+                .contains("must be a regular file")
+        );
+        assert!(output.is_dir());
+    }
+
+    #[tokio::test]
+    async fn concurrent_builds_of_the_same_package_are_serialized() {
+        let dir = tempfile::tempdir().unwrap();
+        let package = dir.path().join("demo-package");
+        write_demo_petal_package(&package);
+        let store = bloom_petals::PetalStore::open(dir.path().join("store")).unwrap();
+        let registry =
+            Arc::new(bloom_petals::NameRegistry::open(dir.path().join("registry")).unwrap());
+        let runner = PetalRunner::new(store, registry, bloom_petals::PetalVm::new().unwrap());
+        let server = IpcServer::new(vfs(), "0", vec![]).with_petals(runner);
+        let params = json!({"package_dir": package.display().to_string(), "out": null});
+        let first = server.dispatch(Request {
+            jsonrpc: "2.0".into(),
+            id: json!(1),
+            method: "petals.build".into(),
+            params: params.clone(),
+        });
+        let second = server.dispatch(Request {
+            jsonrpc: "2.0".into(),
+            id: json!(2),
+            method: "petals.build".into(),
+            params,
+        });
+
+        let (first, second) = tokio::join!(first, second);
+        assert!(first.error.is_none(), "{:?}", first.error);
+        assert!(second.error.is_none(), "{:?}", second.error);
+        assert!(package.join("artifacts/routes/r000001.wasm").is_file());
+        assert!(package.join("artifacts/build-manifest.json").is_file());
     }
 
     #[tokio::test]
@@ -1259,7 +2443,7 @@ summary = "Demo app used by IPC tests."
     #[tokio::test]
     async fn end_to_end_over_uds() {
         let dir = tempfile::tempdir().unwrap();
-        let sock = dir.path().join("bloom.sock");
+        let sock = dir.path().join("private-run/bloom.sock");
         let server = IpcServer::new(vfs(), "0.0.0-test", vec!["ethereum".into()]);
         let server2 = server.clone();
         let sock2 = sock.clone();
@@ -1273,6 +2457,13 @@ summary = "Demo app used by IPC tests."
                 break;
             }
             tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+            let metadata = std::fs::symlink_metadata(&sock).unwrap();
+            assert_eq!(metadata.uid(), rustix::process::geteuid().as_raw());
+            assert_eq!(metadata.permissions().mode() & 0o777, 0o600);
         }
         let client = IpcClient::new(&sock);
 
@@ -1297,9 +2488,45 @@ summary = "Demo app used by IPC tests."
     }
 
     #[tokio::test]
+    async fn client_decodes_machine_rpc_errors_without_json_wrappers() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("private-run/bloom.sock");
+        let expected = MachineError::new(
+            MachineErrorKind::InvalidParams,
+            "INVALID_ARGUMENT",
+            "wallet name is invalid",
+        );
+        let server = IpcServer::new(vfs(), "0", vec![])
+            .with_machine_commands(Arc::new(FailingMachineCommands(expected.clone())));
+        let serving = server.clone();
+        let serving_socket = sock.clone();
+        let handle = tokio::spawn(async move { serving.serve(&serving_socket).await.unwrap() });
+        for _ in 0..50 {
+            if sock.exists() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+
+        let error = IpcClient::new(&sock)
+            .call("machine.execute", json!({ "command": "status" }))
+            .await
+            .unwrap_err();
+        let IpcClientError::Rpc(error) = error else {
+            panic!("expected decoded RPC error");
+        };
+        assert_eq!(error.to_string(), "wallet name is invalid");
+        assert_eq!(error.rpc_code, -32602);
+        assert_eq!(error.machine, Some(expected));
+
+        server.trigger_shutdown();
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
+    }
+
+    #[tokio::test]
     async fn unknown_and_retired_secret_methods_return_minus_32601() {
         let dir = tempfile::tempdir().unwrap();
-        let sock = dir.path().join("bloom.sock");
+        let sock = dir.path().join("private-run/bloom.sock");
         let server = IpcServer::new(vfs(), "0", vec![]);
         let server2 = server.clone();
         let sock2 = sock.clone();

--- a/crates/bloom-daemon/src/ipc.rs
+++ b/crates/bloom-daemon/src/ipc.rs
@@ -25,7 +25,9 @@
 //!
 //! Wire framing is one JSON document per line. Encoding/decoding errors
 //! produce a JSON-RPC `-32700` parse-error response and the connection
-//! continues. Unknown methods produce `-32601`.
+//! continues. Unknown methods produce `-32601`. Every request and response
+//! carries a `bloom_protocol` range; peers fail closed when the ranges do not
+//! overlap.
 
 use std::collections::BTreeMap;
 use std::future::Future;
@@ -51,6 +53,57 @@ use tracing::{debug, info, trace, warn};
 /// Source-build output is capped well below this so successful diagnostic
 /// responses still leave room for package metadata and JSON encoding.
 const MAX_IPC_FRAME_BYTES: usize = 4 * 1024 * 1024;
+
+/// Current Bloom CLI-to-daemon IPC protocol and the range this build can
+/// decode. Package versions are diagnostic; this range is the compatibility
+/// contract enforced on every request and response.
+pub const IPC_PROTOCOL_CURRENT: u32 = 1;
+pub const IPC_PROTOCOL_MIN_SUPPORTED: u32 = 1;
+pub const IPC_PROTOCOL_MAX_SUPPORTED: u32 = IPC_PROTOCOL_CURRENT;
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct IpcProtocolRange {
+    pub current: u32,
+    pub min: u32,
+    pub max: u32,
+}
+
+impl IpcProtocolRange {
+    pub const fn supported() -> Self {
+        Self {
+            current: IPC_PROTOCOL_CURRENT,
+            min: IPC_PROTOCOL_MIN_SUPPORTED,
+            max: IPC_PROTOCOL_MAX_SUPPORTED,
+        }
+    }
+
+    fn is_valid(self) -> bool {
+        self.min <= self.current && self.current <= self.max
+    }
+
+    pub fn negotiate(self, peer: Self) -> Option<u32> {
+        if !self.is_valid() || !peer.is_valid() {
+            return None;
+        }
+        let minimum = self.min.max(peer.min);
+        let maximum = self.max.min(peer.max);
+        (minimum <= maximum).then_some(maximum)
+    }
+}
+
+impl std::fmt::Display for IpcProtocolRange {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.min == self.max {
+            write!(f, "{}", self.current)
+        } else {
+            write!(
+                f,
+                "{} (supported {}..={})",
+                self.current, self.min, self.max
+            )
+        }
+    }
+}
 
 async fn read_bounded_frame<R>(reader: &mut R) -> std::io::Result<Option<Vec<u8>>>
 where
@@ -124,10 +177,19 @@ struct Request {
     params: Value,
 }
 
+#[derive(Debug, Deserialize)]
+struct WireRequest {
+    #[serde(flatten)]
+    request: Request,
+    #[serde(default)]
+    bloom_protocol: Option<IpcProtocolRange>,
+}
+
 #[derive(Debug, Serialize)]
 struct Response {
     jsonrpc: &'static str,
     id: Value,
+    bloom_protocol: IpcProtocolRange,
     #[serde(skip_serializing_if = "Option::is_none")]
     result: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -191,6 +253,7 @@ impl Response {
         Self {
             jsonrpc: "2.0",
             id,
+            bloom_protocol: IpcProtocolRange::supported(),
             result: Some(result),
             error: None,
         }
@@ -199,6 +262,7 @@ impl Response {
         Self {
             jsonrpc: "2.0",
             id,
+            bloom_protocol: IpcProtocolRange::supported(),
             result: None,
             error: Some(RpcError {
                 code,
@@ -212,6 +276,7 @@ impl Response {
         Self {
             jsonrpc: "2.0",
             id,
+            bloom_protocol: IpcProtocolRange::supported(),
             result: None,
             error: Some(RpcError {
                 code: error.rpc_code(),
@@ -521,10 +586,27 @@ impl IpcServer {
             if line.iter().all(u8::is_ascii_whitespace) {
                 continue;
             }
-            let resp = match serde_json::from_slice::<Request>(&line) {
-                Ok(req) => {
-                    trace!(method = %req.method, "ipc.request");
-                    self.dispatch(req).await
+            let resp = match serde_json::from_slice::<WireRequest>(&line) {
+                Ok(wire) => {
+                    trace!(method = %wire.request.method, "ipc.request");
+                    match wire.bloom_protocol {
+                        Some(peer) if IpcProtocolRange::supported().negotiate(peer).is_some() => {
+                            self.dispatch(wire.request).await
+                        }
+                        Some(peer) => Response::err(
+                            wire.request.id,
+                            -32010,
+                            format!(
+                                "incompatible Bloom IPC protocol: daemon supports {}, client supports {peer}",
+                                IpcProtocolRange::supported()
+                            ),
+                        ),
+                        None => Response::err(
+                            wire.request.id,
+                            -32010,
+                            "missing Bloom IPC protocol metadata; upgrade the CLI and daemon together",
+                        ),
+                    }
                 }
                 Err(e) => {
                     debug!(error = %e, "ipc.parse_error");
@@ -1389,6 +1471,18 @@ pub enum IpcClientError {
     Rpc(RpcCallError),
     #[error("invalid IPC response: {0}")]
     Protocol(String),
+    #[error("incompatible Bloom IPC protocol: client supports {client}, daemon supports {daemon}")]
+    Incompatible {
+        client: IpcProtocolRange,
+        daemon: IpcProtocolRange,
+    },
+}
+
+#[derive(Debug)]
+pub struct IpcCallResult {
+    pub result: Value,
+    pub daemon_protocol: IpcProtocolRange,
+    pub negotiated_protocol: u32,
 }
 
 #[derive(Clone, Debug, Eq, Error, PartialEq)]
@@ -1411,12 +1505,22 @@ impl IpcClient {
     }
 
     pub async fn call(&self, method: &str, params: Value) -> Result<Value, IpcClientError> {
+        Ok(self.call_with_protocol(method, params).await?.result)
+    }
+
+    pub async fn call_with_protocol(
+        &self,
+        method: &str,
+        params: Value,
+    ) -> Result<IpcCallResult, IpcClientError> {
         trace!(socket = %self.socket_path.display(), %method, "ipc.client.call");
+        let client_protocol = IpcProtocolRange::supported();
         let req = json!({
             "jsonrpc": "2.0",
             "id": 1,
             "method": method,
             "params": params,
+            "bloom_protocol": client_protocol,
         });
         let mut out = serde_json::to_vec(&req).unwrap();
         if out.len() > MAX_IPC_FRAME_BYTES {
@@ -1435,6 +1539,26 @@ impl IpcClient {
         })?;
         let v: Value = serde_json::from_slice(&line)
             .map_err(|error| IpcClientError::Protocol(error.to_string()))?;
+        let daemon_protocol = v
+            .get("bloom_protocol")
+            .cloned()
+            .ok_or_else(|| {
+                IpcClientError::Protocol(
+                    "daemon does not advertise a Bloom IPC protocol version; upgrade or restart the daemon"
+                        .to_owned(),
+                )
+            })
+            .and_then(|value| {
+                serde_json::from_value::<IpcProtocolRange>(value)
+                    .map_err(|error| IpcClientError::Protocol(error.to_string()))
+            })?;
+        let negotiated_protocol =
+            client_protocol
+                .negotiate(daemon_protocol)
+                .ok_or(IpcClientError::Incompatible {
+                    client: client_protocol,
+                    daemon: daemon_protocol,
+                })?;
         if let Some(error) = v.get("error") {
             debug!(%method, error = %error, "ipc.client.rpc_error");
             let error: RpcError = serde_json::from_value(error.clone())
@@ -1448,7 +1572,11 @@ impl IpcClient {
                 machine,
             }));
         }
-        Ok(v.get("result").cloned().unwrap_or(Value::Null))
+        Ok(IpcCallResult {
+            result: v.get("result").cloned().unwrap_or(Value::Null),
+            daemon_protocol,
+            negotiated_protocol,
+        })
     }
 }
 
@@ -1469,6 +1597,27 @@ mod tests {
         assert!(error.to_string().contains("IPC frame exceeds"));
     }
 
+    #[test]
+    fn protocol_ranges_negotiate_the_highest_shared_version() {
+        let local = IpcProtocolRange {
+            current: 3,
+            min: 1,
+            max: 3,
+        };
+        let overlapping = IpcProtocolRange {
+            current: 4,
+            min: 2,
+            max: 4,
+        };
+        let disjoint = IpcProtocolRange {
+            current: 5,
+            min: 4,
+            max: 5,
+        };
+        assert_eq!(local.negotiate(overlapping), Some(3));
+        assert_eq!(local.negotiate(disjoint), None);
+    }
+
     #[tokio::test]
     async fn client_rejects_oversized_request_before_connecting() {
         let client = IpcClient::new("/definitely/missing/bloom.sock");
@@ -1481,6 +1630,31 @@ mod tests {
             .unwrap_err();
         assert!(matches!(error, IpcClientError::Protocol(_)));
         assert!(error.to_string().contains("IPC request exceeds"));
+    }
+
+    #[tokio::test]
+    async fn client_rejects_a_daemon_that_does_not_advertise_its_protocol() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("legacy.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let legacy_daemon = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (rd, mut wr) = stream.into_split();
+            let mut rd = BufReader::new(rd);
+            let mut request = String::new();
+            rd.read_line(&mut request).await.unwrap();
+            wr.write_all(b"{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"0.0.0-old\"}\n")
+                .await
+                .unwrap();
+        });
+
+        let error = IpcClient::new(&socket)
+            .call("version", Value::Null)
+            .await
+            .unwrap_err();
+        assert!(matches!(error, IpcClientError::Protocol(_)));
+        assert!(error.to_string().contains("does not advertise"));
+        legacy_daemon.await.unwrap();
     }
 
     struct MockBatchConfirmation;
@@ -2536,8 +2710,13 @@ summary = "Demo app used by IPC tests."
         }
         let client = IpcClient::new(&sock);
 
-        let v = client.call("version", Value::Null).await.unwrap();
-        assert_eq!(v.as_str().unwrap(), "0.0.0-test");
+        let version = client
+            .call_with_protocol("version", Value::Null)
+            .await
+            .unwrap();
+        assert_eq!(version.result.as_str().unwrap(), "0.0.0-test");
+        assert_eq!(version.daemon_protocol, IpcProtocolRange::supported());
+        assert_eq!(version.negotiated_protocol, IPC_PROTOCOL_CURRENT);
 
         let chains = client.call("chains", Value::Null).await.unwrap();
         assert_eq!(chains[0], "ethereum");
@@ -2611,6 +2790,29 @@ summary = "Demo app used by IPC tests."
         let stream = UnixStream::connect(&sock).await.unwrap();
         let (rd, mut wr) = stream.into_split();
         let mut rd = BufReader::new(rd);
+
+        for bloom_protocol in [None, Some(json!({"current": 2, "min": 2, "max": 2}))] {
+            let mut request = json!({
+                "jsonrpc": "2.0",
+                "id": "incompatible",
+                "method": "version",
+                "params": null,
+            });
+            if let Some(protocol) = bloom_protocol {
+                request["bloom_protocol"] = protocol;
+            }
+            wr.write_all(serde_json::to_string(&request).unwrap().as_bytes())
+                .await
+                .unwrap();
+            wr.write_all(b"\n").await.unwrap();
+            wr.flush().await.unwrap();
+            let mut line = String::new();
+            rd.read_line(&mut line).await.unwrap();
+            let response: Value = serde_json::from_str(line.trim()).unwrap();
+            assert_eq!(response["error"]["code"], -32010);
+            assert_eq!(response["bloom_protocol"]["current"], IPC_PROTOCOL_CURRENT);
+        }
+
         for (id, method) in ["nope", "write_unlocked", "wallet.sign_policy"]
             .into_iter()
             .enumerate()
@@ -2619,7 +2821,8 @@ summary = "Demo app used by IPC tests."
                 "jsonrpc": "2.0",
                 "id": id,
                 "method": method,
-                "params": {}
+                "params": {},
+                "bloom_protocol": IpcProtocolRange::supported(),
             });
             wr.write_all(serde_json::to_string(&request).unwrap().as_bytes())
                 .await

--- a/crates/bloom-daemon/src/ipc.rs
+++ b/crates/bloom-daemon/src/ipc.rs
@@ -15,12 +15,17 @@
 //! | `version`  | `null`                                | `"x.y.z"`                 |
 //! | `chains`   | `null`                                | `[ "ethereum", ... ]`     |
 //! | `confirm_batch` | `{ "wallet", "txs", "text" }` | batch result              |
+//! | `petals.install` | `{ "path", "ref"? }`             | package metadata          |
+//! | `petals.build` | `{ "package_dir", "out"? }`       | package metadata          |
+//! | `petals.list` | `null`                              | `[ package, ... ]`        |
+//! | `petals.uninstall` | `{ "hash" }`                   | `{ "removed" }`          |
 //! | `shutdown` | `null`                                | `null`                    |
 //!
 //! Wire framing is one JSON document per line. Encoding/decoding errors
 //! produce a JSON-RPC `-32700` parse-error response and the connection
 //! continues. Unknown methods produce `-32601`.
 
+use std::collections::BTreeMap;
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
@@ -131,6 +136,13 @@ pub trait BatchConfirmationService: Send + Sync {
     fn confirm_batch<'a>(&'a self, request: BatchConfirmIpcRequest) -> BatchConfirmFuture<'a>;
 }
 
+/// Narrow seam for trusted remote-source installs. Local package install,
+/// build, list, and uninstall stay implemented by the IPC server against its
+/// daemon-owned [`PetalRunner`].
+pub trait PetalSourceInstallService: Send + Sync {
+    fn install_source(&self, params: Value) -> Result<Value, String>;
+}
+
 /// Server context. Cloning is cheap (Arc-shared).
 #[derive(Clone)]
 pub struct IpcServer {
@@ -138,6 +150,9 @@ pub struct IpcServer {
     pub version: String,
     pub chains: Vec<String>,
     petals: Option<PetalRunner>,
+    petal_runtime_endpoints: BTreeMap<String, BTreeMap<String, String>>,
+    petal_source_installer: Option<Arc<dyn PetalSourceInstallService>>,
+    petal_mutation: Arc<tokio::sync::Mutex<()>>,
     batch_confirmation: Option<Arc<dyn BatchConfirmationService>>,
     shutdown: Arc<Notify>,
 }
@@ -149,6 +164,9 @@ impl IpcServer {
             version: version.into(),
             chains,
             petals: None,
+            petal_runtime_endpoints: BTreeMap::new(),
+            petal_source_installer: None,
+            petal_mutation: Arc::new(tokio::sync::Mutex::new(())),
             batch_confirmation: None,
             shutdown: Arc::new(Notify::new()),
         }
@@ -158,6 +176,22 @@ impl IpcServer {
     /// `-32601 method not found`.
     pub fn with_petals(mut self, runner: PetalRunner) -> Self {
         self.petals = Some(runner);
+        self
+    }
+
+    pub fn with_petal_runtime_endpoints(
+        mut self,
+        endpoints: BTreeMap<String, BTreeMap<String, String>>,
+    ) -> Self {
+        self.petal_runtime_endpoints = endpoints;
+        self
+    }
+
+    pub fn with_petal_source_installer(
+        mut self,
+        installer: Arc<dyn PetalSourceInstallService>,
+    ) -> Self {
+        self.petal_source_installer = Some(installer);
         self
     }
 
@@ -324,6 +358,10 @@ impl IpcServer {
                 Ok(v) => Response::ok(id, v),
                 Err(e) => map_petal_err(id, e),
             },
+            "petals.build" => match self.do_petals_build(&req.params).await {
+                Ok(v) => Response::ok(id, v),
+                Err(e) => map_petal_err(id, e),
+            },
             "petals.run" => match self.do_petals_run(&req.params).await {
                 Ok(v) => Response::ok(id, v),
                 Err(e) => map_petal_err(id, e),
@@ -384,12 +422,114 @@ impl IpcServer {
             .ok_or_else(|| PetalError::vm("petals not enabled on this daemon"))
     }
 
-    /// `params`: `{ bytes_b64? | text?, name?, caps?: ["vfs.read","vfs.write"] }`.
-    /// Either `bytes_b64` (raw wasm or WAT) or `text` (WAT only) must be set.
-    async fn do_petals_install(&self, _params: &Value) -> Result<Value, PetalError> {
-        Err(PetalError::vm(
-            "raw petal IPC install is unsupported; use `bloom petals install <package-dir|.petal.tar|github-url>`",
-        ))
+    /// `params`: `{ path, ref? }` where path is a package directory,
+    /// `.petal.tar`, or trusted remote source URL.
+    async fn do_petals_install(&self, params: &Value) -> Result<Value, PetalError> {
+        let path = params
+            .get("path")
+            .and_then(Value::as_str)
+            .ok_or_else(|| PetalError::vm("missing 'path'"))?;
+        if path.contains("://") || path.starts_with("git@github.com:") {
+            let installer = self.petal_source_installer.clone().ok_or_else(|| {
+                PetalError::vm("trusted remote Petal installs are not enabled on this daemon")
+            })?;
+            let params = params.clone();
+            let mutation = self.petal_mutation.clone().lock_owned().await;
+            return tokio::task::spawn_blocking(move || {
+                let _mutation = mutation;
+                installer.install_source(params)
+            })
+            .await
+            .map_err(|error| {
+                PetalError::vm(format!("petal source install worker failed: {error}"))
+            })?
+            .map_err(PetalError::vm);
+        }
+        if params.get("ref").is_some_and(|value| !value.is_null()) {
+            return Err(PetalError::vm(
+                "--ref is only supported for trusted GitHub source installs",
+            ));
+        }
+
+        let runner = self.petals()?.clone();
+        let path = path.to_owned();
+        let bindings_by_name = self.petal_runtime_endpoints.clone();
+        let mutation = self.petal_mutation.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || {
+            let _mutation = mutation;
+            let metadata = std::fs::metadata(&path)?;
+            let is_dir = metadata.is_dir();
+            if !is_dir && !path.ends_with(".petal.tar") {
+                return Err(PetalError::vm(
+                    "petals install only accepts Petal package directories, .petal.tar archives, or trusted GitHub source repositories",
+                ));
+            }
+            let package = if is_dir {
+                bloom_petals::package::PreparedPetalPackage::from_dir(&path)?
+            } else {
+                bloom_petals::package::PreparedPetalPackage::from_petal_tar(&path)?
+            };
+            let mut consent = bloom_petals::package::petal_consent_summary(&package)?;
+            let bindings = bindings_by_name
+                .get(&consent.name)
+                .cloned()
+                .unwrap_or_default();
+            bloom_petals::package::apply_petal_consent_endpoint_bindings(
+                &mut consent,
+                &bindings,
+            )?;
+            let (result, meta, index) = if is_dir {
+                runner.store().install_petal_package_dir(&path)?
+            } else {
+                runner.store().install_petal_package_tar(&path)?
+            };
+            Ok(json!({
+                "hash": result.hash,
+                "mode": "petal",
+                "size": result.size,
+                "already_present": result.already_present,
+                "petal_mount": meta.petal.as_ref().map(|petal| format!("petals/{}/", petal.name)),
+                "routes": index.routes.len(),
+                "consent_lines": petal_consent_lines(&consent),
+            }))
+        })
+        .await
+        .map_err(|error| PetalError::vm(format!("petal install worker failed: {error}")))?
+    }
+
+    /// `params`: `{ package_dir, out? }`.
+    async fn do_petals_build(&self, params: &Value) -> Result<Value, PetalError> {
+        self.petals()?;
+        let package_dir = params
+            .get("package_dir")
+            .and_then(Value::as_str)
+            .ok_or_else(|| PetalError::vm("missing 'package_dir'"))?;
+        let package_dir = package_dir.to_owned();
+        let out = params.get("out").and_then(Value::as_str).map(str::to_owned);
+        let mutation = self.petal_mutation.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || {
+            let _mutation = mutation;
+            if let Some(out) = out.as_deref() {
+                reject_archive_output_inside_package(&package_dir, out)?;
+            }
+            let package = bloom_petals::package::build_petal_package_dir(&package_dir)?;
+            let consent = bloom_petals::package::petal_consent_summary(&package)?;
+            if let Some(out) = out.as_deref() {
+                package.write_petal_tar(std::fs::File::create(out)?)?;
+            }
+            Ok(json!({
+                "hash": package.hash,
+                "contract": bloom_petals::package::ROUTE_PACKAGE,
+                "wit_digest": bloom_petals::package::contract_wit_digest(),
+                "petal_mount": format!("petals/{}/", package.name),
+                "routes": package.route_index.routes.len(),
+                "artifacts": format!("{package_dir}/artifacts"),
+                "archive": out,
+                "consent_lines": petal_consent_lines(&consent),
+            }))
+        })
+        .await
+        .map_err(|error| PetalError::vm(format!("petal build worker failed: {error}")))?
     }
 
     /// `params`: `{ name_or_hash, stdin_b64?, input?, cap_mask?: ["vfs.read",...] }`.
@@ -401,50 +541,63 @@ impl IpcServer {
     }
 
     async fn do_petals_list(&self) -> Result<Value, PetalError> {
-        let runner = self.petals()?;
-        let names = runner.registry().snapshot();
-        // Build a hash → first-matching-name reverse map so each entry
-        // can carry its registered name (or null).
-        let mut name_for_hash: std::collections::BTreeMap<String, String> = Default::default();
-        for (name, hash) in &names {
-            name_for_hash.entry(hash.clone()).or_insert(name.clone());
-        }
-        let hashes = runner.store().list_package_hashes()?;
-        let mut out = Vec::with_capacity(hashes.len());
-        for hash in hashes {
-            let meta = runner.store().load_meta(&hash)?;
-            let petal_mount = meta
-                .petal
-                .as_ref()
-                .map(|app| format!("petals/{}/", app.name));
-            out.push(json!({
-                "hash": meta.hash,
-                "size": meta.size,
-                "name": name_for_hash.get(&meta.hash).cloned(),
-                "caps": meta.caps.iter().map(|c| c.as_str()).collect::<Vec<_>>(),
-                "installed_at_ms": meta.installed_at_ms,
-                "mode": meta.mode_str(),
-                "petal_mount": petal_mount,
-                "petal": meta.petal,
-                "source": meta.source,
-            }));
-        }
-        Ok(Value::Array(out))
+        let runner = self.petals()?.clone();
+        let mutation = self.petal_mutation.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || {
+            let _mutation = mutation;
+            let names = runner.registry().snapshot();
+            // Build a hash → first-matching-name reverse map so each entry
+            // can carry its registered name (or null).
+            let mut name_for_hash: BTreeMap<String, String> = Default::default();
+            for (name, hash) in &names {
+                name_for_hash.entry(hash.clone()).or_insert(name.clone());
+            }
+            let hashes = runner.store().list_package_hashes()?;
+            let mut out = Vec::with_capacity(hashes.len());
+            for hash in hashes {
+                let meta = runner.store().load_meta(&hash)?;
+                let petal_mount = meta
+                    .petal
+                    .as_ref()
+                    .map(|app| format!("petals/{}/", app.name));
+                out.push(json!({
+                    "hash": meta.hash,
+                    "size": meta.size,
+                    "name": name_for_hash.get(&meta.hash).cloned(),
+                    "caps": meta.caps.iter().map(|c| c.as_str()).collect::<Vec<_>>(),
+                    "installed_at_ms": meta.installed_at_ms,
+                    "mode": meta.mode_str(),
+                    "petal_mount": petal_mount,
+                    "petal": meta.petal,
+                    "source": meta.source,
+                }));
+            }
+            Ok(Value::Array(out))
+        })
+        .await
+        .map_err(|error| PetalError::vm(format!("petal list worker failed: {error}")))?
     }
 
     async fn do_petals_resolve(&self, params: &Value) -> Result<Value, PetalError> {
-        let runner = self.petals()?;
+        let runner = self.petals()?.clone();
         let target = params
             .get("name_or_hash")
             .and_then(|v| v.as_str())
             .ok_or_else(|| PetalError::vm("missing 'name_or_hash'"))?;
-        let hash = runner.resolve(target)?;
-        Ok(json!({ "hash": hash }))
+        let target = target.to_owned();
+        let mutation = self.petal_mutation.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || {
+            let _mutation = mutation;
+            let hash = runner.resolve(&target)?;
+            Ok(json!({ "hash": hash }))
+        })
+        .await
+        .map_err(|error| PetalError::vm(format!("petal resolve worker failed: {error}")))?
     }
 
     /// `params`: `{ name, hash? }`. Omitted/empty `hash` unsets the name.
     async fn do_petals_name(&self, params: &Value) -> Result<Value, PetalError> {
-        let runner = self.petals()?;
+        let runner = self.petals()?.clone();
         let name = params
             .get("name")
             .and_then(|v| v.as_str())
@@ -452,27 +605,42 @@ impl IpcServer {
         let hash = params
             .get("hash")
             .and_then(|v| v.as_str())
-            .filter(|s| !s.is_empty());
-        match hash {
-            Some(h) => {
-                runner.registry().set(name, h)?;
-                Ok(json!({ "name": name, "hash": h }))
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned);
+        let name = name.to_owned();
+        let mutation = self.petal_mutation.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || {
+            let _mutation = mutation;
+            match hash {
+                Some(hash) => {
+                    runner.registry().set(&name, &hash)?;
+                    Ok(json!({ "name": name, "hash": hash }))
+                }
+                None => {
+                    let removed = runner.registry().unset(&name)?;
+                    Ok(json!({ "name": name, "removed": removed }))
+                }
             }
-            None => {
-                let removed = runner.registry().unset(name)?;
-                Ok(json!({ "name": name, "removed": removed }))
-            }
-        }
+        })
+        .await
+        .map_err(|error| PetalError::vm(format!("petal name worker failed: {error}")))?
     }
 
     async fn do_petals_uninstall(&self, params: &Value) -> Result<Value, PetalError> {
-        let runner = self.petals()?;
+        let runner = self.petals()?.clone();
         let hash = params
             .get("hash")
             .and_then(|v| v.as_str())
             .ok_or_else(|| PetalError::vm("missing 'hash'"))?;
-        let removed = runner.uninstall(hash)?;
-        Ok(json!({ "removed": removed }))
+        let hash = hash.to_owned();
+        let mutation = self.petal_mutation.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || {
+            let _mutation = mutation;
+            let removed = runner.uninstall(&hash)?;
+            Ok(json!({ "removed": removed }))
+        })
+        .await
+        .map_err(|error| PetalError::vm(format!("petal uninstall worker failed: {error}")))?
     }
 }
 
@@ -529,6 +697,112 @@ fn parse_write_bytes(params: &Value) -> Result<Vec<u8>, HandlerError> {
     } else {
         Err(HandlerError::invalid("write needs bytes_b64 or text"))
     }
+}
+
+fn reject_archive_output_inside_package(package_dir: &str, out: &str) -> Result<(), PetalError> {
+    let package_dir = std::fs::canonicalize(package_dir)?;
+    let out_path = Path::new(out);
+    let out_parent = out_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let out_abs = std::fs::canonicalize(out_parent)?.join(out_path.file_name().unwrap_or_default());
+    if out_abs.starts_with(package_dir) {
+        return Err(PetalError::vm(
+            "--out must be outside the package directory so archives are not packaged into future builds",
+        ));
+    }
+    Ok(())
+}
+
+fn petal_consent_lines(summary: &bloom_petals::package::PetalConsentSummary) -> Vec<String> {
+    let mut lines = vec!["consent:".to_owned()];
+    if let Some(package_summary) = &summary.package_summary {
+        lines.push(format!("  summary: {package_summary}"));
+    }
+    lines.push(format!("  docs: {}", summary.docs.join(", ")));
+    if !summary.capabilities.is_empty() {
+        lines.push(format!(
+            "  capabilities: {}",
+            summary.capabilities.join(", ")
+        ));
+    }
+    if !summary.network.is_empty() {
+        lines.push("  network:".to_owned());
+        for rule in &summary.network {
+            let binding = rule
+                .binding
+                .as_deref()
+                .map(|binding| format!(" binding={binding}"))
+                .unwrap_or_default();
+            let effective = rule
+                .effective_origin
+                .as_deref()
+                .map(|origin| format!(" effective_origin={origin}"))
+                .unwrap_or_default();
+            lines.push(format!(
+                "    - declared_host={}{}{} methods=[{}] paths=[{}]",
+                rule.host,
+                binding,
+                effective,
+                rule.methods.join(","),
+                rule.paths.join(",")
+            ));
+        }
+    }
+    if !summary.sign_intents.is_empty() {
+        lines.push(format!(
+            "  signing_intents: {}",
+            summary.sign_intents.join(", ")
+        ));
+    }
+    if !summary.store_namespaces.is_empty() {
+        lines.push("  private_store:".to_owned());
+        for namespace in &summary.store_namespaces {
+            let visibility = if namespace.secret {
+                "secret"
+            } else {
+                "private"
+            };
+            lines.push(format!("    - {} {visibility}", namespace.namespace));
+        }
+    }
+    if !summary.routes.is_empty() {
+        lines.push("  routes:".to_owned());
+        for route in &summary.routes {
+            let ops = route
+                .ops
+                .iter()
+                .map(|op| format!("{op:?}").to_ascii_lowercase())
+                .collect::<Vec<_>>()
+                .join(",");
+            let mut flags = Vec::new();
+            if route.side_effecting_read {
+                flags.push("side_effecting_read".to_owned());
+            }
+            if route.write_async {
+                flags.push("write_async".to_owned());
+            }
+            if let Some(ttl) = route.cache_ttl_ms {
+                flags.push(format!("cache_ttl_ms={ttl}"));
+            }
+            let caps = if route.required_caps.is_empty() {
+                "-".to_owned()
+            } else {
+                route.required_caps.join(",")
+            };
+            let flags = if flags.is_empty() {
+                String::new()
+            } else {
+                format!(" flags=[{}]", flags.join(","))
+            };
+            lines.push(format!(
+                "    - {} ops=[{}] caps=[{}]{}",
+                route.path, ops, caps, flags
+            ));
+        }
+    }
+    lines
 }
 
 fn entry_to_json(e: &Entry) -> Value {
@@ -653,9 +927,27 @@ impl IpcClient {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Arc;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
 
     struct MockBatchConfirmation;
+
+    struct TrackingSourceInstaller {
+        active: AtomicUsize,
+        max_active: AtomicUsize,
+    }
+
+    impl PetalSourceInstallService for TrackingSourceInstaller {
+        fn install_source(&self, _params: Value) -> Result<Value, String> {
+            let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+            self.max_active.fetch_max(active, Ordering::SeqCst);
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            self.active.fetch_sub(1, Ordering::SeqCst);
+            Ok(json!({"installed": true}))
+        }
+    }
 
     impl BatchConfirmationService for MockBatchConfirmation {
         fn confirm_batch<'a>(&'a self, request: BatchConfirmIpcRequest) -> BatchConfirmFuture<'a> {
@@ -858,6 +1150,110 @@ summary = "Demo app used by IPC tests."
         assert_eq!(entries[0]["mode"], "local");
         assert_eq!(entries[0]["petal_mount"], "petals/demo/");
         assert_eq!(entries[0]["petal"]["name"], "demo");
+    }
+
+    #[tokio::test]
+    async fn petals_package_build_and_install_are_daemon_owned_rpc_operations() {
+        let dir = tempfile::tempdir().unwrap();
+        let package = dir.path().join("demo-package");
+        let archive = dir.path().join("demo.petal.tar");
+        write_demo_petal_package(&package);
+
+        let store = bloom_petals::PetalStore::open(dir.path().join("store")).unwrap();
+        let registry =
+            Arc::new(bloom_petals::NameRegistry::open(dir.path().join("registry")).unwrap());
+        let runner = PetalRunner::new(store, registry, bloom_petals::PetalVm::new().unwrap());
+        let server = IpcServer::new(vfs(), "0", vec![]).with_petals(runner);
+
+        let build = server
+            .dispatch(Request {
+                jsonrpc: "2.0".into(),
+                id: json!(1),
+                method: "petals.build".into(),
+                params: json!({
+                    "package_dir": package,
+                    "out": archive,
+                }),
+            })
+            .await;
+        assert!(build.error.is_none());
+        assert_eq!(build.result.unwrap()["routes"], 1);
+        assert!(archive.is_file());
+
+        let install = server
+            .dispatch(Request {
+                jsonrpc: "2.0".into(),
+                id: json!(2),
+                method: "petals.install".into(),
+                params: json!({ "path": archive }),
+            })
+            .await;
+        assert!(install.error.is_none());
+        let result = install.result.unwrap();
+        assert_eq!(result["mode"], "petal");
+        assert_eq!(result["petal_mount"], "petals/demo/");
+        assert_eq!(result["routes"], 1);
+    }
+
+    #[tokio::test]
+    async fn petal_mutations_are_serialized_across_concurrent_connections() {
+        let installer = Arc::new(TrackingSourceInstaller {
+            active: AtomicUsize::new(0),
+            max_active: AtomicUsize::new(0),
+        });
+        let server =
+            IpcServer::new(vfs(), "0", vec![]).with_petal_source_installer(installer.clone());
+        let first = server.dispatch(Request {
+            jsonrpc: "2.0".into(),
+            id: json!(1),
+            method: "petals.install".into(),
+            params: json!({"path": "https://github.com/bloom-directory/first"}),
+        });
+        let second = server.dispatch(Request {
+            jsonrpc: "2.0".into(),
+            id: json!(2),
+            method: "petals.install".into(),
+            params: json!({"path": "https://github.com/bloom-directory/second"}),
+        });
+
+        let (first, second) = tokio::join!(first, second);
+        assert!(first.error.is_none());
+        assert!(second.error.is_none());
+        assert_eq!(
+            installer.max_active.load(Ordering::SeqCst),
+            1,
+            "daemon must allow only one Petal mutation at a time"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn blocking_petal_source_work_does_not_stall_the_async_runtime() {
+        let installer = Arc::new(TrackingSourceInstaller {
+            active: AtomicUsize::new(0),
+            max_active: AtomicUsize::new(0),
+        });
+        let server =
+            IpcServer::new(vfs(), "0", vec![]).with_petal_source_installer(installer.clone());
+        let started = std::time::Instant::now();
+        let install = tokio::spawn(async move {
+            server
+                .dispatch(Request {
+                    jsonrpc: "2.0".into(),
+                    id: json!(1),
+                    method: "petals.install".into(),
+                    params: json!({"path": "https://github.com/bloom-directory/slow"}),
+                })
+                .await
+        });
+
+        while installer.active.load(Ordering::SeqCst) == 0 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            started.elapsed() < std::time::Duration::from_millis(75),
+            "synchronous source work stalled the current-thread runtime"
+        );
+        assert!(install.await.unwrap().error.is_none());
     }
 
     #[tokio::test]

--- a/crates/bloom-daemon/src/ipc.rs
+++ b/crates/bloom-daemon/src/ipc.rs
@@ -42,10 +42,46 @@ use bloom_vfs::{Entry, EntryKind, Handler, HandlerError, Vfs, VfsPath};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use thiserror::Error;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::Notify;
 use tracing::{debug, info, trace, warn};
+
+/// Maximum JSON document size on the newline-delimited IPC transport.
+/// Source-build output is capped well below this so successful diagnostic
+/// responses still leave room for package metadata and JSON encoding.
+const MAX_IPC_FRAME_BYTES: usize = 4 * 1024 * 1024;
+
+async fn read_bounded_frame<R>(reader: &mut R) -> std::io::Result<Option<Vec<u8>>>
+where
+    R: AsyncBufRead + Unpin,
+{
+    let mut frame = Vec::new();
+    loop {
+        let available = reader.fill_buf().await?;
+        if available.is_empty() {
+            return if frame.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(frame))
+            };
+        }
+        let newline = available.iter().position(|byte| *byte == b'\n');
+        let payload_len = newline.unwrap_or(available.len());
+        if frame.len().saturating_add(payload_len) > MAX_IPC_FRAME_BYTES {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("IPC frame exceeds {MAX_IPC_FRAME_BYTES} bytes"),
+            ));
+        }
+        frame.extend_from_slice(&available[..payload_len]);
+        let consumed = payload_len + usize::from(newline.is_some());
+        reader.consume(consumed);
+        if newline.is_some() {
+            return Ok(Some(frame));
+        }
+    }
+}
 
 #[derive(Debug, Error)]
 pub enum IpcError {
@@ -478,18 +514,14 @@ impl IpcServer {
     async fn handle_conn(&self, stream: UnixStream) -> std::io::Result<()> {
         let (rd, mut wr) = stream.into_split();
         let mut rd = BufReader::new(rd);
-        let mut line = String::new();
         loop {
-            line.clear();
-            let n = rd.read_line(&mut line).await?;
-            if n == 0 {
+            let Some(line) = read_bounded_frame(&mut rd).await? else {
                 return Ok(());
-            }
-            let trimmed = line.trim();
-            if trimmed.is_empty() {
+            };
+            if line.iter().all(u8::is_ascii_whitespace) {
                 continue;
             }
-            let resp = match serde_json::from_str::<Request>(trimmed) {
+            let resp = match serde_json::from_slice::<Request>(&line) {
                 Ok(req) => {
                     trace!(method = %req.method, "ipc.request");
                     self.dispatch(req).await
@@ -508,6 +540,14 @@ impl IpcServer {
                 br#"{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"internal error"}}"#
                     .to_vec()
             });
+            if out.len() > MAX_IPC_FRAME_BYTES {
+                out = serde_json::to_vec(&Response::err(
+                    resp.id.clone(),
+                    -32002,
+                    format!("IPC response exceeds {MAX_IPC_FRAME_BYTES} bytes"),
+                ))
+                .expect("bounded IPC error response serializes");
+            }
             out.push(b'\n');
             wr.write_all(&out).await?;
             wr.flush().await?;
@@ -1372,9 +1412,6 @@ impl IpcClient {
 
     pub async fn call(&self, method: &str, params: Value) -> Result<Value, IpcClientError> {
         trace!(socket = %self.socket_path.display(), %method, "ipc.client.call");
-        let stream = UnixStream::connect(&self.socket_path).await?;
-        let (rd, mut wr) = stream.into_split();
-        let mut rd = BufReader::new(rd);
         let req = json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -1382,12 +1419,21 @@ impl IpcClient {
             "params": params,
         });
         let mut out = serde_json::to_vec(&req).unwrap();
+        if out.len() > MAX_IPC_FRAME_BYTES {
+            return Err(IpcClientError::Protocol(format!(
+                "IPC request exceeds {MAX_IPC_FRAME_BYTES} bytes"
+            )));
+        }
         out.push(b'\n');
+        let stream = UnixStream::connect(&self.socket_path).await?;
+        let (rd, mut wr) = stream.into_split();
+        let mut rd = BufReader::new(rd);
         wr.write_all(&out).await?;
         wr.flush().await?;
-        let mut line = String::new();
-        rd.read_line(&mut line).await?;
-        let v: Value = serde_json::from_str(line.trim())
+        let line = read_bounded_frame(&mut rd).await?.ok_or_else(|| {
+            IpcClientError::Protocol("daemon closed the connection without a response".into())
+        })?;
+        let v: Value = serde_json::from_slice(&line)
             .map_err(|error| IpcClientError::Protocol(error.to_string()))?;
         if let Some(error) = v.get("error") {
             debug!(%method, error = %error, "ipc.client.rpc_error");
@@ -1413,6 +1459,29 @@ mod tests {
         Arc,
         atomic::{AtomicUsize, Ordering},
     };
+
+    #[tokio::test]
+    async fn bounded_frame_reader_rejects_oversized_input_before_newline() {
+        let input = vec![b'x'; MAX_IPC_FRAME_BYTES + 1];
+        let mut reader = BufReader::new(input.as_slice());
+        let error = read_bounded_frame(&mut reader).await.unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("IPC frame exceeds"));
+    }
+
+    #[tokio::test]
+    async fn client_rejects_oversized_request_before_connecting() {
+        let client = IpcClient::new("/definitely/missing/bloom.sock");
+        let error = client
+            .call(
+                "oversized",
+                json!({ "payload": "x".repeat(MAX_IPC_FRAME_BYTES) }),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(error, IpcClientError::Protocol(_)));
+        assert!(error.to_string().contains("IPC request exceeds"));
+    }
 
     struct MockBatchConfirmation;
 

--- a/crates/bloom-daemon/src/ipc.rs
+++ b/crates/bloom-daemon/src/ipc.rs
@@ -63,6 +63,8 @@ use tracing::{debug, info, trace, warn};
 const MAX_IPC_FRAME_BYTES: usize = 4 * 1024 * 1024;
 const MAX_IPC_MESSAGE_BYTES: usize = 64 * 1024 * 1024;
 const IPC_CHUNK_BYTES: usize = 2 * 1024 * 1024;
+const IPC_DATA_CHUNK_BYTES: usize = 1024 * 1024;
+const IPC_OUTPUT_CHANNEL_CAPACITY: usize = 8;
 
 /// Current Bloom CLI-to-daemon IPC protocol and the range this build can
 /// decode. Package versions are diagnostic; this range is the compatibility
@@ -458,6 +460,7 @@ pub trait PetalSourceInstallService: Send + Sync {
 pub enum IpcOutputStream {
     Stdout,
     Stderr,
+    Data,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -468,12 +471,12 @@ pub struct IpcOutputEvent {
 
 #[derive(Clone)]
 pub struct IpcOperationContext {
-    output: Option<tokio::sync::mpsc::UnboundedSender<IpcOutputEvent>>,
+    output: Option<tokio::sync::mpsc::Sender<IpcOutputEvent>>,
     cancelled: Arc<AtomicBool>,
 }
 
 impl IpcOperationContext {
-    fn connected(output: tokio::sync::mpsc::UnboundedSender<IpcOutputEvent>) -> Self {
+    fn connected(output: tokio::sync::mpsc::Sender<IpcOutputEvent>) -> Self {
         Self {
             output: Some(output),
             cancelled: Arc::new(AtomicBool::new(false)),
@@ -496,12 +499,26 @@ impl IpcOperationContext {
             return true;
         };
         if output
-            .send(IpcOutputEvent {
+            .blocking_send(IpcOutputEvent {
                 stream,
                 bytes: bytes.into(),
             })
             .is_err()
         {
+            self.cancel();
+            return false;
+        }
+        true
+    }
+
+    async fn emit_async(&self, stream: IpcOutputStream, bytes: Vec<u8>) -> bool {
+        if self.is_cancelled() {
+            return false;
+        }
+        let Some(output) = &self.output else {
+            return true;
+        };
+        if output.send(IpcOutputEvent { stream, bytes }).await.is_err() {
             self.cancel();
             return false;
         }
@@ -800,7 +817,8 @@ impl IpcServer {
                     trace!(method = %wire.request.method, "ipc.request");
                     match wire.bloom_protocol {
                         Some(peer) if IpcProtocolRange::supported().negotiate(peer).is_some() => {
-                            let (output_tx, mut output_rx) = tokio::sync::mpsc::unbounded_channel();
+                            let (output_tx, mut output_rx) =
+                                tokio::sync::mpsc::channel(IPC_OUTPUT_CHANNEL_CAPACITY);
                             let context = IpcOperationContext::connected(output_tx);
                             let mut dispatched =
                                 Box::pin(self.dispatch_with_context(wire.request, context.clone()));
@@ -908,7 +926,7 @@ impl IpcServer {
                 Ok(v) => Response::ok(id, v),
                 Err(e) => map_handler_err(id, e),
             },
-            "read" => match self.do_read(&req.params).await {
+            "read" => match self.do_read(&req.params, &context).await {
                 Ok(v) => Response::ok(id, v),
                 Err(e) => map_handler_err(id, e),
             },
@@ -1014,9 +1032,27 @@ impl IpcServer {
         Ok(entry_to_json(&e))
     }
 
-    async fn do_read(&self, params: &Value) -> Result<Value, HandlerError> {
+    async fn do_read(
+        &self,
+        params: &Value,
+        context: &IpcOperationContext,
+    ) -> Result<Value, HandlerError> {
         let path = parse_path(params)?;
         let bytes = self.vfs.read(&path).await?;
+        if bytes.len() > IPC_DATA_CHUNK_BYTES {
+            let len = bytes.len();
+            for chunk in bytes.chunks(IPC_DATA_CHUNK_BYTES) {
+                if !context
+                    .emit_async(IpcOutputStream::Data, chunk.to_vec())
+                    .await
+                {
+                    return Err(HandlerError::backend(
+                        "IPC read cancelled by disconnected client",
+                    ));
+                }
+            }
+            return Ok(json!({ "streamed": true, "len": len }));
+        }
         Ok(json!({ "bytes_b64": B64.encode(&bytes), "len": bytes.len() }))
     }
 
@@ -1138,11 +1174,17 @@ impl IpcServer {
                     "Petal install cancelled by disconnected client",
                 ));
             }
-            let (result, meta, index) = if is_dir {
-                runner.store().install_petal_package_dir(&path)?
-            } else {
-                runner.store().install_petal_package_tar(&path)?
-            };
+            let (result, meta, index) = runner
+                .store()
+                .install_prepared_petal_package_with_source_guarded(package, None, || {
+                    if context.is_cancelled() {
+                        Err(PetalError::vm(
+                            "Petal install cancelled by disconnected client",
+                        ))
+                    } else {
+                        Ok(())
+                    }
+                })?;
             Ok(json!({
                 "hash": result.hash,
                 "mode": "petal",
@@ -1198,7 +1240,16 @@ impl IpcServer {
                     "Petal build cancelled by disconnected client",
                 ));
             }
-            let package = bloom_petals::package::build_petal_package_dir(&package_dir)?;
+            let package =
+                bloom_petals::package::build_petal_package_dir_guarded(&package_dir, || {
+                    if context.is_cancelled() {
+                        Err(PetalError::vm(
+                            "Petal build cancelled by disconnected client",
+                        ))
+                    } else {
+                        Ok(())
+                    }
+                })?;
             let consent = bloom_petals::package::petal_consent_summary(&package)?;
             if context.is_cancelled() {
                 return Err(PetalError::vm(
@@ -1831,7 +1882,36 @@ impl IpcClient {
         method: &str,
         params: Value,
     ) -> Result<IpcCallResult, IpcClientError> {
-        self.call_streaming(method, params, |_| Ok(())).await
+        let mut streamed_data = Vec::new();
+        let mut reply = self
+            .call_streaming(method, params, |event| {
+                if event.stream == IpcOutputStream::Data {
+                    streamed_data.extend_from_slice(&event.bytes);
+                }
+                Ok(())
+            })
+            .await?;
+        if reply.result.get("streamed").and_then(Value::as_bool) == Some(true) {
+            let expected = reply
+                .result
+                .get("len")
+                .and_then(Value::as_u64)
+                .ok_or_else(|| {
+                    IpcClientError::Protocol("streamed response is missing len".into())
+                })?;
+            if streamed_data.len() as u64 != expected {
+                return Err(IpcClientError::Protocol(format!(
+                    "streamed byte count mismatch: expected {expected}, received {}",
+                    streamed_data.len()
+                )));
+            }
+            let result = reply.result.as_object_mut().ok_or_else(|| {
+                IpcClientError::Protocol("streamed response is not an object".into())
+            })?;
+            result.insert("bytes_b64".into(), Value::String(B64.encode(streamed_data)));
+            result.remove("streamed");
+        }
+        Ok(reply)
     }
 
     pub async fn call_streaming<F>(
@@ -3312,6 +3392,48 @@ summary = "Demo app used by IPC tests."
                 .unwrap();
             handle.await.unwrap();
         }
+    }
+
+    #[tokio::test]
+    async fn vfs_read_streams_above_the_logical_message_limit() {
+        let size = MAX_IPC_MESSAGE_BYTES / 4 * 3 + 64 * 1024;
+        let body = vec![0x5a; size];
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("private-run/bloom.sock");
+        let vfs = Vfs::builder()
+            .mount(
+                "stub",
+                Arc::new(SingleFileHandler::new("large", body.clone())),
+            )
+            .build();
+        let server = IpcServer::new(vfs, "0", vec![]);
+        let serving = server.clone();
+        let serving_socket = socket.clone();
+        let handle = tokio::spawn(async move { serving.serve(&serving_socket).await.unwrap() });
+        for _ in 0..100 {
+            if socket.exists() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        let mut received = Vec::new();
+        let result = IpcClient::new(&socket)
+            .call_streaming("read", json!({"path": "/stub/large"}), |event| {
+                assert_eq!(event.stream, IpcOutputStream::Data);
+                received.extend_from_slice(&event.bytes);
+                Ok(())
+            })
+            .await
+            .unwrap();
+        assert_eq!(result.result["streamed"], true);
+        assert_eq!(received, body);
+
+        IpcClient::new(&socket)
+            .call("shutdown", Value::Null)
+            .await
+            .unwrap();
+        handle.await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/bloom-daemon/src/ipc.rs
+++ b/crates/bloom-daemon/src/ipc.rs
@@ -23,9 +23,13 @@
 //! | `machine.execute` | tagged [`MachineCommand`]        | [`MachineCommandOutput`] |
 //! | `shutdown` | `null`                                | `null`                    |
 //!
-//! Wire framing is one JSON document per line. Encoding/decoding errors
-//! produce a JSON-RPC `-32700` parse-error response and the connection
-//! continues. Unknown methods produce `-32601`. Every request and response
+//! Wire framing is one JSON document per line. Logical documents above the
+//! physical frame limit use ordered base64 chunk envelopes and are capped at
+//! [`MAX_IPC_MESSAGE_BYTES`]. Long-running operations may emit `bloom.output`
+//! notifications containing base64-encoded stdout/stderr bytes before their
+//! final response. Dropping the connection cancels the active operation.
+//! Encoding/decoding errors produce a JSON-RPC `-32700` parse-error response.
+//! Unknown methods produce `-32601`. Every request, response, and notification
 //! carries a `bloom_protocol` range; peers fail closed when the ranges do not
 //! overlap.
 
@@ -34,7 +38,10 @@ use std::future::Future;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 use std::time::UNIX_EPOCH;
 
 use base64::Engine as _;
@@ -44,15 +51,18 @@ use bloom_vfs::{Entry, EntryKind, Handler, HandlerError, Vfs, VfsPath};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use thiserror::Error;
-use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{
+    AsyncBufRead, AsyncBufReadExt, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader,
+};
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::Notify;
 use tracing::{debug, info, trace, warn};
 
-/// Maximum JSON document size on the newline-delimited IPC transport.
-/// Source-build output is capped well below this so successful diagnostic
-/// responses still leave room for package metadata and JSON encoding.
+/// Maximum physical newline-delimited frame and reassembled logical message.
+/// Logical messages above one frame are transported as ordered base64 chunks.
 const MAX_IPC_FRAME_BYTES: usize = 4 * 1024 * 1024;
+const MAX_IPC_MESSAGE_BYTES: usize = 64 * 1024 * 1024;
+const IPC_CHUNK_BYTES: usize = 2 * 1024 * 1024;
 
 /// Current Bloom CLI-to-daemon IPC protocol and the range this build can
 /// decode. Package versions are diagnostic; this range is the compatibility
@@ -136,6 +146,109 @@ where
     }
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+struct IpcChunkEnvelope {
+    bloom_chunk: IpcChunk,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct IpcChunk {
+    sequence: u32,
+    final_chunk: bool,
+    bytes_b64: String,
+}
+
+async fn read_ipc_message<R>(reader: &mut R) -> std::io::Result<Option<Vec<u8>>>
+where
+    R: AsyncBufRead + Unpin,
+{
+    let Some(first) = read_bounded_frame(reader).await? else {
+        return Ok(None);
+    };
+    let Ok(mut envelope) = serde_json::from_slice::<IpcChunkEnvelope>(&first) else {
+        return Ok(Some(first));
+    };
+    let mut message = Vec::new();
+    let mut expected_sequence = 0_u32;
+    loop {
+        if envelope.bloom_chunk.sequence != expected_sequence {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "IPC chunk sequence is not contiguous",
+            ));
+        }
+        let chunk = B64
+            .decode(&envelope.bloom_chunk.bytes_b64)
+            .map_err(|error| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("IPC chunk is not valid base64: {error}"),
+                )
+            })?;
+        if message.len().saturating_add(chunk.len()) > MAX_IPC_MESSAGE_BYTES {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("IPC message exceeds {MAX_IPC_MESSAGE_BYTES} bytes"),
+            ));
+        }
+        message.extend_from_slice(&chunk);
+        if envelope.bloom_chunk.final_chunk {
+            return Ok(Some(message));
+        }
+        expected_sequence = expected_sequence.checked_add(1).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "IPC chunk sequence overflow",
+            )
+        })?;
+        let next = read_bounded_frame(reader).await?.ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "IPC chunked message ended before its final chunk",
+            )
+        })?;
+        envelope = serde_json::from_slice(&next).map_err(|error| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("invalid IPC chunk envelope: {error}"),
+            )
+        })?;
+    }
+}
+
+async fn write_ipc_message<W>(writer: &mut W, message: &[u8]) -> std::io::Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    if message.len() > MAX_IPC_MESSAGE_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("IPC message exceeds {MAX_IPC_MESSAGE_BYTES} bytes"),
+        ));
+    }
+    if message.len() <= MAX_IPC_FRAME_BYTES {
+        writer.write_all(message).await?;
+        writer.write_all(b"\n").await?;
+        return writer.flush().await;
+    }
+    let chunks = message.chunks(IPC_CHUNK_BYTES);
+    let chunk_count = chunks.len();
+    for (sequence, chunk) in chunks.enumerate() {
+        let frame = serde_json::to_vec(&IpcChunkEnvelope {
+            bloom_chunk: IpcChunk {
+                sequence: sequence as u32,
+                final_chunk: sequence + 1 == chunk_count,
+                bytes_b64: B64.encode(chunk),
+            },
+        })
+        .expect("IPC chunk envelope serializes");
+        debug_assert!(frame.len() <= MAX_IPC_FRAME_BYTES);
+        writer.write_all(&frame).await?;
+        writer.write_all(b"\n").await?;
+    }
+    writer.flush().await
+}
+
 #[derive(Debug, Error)]
 pub enum IpcError {
     #[error("io: {0}")]
@@ -194,6 +307,34 @@ struct Response {
     result: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<RpcError>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct OutputNotification {
+    jsonrpc: &'static str,
+    method: &'static str,
+    bloom_protocol: IpcProtocolRange,
+    params: OutputNotificationParams,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct OutputNotificationParams {
+    stream: IpcOutputStream,
+    bytes_b64: String,
+}
+
+impl OutputNotification {
+    fn new(event: IpcOutputEvent) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            method: "bloom.output",
+            bloom_protocol: IpcProtocolRange::supported(),
+            params: OutputNotificationParams {
+                stream: event.stream,
+                bytes_b64: B64.encode(event.bytes),
+            },
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -309,7 +450,71 @@ pub trait BatchConfirmationService: Send + Sync {
 /// build, list, and uninstall stay implemented by the IPC server against its
 /// daemon-owned [`PetalRunner`].
 pub trait PetalSourceInstallService: Send + Sync {
-    fn install_source(&self, params: Value) -> Result<Value, String>;
+    fn install_source(&self, params: Value, context: IpcOperationContext) -> Result<Value, String>;
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IpcOutputStream {
+    Stdout,
+    Stderr,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IpcOutputEvent {
+    pub stream: IpcOutputStream,
+    pub bytes: Vec<u8>,
+}
+
+#[derive(Clone)]
+pub struct IpcOperationContext {
+    output: Option<tokio::sync::mpsc::UnboundedSender<IpcOutputEvent>>,
+    cancelled: Arc<AtomicBool>,
+}
+
+impl IpcOperationContext {
+    fn connected(output: tokio::sync::mpsc::UnboundedSender<IpcOutputEvent>) -> Self {
+        Self {
+            output: Some(output),
+            cancelled: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    #[cfg(test)]
+    fn detached() -> Self {
+        Self {
+            output: None,
+            cancelled: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    pub fn emit(&self, stream: IpcOutputStream, bytes: impl Into<Vec<u8>>) -> bool {
+        if self.is_cancelled() {
+            return false;
+        }
+        let Some(output) = &self.output else {
+            return true;
+        };
+        if output
+            .send(IpcOutputEvent {
+                stream,
+                bytes: bytes.into(),
+            })
+            .is_err()
+        {
+            self.cancel();
+            return false;
+        }
+        true
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Acquire)
+    }
+
+    fn cancel(&self) {
+        self.cancelled.store(true, Ordering::Release);
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -514,9 +719,13 @@ impl IpcServer {
         use std::os::unix::fs::PermissionsExt as _;
         std::fs::set_permissions(&staged_socket, std::fs::Permissions::from_mode(0o600))?;
         let identity = verify_socket_security(&staged_socket, rustix::process::geteuid().as_raw())?;
-        let replacing_stale = validate_stale_socket(&target)?;
+        let stale_identity = validate_stale_socket(&target)?;
+        let revalidated_stale_identity = validate_stale_socket(&target)?;
+        if stale_identity != revalidated_stale_identity {
+            return Err(IpcError::EndpointBusy(target));
+        }
         std::fs::rename(&staged_socket, &target)?;
-        if replacing_stale {
+        if stale_identity.is_some() {
             debug!(socket = %target.display(), "ipc.stale_socket_replaced");
         }
         drop(staging);
@@ -580,7 +789,7 @@ impl IpcServer {
         let (rd, mut wr) = stream.into_split();
         let mut rd = BufReader::new(rd);
         loop {
-            let Some(line) = read_bounded_frame(&mut rd).await? else {
+            let Some(line) = read_ipc_message(&mut rd).await? else {
                 return Ok(());
             };
             if line.iter().all(u8::is_ascii_whitespace) {
@@ -591,7 +800,56 @@ impl IpcServer {
                     trace!(method = %wire.request.method, "ipc.request");
                     match wire.bloom_protocol {
                         Some(peer) if IpcProtocolRange::supported().negotiate(peer).is_some() => {
-                            self.dispatch(wire.request).await
+                            let (output_tx, mut output_rx) = tokio::sync::mpsc::unbounded_channel();
+                            let context = IpcOperationContext::connected(output_tx);
+                            let mut dispatched =
+                                Box::pin(self.dispatch_with_context(wire.request, context.clone()));
+                            let mut disconnect = [0_u8; 1];
+                            let response = loop {
+                                tokio::select! {
+                                    biased;
+                                    event = output_rx.recv() => {
+                                        if let Some(event) = event {
+                                            let notification = serde_json::to_vec(
+                                                &OutputNotification::new(event)
+                                            ).expect("IPC output notification serializes");
+                                            if let Err(error) = write_ipc_message(&mut wr, &notification).await {
+                                                context.cancel();
+                                                let _ = dispatched.await;
+                                                return Err(error);
+                                            }
+                                        }
+                                    }
+                                    response = &mut dispatched => break response,
+                                    read = rd.read(&mut disconnect) => {
+                                        match read {
+                                            Ok(0) => {
+                                                context.cancel();
+                                                let _ = dispatched.await;
+                                                return Ok(());
+                                            }
+                                            Ok(_) => {
+                                                context.cancel();
+                                                return Err(std::io::Error::new(
+                                                    std::io::ErrorKind::InvalidData,
+                                                    "pipelined IPC requests are unsupported",
+                                                ));
+                                            }
+                                            Err(error) => {
+                                                context.cancel();
+                                                return Err(error);
+                                            }
+                                        }
+                                    }
+                                }
+                            };
+                            while let Ok(event) = output_rx.try_recv() {
+                                let notification =
+                                    serde_json::to_vec(&OutputNotification::new(event))
+                                        .expect("IPC output notification serializes");
+                                write_ipc_message(&mut wr, &notification).await?;
+                            }
+                            response
                         }
                         Some(peer) => Response::err(
                             wire.request.id,
@@ -613,7 +871,7 @@ impl IpcServer {
                     Response::err(Value::Null, -32700, format!("parse error: {e}"))
                 }
             };
-            let mut out = serde_json::to_vec(&resp).unwrap_or_else(|e| {
+            let out = serde_json::to_vec(&resp).unwrap_or_else(|e| {
                 debug!(error = %e, "ipc.response_serialise_failed");
                 // We cannot echo the request id here (serialisation of the
                 // proper Response already failed, so we may not have a
@@ -622,21 +880,17 @@ impl IpcServer {
                 br#"{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"internal error"}}"#
                     .to_vec()
             });
-            if out.len() > MAX_IPC_FRAME_BYTES {
-                out = serde_json::to_vec(&Response::err(
-                    resp.id.clone(),
-                    -32002,
-                    format!("IPC response exceeds {MAX_IPC_FRAME_BYTES} bytes"),
-                ))
-                .expect("bounded IPC error response serializes");
-            }
-            out.push(b'\n');
-            wr.write_all(&out).await?;
-            wr.flush().await?;
+            write_ipc_message(&mut wr, &out).await?;
         }
     }
 
+    #[cfg(test)]
     async fn dispatch(&self, req: Request) -> Response {
+        self.dispatch_with_context(req, IpcOperationContext::detached())
+            .await
+    }
+
+    async fn dispatch_with_context(&self, req: Request, context: IpcOperationContext) -> Response {
         if !req.jsonrpc.is_empty() && req.jsonrpc != "2.0" {
             debug!(version = %req.jsonrpc, "ipc.dispatch.bad_version");
             return Response::err(req.id, -32600, "jsonrpc must be 2.0");
@@ -694,11 +948,11 @@ impl IpcServer {
                 Ok(v) => Response::ok(id, v),
                 Err(e) => map_handler_err(id, e),
             },
-            "petals.install" => match self.do_petals_install(&req.params).await {
+            "petals.install" => match self.do_petals_install(&req.params, context.clone()).await {
                 Ok(v) => Response::ok(id, v),
                 Err(e) => map_petal_err(id, e),
             },
-            "petals.build" => match self.do_petals_build(&req.params).await {
+            "petals.build" => match self.do_petals_build(&req.params, context).await {
                 Ok(v) => Response::ok(id, v),
                 Err(e) => map_petal_err(id, e),
             },
@@ -811,7 +1065,11 @@ impl IpcServer {
 
     /// `params`: `{ path, ref? }` where path is a package directory,
     /// `.petal.tar`, or trusted remote source URL.
-    async fn do_petals_install(&self, params: &Value) -> Result<Value, PetalError> {
+    async fn do_petals_install(
+        &self,
+        params: &Value,
+        context: IpcOperationContext,
+    ) -> Result<Value, PetalError> {
         #[derive(Deserialize)]
         #[serde(deny_unknown_fields)]
         struct InstallRequest {
@@ -832,7 +1090,10 @@ impl IpcServer {
             let mutation = self.petal_mutation.clone().lock_owned().await;
             return tokio::task::spawn_blocking(move || {
                 let _mutation = mutation;
-                installer.install_source(params)
+                if context.is_cancelled() {
+                    return Err("Petal source install cancelled by disconnected client".to_owned());
+                }
+                installer.install_source(params, context)
             })
             .await
             .map_err(|error| {
@@ -855,6 +1116,11 @@ impl IpcServer {
         let mutation = self.petal_mutation.clone().lock_owned().await;
         tokio::task::spawn_blocking(move || {
             let _mutation = mutation;
+            if context.is_cancelled() {
+                return Err(PetalError::vm(
+                    "Petal install cancelled by disconnected client",
+                ));
+            }
             let is_dir = std::fs::metadata(&path)?.is_dir();
             let package = if is_dir {
                 bloom_petals::package::PreparedPetalPackage::from_dir(&path)?
@@ -867,6 +1133,11 @@ impl IpcServer {
                 .cloned()
                 .unwrap_or_default();
             bloom_petals::package::apply_petal_consent_endpoint_bindings(&mut consent, &bindings)?;
+            if context.is_cancelled() {
+                return Err(PetalError::vm(
+                    "Petal install cancelled by disconnected client",
+                ));
+            }
             let (result, meta, index) = if is_dir {
                 runner.store().install_petal_package_dir(&path)?
             } else {
@@ -887,7 +1158,11 @@ impl IpcServer {
     }
 
     /// `params`: `{ package_dir, out? }`.
-    async fn do_petals_build(&self, params: &Value) -> Result<Value, PetalError> {
+    async fn do_petals_build(
+        &self,
+        params: &Value,
+        context: IpcOperationContext,
+    ) -> Result<Value, PetalError> {
         self.petals()?;
         #[derive(Deserialize)]
         #[serde(deny_unknown_fields)]
@@ -918,14 +1193,29 @@ impl IpcServer {
         let mutation = self.petal_mutation.clone().lock_owned().await;
         tokio::task::spawn_blocking(move || {
             let _mutation = mutation;
+            if context.is_cancelled() {
+                return Err(PetalError::vm(
+                    "Petal build cancelled by disconnected client",
+                ));
+            }
             let package = bloom_petals::package::build_petal_package_dir(&package_dir)?;
             let consent = bloom_petals::package::petal_consent_summary(&package)?;
+            if context.is_cancelled() {
+                return Err(PetalError::vm(
+                    "Petal build cancelled by disconnected client",
+                ));
+            }
             if let Some(out) = output.as_ref() {
                 let parent = out.parent().expect("validated archive has a parent");
                 let mut archive = tempfile::NamedTempFile::new_in(parent)?;
                 package.write_petal_tar(&mut archive)?;
                 archive.flush()?;
                 archive.as_file().sync_all()?;
+                if context.is_cancelled() {
+                    return Err(PetalError::vm(
+                        "Petal build cancelled by disconnected client",
+                    ));
+                }
                 archive.persist(out).map_err(|error| error.error)?;
             }
             Ok(json!({
@@ -1159,12 +1449,12 @@ fn endpoint_lock_path(socket_path: &Path) -> Result<PathBuf, IpcError> {
     Ok(socket_path.with_file_name(std::ffi::OsString::from_vec(lock_name)))
 }
 
-fn validate_stale_socket(socket_path: &Path) -> Result<bool, IpcError> {
+fn validate_stale_socket(socket_path: &Path) -> Result<Option<SocketIdentity>, IpcError> {
     use std::os::unix::fs::{FileTypeExt as _, MetadataExt as _};
 
     let metadata = match std::fs::symlink_metadata(socket_path) {
         Ok(metadata) => metadata,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => return Err(error.into()),
     };
     let effective_uid = rustix::process::geteuid().as_raw();
@@ -1174,7 +1464,32 @@ fn validate_stale_socket(socket_path: &Path) -> Result<bool, IpcError> {
             reason: "pre-existing path is not a socket owned by the daemon user".to_owned(),
         });
     }
-    Ok(true)
+    let identity = SocketIdentity {
+        device: metadata.dev(),
+        inode: metadata.ino(),
+    };
+    match std::os::unix::net::UnixStream::connect(socket_path) {
+        Ok(_) => return Err(IpcError::EndpointBusy(socket_path.to_owned())),
+        Err(error) if error.kind() == std::io::ErrorKind::ConnectionRefused => {}
+        Err(error) => {
+            return Err(IpcError::InsecureSocket {
+                path: socket_path.to_owned(),
+                reason: format!("cannot prove pre-existing socket is stale: {error}"),
+            });
+        }
+    }
+    let revalidated = std::fs::symlink_metadata(socket_path)?;
+    let revalidated_identity = SocketIdentity {
+        device: revalidated.dev(),
+        inode: revalidated.ino(),
+    };
+    if !revalidated.file_type().is_socket()
+        || revalidated.uid() != effective_uid
+        || revalidated_identity != identity
+    {
+        return Err(IpcError::EndpointBusy(socket_path.to_owned()));
+    }
+    Ok(Some(identity))
 }
 
 fn verify_socket_security(
@@ -1471,6 +1786,8 @@ pub enum IpcClientError {
     Rpc(RpcCallError),
     #[error("invalid IPC response: {0}")]
     Protocol(String),
+    #[error("refusing insecure Bloom daemon endpoint: {0}")]
+    EndpointSecurity(String),
     #[error("incompatible Bloom IPC protocol: client supports {client}, daemon supports {daemon}")]
     Incompatible {
         client: IpcProtocolRange,
@@ -1483,6 +1800,7 @@ pub struct IpcCallResult {
     pub result: Value,
     pub daemon_protocol: IpcProtocolRange,
     pub negotiated_protocol: u32,
+    pub output_events: usize,
 }
 
 #[derive(Clone, Debug, Eq, Error, PartialEq)]
@@ -1513,6 +1831,18 @@ impl IpcClient {
         method: &str,
         params: Value,
     ) -> Result<IpcCallResult, IpcClientError> {
+        self.call_streaming(method, params, |_| Ok(())).await
+    }
+
+    pub async fn call_streaming<F>(
+        &self,
+        method: &str,
+        params: Value,
+        mut on_output: F,
+    ) -> Result<IpcCallResult, IpcClientError>
+    where
+        F: FnMut(IpcOutputEvent) -> std::io::Result<()>,
+    {
         trace!(socket = %self.socket_path.display(), %method, "ipc.client.call");
         let client_protocol = IpcProtocolRange::supported();
         let req = json!({
@@ -1522,23 +1852,79 @@ impl IpcClient {
             "params": params,
             "bloom_protocol": client_protocol,
         });
-        let mut out = serde_json::to_vec(&req).unwrap();
-        if out.len() > MAX_IPC_FRAME_BYTES {
+        let out = serde_json::to_vec(&req).unwrap();
+        if out.len() > MAX_IPC_MESSAGE_BYTES {
             return Err(IpcClientError::Protocol(format!(
-                "IPC request exceeds {MAX_IPC_FRAME_BYTES} bytes"
+                "IPC request exceeds {MAX_IPC_MESSAGE_BYTES} bytes"
             )));
         }
-        out.push(b'\n');
+        match verify_socket_security(&self.socket_path, rustix::process::geteuid().as_raw()) {
+            Ok(_) => {}
+            Err(IpcError::Io(error)) => return Err(IpcClientError::Transport(error)),
+            Err(error) => return Err(IpcClientError::EndpointSecurity(error.to_string())),
+        }
         let stream = UnixStream::connect(&self.socket_path).await?;
+        let observed_uid = stream.peer_cred()?.uid();
+        let expected_uid = rustix::process::geteuid().as_raw();
+        if !peer_uid_allowed(expected_uid, observed_uid) {
+            return Err(IpcClientError::EndpointSecurity(format!(
+                "daemon peer uid mismatch: expected {expected_uid}, observed {observed_uid}"
+            )));
+        }
         let (rd, mut wr) = stream.into_split();
         let mut rd = BufReader::new(rd);
-        wr.write_all(&out).await?;
-        wr.flush().await?;
-        let line = read_bounded_frame(&mut rd).await?.ok_or_else(|| {
-            IpcClientError::Protocol("daemon closed the connection without a response".into())
-        })?;
-        let v: Value = serde_json::from_slice(&line)
-            .map_err(|error| IpcClientError::Protocol(error.to_string()))?;
+        write_ipc_message(&mut wr, &out).await?;
+        let mut output_events = 0_usize;
+        let v = loop {
+            let line = read_ipc_message(&mut rd).await?.ok_or_else(|| {
+                IpcClientError::Protocol("daemon closed the connection without a response".into())
+            })?;
+            let value: Value = serde_json::from_slice(&line)
+                .map_err(|error| IpcClientError::Protocol(error.to_string()))?;
+            if value.get("method").and_then(Value::as_str) == Some("bloom.output") {
+                let notification_protocol = value
+                    .get("bloom_protocol")
+                    .cloned()
+                    .ok_or_else(|| {
+                        IpcClientError::Protocol(
+                            "output notification does not advertise a Bloom IPC protocol version"
+                                .into(),
+                        )
+                    })
+                    .and_then(|value| {
+                        serde_json::from_value::<IpcProtocolRange>(value)
+                            .map_err(|error| IpcClientError::Protocol(error.to_string()))
+                    })?;
+                if client_protocol.negotiate(notification_protocol).is_none() {
+                    return Err(IpcClientError::Incompatible {
+                        client: client_protocol,
+                        daemon: notification_protocol,
+                    });
+                }
+                let params = value.get("params").ok_or_else(|| {
+                    IpcClientError::Protocol("output notification is missing params".into())
+                })?;
+                let stream = serde_json::from_value::<IpcOutputStream>(
+                    params.get("stream").cloned().ok_or_else(|| {
+                        IpcClientError::Protocol("output notification is missing its stream".into())
+                    })?,
+                )
+                .map_err(|error| IpcClientError::Protocol(error.to_string()))?;
+                let bytes =
+                    B64.decode(params.get("bytes_b64").and_then(Value::as_str).ok_or_else(
+                        || {
+                            IpcClientError::Protocol(
+                                "output notification is missing bytes_b64".into(),
+                            )
+                        },
+                    )?)
+                    .map_err(|error| IpcClientError::Protocol(error.to_string()))?;
+                on_output(IpcOutputEvent { stream, bytes })?;
+                output_events = output_events.saturating_add(1);
+                continue;
+            }
+            break value;
+        };
         let daemon_protocol = v
             .get("bloom_protocol")
             .cloned()
@@ -1576,6 +1962,7 @@ impl IpcClient {
             result: v.get("result").cloned().unwrap_or(Value::Null),
             daemon_protocol,
             negotiated_protocol,
+            output_events,
         })
     }
 }
@@ -1585,7 +1972,7 @@ mod tests {
     use super::*;
     use std::sync::{
         Arc,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     };
 
     #[tokio::test]
@@ -1624,7 +2011,7 @@ mod tests {
         let error = client
             .call(
                 "oversized",
-                json!({ "payload": "x".repeat(MAX_IPC_FRAME_BYTES) }),
+                json!({ "payload": "x".repeat(MAX_IPC_MESSAGE_BYTES) }),
             )
             .await
             .unwrap_err();
@@ -1637,6 +2024,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let socket = dir.path().join("legacy.sock");
         let listener = UnixListener::bind(&socket).unwrap();
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(&socket, std::fs::Permissions::from_mode(0o600)).unwrap();
         let legacy_daemon = tokio::spawn(async move {
             let (stream, _) = listener.accept().await.unwrap();
             let (rd, mut wr) = stream.into_split();
@@ -1655,6 +2044,33 @@ mod tests {
         assert!(matches!(error, IpcClientError::Protocol(_)));
         assert!(error.to_string().contains("does not advertise"));
         legacy_daemon.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn chunked_transport_round_trips_messages_above_the_physical_frame_limit() {
+        let message = vec![0xa5; MAX_IPC_FRAME_BYTES + 17];
+        let expected = message.clone();
+        let (mut writer, reader) = tokio::io::duplex(64 * 1024);
+        let writing = tokio::spawn(async move { write_ipc_message(&mut writer, &message).await });
+        let mut reader = BufReader::new(reader);
+        let received = read_ipc_message(&mut reader).await.unwrap().unwrap();
+        writing.await.unwrap().unwrap();
+        assert_eq!(received, expected);
+    }
+
+    #[tokio::test]
+    async fn client_rejects_insecure_socket_metadata_before_sending_a_request() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("insecure.sock");
+        let _listener = UnixListener::bind(&socket).unwrap();
+        std::fs::set_permissions(&socket, std::fs::Permissions::from_mode(0o666)).unwrap();
+        let error = IpcClient::new(&socket)
+            .call("version", Value::Null)
+            .await
+            .unwrap_err();
+        assert!(matches!(error, IpcClientError::EndpointSecurity(_)));
     }
 
     struct MockBatchConfirmation;
@@ -1687,8 +2103,33 @@ mod tests {
         max_active: AtomicUsize,
     }
 
+    struct BlockingSourceInstaller {
+        started: AtomicBool,
+        cancelled: AtomicBool,
+        committed: AtomicBool,
+    }
+
+    impl PetalSourceInstallService for BlockingSourceInstaller {
+        fn install_source(
+            &self,
+            _params: Value,
+            context: IpcOperationContext,
+        ) -> Result<Value, String> {
+            self.started.store(true, Ordering::SeqCst);
+            while !context.is_cancelled() {
+                std::thread::sleep(std::time::Duration::from_millis(5));
+            }
+            self.cancelled.store(true, Ordering::SeqCst);
+            Err("cancelled before commit".to_owned())
+        }
+    }
+
     impl PetalSourceInstallService for TrackingSourceInstaller {
-        fn install_source(&self, _params: Value) -> Result<Value, String> {
+        fn install_source(
+            &self,
+            _params: Value,
+            _context: IpcOperationContext,
+        ) -> Result<Value, String> {
             let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
             self.max_active.fetch_max(active, Ordering::SeqCst);
             std::thread::sleep(std::time::Duration::from_millis(100));
@@ -1714,6 +2155,25 @@ mod tests {
     struct SingleFileHandler {
         name: String,
         body: Vec<u8>,
+    }
+
+    struct CapturedWriteHandler(tokio::sync::Mutex<Vec<u8>>);
+
+    #[async_trait::async_trait]
+    impl Handler for CapturedWriteHandler {
+        async fn lookup(&self, path: &VfsPath) -> Result<Entry, HandlerError> {
+            Ok(Entry::file(
+                path.segments()
+                    .last()
+                    .map(String::as_str)
+                    .unwrap_or("large"),
+            ))
+        }
+
+        async fn write(&self, _path: &VfsPath, data: &[u8]) -> Result<(), HandlerError> {
+            *self.0.lock().await = data.to_vec();
+            Ok(())
+        }
     }
 
     struct AtomicProjectionHandler {
@@ -1965,7 +2425,7 @@ mod tests {
     }
 
     #[test]
-    fn peer_uid_policy_accepts_only_the_effective_uid() {
+    fn peer_uid_policy_protects_both_server_and_client_directions() {
         assert!(peer_uid_allowed(501, 501));
         assert!(!peer_uid_allowed(501, 0));
         assert!(!peer_uid_allowed(501, 502));
@@ -1986,6 +2446,26 @@ mod tests {
             .unwrap_err();
         assert!(matches!(error, IpcError::InsecureSocket { .. }));
         assert_eq!(std::fs::read(&socket).unwrap(), b"do not remove");
+    }
+
+    #[tokio::test]
+    async fn server_refuses_to_replace_an_independently_bound_live_listener() {
+        use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("independent.sock");
+        let listener = std::os::unix::net::UnixListener::bind(&socket).unwrap();
+        std::fs::set_permissions(&socket, std::fs::Permissions::from_mode(0o600)).unwrap();
+        let inode = std::fs::symlink_metadata(&socket).unwrap().ino();
+
+        let error = IpcServer::new(vfs(), "replacement", vec![])
+            .serve(&socket)
+            .await
+            .unwrap_err();
+        assert!(matches!(error, IpcError::EndpointBusy(_)));
+        assert_eq!(std::fs::symlink_metadata(&socket).unwrap().ino(), inode);
+        assert!(std::os::unix::net::UnixStream::connect(&socket).is_ok());
+        drop(listener);
     }
 
     #[tokio::test]
@@ -2684,6 +3164,63 @@ summary = "Demo app used by IPC tests."
     }
 
     #[tokio::test]
+    async fn disconnect_cancels_blocked_source_install_before_commit() {
+        let installer = Arc::new(BlockingSourceInstaller {
+            started: AtomicBool::new(false),
+            cancelled: AtomicBool::new(false),
+            committed: AtomicBool::new(false),
+        });
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("private-run/bloom.sock");
+        let server =
+            IpcServer::new(vfs(), "0", vec![]).with_petal_source_installer(installer.clone());
+        let serving = server.clone();
+        let serving_socket = socket.clone();
+        let server_task =
+            tokio::spawn(async move { serving.serve(&serving_socket).await.unwrap() });
+        for _ in 0..100 {
+            if socket.exists() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        let client = IpcClient::new(&socket);
+        let install_task = tokio::spawn(async move {
+            client
+                .call(
+                    "petals.install",
+                    json!({"path": "https://github.com/bloom-directory/blocked"}),
+                )
+                .await
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while !installer.started.load(Ordering::SeqCst) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+
+        install_task.abort();
+        let _ = install_task.await;
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while !installer.cancelled.load(Ordering::SeqCst) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        assert!(!installer.committed.load(Ordering::SeqCst));
+
+        server.trigger_shutdown();
+        tokio::time::timeout(std::time::Duration::from_secs(2), server_task)
+            .await
+            .unwrap()
+            .unwrap();
+    }
+
+    #[tokio::test]
     async fn end_to_end_over_uds() {
         let dir = tempfile::tempdir().unwrap();
         let sock = dir.path().join("private-run/bloom.sock");
@@ -2733,6 +3270,86 @@ summary = "Demo app used by IPC tests."
 
         let _ = client.call("shutdown", Value::Null).await;
         let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
+    }
+
+    #[tokio::test]
+    async fn vfs_read_succeeds_below_and_above_the_single_frame_base64_threshold() {
+        let effective_threshold = MAX_IPC_FRAME_BYTES / 4 * 3;
+        for size in [
+            effective_threshold - 64 * 1024,
+            effective_threshold + 64 * 1024,
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let socket = dir.path().join("private-run/bloom.sock");
+            let body = vec![0x5a; size];
+            let vfs = Vfs::builder()
+                .mount(
+                    "stub",
+                    Arc::new(SingleFileHandler::new("large", body.clone())),
+                )
+                .build();
+            let server = IpcServer::new(vfs, "0", vec![]);
+            let serving = server.clone();
+            let serving_socket = socket.clone();
+            let handle = tokio::spawn(async move { serving.serve(&serving_socket).await.unwrap() });
+            for _ in 0..100 {
+                if socket.exists() {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+            let result = IpcClient::new(&socket)
+                .call("read", json!({"path": "/stub/large"}))
+                .await
+                .unwrap();
+            assert_eq!(
+                B64.decode(result["bytes_b64"].as_str().unwrap()).unwrap(),
+                body
+            );
+            IpcClient::new(&socket)
+                .call("shutdown", Value::Null)
+                .await
+                .unwrap();
+            handle.await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn vfs_write_succeeds_above_the_single_frame_base64_threshold() {
+        let size = MAX_IPC_FRAME_BYTES / 4 * 3 + 64 * 1024;
+        let body = vec![0x5a; size];
+        let handler = Arc::new(CapturedWriteHandler(tokio::sync::Mutex::new(Vec::new())));
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("private-run/bloom.sock");
+        let server = IpcServer::new(
+            Vfs::builder().mount("capture", handler.clone()).build(),
+            "0",
+            vec![],
+        );
+        let serving = server.clone();
+        let serving_socket = socket.clone();
+        let server_task =
+            tokio::spawn(async move { serving.serve(&serving_socket).await.unwrap() });
+        for _ in 0..100 {
+            if socket.exists() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        IpcClient::new(&socket)
+            .call(
+                "write",
+                json!({"path": "/capture/large", "bytes_b64": B64.encode(&body)}),
+            )
+            .await
+            .unwrap();
+        assert_eq!(&*handler.0.lock().await, &body);
+        IpcClient::new(&socket)
+            .call("shutdown", Value::Null)
+            .await
+            .unwrap();
+        server_task.await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/bloom-daemon/src/lib.rs
+++ b/crates/bloom-daemon/src/lib.rs
@@ -4651,12 +4651,20 @@ mod tests {
         let payload = b"exact owner order".to_vec();
         let payload_digest =
             bloom_broker_api::Digest32::from_bytes(sha2::Sha256::digest(&payload).into());
+        let claim_payload_digest = {
+            let mut digest = sha2::Sha256::new();
+            digest.update(b"bloom.petal.payload-batch.v1\0");
+            digest.update(1_u64.to_be_bytes());
+            digest.update((payload.len() as u64).to_be_bytes());
+            digest.update(&payload);
+            bloom_broker_api::Digest32::from_bytes(digest.finalize().into())
+        };
         let claim = bloom_broker_api::PetalUseClaim {
             package_hash: bloom_broker_api::Digest32::from_bytes([0xbb; 32]),
             route: context.route_id.clone(),
             operation_class: bloom_broker_api::Token::new("order.place").unwrap(),
             crypto_suite: bloom_broker_api::CryptoSuite::Secp256k1Sha256Recoverable,
-            payload_digest: payload_digest.clone(),
+            payload_digest: claim_payload_digest,
             ordered_hashes: vec![payload_digest.clone()],
             declared_debits: Vec::new(),
             declared_destinations: Vec::new(),

--- a/crates/bloom-it/tests/macos_launchagent.rs
+++ b/crates/bloom-it/tests/macos_launchagent.rs
@@ -87,7 +87,8 @@ fn session_agent_has_no_service_authority_and_stops_with_the_login_domain() {
     .expect("read session LaunchAgent source");
 
     assert!(source.contains("@BLOOM_MACHINE_BINARY@"));
-    assert!(source.contains("<string>--session-sentinel</string>"));
+    assert!(source.contains("<string>serve</string>"));
+    assert!(source.contains("<string>session-sentinel</string>"));
     assert!(source.contains("BLOOM_CONFIG_ROOT"));
     assert!(source.contains("/private/var/run/bloom"));
     assert!(source.contains("<string>Aqua</string>"));
@@ -168,7 +169,8 @@ fn root_pf_monitor_has_no_rpc_or_custody_surface_and_services_require_its_attest
     )
     .unwrap();
     assert!(plist.contains("<string>root</string>"));
-    assert!(plist.contains("--triad-pf-monitor-once"));
+    assert!(plist.contains("<string>serve</string>"));
+    assert!(plist.contains("<string>triad-pf-monitor-once</string>"));
     assert!(plist.contains("<key>StartInterval</key>"));
     assert!(!plist.contains("<key>Sockets</key>"));
 
@@ -225,7 +227,7 @@ fn live_installer_provisions_fail_closed_directory_service_records() {
         "AuthenticationAuthority ';DisabledUser;'",
         "BLOOM_RELEASE_PUBLIC_KEY",
         "pinned release key must be root owned",
-        "--triad-render-macos-enrollment",
+        "init triad-render-macos-enrollment",
         "$payload/installer/macos/config/",
         "dsmemberutil flushcache",
         "chown \"$broker_user:$machine_broker_group\" \"$runtime/machine-broker\"",
@@ -271,7 +273,7 @@ fn macos_installer_does_not_hide_removed_lifecycle_logic() {
     let source =
         fs::read_to_string(workspace().join("packaging/triad/release/install-macos.sh")).unwrap();
     for removed in [
-        "--triad-render-macos-identity-rotation",
+        "init triad-render-macos-identity-rotation",
         "recover_interrupted",
         "retained_restore",
         "transaction_staging",

--- a/crates/bloom-it/tests/triad_release.rs
+++ b/crates/bloom-it/tests/triad_release.rs
@@ -388,7 +388,7 @@ fn triad_developer_launcher_owns_only_its_service_processes() {
 fn serve_starts_audited_projection_refresh_after_fallible_setup() {
     let source = fs::read_to_string(workspace().join("crates/bloom/src/main.rs")).unwrap();
     let serve = source
-        .split("Cmd::Serve { endpoint, mount } => {")
+        .split("Cmd::Serve {")
         .nth(1)
         .expect("serve command arm");
     let mount = serve.find("let mount_handle = mount_bloom").unwrap();
@@ -1276,7 +1276,8 @@ fn macos_installer_stages_unix_principals_launchdaemons_and_confirmed_uninstall(
     }
     let containment_plist = root.join("Library/LaunchDaemons/com.bloom.containment.plist");
     let containment_source = fs::read_to_string(&containment_plist).unwrap();
-    assert!(containment_source.contains("--triad-pf-monitor-once"));
+    assert!(containment_source.contains("<string>serve</string>"));
+    assert!(containment_source.contains("<string>triad-pf-monitor-once</string>"));
     assert!(!containment_source.contains("@BLOOM_"));
     assert_eq!(
         fs::metadata(&containment_plist)

--- a/crates/bloom-it/tests/triad_release.rs
+++ b/crates/bloom-it/tests/triad_release.rs
@@ -785,10 +785,8 @@ fn acceptance_rerun_is_bound_to_the_verified_bundle_when_present() {
             .output()
             .unwrap();
         assert!(output.status.success());
-        assert_eq!(
-            String::from_utf8(output.stdout).unwrap().trim(),
-            expected_version
-        );
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        assert_eq!(stdout.lines().next().unwrap_or_default(), expected_version);
     }
 }
 

--- a/crates/bloom-mount/src/adapter.rs
+++ b/crates/bloom-mount/src/adapter.rs
@@ -1037,9 +1037,19 @@ impl FileSystem for BloomFs {
                                 e.size
                             }
                             Err(error) => {
-                                self.render_cache.put_error(path, error, RENDER_CACHE_TTL);
-                                warn!(path = %path, ?error, "mount.adapter.getattr.render_failed");
-                                return Err(error);
+                                if e.size > 0 && matches!(error, FsError::Io) {
+                                    // The handler supplied a trustworthy local
+                                    // size hint. Keep filesystem metadata
+                                    // usable when rendering dynamic content
+                                    // fails, and leave the error uncached so
+                                    // an explicit READ can retry the backend.
+                                    warn!(path = %path, ?error, "mount.adapter.getattr.using_size_hint_after_render_failure");
+                                    e.size
+                                } else {
+                                    self.render_cache.put_error(path, error, RENDER_CACHE_TTL);
+                                    warn!(path = %path, ?error, "mount.adapter.getattr.render_failed");
+                                    return Err(error);
+                                }
                             }
                         },
                     }
@@ -3044,6 +3054,7 @@ mod tests {
 
     struct ClassifiedReadHandler {
         result: TestReadResult,
+        size_hint: u64,
         reads: parking_lot::Mutex<u32>,
     }
 
@@ -3051,6 +3062,15 @@ mod tests {
         fn new(result: TestReadResult) -> Arc<Self> {
             Arc::new(Self {
                 result,
+                size_hint: 0,
+                reads: parking_lot::Mutex::new(0),
+            })
+        }
+
+        fn with_size_hint(result: TestReadResult, size_hint: u64) -> Arc<Self> {
+            Arc::new(Self {
+                result,
+                size_hint,
                 reads: parking_lot::Mutex::new(0),
             })
         }
@@ -3065,7 +3085,7 @@ mod tests {
         async fn lookup(&self, p: &VfsPath) -> Result<Entry, HandlerError> {
             match p.segments() {
                 [] => Ok(Entry::dir("")),
-                [name] if name == "value" => Ok(Entry::file("value")),
+                [name] if name == "value" => Ok(Entry::file("value").with_size(self.size_hint)),
                 _ => Err(HandlerError::NotFound(p.to_string_path())),
             }
         }
@@ -3081,7 +3101,7 @@ mod tests {
 
         async fn list(&self, p: &VfsPath) -> Result<Vec<Entry>, HandlerError> {
             if p.is_root() {
-                Ok(vec![Entry::file("value")])
+                Ok(vec![Entry::file("value").with_size(self.size_hint)])
             } else {
                 Err(HandlerError::NotADir(p.to_string_path()))
             }
@@ -3104,6 +3124,19 @@ mod tests {
         let error = fs.getattr(&fake_ctx(), &value).await.unwrap_err();
         assert_eq!(error, FsError::Io);
         assert_eq!(handler.read_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn getattr_backend_error_uses_local_size_hint_without_caching_the_error() {
+        let handler = ClassifiedReadHandler::with_size_hint(TestReadResult::Backend, 410);
+        let (fs, value) = classified_read_handle(handler.clone()).await;
+        let attrs = fs.getattr(&fake_ctx(), &value).await.unwrap();
+        assert_eq!(attrs.size, 410);
+        assert_eq!(handler.read_count(), 1);
+
+        let error = fs.read(&fake_ctx(), &value, 0, 1024).await.unwrap_err();
+        assert_eq!(error, FsError::Io);
+        assert_eq!(handler.read_count(), 2);
     }
 
     #[tokio::test]

--- a/crates/bloom-petals/src/package.rs
+++ b/crates/bloom-petals/src/package.rs
@@ -925,24 +925,96 @@ pub fn store_policy_from_manifest_toml(bytes: &[u8]) -> Result<StoreNamespacePol
 }
 
 pub fn build_petal_package_dir(root: impl AsRef<Path>) -> Result<PreparedPetalPackage, PetalError> {
+    build_petal_package_dir_guarded(root, || Ok(()))
+}
+
+pub fn build_petal_package_dir_guarded<F>(
+    root: impl AsRef<Path>,
+    commit_guard: F,
+) -> Result<PreparedPetalPackage, PetalError>
+where
+    F: FnOnce() -> Result<(), PetalError>,
+{
     let root = root.as_ref();
     PetalPackage::scan_dir(root)?;
     validate_generated_artifact_paths(root)?;
-    remove_generated_artifacts(root)?;
-    let source_package = PreparedPetalPackage::from_dir(root)?;
+    let source_files = collect_package_dir(root)?
+        .into_iter()
+        .filter(|file| {
+            file.path != "artifacts/build-manifest.json"
+                && !file.path.starts_with("artifacts/routes/")
+        })
+        .collect::<Vec<_>>();
+    let source_package = PreparedPetalPackage::from_files(source_files.clone())?;
     let manifest = build_manifest_for_package(&source_package)?;
+    let parent = root
+        .parent()
+        .ok_or_else(|| PetalError::InvalidWasm("Petal package directory has no parent".into()))?;
+    let staged = tempfile::tempdir_in(parent)?;
 
     for route in &source_package.route_index.routes {
         let artifact = route_artifact_bytes(&source_package, route)?;
-        write_package_file(root, &route.artifact_path, &artifact)?;
+        write_package_file(staged.path(), &route.artifact_path, &artifact)?;
     }
     write_package_file(
-        root,
+        staged.path(),
         "artifacts/build-manifest.json",
         &serde_json::to_vec_pretty(&manifest)?,
     )?;
+    let mut final_files = source_files;
+    final_files.extend(collect_package_dir(staged.path())?);
+    let package = PreparedPetalPackage::from_files(final_files)?;
 
-    PreparedPetalPackage::from_dir(root)
+    commit_guard()?;
+    commit_generated_artifacts(root, staged.path())?;
+    Ok(package)
+}
+
+fn commit_generated_artifacts(root: &Path, staged_root: &Path) -> Result<(), PetalError> {
+    let artifacts = root.join("artifacts");
+    std::fs::create_dir_all(&artifacts)?;
+    let backup =
+        tempfile::tempdir_in(root.parent().ok_or_else(|| {
+            PetalError::InvalidWasm("Petal package directory has no parent".into())
+        })?)?;
+    let routes = artifacts.join("routes");
+    let manifest = artifacts.join("build-manifest.json");
+    let backup_routes = backup.path().join("routes");
+    let backup_manifest = backup.path().join("build-manifest.json");
+    let staged_routes = staged_root.join("artifacts/routes");
+    let staged_manifest = staged_root.join("artifacts/build-manifest.json");
+
+    let had_routes = routes.exists();
+    let had_manifest = manifest.exists();
+    if had_routes {
+        std::fs::rename(&routes, &backup_routes)?;
+    }
+    if had_manifest && let Err(error) = std::fs::rename(&manifest, &backup_manifest) {
+        if had_routes {
+            let _ = std::fs::rename(&backup_routes, &routes);
+        }
+        return Err(error.into());
+    }
+
+    let install_result = (|| -> Result<(), std::io::Error> {
+        if staged_routes.exists() {
+            std::fs::rename(&staged_routes, &routes)?;
+        }
+        std::fs::rename(&staged_manifest, &manifest)?;
+        Ok(())
+    })();
+    if let Err(error) = install_result {
+        let _ = std::fs::remove_dir_all(&routes);
+        let _ = std::fs::remove_file(&manifest);
+        if had_routes {
+            let _ = std::fs::rename(&backup_routes, &routes);
+        }
+        if had_manifest {
+            let _ = std::fs::rename(&backup_manifest, &manifest);
+        }
+        return Err(error.into());
+    }
+    Ok(())
 }
 
 pub fn petal_consent_summary(
@@ -1350,35 +1422,6 @@ fn validate_generated_artifact_paths(root: &Path) -> Result<(), PetalError> {
         ));
     }
     Ok(())
-}
-
-fn remove_generated_artifacts(root: &Path) -> Result<(), PetalError> {
-    let artifacts = root.join("artifacts");
-    let routes = artifacts.join("routes");
-    match std::fs::remove_dir_all(&routes) {
-        Ok(()) => Ok(()),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(e) => Err(PetalError::Io(e)),
-    }?;
-
-    let manifest = artifacts.join("build-manifest.json");
-    match std::fs::remove_file(&manifest) {
-        Ok(()) => Ok(()),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(e) => Err(PetalError::Io(e)),
-    }?;
-    match std::fs::remove_dir(&artifacts) {
-        Ok(()) => Ok(()),
-        Err(e)
-            if matches!(
-                e.kind(),
-                std::io::ErrorKind::NotFound | std::io::ErrorKind::DirectoryNotEmpty
-            ) =>
-        {
-            Ok(())
-        }
-        Err(e) => Err(PetalError::Io(e)),
-    }
 }
 
 fn route_kind_and_ops(source_path: &str) -> (RouteEntryKind, Vec<RouteOp>) {
@@ -4962,6 +5005,37 @@ name = "echo"
         let artifact = std::fs::read(tmp.path().join(&route.artifact_path)).unwrap();
         let source = std::fs::read(tmp.path().join(&route.source_path)).unwrap();
         assert_eq!(artifact, source);
+    }
+
+    #[test]
+    fn cancelled_petal_build_preserves_existing_generated_artifacts() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_petal_package(tmp.path());
+        write_package_file(
+            tmp.path(),
+            "artifacts/routes/r000001.wasm",
+            b"previous artifact",
+        );
+        write_package_file(
+            tmp.path(),
+            "artifacts/build-manifest.json",
+            b"previous manifest",
+        );
+
+        let error = build_petal_package_dir_guarded(tmp.path(), || {
+            Err(PetalError::vm("cancelled before commit"))
+        })
+        .unwrap_err();
+
+        assert!(error.to_string().contains("cancelled before commit"));
+        assert_eq!(
+            std::fs::read(tmp.path().join("artifacts/routes/r000001.wasm")).unwrap(),
+            b"previous artifact"
+        );
+        assert_eq!(
+            std::fs::read(tmp.path().join("artifacts/build-manifest.json")).unwrap(),
+            b"previous manifest"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/bloom-petals/src/store.rs
+++ b/crates/bloom-petals/src/store.rs
@@ -207,6 +207,18 @@ impl PetalStore {
         package: PreparedPetalPackage,
         source: Option<PetalSourceProvenance>,
     ) -> Result<(InstallResult, PetalMeta, RouteIndex), PetalError> {
+        self.install_prepared_petal_package_with_source_guarded(package, source, || Ok(()))
+    }
+
+    pub fn install_prepared_petal_package_with_source_guarded<F>(
+        &self,
+        package: PreparedPetalPackage,
+        source: Option<PetalSourceProvenance>,
+        commit_guard: F,
+    ) -> Result<(InstallResult, PetalMeta, RouteIndex), PetalError>
+    where
+        F: Fn() -> Result<(), PetalError>,
+    {
         verify_prepared_package(&package)?;
         let hash = package.hash.clone();
         validate_hash_arg(&hash)?;
@@ -277,11 +289,13 @@ impl PetalStore {
             route_index_schema: ROUTE_INDEX_SCHEMA.to_string(),
         });
         meta.source = source;
+        commit_guard()?;
         self.write_meta(&meta)?;
 
         // This atomic rename is the installation commit point. Before it,
         // readers continue to resolve the previous package; after it, they
         // resolve only this fully prepared and verified package.
+        commit_guard()?;
         self.write_petal_owner(&package.name, &hash)?;
 
         // Keep prior package data until the next store open. A request that
@@ -1013,6 +1027,37 @@ name = "echo"
         assert_eq!(meta.source.as_ref(), Some(&provenance));
         let loaded = store.load_meta(&result.hash).unwrap();
         assert_eq!(loaded.source.as_ref(), Some(&provenance));
+    }
+
+    #[test]
+    fn cancelled_prepared_install_does_not_publish_an_owner() {
+        let (d, store) = store();
+        let package_dir = d.path().join("cancelled-pkg");
+        write_file(
+            &package_dir,
+            "petal.toml",
+            br#"schema = "bloom.petal.package.v1"
+name = "echo"
+"#,
+        );
+        write_file(&package_dir, "README.md", b"# echo");
+        write_file(&package_dir, "AGENTS.md", b"# echo agents");
+        write_file(
+            &package_dir,
+            "petal/echo/[name].txt.wasm",
+            route_component_wasm(),
+        );
+        let package = PreparedPetalPackage::from_dir(&package_dir).unwrap();
+
+        let error = store
+            .install_prepared_petal_package_with_source_guarded(package, None, || {
+                Err(PetalError::vm("cancelled before commit"))
+            })
+            .unwrap_err();
+
+        assert!(error.to_string().contains("cancelled before commit"));
+        assert_eq!(store.resolve_petal_owner("echo").unwrap(), None);
+        assert!(store.list_package_hashes().unwrap().is_empty());
     }
 
     #[test]

--- a/crates/bloom-proto/src/audit.rs
+++ b/crates/bloom-proto/src/audit.rs
@@ -471,6 +471,12 @@ impl AuditLog {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
+        if identity.is_none() && path.exists() && first_nonempty_line_is_signed(&path)? {
+            return Err(AuditError::Degraded(
+                "refusing to reopen a signed audit journal without its application identity"
+                    .to_owned(),
+            ));
+        }
         let rotation_recovery_error = recover_rotation_marker
             .then(|| {
                 identity.as_ref().and_then(|current| {
@@ -1948,6 +1954,27 @@ mod tests {
         assert_eq!(genesis.data["legacy_count"], 2);
         assert!(path.with_extension("legacy-unsigned-v0.jsonl").is_file());
         AuditLog::verify_signed(&path, &identity).unwrap();
+    }
+
+    #[test]
+    fn signed_journal_cannot_be_reopened_or_extended_as_unsigned() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("audit.jsonl");
+        let signed = AuditLog::open_signed(&path, identity(81, "machine-audit-signed")).unwrap();
+        signed.append(record("signed", 1)).unwrap();
+        let original = std::fs::read(&path).unwrap();
+        drop(signed);
+
+        let error = match AuditLog::open(&path) {
+            Ok(_) => panic!("signed journal reopened without its identity"),
+            Err(error) => error,
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("without its application identity")
+        );
+        assert_eq!(std::fs::read(&path).unwrap(), original);
     }
 
     #[test]

--- a/crates/bloom-vfs/Cargo.toml
+++ b/crates/bloom-vfs/Cargo.toml
@@ -47,6 +47,7 @@ fs2.workspace = true
 rand.workspace = true
 mpp.workspace = true
 qrcode.workspace = true
+rustix.workspace = true
 
 [dev-dependencies]
 bloom-proto = { workspace = true, features = ["audit-test-seam"] }

--- a/crates/bloom-vfs/src/docs/README.md
+++ b/crates/bloom-vfs/src/docs/README.md
@@ -131,14 +131,23 @@ does not create a Machine-local wallet and returns before the owner ceremony
 completes:
 
 ```sh
+BEFORE_REGISTRATIONS="$(mktemp)"
+ls /bloom/wallets/registrations > "$BEFORE_REGISTRATIONS"
 printf 'main\n' > /bloom/wallets/new
-cat /bloom/wallets/registrations/main/status.json
-cat /bloom/wallets/registrations/main/ceremony_url
+AFTER_REGISTRATIONS="$(mktemp)"
+ls /bloom/wallets/registrations > "$AFTER_REGISTRATIONS"
+comm -13 "$BEFORE_REGISTRATIONS" "$AFTER_REGISTRATIONS"
+REGISTRATION_ID='<candidate-operation-id>'
+cat /bloom/wallets/registrations/"$REGISTRATION_ID"/status.json
 ```
 
-Open or forward `ceremony_url` to a human, then poll `status.json` until its
-`state` is `completed`; only then does `wallets/main/address` exist. Write to
-`wallets/registrations/<name>/cancel` to cancel a live registration. Broker
+Compare the before and after listings. For every new candidate, verify that
+`requested_name` in `status.json` is `main` before opening its `ceremony_url`,
+polling it, or cancelling it. Concurrent registrations for the same requested
+name remain ambiguous through this write-only sink, so serialize same-name
+writes. Poll until `ceremony_state` is `COMPLETED`; only then does
+`wallets/main/address` exist. Write `cancel` to
+`wallets/registrations/<operation-id>/cancel` to cancel a live registration. Broker
 owns ceremony orchestration and Signer owns custody. If either is unavailable,
 the operation fails closed; Machine has no local fallback. Import, recovery,
 rebind, and deletion likewise use Broker custody ceremonies, never mounted

--- a/crates/bloom-vfs/src/docs/agent-guidance.md
+++ b/crates/bloom-vfs/src/docs/agent-guidance.md
@@ -49,12 +49,20 @@ does not create a local wallet**, and the write returns before the ceremony
 completes:
 
 ```sh
+BEFORE_REGISTRATIONS="$(mktemp)"
+ls wallets/registrations > "$BEFORE_REGISTRATIONS"
 printf 'main\n' > wallets/new
-cat wallets/registrations/main/status.json
-cat wallets/registrations/main/ceremony_url
+AFTER_REGISTRATIONS="$(mktemp)"
+ls wallets/registrations > "$AFTER_REGISTRATIONS"
+comm -13 "$BEFORE_REGISTRATIONS" "$AFTER_REGISTRATIONS"
+REGISTRATION_ID='<candidate-operation-id>'
+cat wallets/registrations/"$REGISTRATION_ID"/status.json
 ```
 
-- Read `status.json` and `ceremony_url` right after the write.
+- Compare the before and after listings. For every new candidate, verify its
+  `requested_name` before opening or polling its `ceremony_url`, or cancelling
+  it. Concurrent registrations for the same requested name remain ambiguous
+  through this write-only sink, so serialize same-name writes.
 - Open or forward `ceremony_url` to a human; do not attempt it yourself. Never
   imitate WebAuthn, supply PRF material, read recovery material, or silently
   downgrade to a Machine-local credential flow — none of that is available or safe from
@@ -64,13 +72,13 @@ cat wallets/registrations/main/ceremony_url
   (iCloud Keychain, Google Password Manager), or a compatible hardware
   security key — and specifically to choose **"Use browser, device, or
   hardware key"** if Bitwarden intercepts the prompt.
-- Do not proceed until `status.json`'s `state` is `completed`; only then read
+- Do not proceed until `status.json`'s `ceremony_state` is `COMPLETED`; only then read
   the new wallet's address at `wallets/<name>/address`.
 - Registration requires Machine's authenticated Broker edge. If Broker or
   Signer is unavailable, the write fails closed; do not fall back to a
   Machine-owned wallet-creation path.
-- To cancel a live registration, write anything to
-  `wallets/registrations/<name>/cancel`.
+- To cancel a live registration, write `cancel` to
+  `wallets/registrations/<operation-id>/cancel`.
 
 Import, recovery, rebind, and deletion are also Broker custody operations.
 Sensitive inputs belong only in the Broker-hosted owner ceremony, never in a

--- a/crates/bloom-vfs/src/docs/agent-guidance.md
+++ b/crates/bloom-vfs/src/docs/agent-guidance.md
@@ -70,7 +70,7 @@ cat wallets/registrations/main/status.json
 - Registration requires Machine's authenticated Broker edge. If Broker or
   Signer is unavailable, the write fails closed; do not fall back to a
   Machine-owned wallet-creation path.
-- To cancel a live registration, write `cancel` to
+- To cancel a live registration, write `y`, `yes`, or `cancel` to
   `wallets/registrations/<petname>/cancel`.
 
 Import, recovery, rebind, and deletion are also Broker custody operations.

--- a/crates/bloom-vfs/src/docs/examples.md
+++ b/crates/bloom-vfs/src/docs/examples.md
@@ -28,20 +28,31 @@ ls /bloom/wallets/alice/chains/anvil/outbox/sent/
 ## Creating a wallet (asynchronous passkey registration)
 
 ```sh
-# 1. Start registration — this is NOT a local wallet and does not block.
+# 1. Capture the existing IDs, then start registration. This does not block.
+BEFORE_REGISTRATIONS="$(mktemp)"
+ls /bloom/wallets/registrations > "$BEFORE_REGISTRATIONS"
 printf 'main\n' > /bloom/wallets/new
 
-# 2. Read status and the ceremony URL, and open/forward the URL to a human.
-cat /bloom/wallets/registrations/main/status.json
-cat /bloom/wallets/registrations/main/ceremony_url
+# 2. Compare the after-listing and inspect each new candidate.
+AFTER_REGISTRATIONS="$(mktemp)"
+ls /bloom/wallets/registrations > "$AFTER_REGISTRATIONS"
+comm -13 "$BEFORE_REGISTRATIONS" "$AFTER_REGISTRATIONS"
+REGISTRATION_ID='<candidate-operation-id>'
+cat /bloom/wallets/registrations/"$REGISTRATION_ID"/status.json
 
-# 3. Poll status until "state" is "completed", then read the new wallet.
-cat /bloom/wallets/registrations/main/status.json
+# 3. Open/forward its ceremony_url to a human. Poll until ceremony_state is
+#    COMPLETED, then read the new wallet.
+cat /bloom/wallets/registrations/"$REGISTRATION_ID"/status.json
 cat /bloom/wallets/main/address
 ```
 
+Verify the candidate's `requested_name` before opening its `ceremony_url`,
+polling it, or cancelling it. Concurrent registrations for the same requested
+name remain ambiguous through this write-only sink, so serialize same-name
+writes.
+
 Requires a running `bloom serve` daemon. Cancel a live registration with
-`printf 'x' > /bloom/wallets/registrations/main/cancel`.
+`printf 'cancel' > /bloom/wallets/registrations/"$REGISTRATION_ID"/cancel`.
 
 ## Tools
 

--- a/crates/bloom-vfs/src/exact_signing.rs
+++ b/crates/bloom-vfs/src/exact_signing.rs
@@ -1008,14 +1008,22 @@ mod tests {
         let temporary = tempfile::tempdir().unwrap();
         let state = temporary.path().join("petal-exact.json");
         let payload = b"exact venue payload";
-        let payload_digest = Digest32::from_bytes(Sha256::digest(payload).into());
+        let ordered_hash = Digest32::from_bytes(Sha256::digest(payload).into());
+        let claim_payload_digest = {
+            let mut digest = Sha256::new();
+            digest.update(b"bloom.petal.payload-batch.v1\0");
+            digest.update(1_u64.to_be_bytes());
+            digest.update((payload.len() as u64).to_be_bytes());
+            digest.update(payload);
+            Digest32::from_bytes(digest.finalize().into())
+        };
         let claim = PetalUseClaim {
             package_hash,
             route: "orders/place".into(),
             operation_class: token("order.place"),
             crypto_suite: CryptoSuite::Secp256k1Sha256Recoverable,
-            payload_digest: payload_digest.clone(),
-            ordered_hashes: vec![payload_digest.clone()],
+            payload_digest: claim_payload_digest,
+            ordered_hashes: vec![ordered_hash.clone()],
             declared_debits: Vec::new(),
             declared_destinations: Vec::new(),
             declared_fee: bloom_broker_api::DeclaredFee::None,
@@ -1030,7 +1038,7 @@ mod tests {
                 "wallet",
                 "order.place",
                 payload,
-                payload_digest.clone(),
+                ordered_hash.clone(),
                 CryptoSuite::Secp256k1Sha256Recoverable,
                 &serde_json::json!({"asset": "BTC"}),
                 &subject,
@@ -1050,7 +1058,7 @@ mod tests {
                 "wallet",
                 "order.place",
                 payload,
-                payload_digest,
+                ordered_hash,
                 CryptoSuite::Secp256k1Sha256Recoverable,
                 &serde_json::json!({"asset": "BTC"}),
                 &subject,

--- a/crates/bloom-vfs/src/handler.rs
+++ b/crates/bloom-vfs/src/handler.rs
@@ -107,6 +107,13 @@ impl Entry {
         self
     }
 
+    pub fn with_size(mut self, size: u64) -> Self {
+        if self.kind == EntryKind::File {
+            self.size = size;
+        }
+        self
+    }
+
     pub fn with_modified_ms(self, modified_ms: u128) -> Self {
         if modified_ms > u64::MAX as u128 {
             return self;
@@ -355,6 +362,12 @@ mod tests {
         let modified = SystemTime::UNIX_EPOCH + Duration::from_secs(123);
         let e = Entry::file("artifact.json").with_modified(modified);
         assert_eq!(e.modified, Some(modified));
+    }
+
+    #[test]
+    fn with_size_records_file_hint_but_not_directory_hint() {
+        assert_eq!(Entry::file("status.json").with_size(410).size, 410);
+        assert_eq!(Entry::dir("wallets").with_size(410).size, 0);
     }
 
     #[test]

--- a/crates/bloom-vfs/src/handlers/docs.rs
+++ b/crates/bloom-vfs/src/handlers/docs.rs
@@ -276,9 +276,16 @@ mod tests {
                 .await
                 .unwrap();
             let s = String::from_utf8(bytes).unwrap();
+            let normalized = s.to_ascii_lowercase();
             assert!(
                 s.contains("wallets/registrations/") && s.contains("status.json"),
-                "{name} must document wallets/registrations/<name>/status.json"
+                "{name} must document operation-ID registration status"
+            );
+            assert!(
+                normalized.contains("requested_name")
+                    && normalized.contains("before")
+                    && normalized.contains("concurrent"),
+                "{name} must document safe registration correlation and its concurrency limit"
             );
             assert!(
                 !(s.contains("plain name") && s.contains("creates a local wallet")),

--- a/crates/bloom-vfs/src/handlers/wallets.rs
+++ b/crates/bloom-vfs/src/handlers/wallets.rs
@@ -7,7 +7,8 @@
 //! Paths handled:
 //! - `wallets/`                                                     — list wallets
 //! - `wallets/new`                                                  — write a wallet name to prepare registration
-//! - `wallets/registrations/<petname>/{status.json,result.json}`    — public registration projection
+//! - `wallets/registrations/<petname>/status.json`                 — public registration projection
+//! - `wallets/registrations/<petname>/result.json`                 — completed registration result
 //! - `wallets/registrations/<petname>/cancel`                       — write `cancel` before acceptance
 //! - `wallets/<wallet>/address`                                     — checksummed owner/signer address
 //! - `wallets/<wallet>/address.qr.svg`                              — scannable QR image for the owner/signer address
@@ -422,6 +423,10 @@ impl WalletsHandler {
         Ok(record)
     }
 
+    fn registration_result_ready(projection: &WalletRegistrationProjection) -> bool {
+        projection.ceremony_state == bloom_broker_api::CeremonyState::Completed
+    }
+
     async fn prepare_wallet_registration(&self, data: &[u8]) -> Result<(), HandlerError> {
         use sha2::Digest as _;
 
@@ -447,20 +452,32 @@ impl WalletsHandler {
         }
         let wallet_id = bloom_broker_api::Token::new(requested_name.to_owned())
             .map_err(|error| HandlerError::invalid(error.to_string()))?;
-        let mut existing_paths =
-            self.registration_records()?
-                .into_iter()
-                .filter_map(|(path, existing)| {
-                    (existing.requested_name == requested_name).then_some(path)
-                });
-        let registration_path = existing_paths
-            .next()
-            .unwrap_or_else(|| self.registration_path(requested_name));
-        if existing_paths.next().is_some() {
+        let mut existing_records = self
+            .registration_records()?
+            .into_iter()
+            .filter(|(_, existing)| existing.requested_name == requested_name);
+        let existing = existing_records.next();
+        if existing_records.next().is_some() {
             return Err(HandlerError::backend(
                 "multiple wallet registration projections claim the same petname",
             ));
         }
+        if let Some((_, projection)) = &existing
+            && projection.ceremony_state == bloom_broker_api::CeremonyState::AwaitingUser
+        {
+            // A shell retry (or an NFS client replaying a committed write) must
+            // not allocate a second Broker operation for the same live
+            // registration. Refreshing also proves that the retained launch is
+            // still actionable before reporting the retry as successful.
+            let refreshed = self.registration_projection(requested_name).await?;
+            if refreshed.ceremony_state == bloom_broker_api::CeremonyState::AwaitingUser {
+                return Ok(());
+            }
+        }
+        let registration_path = self.registration_path(requested_name);
+        let legacy_registration_path = existing
+            .map(|(path, _)| path)
+            .filter(|path| path != &registration_path);
 
         let mut operation_bytes = [0_u8; 32];
         rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut operation_bytes);
@@ -510,7 +527,11 @@ impl WalletsHandler {
             ceremony_expires_at_ms: Some(prepared.ceremony_expires_at_ms),
             signer_contribution_digest: prepared.signer_contribution_digest,
         };
-        write_atomic_json(&registration_path, &projection)
+        write_atomic_json(&registration_path, &projection)?;
+        if let Some(legacy_path) = legacy_registration_path {
+            std::fs::remove_file(legacy_path)?;
+        }
+        Ok(())
     }
 
     async fn registration_projection(
@@ -1887,11 +1908,17 @@ impl WalletsHandler {
                     let _ = self.registration_projection(requested_name).await?;
                     Ok(Entry::dir(requested_name))
                 }
-                [_, requested_name, leaf]
-                    if matches!(leaf.as_str(), "status.json" | "result.json") =>
-                {
+                [_, requested_name, leaf] if leaf == "status.json" => {
                     let _ = self.registration_projection(requested_name).await?;
                     Ok(Entry::file(leaf))
+                }
+                [_, requested_name, leaf] if leaf == "result.json" => {
+                    let projection = self.registration_projection(requested_name).await?;
+                    if Self::registration_result_ready(&projection) {
+                        Ok(Entry::file(leaf))
+                    } else {
+                        Err(HandlerError::not_found(path.to_string_path()))
+                    }
                 }
                 [_, requested_name, leaf] if leaf == "cancel" => {
                     let _ = self.registration_projection(requested_name).await?;
@@ -2036,6 +2063,10 @@ impl WalletsHandler {
                     Ok(bytes)
                 }
                 [_, requested_name, leaf] if leaf == "result.json" => {
+                    let projection = self.registration_projection(requested_name).await?;
+                    if !Self::registration_result_ready(&projection) {
+                        return Err(HandlerError::not_found(path.to_string_path()));
+                    }
                     self.wallet_registration_result_json(requested_name).await
                 }
                 _ => Err(HandlerError::NotAFile(path.to_string_path())),
@@ -2242,12 +2273,13 @@ impl WalletsHandler {
                     .map(|name| Entry::dir(&name))
                     .collect()),
                 [_, requested_name] => {
-                    let _ = self.registration_projection(requested_name).await?;
-                    Ok(vec![
-                        Entry::file("status.json"),
-                        Entry::writable_file("cancel"),
-                        Entry::file("result.json"),
-                    ])
+                    let projection = self.registration_projection(requested_name).await?;
+                    let mut entries =
+                        vec![Entry::file("status.json"), Entry::writable_file("cancel")];
+                    if Self::registration_result_ready(&projection) {
+                        entries.push(Entry::file("result.json"));
+                    }
+                    Ok(entries)
                 }
                 _ => Err(HandlerError::NotADir(path.to_string_path())),
             };
@@ -3518,6 +3550,55 @@ mod tests {
                 });
         assert_eq!(registration_wallet_id.as_ref(), Some(&token("main")));
 
+        let pending_entries = fixture
+            .handler
+            .list(&VfsPath::parse("/registrations/main").unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            pending_entries
+                .iter()
+                .map(|entry| entry.name.as_str())
+                .collect::<Vec<_>>(),
+            ["status.json", "cancel"]
+        );
+        assert!(matches!(
+            fixture
+                .handler
+                .lookup(&VfsPath::parse("/registrations/main/result.json").unwrap())
+                .await,
+            Err(HandlerError::NotFound(_))
+        ));
+        assert!(matches!(
+            fixture
+                .handler
+                .read(&VfsPath::parse("/registrations/main/result.json").unwrap())
+                .await,
+            Err(HandlerError::NotFound(_))
+        ));
+
+        let prepare_count = broker
+            .requests
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|request| matches!(request, MachineBrokerRequest::WalletRegistrationPrepare(_)))
+            .count();
+        fixture.handler.write(&new, b"main\n").await.unwrap();
+        assert_eq!(
+            broker
+                .requests
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|request| {
+                    matches!(request, MachineBrokerRequest::WalletRegistrationPrepare(_))
+                })
+                .count(),
+            prepare_count,
+            "retrying a live registration must reuse its Broker operation"
+        );
+
         *broker.omit_ceremony_url.lock().unwrap() = true;
         assert!(matches!(
             fixture.handler.read(&status_path).await,
@@ -3545,6 +3626,25 @@ mod tests {
             serde_json::from_slice(&fixture.handler.read(&status_path).await.unwrap()).unwrap();
         assert_eq!(terminal["ceremony_state"], "CANCELLED");
         assert!(terminal["ceremony_url"].is_null());
+        assert!(matches!(
+            fixture
+                .handler
+                .read(&VfsPath::parse("/registrations/main/result.json").unwrap())
+                .await,
+            Err(HandlerError::NotFound(_))
+        ));
+
+        *broker.state.lock().unwrap() = CeremonyState::Completed;
+        let completed_entries = fixture
+            .handler
+            .list(&VfsPath::parse("/registrations/main").unwrap())
+            .await
+            .unwrap();
+        assert!(
+            completed_entries
+                .iter()
+                .any(|entry| entry.name == "result.json")
+        );
         let result = fixture
             .handler
             .read(&VfsPath::parse("/registrations/main/result.json").unwrap())

--- a/crates/bloom-vfs/src/handlers/wallets.rs
+++ b/crates/bloom-vfs/src/handlers/wallets.rs
@@ -343,6 +343,12 @@ impl WalletsHandler {
         })
     }
 
+    fn custody_broker(&self) -> Result<&MachineBrokerClient, HandlerError> {
+        self.broker.as_ref().ok_or_else(|| {
+            HandlerError::backend("custody requires the authenticated Machine-to-Broker edge")
+        })
+    }
+
     fn registration_root(&self) -> std::path::PathBuf {
         self.policy_projection_root.join("registrations")
     }
@@ -499,7 +505,7 @@ impl WalletsHandler {
         }))
         .map_err(|error| HandlerError::invalid(format!("canonicalize registration: {error}")))?;
         let prepared = self
-            .broker()?
+            .custody_broker()?
             .prepare_custody(
                 bloom_machine_client::CustodyPrepareMethod::WalletRegistration,
                 bloom_broker_api::CustodyPrepareRequest {
@@ -577,7 +583,7 @@ impl WalletsHandler {
             return Ok(projection);
         }
         let status = self
-            .broker()?
+            .custody_broker()?
             .ceremony_status(projection.operation_id.clone())
             .await
             .map_err(|error| HandlerError::backend(error.to_string()))?;
@@ -622,7 +628,7 @@ impl WalletsHandler {
             ));
         }
         let status = self
-            .broker()?
+            .custody_broker()?
             .cancel_ceremony(operation_id.clone())
             .await
             .map_err(|error| HandlerError::backend(error.to_string()))?;
@@ -645,7 +651,7 @@ impl WalletsHandler {
         let projection = self.registration_projection(requested_name).await?;
         let operation_id = projection.operation_id;
         let result = self
-            .broker()?
+            .custody_broker()?
             .custody_result(bloom_broker_api::OperationRequest {
                 operation_id: operation_id.clone(),
             })
@@ -3541,10 +3547,14 @@ mod tests {
     async fn direct_machine_wallet_creation_is_removed_for_every_legacy_body() {
         let f = make_handler();
         let path = VfsPath::parse("/new").unwrap();
-        assert!(matches!(
-            f.handler.write(&path, b"alice").await,
-            Err(HandlerError::Backend(_))
-        ));
+        let error = f.handler.write(&path, b"alice").await.unwrap_err();
+        assert!(matches!(&error, HandlerError::Backend(_)));
+        assert!(
+            error
+                .to_string()
+                .contains("custody requires the authenticated Machine-to-Broker edge"),
+            "unexpected missing-Broker error: {error}"
+        );
         for body in [
             &b"name = \"bob\"\nkind = \"local\"\npassphrase = \"secret\"\n"[..],
             b"name = \"observer\"\nkind = \"watch\"\naddress = \"0x0000000000000000000000000000000000000001\"\n",

--- a/crates/bloom-vfs/src/handlers/wallets.rs
+++ b/crates/bloom-vfs/src/handlers/wallets.rs
@@ -6,7 +6,7 @@
 //!
 //! Paths handled:
 //! - `wallets/`                                                     — list wallets
-//! - `wallets/new`                                                  — write non-secret metadata to prepare registration
+//! - `wallets/new`                                                  — write a wallet name to prepare registration
 //! - `wallets/registrations/<operation>/{status.json,result.json}`  — public registration projection
 //! - `wallets/registrations/<operation>/cancel`                     — write `cancel` before acceptance
 //! - `wallets/<wallet>/address`                                     — checksummed owner/signer address
@@ -80,13 +80,6 @@ struct ApprovalCeremonyProjection {
     operation_id: bloom_broker_api::OperationId,
     source_approval_id: Option<bloom_broker_api::Digest32>,
     response: bloom_broker_api::SealedApprovalPrepareResponse,
-}
-
-#[derive(Clone, Debug, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
-struct WalletRegistrationRequest {
-    schema: String,
-    requested_name: String,
 }
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
@@ -384,27 +377,19 @@ impl WalletsHandler {
     async fn prepare_wallet_registration(&self, data: &[u8]) -> Result<(), HandlerError> {
         use sha2::Digest as _;
 
-        const REQUEST_SCHEMA: &str = "bloom.wallet-registration-request.1";
         const PROJECTION_SCHEMA: &str = "bloom.machine-wallet-registration-projection.1";
         const MAX_REQUEST_BYTES: usize = 4096;
         if data.len() > MAX_REQUEST_BYTES {
-            return Err(HandlerError::invalid(
-                "wallet registration metadata is too large",
-            ));
+            return Err(HandlerError::invalid("wallet name is too large"));
         }
-        let request: WalletRegistrationRequest = serde_json::from_slice(data).map_err(|error| {
-            HandlerError::invalid(format!(
-                "wallet registration requires JSON metadata: {error}"
-            ))
-        })?;
-        if request.schema != REQUEST_SCHEMA {
-            return Err(HandlerError::invalid(format!(
-                "wallet registration schema must be {REQUEST_SCHEMA}"
-            )));
-        }
-        if request.requested_name.is_empty()
-            || request.requested_name.len() > 64
-            || !request.requested_name.chars().all(|character| {
+        let requested_name = std::str::from_utf8(data)
+            .map_err(|error| {
+                HandlerError::invalid(format!("wallet name must be valid UTF-8: {error}"))
+            })?
+            .trim();
+        if requested_name.is_empty()
+            || requested_name.len() > 64
+            || !requested_name.chars().all(|character| {
                 character.is_ascii_alphanumeric() || matches!(character, '-' | '_')
             })
         {
@@ -412,7 +397,7 @@ impl WalletsHandler {
                 "wallet name must be 1-64 ASCII alphanumeric, '-' or '_' characters",
             ));
         }
-        let wallet_id = bloom_broker_api::Token::new(request.requested_name.clone())
+        let wallet_id = bloom_broker_api::Token::new(requested_name.to_owned())
             .map_err(|error| HandlerError::invalid(error.to_string()))?;
 
         let mut operation_bytes = [0_u8; 32];
@@ -455,7 +440,7 @@ impl WalletsHandler {
         }
         let projection = WalletRegistrationProjection {
             schema: PROJECTION_SCHEMA.into(),
-            requested_name: request.requested_name,
+            requested_name: requested_name.to_owned(),
             operation_id,
             ceremony_kind: prepared.ceremony_kind,
             ceremony_state: bloom_broker_api::CeremonyState::AwaitingUser,
@@ -1980,7 +1965,7 @@ impl WalletsHandler {
             return Err(HandlerError::NotAFile(path.to_string_path()));
         }
         if segs.len() == 1 && segs[0] == "new" {
-            return Ok(b"{\"schema\":\"bloom.wallet-registration-request.1\",\"requested_name\":\"main\"}\n".to_vec());
+            return Ok(b"Write a wallet name matching [A-Za-z0-9_-]{1,64}.\n".to_vec());
         }
         if segs[0] == "registrations" {
             return match segs {
@@ -3372,9 +3357,12 @@ mod tests {
     async fn direct_machine_wallet_creation_is_removed_for_every_legacy_body() {
         let f = make_handler();
         let path = VfsPath::parse("/new").unwrap();
+        assert!(matches!(
+            f.handler.write(&path, b"alice").await,
+            Err(HandlerError::Backend(_))
+        ));
         for body in [
-            &b"alice"[..],
-            b"name = \"bob\"\nkind = \"local\"\npassphrase = \"secret\"\n",
+            &b"name = \"bob\"\nkind = \"local\"\npassphrase = \"secret\"\n"[..],
             b"name = \"observer\"\nkind = \"watch\"\naddress = \"0x0000000000000000000000000000000000000001\"\n",
             b"name = \"imported\"\nkind = \"import\"\nprivate_key = \"secret\"\n",
         ] {
@@ -3399,7 +3387,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn mounted_registration_is_non_secret_broker_custody_adapter() {
+    async fn mounted_registration_accepts_a_trimmed_plain_name() {
         let mut fixture = make_handler();
         let broker = Arc::new(RegistrationBroker {
             requests: Mutex::new(Vec::new()),
@@ -3411,26 +3399,12 @@ mod tests {
             .with_broker(Some(MachineBrokerClient::new(broker.clone())));
 
         let new = VfsPath::parse("/new").unwrap();
-        let secret_attempt = br#"{"schema":"bloom.wallet-registration-request.1","requested_name":"main","private_key":"nope"}"#;
-        assert!(matches!(
-            fixture.handler.write(&new, secret_attempt).await,
-            Err(HandlerError::Invalid(_))
-        ));
-        assert!(matches!(
-            fixture.handler.write(
-                &new,
-                br#"{"schema":"bloom.wallet-registration-request.1","requested_name":"main/sub"}"#,
-            ).await,
-            Err(HandlerError::Invalid(_))
-        ));
-        fixture
-            .handler
-            .write(
-                &new,
-                br#"{"schema":"bloom.wallet-registration-request.1","requested_name":"main"}"#,
-            )
-            .await
-            .unwrap();
+        fixture.handler.write(&new, b" \nmain\t\n").await.unwrap();
+
+        assert_eq!(
+            fixture.handler.read(&new).await.unwrap(),
+            b"Write a wallet name matching [A-Za-z0-9_-]{1,64}.\n"
+        );
 
         let registrations = fixture
             .handler
@@ -3448,16 +3422,19 @@ mod tests {
             status["ceremony_url"],
             "http://localhost:18734/ceremony/registration-secret"
         );
-        let requests = broker.requests.lock().unwrap();
-        let registration = requests.iter().find_map(|request| match request {
-            MachineBrokerRequest::WalletRegistrationPrepare(request) => Some(request),
-            _ => None,
-        });
-        assert_eq!(
-            registration.and_then(|request| request.wallet_id.as_ref()),
-            Some(&token("main"))
-        );
-        drop(requests);
+        let registration_wallet_id =
+            broker
+                .requests
+                .lock()
+                .unwrap()
+                .iter()
+                .find_map(|request| match request {
+                    MachineBrokerRequest::WalletRegistrationPrepare(request) => {
+                        request.wallet_id.clone()
+                    }
+                    _ => None,
+                });
+        assert_eq!(registration_wallet_id.as_ref(), Some(&token("main")));
 
         *broker.omit_ceremony_url.lock().unwrap() = true;
         assert!(matches!(
@@ -3510,6 +3487,67 @@ mod tests {
                     MachineBrokerRequest::WalletRegistrationPrepare(_)
                 ))
         );
+    }
+
+    #[tokio::test]
+    async fn mounted_registration_rejects_invalid_names_without_calling_broker() {
+        let mut fixture = make_handler();
+        let broker = Arc::new(RegistrationBroker {
+            requests: Mutex::new(Vec::new()),
+            state: Mutex::new(CeremonyState::AwaitingUser),
+            omit_ceremony_url: Mutex::new(false),
+        });
+        fixture.handler = fixture
+            .handler
+            .with_broker(Some(MachineBrokerClient::new(broker.clone())));
+        let new = VfsPath::parse("/new").unwrap();
+
+        for body in [
+            &b" \n\t"[..],
+            b"main/sub",
+            br#"{"schema":"bloom.wallet-registration-request.1","requested_name":"main"}"#,
+            &[0xff],
+            &[b'a'; 65],
+        ] {
+            assert!(
+                matches!(
+                    fixture.handler.write(&new, body).await,
+                    Err(HandlerError::Invalid(_))
+                ),
+                "unexpected registration result for {body:?}"
+            );
+            assert!(
+                broker.requests.lock().unwrap().is_empty(),
+                "invalid registration reached Broker for {body:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn mounted_registration_accepts_a_64_character_name() {
+        let mut fixture = make_handler();
+        let broker = Arc::new(RegistrationBroker {
+            requests: Mutex::new(Vec::new()),
+            state: Mutex::new(CeremonyState::AwaitingUser),
+            omit_ceremony_url: Mutex::new(false),
+        });
+        fixture.handler = fixture
+            .handler
+            .with_broker(Some(MachineBrokerClient::new(broker.clone())));
+        let name = "a".repeat(64);
+
+        fixture
+            .handler
+            .write(&VfsPath::parse("/new").unwrap(), name.as_bytes())
+            .await
+            .unwrap();
+
+        let requests = broker.requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        let MachineBrokerRequest::WalletRegistrationPrepare(request) = &requests[0] else {
+            panic!("expected wallet registration prepare request")
+        };
+        assert_eq!(request.wallet_id.as_ref(), Some(&token(&name)));
     }
 
     #[tokio::test]

--- a/crates/bloom-vfs/src/handlers/wallets.rs
+++ b/crates/bloom-vfs/src/handlers/wallets.rs
@@ -1480,7 +1480,7 @@ impl WalletsHandler {
 
     fn outbox_dir_entries() -> Vec<Entry> {
         vec![
-            Entry::file("new.tx"),
+            Entry::writable_file("new.tx"),
             Entry::dir("pending"),
             Entry::dir("sent"),
             Entry::dir("failed"),
@@ -3916,6 +3916,17 @@ mod tests {
         .unwrap();
         let r = f.handler.list(&p).await;
         assert!(r.is_err(), "expected NotFound, got {r:?}");
+    }
+
+    #[tokio::test]
+    async fn outbox_listing_advertises_new_tx_as_writable() {
+        let f = make_handler_with_chain(true);
+        let p = VfsPath::parse(&format!("/{}/chains/anvil/outbox", f.wallet_name)).unwrap();
+
+        let entries = f.handler.list(&p).await.unwrap();
+        let new_tx = entries.iter().find(|entry| entry.name == "new.tx").unwrap();
+
+        assert_eq!(new_tx.mode, 0o644);
     }
 
     /// Fix #9: writing an empty body to `pending/<id>/confirm` must

--- a/crates/bloom-vfs/src/handlers/wallets.rs
+++ b/crates/bloom-vfs/src/handlers/wallets.rs
@@ -26,7 +26,7 @@
 //! - `wallets/<wallet>/chains/<chain>/outbox/sent/<id>/<file>`      — read sent
 //! - `wallets/<wallet>/chains/<chain>/outbox/failed/<id>/<file>`    — read failed
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -1673,6 +1673,18 @@ fn parse_state_seg(s: &str) -> Result<OutboxState, HandlerError> {
     OutboxState::parse(s).ok_or_else(|| HandlerError::not_found(format!("outbox state '{}'", s)))
 }
 
+fn regular_outbox_artifact(dir: &Path, fname: &str) -> Result<PathBuf, HandlerError> {
+    let path = dir.join(fname);
+    match std::fs::symlink_metadata(&path) {
+        Ok(metadata) if metadata.file_type().is_file() => Ok(path),
+        Ok(_) => Err(HandlerError::not_found(fname)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            Err(HandlerError::not_found(fname))
+        }
+        Err(error) => Err(HandlerError::Io(error)),
+    }
+}
+
 fn first_confirm_line(confirm_text: &str) -> &str {
     confirm_text.lines().next().unwrap_or(confirm_text).trim()
 }
@@ -2331,6 +2343,7 @@ impl WalletsHandler {
                 {
                     Ok(Entry::writable_file(fname).with_modified_ms(entry.staged.created_ms))
                 } else {
+                    regular_outbox_artifact(&entry.dir, fname)?;
                     Ok(Entry::file(fname).with_modified_ms(entry.staged.created_ms))
                 }
             }
@@ -2456,8 +2469,14 @@ impl WalletsHandler {
                     .outbox
                     .read_in_state(wallet, chain, id, st)
                     .map_err(err_be)?;
-                let path = entry.dir.join(fname.as_str());
-                let bytes = std::fs::read(&path).map_err(HandlerError::Io)?;
+                let path = regular_outbox_artifact(&entry.dir, fname)?;
+                let bytes = std::fs::read(&path).map_err(|error| {
+                    if error.kind() == std::io::ErrorKind::NotFound {
+                        HandlerError::not_found(fname)
+                    } else {
+                        HandlerError::Io(error)
+                    }
+                })?;
                 Ok(bytes)
             }
             [s] if s == "pending_external.jsonl" => {
@@ -2620,27 +2639,23 @@ impl WalletsHandler {
                 let mut out = Vec::new();
                 if let Ok(rd) = std::fs::read_dir(&entry.dir) {
                     for r in rd.flatten() {
-                        if let Some(n) = r.file_name().to_str() {
-                            if r.file_type().map(|t| t.is_file()).unwrap_or(false) {
-                                // Pending entries' control files are writable;
-                                // everything else is read-only metadata.
-                                if entry.state == OutboxState::Pending
-                                    && matches!(
-                                        n,
-                                        "confirm" | "confirm.override" | "replace" | "cancel"
-                                    )
-                                {
-                                    out.push(
-                                        Entry::writable_file(n)
-                                            .with_modified_ms(entry.staged.created_ms),
-                                    );
-                                } else {
-                                    out.push(
-                                        Entry::file(n).with_modified_ms(entry.staged.created_ms),
-                                    );
-                                }
+                        if let Some(n) = r.file_name().to_str()
+                            && r.file_type().map(|t| t.is_file()).unwrap_or(false)
+                        {
+                            // Pending entries' control files are writable;
+                            // everything else is read-only metadata.
+                            if entry.state == OutboxState::Pending
+                                && matches!(
+                                    n,
+                                    "confirm" | "confirm.override" | "replace" | "cancel"
+                                )
+                            {
+                                out.push(
+                                    Entry::writable_file(n)
+                                        .with_modified_ms(entry.staged.created_ms),
+                                );
                             } else {
-                                out.push(Entry::dir(n).with_modified_ms(entry.staged.created_ms));
+                                out.push(Entry::file(n).with_modified_ms(entry.staged.created_ms));
                             }
                         }
                     }
@@ -3965,6 +3980,134 @@ mod tests {
         let new_tx = entries.iter().find(|entry| entry.name == "new.tx").unwrap();
 
         assert_eq!(new_tx.mode, 0o644);
+    }
+
+    #[tokio::test]
+    async fn outbox_lookup_rejects_absent_artifacts_but_preserves_virtual_sinks() {
+        let f = make_handler_with_chain(true);
+        for (state_name, state, id) in [
+            ("pending", OutboxState::Pending, "0001-pending"),
+            ("sent", OutboxState::Sent, "0002-sent"),
+            ("failed", OutboxState::Failed, "0003-failed"),
+        ] {
+            seed_pending(&f, id);
+            let entry = f
+                .handler
+                .tx_engine
+                .outbox
+                .read_in_state(&f.wallet_name, "anvil", id, OutboxState::Pending)
+                .unwrap();
+            std::fs::write(entry.dir.join("runtime-result-42.json"), state_name).unwrap();
+            if state != OutboxState::Pending {
+                f.handler
+                    .tx_engine
+                    .outbox
+                    .transition(&entry, state)
+                    .unwrap();
+            }
+
+            let real_suffix = format!("{state_name}/{id}/runtime-result-42.json");
+            let real = VfsPath::parse(&format!(
+                "/{}/chains/anvil/outbox/{real_suffix}",
+                f.wallet_name
+            ))
+            .unwrap();
+            let metadata = f.handler.lookup(&real).await.unwrap();
+            assert_eq!(metadata.kind, crate::handler::EntryKind::File);
+            assert_eq!(metadata.mode, 0o444);
+            assert_eq!(f.handler.read(&real).await.unwrap(), state_name.as_bytes());
+
+            let absent = VfsPath::parse(&format!(
+                "/{}/chains/anvil/outbox/{state_name}/{id}/does-not-exist.json",
+                f.wallet_name
+            ))
+            .unwrap();
+            assert!(matches!(
+                f.handler.lookup(&absent).await,
+                Err(HandlerError::NotFound(_))
+            ));
+            assert!(matches!(
+                f.handler.read(&absent).await,
+                Err(HandlerError::NotFound(_))
+            ));
+        }
+
+        let new_tx =
+            VfsPath::parse(&format!("/{}/chains/anvil/outbox/new.tx", f.wallet_name)).unwrap();
+        let metadata = f.handler.lookup(&new_tx).await.unwrap();
+        assert_eq!(metadata.kind, crate::handler::EntryKind::File);
+        assert_eq!(metadata.mode, 0o644);
+
+        for control in ["confirm", "confirm.override", "replace", "cancel"] {
+            let path = VfsPath::parse(&format!(
+                "/{}/chains/anvil/outbox/pending/0001-pending/{control}",
+                f.wallet_name
+            ))
+            .unwrap();
+            let metadata = f.handler.lookup(&path).await.unwrap();
+            assert_eq!(metadata.kind, crate::handler::EntryKind::File);
+            assert_eq!(metadata.mode, 0o644);
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn outbox_lookup_and_read_reject_non_regular_artifacts() {
+        use std::os::unix::fs::symlink;
+
+        let f = make_handler_with_chain(true);
+        seed_pending(&f, "0001-test");
+        let entry = f
+            .handler
+            .tx_engine
+            .outbox
+            .read_in_state(&f.wallet_name, "anvil", "0001-test", OutboxState::Pending)
+            .unwrap();
+        std::fs::create_dir(entry.dir.join("artifact-dir")).unwrap();
+        let outside = f._tmp.path().join("outside-secret.json");
+        std::fs::write(&outside, b"secret").unwrap();
+        symlink(&outside, entry.dir.join("artifact-link.json")).unwrap();
+
+        for artifact in ["artifact-dir", "artifact-link.json"] {
+            let path = VfsPath::parse(&format!(
+                "/{}/chains/anvil/outbox/pending/0001-test/{artifact}",
+                f.wallet_name
+            ))
+            .unwrap();
+            assert!(matches!(
+                f.handler.lookup(&path).await,
+                Err(HandlerError::NotFound(_))
+            ));
+            assert!(matches!(
+                f.handler.read(&path).await,
+                Err(HandlerError::NotFound(_))
+            ));
+        }
+
+        let directory = VfsPath::parse(&format!(
+            "/{}/chains/anvil/outbox/pending/0001-test",
+            f.wallet_name
+        ))
+        .unwrap();
+        let entries = f.handler.list(&directory).await.unwrap();
+        assert!(!entries.iter().any(|entry| entry.name == "artifact-dir"));
+        assert!(
+            !entries
+                .iter()
+                .any(|entry| entry.name == "artifact-link.json")
+        );
+
+        let intent = entries
+            .iter()
+            .find(|entry| entry.name == "intent.json")
+            .unwrap();
+        assert_eq!(intent.kind, crate::handler::EntryKind::File);
+        assert_eq!(intent.mode, 0o444);
+        for control in ["confirm", "confirm.override", "replace", "cancel"] {
+            let metadata = entries.iter().find(|entry| entry.name == control).unwrap();
+            assert_eq!(metadata.kind, crate::handler::EntryKind::File);
+            assert_eq!(metadata.mode, 0o644);
+        }
     }
 
     /// Fix #9: writing an empty body to `pending/<id>/confirm` must

--- a/crates/bloom-vfs/src/handlers/wallets.rs
+++ b/crates/bloom-vfs/src/handlers/wallets.rs
@@ -209,17 +209,18 @@ impl WalletsHandler {
             .map_err(|error| HandlerError::backend(error.to_string()))
     }
 
-    async fn wallet_projection_list(&self) -> Result<Vec<WalletProjection>, HandlerError> {
-        self.wallet_projections
-            .as_ref()
-            .ok_or_else(|| {
-                HandlerError::backend(
-                    "SERVICE_UNAVAILABLE: Machine wallet projection reader is not configured",
-                )
-            })?
-            .list_wallets()
-            .await
-            .map_err(|error| HandlerError::backend(error.to_string()))
+    async fn wallet_projection_list(&self) -> Vec<WalletProjection> {
+        let Some(projections) = &self.wallet_projections else {
+            return Vec::new();
+        };
+        match projections.list_wallets().await {
+            Ok(wallets) => wallets,
+            // Root directory enumeration is navigation, not an authority
+            // decision. Prefer a previously authenticated cache when the live
+            // edge is unavailable, and keep `new`/`registrations` reachable
+            // even if no safe cached projection remains.
+            Err(_) => projections.cached_wallets().unwrap_or_default(),
+        }
     }
 
     async fn planning_wallet_inputs(
@@ -427,6 +428,16 @@ impl WalletsHandler {
         projection.ceremony_state == bloom_broker_api::CeremonyState::Completed
     }
 
+    fn registration_status_entry(
+        projection: &WalletRegistrationProjection,
+    ) -> Result<Entry, HandlerError> {
+        let size = serde_json::to_vec_pretty(projection)
+            .map_err(|error| HandlerError::backend(error.to_string()))?
+            .len()
+            .saturating_add(1);
+        Ok(Entry::file("status.json").with_size(size as u64))
+    }
+
     async fn prepare_wallet_registration(&self, data: &[u8]) -> Result<(), HandlerError> {
         use sha2::Digest as _;
 
@@ -539,6 +550,32 @@ impl WalletsHandler {
         requested_name: &str,
     ) -> Result<WalletRegistrationProjection, HandlerError> {
         let (path, mut projection) = self.registration_record(requested_name)?;
+        if projection.ceremony_state == bloom_broker_api::CeremonyState::AwaitingUser
+            && projection
+                .ceremony_expires_at_ms
+                .as_ref()
+                .is_some_and(|expires_at| expires_at.get() <= now_ms_u64())
+        {
+            // Ceremony launch data is already bound to a trusted expiry. Do
+            // not turn an expired, persisted registration into filesystem EIO
+            // merely because the Broker no longer retains the operation (for
+            // example after restarting a local development triad).
+            projection.ceremony_state = bloom_broker_api::CeremonyState::Expired;
+            projection.ceremony_url = None;
+            projection.ceremony_expires_at_ms = None;
+            write_atomic_json(&path, &projection)?;
+            return Ok(projection);
+        }
+        if matches!(
+            projection.ceremony_state,
+            bloom_broker_api::CeremonyState::Completed
+                | bloom_broker_api::CeremonyState::Succeeded
+                | bloom_broker_api::CeremonyState::Cancelled
+                | bloom_broker_api::CeremonyState::Expired
+                | bloom_broker_api::CeremonyState::Failed
+        ) {
+            return Ok(projection);
+        }
         let status = self
             .broker()?
             .ceremony_status(projection.operation_id.clone())
@@ -1905,12 +1942,12 @@ impl WalletsHandler {
             return match segs {
                 [_] => Ok(Entry::dir("registrations")),
                 [_, requested_name] => {
-                    let _ = self.registration_projection(requested_name).await?;
+                    let _ = self.registration_record(requested_name)?;
                     Ok(Entry::dir(requested_name))
                 }
                 [_, requested_name, leaf] if leaf == "status.json" => {
-                    let _ = self.registration_projection(requested_name).await?;
-                    Ok(Entry::file(leaf))
+                    let (_, projection) = self.registration_record(requested_name)?;
+                    Self::registration_status_entry(&projection)
                 }
                 [_, requested_name, leaf] if leaf == "result.json" => {
                     let projection = self.registration_projection(requested_name).await?;
@@ -1921,7 +1958,7 @@ impl WalletsHandler {
                     }
                 }
                 [_, requested_name, leaf] if leaf == "cancel" => {
-                    let _ = self.registration_projection(requested_name).await?;
+                    let _ = self.registration_record(requested_name)?;
                     Ok(Entry::writable_file("cancel"))
                 }
                 _ => Err(HandlerError::not_found(path.to_string_path())),
@@ -2257,7 +2294,7 @@ impl WalletsHandler {
         if segs.is_empty() {
             let mut out: Vec<Entry> = self
                 .wallet_projection_list()
-                .await?
+                .await
                 .into_iter()
                 .map(|projection| Entry::dir(projection.wallet.wallet_id.as_str()))
                 .collect();
@@ -2273,9 +2310,14 @@ impl WalletsHandler {
                     .map(|name| Entry::dir(&name))
                     .collect()),
                 [_, requested_name] => {
-                    let projection = self.registration_projection(requested_name).await?;
-                    let mut entries =
-                        vec![Entry::file("status.json"), Entry::writable_file("cancel")];
+                    // Directory enumeration and GETATTR must remain local:
+                    // shells issue them implicitly for `cd` and `ls`, and a
+                    // stale or unavailable Broker is not a filesystem error.
+                    let (_, projection) = self.registration_record(requested_name)?;
+                    let mut entries = vec![
+                        Self::registration_status_entry(&projection)?,
+                        Entry::writable_file("cancel"),
+                    ];
                     if Self::registration_result_ready(&projection) {
                         entries.push(Entry::file("result.json"));
                     }
@@ -3031,6 +3073,37 @@ mod tests {
     #[derive(Clone)]
     struct StaticProjection(WalletProjection);
 
+    struct UnavailableProjection;
+
+    #[async_trait]
+    impl WalletProjectionReader for UnavailableProjection {
+        async fn list_wallets(
+            &self,
+        ) -> Result<Vec<WalletProjection>, bloom_broker_api::ProtocolError> {
+            Err(ProtocolError::new(
+                ProtocolErrorCode::ServiceUnavailable,
+                "wallet projection edge unavailable",
+            ))
+        }
+
+        async fn get_wallet(
+            &self,
+            _wallet_id: &Token,
+        ) -> Result<WalletProjection, bloom_broker_api::ProtocolError> {
+            Err(ProtocolError::new(
+                ProtocolErrorCode::ServiceUnavailable,
+                "wallet projection edge unavailable",
+            ))
+        }
+
+        fn cached_wallets(&self) -> Result<Vec<WalletProjection>, bloom_broker_api::ProtocolError> {
+            Err(ProtocolError::new(
+                ProtocolErrorCode::ServiceUnavailable,
+                "wallet projection cache unavailable",
+            ))
+        }
+    }
+
     #[async_trait]
     impl WalletProjectionReader for StaticProjection {
         async fn list_wallets(
@@ -3481,6 +3554,15 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn wallet_root_controls_remain_accessible_when_projection_reader_is_unavailable() {
+        let mut f = make_handler();
+        f.handler.wallet_projections = Some(Arc::new(UnavailableProjection));
+        let entries = f.handler.list(&VfsPath::parse("/").unwrap()).await.unwrap();
+        let names: Vec<&str> = entries.iter().map(|entry| entry.name.as_str()).collect();
+        assert_eq!(names, ["new", "registrations"]);
+    }
+
+    #[tokio::test]
     async fn mounted_registration_accepts_a_trimmed_plain_name() {
         let mut fixture = make_handler();
         let broker = Arc::new(RegistrationBroker {
@@ -3550,6 +3632,22 @@ mod tests {
                 });
         assert_eq!(registration_wallet_id.as_ref(), Some(&token("main")));
 
+        let metadata_request_count = broker.requests.lock().unwrap().len();
+        fixture
+            .handler
+            .lookup(&VfsPath::parse("/registrations/main").unwrap())
+            .await
+            .unwrap();
+        fixture
+            .handler
+            .lookup(&VfsPath::parse("/registrations/main/status.json").unwrap())
+            .await
+            .unwrap();
+        fixture
+            .handler
+            .lookup(&VfsPath::parse("/registrations/main/cancel").unwrap())
+            .await
+            .unwrap();
         let pending_entries = fixture
             .handler
             .list(&VfsPath::parse("/registrations/main").unwrap())
@@ -3561,6 +3659,11 @@ mod tests {
                 .map(|entry| entry.name.as_str())
                 .collect::<Vec<_>>(),
             ["status.json", "cancel"]
+        );
+        assert_eq!(
+            broker.requests.lock().unwrap().len(),
+            metadata_request_count,
+            "registration directory metadata must not contact the Broker"
         );
         assert!(matches!(
             fixture
@@ -3634,7 +3737,16 @@ mod tests {
             Err(HandlerError::NotFound(_))
         ));
 
+        let (projection_path, mut completion_projection) =
+            fixture.handler.registration_record("main").unwrap();
+        completion_projection.ceremony_state = CeremonyState::AwaitingUser;
+        completion_projection.ceremony_url =
+            Some("http://localhost:18734/ceremony/registration-secret".into());
+        completion_projection.ceremony_expires_at_ms = Some(DecimalU64::new(u64::MAX));
+        write_atomic_json(&projection_path, &completion_projection).unwrap();
         *broker.state.lock().unwrap() = CeremonyState::Completed;
+        let _: serde_json::Value =
+            serde_json::from_slice(&fixture.handler.read(&status_path).await.unwrap()).unwrap();
         let completed_entries = fixture
             .handler
             .list(&VfsPath::parse("/registrations/main").unwrap())
@@ -3665,6 +3777,32 @@ mod tests {
                     request,
                     MachineBrokerRequest::WalletRegistrationPrepare(_)
                 ))
+        );
+
+        let (projection_path, mut expired_projection) =
+            fixture.handler.registration_record("main").unwrap();
+        expired_projection.ceremony_state = CeremonyState::AwaitingUser;
+        expired_projection.ceremony_url = Some("http://localhost:18734/ceremony/expired".into());
+        expired_projection.ceremony_expires_at_ms = Some(DecimalU64::new(1));
+        write_atomic_json(&projection_path, &expired_projection).unwrap();
+        let requests_before_expiry_reconciliation = broker.requests.lock().unwrap().len();
+
+        let expired: serde_json::Value =
+            serde_json::from_slice(&fixture.handler.read(&status_path).await.unwrap()).unwrap();
+        assert_eq!(expired["ceremony_state"], "EXPIRED");
+        assert!(expired["ceremony_url"].is_null());
+        assert_eq!(
+            broker.requests.lock().unwrap().len(),
+            requests_before_expiry_reconciliation,
+            "trusted local expiry must reconcile without a Broker request"
+        );
+        let expired_again: serde_json::Value =
+            serde_json::from_slice(&fixture.handler.read(&status_path).await.unwrap()).unwrap();
+        assert_eq!(expired_again["ceremony_state"], "EXPIRED");
+        assert_eq!(
+            broker.requests.lock().unwrap().len(),
+            requests_before_expiry_reconciliation,
+            "persisted terminal status must not be refreshed from the Broker"
         );
     }
 

--- a/crates/bloom-vfs/src/handlers/wallets.rs
+++ b/crates/bloom-vfs/src/handlers/wallets.rs
@@ -9,7 +9,7 @@
 //! - `wallets/new`                                                  — write a wallet name to prepare registration
 //! - `wallets/registrations/<petname>/status.json`                 — public registration projection
 //! - `wallets/registrations/<petname>/result.json`                 — completed registration result
-//! - `wallets/registrations/<petname>/cancel`                       — write `cancel` before acceptance
+//! - `wallets/registrations/<petname>/cancel`                       — write `y`, `yes`, or `cancel` before acceptance
 //! - `wallets/<wallet>/address`                                     — checksummed owner/signer address
 //! - `wallets/<wallet>/address.qr.svg`                              — scannable QR image for the owner/signer address
 //! - `wallets/<wallet>/address.qr.png`                              — scannable QR image for the owner/signer address
@@ -2244,9 +2244,19 @@ impl WalletsHandler {
                 && leaf == "cancel"
             {
                 self.write_permit()?;
-                if data != b"cancel" && data != b"cancel\n" {
+                let confirmation = std::str::from_utf8(data)
+                    .map_err(|_| {
+                        HandlerError::invalid(
+                            "registration cancellation requires UTF-8 confirmation",
+                        )
+                    })?
+                    .trim();
+                if !confirmation.eq_ignore_ascii_case("y")
+                    && !confirmation.eq_ignore_ascii_case("yes")
+                    && !confirmation.eq_ignore_ascii_case("cancel")
+                {
                     return Err(HandlerError::invalid(
-                        "registration cancellation accepts only `cancel`",
+                        "registration cancellation accepts only `y`, `yes`, or `cancel`",
                     ));
                 }
                 return self.cancel_wallet_registration(requested_name).await;
@@ -3716,12 +3726,22 @@ mod tests {
                 .await,
             Err(HandlerError::Invalid(_))
         ));
+        assert!(matches!(
+            fixture
+                .handler
+                .write(
+                    &VfsPath::parse("/registrations/main/cancel").unwrap(),
+                    b"maybe\n",
+                )
+                .await,
+            Err(HandlerError::Invalid(_))
+        ));
 
         fixture
             .handler
             .write(
                 &VfsPath::parse("/registrations/main/cancel").unwrap(),
-                b"cancel\n",
+                b"y\n",
             )
             .await
             .unwrap();

--- a/crates/bloom-vfs/src/handlers/wallets.rs
+++ b/crates/bloom-vfs/src/handlers/wallets.rs
@@ -31,6 +31,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use bloom_broker_api::ProtocolErrorCode;
 use bloom_evm::ChainRegistry;
 use bloom_machine_client::WalletProjection;
 use bloom_machine_client::{MachineBrokerClient, WalletProjectionReader};
@@ -83,7 +84,7 @@ struct ApprovalCeremonyProjection {
     response: bloom_broker_api::SealedApprovalPrepareResponse,
 }
 
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(deny_unknown_fields)]
 struct WalletRegistrationProjection {
     schema: String,
@@ -209,17 +210,28 @@ impl WalletsHandler {
             .map_err(|error| HandlerError::backend(error.to_string()))
     }
 
-    async fn wallet_projection_list(&self) -> Vec<WalletProjection> {
+    async fn wallet_projection_list(&self) -> Result<Vec<WalletProjection>, HandlerError> {
         let Some(projections) = &self.wallet_projections else {
-            return Vec::new();
+            return Ok(Vec::new());
         };
         match projections.list_wallets().await {
-            Ok(wallets) => wallets,
+            Ok(wallets) => Ok(wallets),
             // Root directory enumeration is navigation, not an authority
             // decision. Prefer a previously authenticated cache when the live
             // edge is unavailable, and keep `new`/`registrations` reachable
             // even if no safe cached projection remains.
-            Err(_) => projections.cached_wallets().unwrap_or_default(),
+            Err(error) if error.code == ProtocolErrorCode::ServiceUnavailable => {
+                match projections.cached_wallets() {
+                    Ok(wallets) => Ok(wallets),
+                    Err(cache_error)
+                        if cache_error.code == ProtocolErrorCode::ServiceUnavailable =>
+                    {
+                        Ok(Vec::new())
+                    }
+                    Err(cache_error) => Err(HandlerError::backend(cache_error.to_string())),
+                }
+            }
+            Err(error) => Err(HandlerError::backend(error.to_string())),
         }
     }
 
@@ -390,6 +402,37 @@ impl WalletsHandler {
                     "Machine wallet registration projection identity is invalid",
                 ));
             }
+            if let Some(existing_index) = records.iter().position(
+                |(_, existing): &(std::path::PathBuf, WalletRegistrationProjection)| {
+                    existing.requested_name == projection.requested_name
+                },
+            ) {
+                let canonical_path = self.registration_path(&projection.requested_name);
+                let (existing_path, existing_projection) = &records[existing_index];
+                if existing_projection != &projection
+                    || existing_projection.operation_id != projection.operation_id
+                    || (existing_path != &canonical_path && path != canonical_path)
+                {
+                    return Err(HandlerError::backend(
+                        "multiple wallet registration projections claim the same petname",
+                    ));
+                }
+                let legacy_path = if path == canonical_path {
+                    let legacy = existing_path.clone();
+                    records[existing_index] = (path, projection);
+                    legacy
+                } else {
+                    path
+                };
+                if let Err(error) = std::fs::remove_file(&legacy_path) {
+                    tracing::warn!(
+                        path = %legacy_path.display(),
+                        %error,
+                        "wallet_registration.legacy_duplicate_cleanup_failed"
+                    );
+                }
+                continue;
+            }
             records.push((path, projection));
         }
         Ok(records)
@@ -556,22 +599,6 @@ impl WalletsHandler {
         requested_name: &str,
     ) -> Result<WalletRegistrationProjection, HandlerError> {
         let (path, mut projection) = self.registration_record(requested_name)?;
-        if projection.ceremony_state == bloom_broker_api::CeremonyState::AwaitingUser
-            && projection
-                .ceremony_expires_at_ms
-                .as_ref()
-                .is_some_and(|expires_at| expires_at.get() <= now_ms_u64())
-        {
-            // Ceremony launch data is already bound to a trusted expiry. Do
-            // not turn an expired, persisted registration into filesystem EIO
-            // merely because the Broker no longer retains the operation (for
-            // example after restarting a local development triad).
-            projection.ceremony_state = bloom_broker_api::CeremonyState::Expired;
-            projection.ceremony_url = None;
-            projection.ceremony_expires_at_ms = None;
-            write_atomic_json(&path, &projection)?;
-            return Ok(projection);
-        }
         if matches!(
             projection.ceremony_state,
             bloom_broker_api::CeremonyState::Completed
@@ -582,11 +609,30 @@ impl WalletsHandler {
         ) {
             return Ok(projection);
         }
-        let status = self
+        let local_launch_expired = projection
+            .ceremony_expires_at_ms
+            .as_ref()
+            .is_some_and(|expires_at| expires_at.get() <= now_ms_u64());
+        let status = match self
             .custody_broker()?
             .ceremony_status(projection.operation_id.clone())
             .await
-            .map_err(|error| HandlerError::backend(error.to_string()))?;
+        {
+            Ok(status) => status,
+            Err(error)
+                if local_launch_expired && error.code == ProtocolErrorCode::ServiceUnavailable =>
+            {
+                // Never infer a terminal result from the launch deadline. The
+                // owner may have completed at the boundary while Broker was
+                // becoming unavailable. Remove only the stale bearer URL and
+                // retain the operation for a later authoritative retry.
+                projection.ceremony_url = None;
+                projection.ceremony_expires_at_ms = None;
+                write_atomic_json(&path, &projection)?;
+                return Err(HandlerError::backend(error.to_string()));
+            }
+            Err(error) => return Err(HandlerError::backend(error.to_string())),
+        };
         if status.operation_id != projection.operation_id
             || status.ceremony_kind != bloom_broker_api::CeremonyKind::WalletRegistration
         {
@@ -2322,7 +2368,7 @@ impl WalletsHandler {
         if segs.is_empty() {
             let mut out: Vec<Entry> = self
                 .wallet_projection_list()
-                .await
+                .await?
                 .into_iter()
                 .map(|projection| Entry::dir(projection.wallet.wallet_id.as_str()))
                 .collect();
@@ -3015,6 +3061,7 @@ mod tests {
         requests: Mutex<Vec<MachineBrokerRequest>>,
         state: Mutex<CeremonyState>,
         omit_ceremony_url: Mutex<bool>,
+        status_error: Mutex<Option<ProtocolErrorCode>>,
     }
 
     impl MachineBrokerService for RegistrationBroker {
@@ -3037,6 +3084,12 @@ mod tests {
                         }),
                     ),
                     MachineBrokerRequest::CeremonyStatus(request) => {
+                        if let Some(code) = *self.status_error.lock().unwrap() {
+                            return Err(ProtocolError::new(
+                                code,
+                                "registration status unavailable",
+                            ));
+                        }
                         let state = *self.state.lock().unwrap();
                         let omit_ceremony_url = *self.omit_ceremony_url.lock().unwrap();
                         Ok(MachineBrokerResponse::CeremonyStatus(
@@ -3097,6 +3150,31 @@ mod tests {
     struct StaticProjection(WalletProjection);
 
     struct UnavailableProjection;
+
+    struct IntegrityFailureProjection(Arc<dyn WalletProjectionReader>);
+
+    #[async_trait]
+    impl WalletProjectionReader for IntegrityFailureProjection {
+        async fn list_wallets(
+            &self,
+        ) -> Result<Vec<WalletProjection>, bloom_broker_api::ProtocolError> {
+            Err(ProtocolError::new(
+                ProtocolErrorCode::MalformedFrame,
+                "wallet projection identity is invalid",
+            ))
+        }
+
+        async fn get_wallet(
+            &self,
+            wallet_id: &Token,
+        ) -> Result<WalletProjection, bloom_broker_api::ProtocolError> {
+            self.0.get_wallet(wallet_id).await
+        }
+
+        fn cached_wallets(&self) -> Result<Vec<WalletProjection>, bloom_broker_api::ProtocolError> {
+            self.0.cached_wallets()
+        }
+    }
 
     #[async_trait]
     impl WalletProjectionReader for UnavailableProjection {
@@ -3590,12 +3668,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn wallet_root_does_not_mask_projection_integrity_failures_with_cached_wallets() {
+        let mut f = make_handler();
+        let cached = f.handler.wallet_projections.take().unwrap();
+        f.handler.wallet_projections = Some(Arc::new(IntegrityFailureProjection(cached)));
+        let error = f
+            .handler
+            .list(&VfsPath::parse("/").unwrap())
+            .await
+            .unwrap_err();
+        assert!(matches!(error, HandlerError::Backend(_)));
+        assert!(
+            error
+                .to_string()
+                .contains("wallet projection identity is invalid")
+        );
+    }
+
+    #[tokio::test]
     async fn mounted_registration_accepts_a_trimmed_plain_name() {
         let mut fixture = make_handler();
         let broker = Arc::new(RegistrationBroker {
             requests: Mutex::new(Vec::new()),
             state: Mutex::new(CeremonyState::AwaitingUser),
             omit_ceremony_url: Mutex::new(false),
+            status_error: Mutex::new(None),
         });
         fixture.handler = fixture
             .handler
@@ -3779,7 +3876,7 @@ mod tests {
         completion_projection.ceremony_state = CeremonyState::AwaitingUser;
         completion_projection.ceremony_url =
             Some("http://localhost:18734/ceremony/registration-secret".into());
-        completion_projection.ceremony_expires_at_ms = Some(DecimalU64::new(u64::MAX));
+        completion_projection.ceremony_expires_at_ms = Some(DecimalU64::new(1));
         write_atomic_json(&projection_path, &completion_projection).unwrap();
         *broker.state.lock().unwrap() = CeremonyState::Completed;
         let _: serde_json::Value =
@@ -3822,6 +3919,7 @@ mod tests {
         expired_projection.ceremony_url = Some("http://localhost:18734/ceremony/expired".into());
         expired_projection.ceremony_expires_at_ms = Some(DecimalU64::new(1));
         write_atomic_json(&projection_path, &expired_projection).unwrap();
+        *broker.state.lock().unwrap() = CeremonyState::Expired;
         let requests_before_expiry_reconciliation = broker.requests.lock().unwrap().len();
 
         let expired: serde_json::Value =
@@ -3830,15 +3928,15 @@ mod tests {
         assert!(expired["ceremony_url"].is_null());
         assert_eq!(
             broker.requests.lock().unwrap().len(),
-            requests_before_expiry_reconciliation,
-            "trusted local expiry must reconcile without a Broker request"
+            requests_before_expiry_reconciliation + 1,
+            "local expiry must reconcile with Broker before becoming terminal"
         );
         let expired_again: serde_json::Value =
             serde_json::from_slice(&fixture.handler.read(&status_path).await.unwrap()).unwrap();
         assert_eq!(expired_again["ceremony_state"], "EXPIRED");
         assert_eq!(
             broker.requests.lock().unwrap().len(),
-            requests_before_expiry_reconciliation,
+            requests_before_expiry_reconciliation + 1,
             "persisted terminal status must not be refreshed from the Broker"
         );
     }
@@ -3850,6 +3948,7 @@ mod tests {
             requests: Mutex::new(Vec::new()),
             state: Mutex::new(CeremonyState::AwaitingUser),
             omit_ceremony_url: Mutex::new(false),
+            status_error: Mutex::new(None),
         });
         fixture.handler = fixture
             .handler
@@ -3878,12 +3977,97 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn identical_canonical_and_legacy_registration_records_recover_after_crash() {
+        let mut fixture = make_handler();
+        let broker = Arc::new(RegistrationBroker {
+            requests: Mutex::new(Vec::new()),
+            state: Mutex::new(CeremonyState::AwaitingUser),
+            omit_ceremony_url: Mutex::new(false),
+            status_error: Mutex::new(None),
+        });
+        fixture.handler = fixture
+            .handler
+            .with_broker(Some(MachineBrokerClient::new(broker.clone())));
+        fixture
+            .handler
+            .write(&VfsPath::parse("/new").unwrap(), b"main")
+            .await
+            .unwrap();
+
+        let canonical = fixture.handler.registration_path("main");
+        let projection: WalletRegistrationProjection = read_json(&canonical).unwrap();
+        let legacy = fixture
+            .handler
+            .registration_path(projection.operation_id.as_str());
+        std::fs::copy(&canonical, &legacy).unwrap();
+
+        let entries = fixture
+            .handler
+            .list(&VfsPath::parse("/registrations").unwrap())
+            .await
+            .unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "main");
+        assert!(canonical.is_file());
+        assert!(!legacy.exists());
+        assert_eq!(
+            broker
+                .requests
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|request| matches!(
+                    request,
+                    MachineBrokerRequest::WalletRegistrationPrepare(_)
+                ))
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn expired_registration_clears_stale_url_but_stays_retryable_when_broker_is_unavailable()
+    {
+        let mut fixture = make_handler();
+        let broker = Arc::new(RegistrationBroker {
+            requests: Mutex::new(Vec::new()),
+            state: Mutex::new(CeremonyState::AwaitingUser),
+            omit_ceremony_url: Mutex::new(false),
+            status_error: Mutex::new(None),
+        });
+        fixture.handler = fixture
+            .handler
+            .with_broker(Some(MachineBrokerClient::new(broker.clone())));
+        fixture
+            .handler
+            .write(&VfsPath::parse("/new").unwrap(), b"main")
+            .await
+            .unwrap();
+        let (path, mut projection) = fixture.handler.registration_record("main").unwrap();
+        projection.ceremony_expires_at_ms = Some(DecimalU64::new(1));
+        write_atomic_json(&path, &projection).unwrap();
+        *broker.status_error.lock().unwrap() = Some(ProtocolErrorCode::ServiceUnavailable);
+
+        let error = fixture
+            .handler
+            .read(&VfsPath::parse("/registrations/main/status.json").unwrap())
+            .await
+            .unwrap_err();
+        assert!(matches!(error, HandlerError::Backend(_)));
+        let retained: WalletRegistrationProjection = read_json(&path).unwrap();
+        assert_eq!(retained.ceremony_state, CeremonyState::AwaitingUser);
+        assert!(retained.ceremony_url.is_none());
+        assert!(retained.ceremony_expires_at_ms.is_none());
+    }
+
+    #[tokio::test]
     async fn mounted_registration_accepts_a_64_character_name() {
         let mut fixture = make_handler();
         let broker = Arc::new(RegistrationBroker {
             requests: Mutex::new(Vec::new()),
             state: Mutex::new(CeremonyState::AwaitingUser),
             omit_ceremony_url: Mutex::new(false),
+            status_error: Mutex::new(None),
         });
         fixture.handler = fixture
             .handler

--- a/crates/bloom-vfs/src/handlers/wallets.rs
+++ b/crates/bloom-vfs/src/handlers/wallets.rs
@@ -27,7 +27,7 @@
 //! - `wallets/<wallet>/chains/<chain>/outbox/sent/<id>/<file>`      — read sent
 //! - `wallets/<wallet>/chains/<chain>/outbox/failed/<id>/<file>`    — read failed
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -1778,16 +1778,28 @@ fn parse_state_seg(s: &str) -> Result<OutboxState, HandlerError> {
     OutboxState::parse(s).ok_or_else(|| HandlerError::not_found(format!("outbox state '{}'", s)))
 }
 
-fn regular_outbox_artifact(dir: &Path, fname: &str) -> Result<PathBuf, HandlerError> {
+fn open_regular_outbox_artifact(dir: &Path, fname: &str) -> Result<std::fs::File, HandlerError> {
     let path = dir.join(fname);
-    match std::fs::symlink_metadata(&path) {
-        Ok(metadata) if metadata.file_type().is_file() => Ok(path),
-        Ok(_) => Err(HandlerError::not_found(fname)),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            Err(HandlerError::not_found(fname))
+    let descriptor = rustix::fs::open(
+        &path,
+        rustix::fs::OFlags::RDONLY
+            | rustix::fs::OFlags::CLOEXEC
+            | rustix::fs::OFlags::NOFOLLOW
+            | rustix::fs::OFlags::NONBLOCK,
+        rustix::fs::Mode::empty(),
+    )
+    .map_err(|error| {
+        if matches!(error, rustix::io::Errno::NOENT | rustix::io::Errno::LOOP) {
+            HandlerError::not_found(fname)
+        } else {
+            HandlerError::Io(std::io::Error::from_raw_os_error(error.raw_os_error()))
         }
-        Err(error) => Err(HandlerError::Io(error)),
+    })?;
+    let file = std::fs::File::from(descriptor);
+    if !file.metadata()?.file_type().is_file() {
+        return Err(HandlerError::not_found(fname));
     }
+    Ok(file)
 }
 
 fn first_confirm_line(confirm_text: &str) -> &str {
@@ -2474,7 +2486,7 @@ impl WalletsHandler {
                 {
                     Ok(Entry::writable_file(fname).with_modified_ms(entry.staged.created_ms))
                 } else {
-                    regular_outbox_artifact(&entry.dir, fname)?;
+                    open_regular_outbox_artifact(&entry.dir, fname)?;
                     Ok(Entry::file(fname).with_modified_ms(entry.staged.created_ms))
                 }
             }
@@ -2600,14 +2612,9 @@ impl WalletsHandler {
                     .outbox
                     .read_in_state(wallet, chain, id, st)
                     .map_err(err_be)?;
-                let path = regular_outbox_artifact(&entry.dir, fname)?;
-                let bytes = std::fs::read(&path).map_err(|error| {
-                    if error.kind() == std::io::ErrorKind::NotFound {
-                        HandlerError::not_found(fname)
-                    } else {
-                        HandlerError::Io(error)
-                    }
-                })?;
+                let mut file = open_regular_outbox_artifact(&entry.dir, fname)?;
+                let mut bytes = Vec::new();
+                std::io::Read::read_to_end(&mut file, &mut bytes)?;
                 Ok(bytes)
             }
             [s] if s == "pending_external.jsonl" => {
@@ -4430,6 +4437,32 @@ mod tests {
             assert_eq!(metadata.kind, crate::handler::EntryKind::File);
             assert_eq!(metadata.mode, 0o644);
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn opened_outbox_artifact_is_pinned_across_path_replacement() {
+        use std::io::Read as _;
+        use std::os::unix::fs::symlink;
+
+        let directory = tempfile::tempdir().unwrap();
+        let artifact = directory.path().join("result.json");
+        let displaced = directory.path().join("result.original.json");
+        let outside = directory.path().join("outside-secret.json");
+        std::fs::write(&artifact, b"original").unwrap();
+        std::fs::write(&outside, b"secret").unwrap();
+
+        let mut opened = open_regular_outbox_artifact(directory.path(), "result.json").unwrap();
+        std::fs::rename(&artifact, &displaced).unwrap();
+        symlink(&outside, &artifact).unwrap();
+
+        let mut bytes = Vec::new();
+        opened.read_to_end(&mut bytes).unwrap();
+        assert_eq!(bytes, b"original");
+        assert!(matches!(
+            open_regular_outbox_artifact(directory.path(), "result.json"),
+            Err(HandlerError::NotFound(_))
+        ));
     }
 
     /// Fix #9: writing an empty body to `pending/<id>/confirm` must

--- a/crates/bloom-vfs/src/router.rs
+++ b/crates/bloom-vfs/src/router.rs
@@ -223,6 +223,55 @@ impl Vfs {
         let rest = path.shift();
         h.read_at_block(&rest, block).await
     }
+
+    async fn write_under_mutation_gate(
+        &self,
+        path: &VfsPath,
+        data: &[u8],
+    ) -> Result<(), HandlerError> {
+        let head = path.first().ok_or(HandlerError::PermissionDenied)?;
+        let h = self
+            .handlers
+            .get(head)
+            .ok_or_else(|| HandlerError::NotFound(path.to_string_path()))?;
+        let rest = path.shift();
+        let correlation = self.begin_effect(AUDIT_KIND_WRITE, path, data)?;
+        let write_result = h.write(&rest, data).await;
+        match &write_result {
+            Ok(()) => self.finish_effect(
+                AUDIT_KIND_WRITE,
+                path,
+                correlation.as_deref(),
+                "ok",
+                serde_json::json!({}),
+            )?,
+            Err(error) => self.finish_effect(
+                AUDIT_KIND_WRITE,
+                path,
+                correlation.as_deref(),
+                "error",
+                serde_json::json!({"error": error.to_string()}),
+            )?,
+        }
+        write_result?;
+        if let Some(cache) = &self.cache {
+            cache.invalidate(&path_to_cache_key(path));
+        }
+        Ok(())
+    }
+
+    /// Write and capture its identity projection while excluding every other
+    /// write through this VFS, including mounted and IPC writes.
+    pub async fn write_then_lookup(
+        &self,
+        write_path: &VfsPath,
+        data: &[u8],
+        projection_path: &VfsPath,
+    ) -> Result<Entry, HandlerError> {
+        let _mutation_guard = self.audit_effect_lock.lock().await;
+        self.write_under_mutation_gate(write_path, data).await?;
+        Handler::lookup(self, projection_path).await
+    }
 }
 
 fn root_agent_guidance_entry(path: &VfsPath) -> Option<&'static str> {
@@ -352,40 +401,8 @@ impl Handler for Vfs {
     }
 
     async fn write(&self, path: &VfsPath, data: &[u8]) -> Result<(), HandlerError> {
-        let head = path.first().ok_or(HandlerError::PermissionDenied)?;
-        let h = self
-            .handlers
-            .get(head)
-            .ok_or_else(|| HandlerError::NotFound(path.to_string_path()))?;
-        let rest = path.shift();
-        let _audit_guard = self.audit_effect_lock.lock().await;
-        let correlation = self.begin_effect(AUDIT_KIND_WRITE, path, data)?;
-        let write_result = h.write(&rest, data).await;
-        match &write_result {
-            Ok(()) => self.finish_effect(
-                AUDIT_KIND_WRITE,
-                path,
-                correlation.as_deref(),
-                "ok",
-                serde_json::json!({}),
-            )?,
-            Err(error) => self.finish_effect(
-                AUDIT_KIND_WRITE,
-                path,
-                correlation.as_deref(),
-                "error",
-                serde_json::json!({"error": error.to_string()}),
-            )?,
-        }
-        write_result?;
-
-        // Successful write — invalidate cache, then audit. Cache
-        // invalidation goes first so a concurrent reader can't observe
-        // a stale value with the audit entry already present.
-        if let Some(cache) = &self.cache {
-            cache.invalidate(&path_to_cache_key(path));
-        }
-        Ok(())
+        let _mutation_guard = self.audit_effect_lock.lock().await;
+        self.write_under_mutation_gate(path, data).await
     }
 
     async fn prepare_write_open(&self, path: &VfsPath) -> Result<(), HandlerError> {
@@ -507,6 +524,7 @@ mod tests {
     use crate::handler::Entry;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
+    use tokio::sync::{Mutex, Notify};
 
     struct EchoHandler;
 
@@ -531,6 +549,67 @@ mod tests {
                 Err(HandlerError::NotADir(p.to_string_path()))
             }
         }
+    }
+
+    struct AtomicProjectionHandler {
+        latest: Mutex<String>,
+        lookup_started: Notify,
+        release_lookup: Notify,
+    }
+
+    #[async_trait]
+    impl Handler for AtomicProjectionHandler {
+        async fn lookup(&self, path: &VfsPath) -> Result<Entry, HandlerError> {
+            if path.to_string_path() != "/latest" {
+                return Err(HandlerError::NotFound(path.to_string_path()));
+            }
+            self.lookup_started.notify_one();
+            self.release_lookup.notified().await;
+            let latest = self.latest.lock().await.clone();
+            Ok(Entry::symlink("latest", &latest))
+        }
+
+        async fn write(&self, _path: &VfsPath, data: &[u8]) -> Result<(), HandlerError> {
+            *self.latest.lock().await = String::from_utf8(data.to_vec()).unwrap();
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn write_then_lookup_excludes_direct_vfs_writes_until_identity_is_captured() {
+        let handler = Arc::new(AtomicProjectionHandler {
+            latest: Mutex::new(String::new()),
+            lookup_started: Notify::new(),
+            release_lookup: Notify::new(),
+        });
+        let vfs = Vfs::builder().mount("ids", handler.clone()).build();
+        let atomic_vfs = vfs.clone();
+        let atomic = tokio::spawn(async move {
+            atomic_vfs
+                .write_then_lookup(
+                    &VfsPath::parse("/ids/new").unwrap(),
+                    b"atomic",
+                    &VfsPath::parse("/ids/latest").unwrap(),
+                )
+                .await
+                .unwrap()
+        });
+
+        handler.lookup_started.notified().await;
+        let ordinary_vfs = vfs.clone();
+        let ordinary = tokio::spawn(async move {
+            ordinary_vfs
+                .write(&VfsPath::parse("/ids/new").unwrap(), b"ordinary")
+                .await
+                .unwrap();
+        });
+        tokio::task::yield_now().await;
+        handler.release_lookup.notify_one();
+
+        let identity = atomic.await.unwrap();
+        ordinary.await.unwrap();
+        assert_eq!(identity.link_target.as_deref(), Some("atomic"));
+        assert_eq!(&*handler.latest.lock().await, "ordinary");
     }
 
     #[tokio::test]

--- a/crates/bloom/src/github_source.rs
+++ b/crates/bloom/src/github_source.rs
@@ -356,7 +356,19 @@ fn install_github_source_with_expectation(
         let (result, meta, index) = daemon
             .petals
             .store()
-            .install_prepared_petal_package_with_source(package, Some(provenance.clone()))
+            .install_prepared_petal_package_with_source_guarded(
+                package,
+                Some(provenance.clone()),
+                || {
+                    if context.is_some_and(|context| context.is_cancelled()) {
+                        Err(bloom_petals::PetalError::vm(
+                            "Petal source install cancelled by disconnected client",
+                        ))
+                    } else {
+                        Ok(())
+                    }
+                },
+            )
             .context("install generated Petal package")?;
         Ok((result, meta, index, consent, provenance))
     })();
@@ -2190,6 +2202,9 @@ mod tests {
                     bloom_daemon::ipc::IpcOutputStream::Stderr => {
                         stderr.extend_from_slice(&event.bytes)
                     }
+                    bloom_daemon::ipc::IpcOutputStream::Data => {
+                        panic!("source build emitted an IPC data stream")
+                    }
                 }
             }
         })
@@ -2208,6 +2223,9 @@ mod tests {
                 }
                 bloom_daemon::ipc::IpcOutputStream::Stderr => {
                     stderr.extend_from_slice(&event.bytes)
+                }
+                bloom_daemon::ipc::IpcOutputStream::Data => {
+                    panic!("source build emitted an IPC data stream")
                 }
             }
         }

--- a/crates/bloom/src/github_source.rs
+++ b/crates/bloom/src/github_source.rs
@@ -1886,7 +1886,7 @@ mod tests {
             .with_petals(daemon.petals.clone())
             .with_petal_source_installer(std::sync::Arc::new(installer));
         let socket_dir = tempfile::tempdir().unwrap();
-        let socket = socket_dir.path().join("bloom.sock");
+        let socket = socket_dir.path().join("private-run/bloom.sock");
         let serving = server.clone();
         let serving_socket = socket.clone();
         let task = tokio::spawn(async move { serving.serve(&serving_socket).await.unwrap() });

--- a/crates/bloom/src/github_source.rs
+++ b/crates/bloom/src/github_source.rs
@@ -1,5 +1,6 @@
+use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use anyhow::{Context, Result, anyhow, bail};
 use bloom_daemon::Daemon;
@@ -14,6 +15,8 @@ use sha2::{Digest, Sha256};
 use url::Url;
 
 const TRUSTED_GITHUB_OWNER: &str = "bloom-directory";
+// Two maximally JSON-escaped streams still fit within the 4 MiB IPC frame.
+const SOURCE_BUILD_STREAM_LIMIT: usize = 256 * 1024;
 const NEAR_INTENTS_RELEASE_COMMIT: &str = "08e9bd83786425656bdd87e35031030cb7f3dc14";
 const ENSO_RELEASE_COMMIT: &str = "59e3c884f83c9c97b69b1b415becf8572791273b";
 
@@ -72,13 +75,13 @@ struct SourceBuildOutput {
 }
 
 #[derive(Clone, Debug)]
-struct SourceBuildCommandFailure {
+struct SourceBuildFailure {
     message: String,
     stdout: String,
     stderr: String,
 }
 
-impl std::fmt::Display for SourceBuildCommandFailure {
+impl std::fmt::Display for SourceBuildFailure {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             formatter,
@@ -88,17 +91,18 @@ impl std::fmt::Display for SourceBuildCommandFailure {
     }
 }
 
-impl std::error::Error for SourceBuildCommandFailure {}
+impl std::error::Error for SourceBuildFailure {}
 
 #[derive(Debug)]
-pub(crate) struct GitHubSourceBuildFailure {
+pub(crate) struct GitHubSourceInstallFailure {
     pub progress: Vec<String>,
+    pub completion_progress: Vec<String>,
     pub stdout: String,
     pub stderr: String,
     pub message: String,
 }
 
-impl std::fmt::Display for GitHubSourceBuildFailure {
+impl std::fmt::Display for GitHubSourceInstallFailure {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             formatter,
@@ -108,9 +112,9 @@ impl std::fmt::Display for GitHubSourceBuildFailure {
     }
 }
 
-impl std::error::Error for GitHubSourceBuildFailure {}
+impl std::error::Error for GitHubSourceInstallFailure {}
 
-pub(crate) fn source_build_failure(error: &anyhow::Error) -> Option<&GitHubSourceBuildFailure> {
+pub(crate) fn source_install_failure(error: &anyhow::Error) -> Option<&GitHubSourceInstallFailure> {
     error.downcast_ref()
 }
 
@@ -241,66 +245,88 @@ fn install_github_source_with_expectation(
     let build_output = match run_source_build(tmp.path()) {
         Ok(output) => output,
         Err(error) => {
-            if let Some(failure) = error.downcast_ref::<SourceBuildCommandFailure>() {
-                return Err(anyhow::Error::new(GitHubSourceBuildFailure {
+            if let Some(failure) = error.downcast_ref::<SourceBuildFailure>() {
+                return Err(anyhow::Error::new(GitHubSourceInstallFailure {
                     progress,
+                    completion_progress: Vec::new(),
                     stdout: failure.stdout.clone(),
                     stderr: failure.stderr.clone(),
                     message: failure.message.clone(),
                 }));
             }
-            return Err(error);
+            return Err(anyhow::Error::new(GitHubSourceInstallFailure {
+                progress,
+                completion_progress: Vec::new(),
+                stdout: String::new(),
+                stderr: String::new(),
+                message: format!("{error:#}"),
+            }));
         }
     };
 
-    let completion_progress = vec!["Validating Petal package...".to_owned()];
-    let package =
-        PreparedPetalPackage::from_dir(tmp.path()).context("validate generated Petal package")?;
-    if let Some(expected) = expected {
-        if package.name != expected.name {
-            bail!(
-                "pre-installed Petal {} built unexpected package name {:?}",
-                expected.name,
-                package.name
-            );
+    let mut completion_progress = Vec::new();
+    let installed = (|| -> Result<_> {
+        completion_progress.push("Validating Petal package...".to_owned());
+        let package = PreparedPetalPackage::from_dir(tmp.path())
+            .context("validate generated Petal package")?;
+        if let Some(expected) = expected {
+            if package.name != expected.name {
+                bail!(
+                    "pre-installed Petal {} built unexpected package name {:?}",
+                    expected.name,
+                    package.name
+                );
+            }
+            if let Some(expected_hash) = expected.expected_hash
+                && package.hash != expected_hash
+            {
+                bail!(
+                    "pre-installed Petal {} package hash {} does not match expected hash {}",
+                    expected.name,
+                    package.hash,
+                    expected_hash
+                );
+            }
         }
-        if let Some(expected_hash) = expected.expected_hash
-            && package.hash != expected_hash
-        {
-            bail!(
-                "pre-installed Petal {} package hash {} does not match expected hash {}",
-                expected.name,
-                package.hash,
-                expected_hash
-            );
-        }
-    }
-    let mut consent = petal_consent_summary(&package).context("build app consent summary")?;
-    let bindings = daemon
-        .config
-        .petals
-        .runtime
-        .get(&consent.name)
-        .map(|app| &app.endpoints)
-        .cloned()
-        .unwrap_or_default();
-    bloom_petals::package::apply_petal_consent_endpoint_bindings(&mut consent, &bindings)
-        .context("apply configured Petal endpoint bindings")?;
-    let provenance = PetalSourceProvenance {
-        source_kind: "github".to_string(),
-        url: repo.canonical_url.clone(),
-        owner: repo.owner.clone(),
-        repo: repo.repo.clone(),
-        requested_ref: resolved.requested_ref.clone(),
-        resolved_commit: resolved.commit.clone(),
-        selected_tag: resolved.selected_tag.clone(),
-        package_hash: package.hash.clone(),
-    };
-    let (result, meta, index) = daemon
-        .petals
-        .store()
-        .install_prepared_petal_package_with_source(package, Some(provenance.clone()))
-        .context("install generated Petal package")?;
+        completion_progress.push("Building Petal consent summary...".to_owned());
+        let mut consent = petal_consent_summary(&package).context("build app consent summary")?;
+        let bindings = daemon
+            .config
+            .petals
+            .runtime
+            .get(&consent.name)
+            .map(|app| &app.endpoints)
+            .cloned()
+            .unwrap_or_default();
+        bloom_petals::package::apply_petal_consent_endpoint_bindings(&mut consent, &bindings)
+            .context("apply configured Petal endpoint bindings")?;
+        let provenance = PetalSourceProvenance {
+            source_kind: "github".to_string(),
+            url: repo.canonical_url.clone(),
+            owner: repo.owner.clone(),
+            repo: repo.repo.clone(),
+            requested_ref: resolved.requested_ref.clone(),
+            resolved_commit: resolved.commit.clone(),
+            selected_tag: resolved.selected_tag.clone(),
+            package_hash: package.hash.clone(),
+        };
+        completion_progress.push("Installing Petal package...".to_owned());
+        let (result, meta, index) = daemon
+            .petals
+            .store()
+            .install_prepared_petal_package_with_source(package, Some(provenance.clone()))
+            .context("install generated Petal package")?;
+        Ok((result, meta, index, consent, provenance))
+    })();
+    let (result, meta, index, consent, provenance) = installed.map_err(|error| {
+        anyhow::Error::new(GitHubSourceInstallFailure {
+            progress: progress.clone(),
+            completion_progress: completion_progress.clone(),
+            stdout: build_output.stdout.clone(),
+            stderr: build_output.stderr.clone(),
+            message: format!("{error:#}"),
+        })
+    })?;
 
     Ok(GitHubInstallOutput {
         result,
@@ -935,29 +961,81 @@ fn run_source_build(root: &Path) -> Result<SourceBuildOutput> {
     if !command.is_file() {
         bail!("build command missing: {}", build.command);
     }
-    let output = Command::new(&command)
+    let mut child = Command::new(&command)
         .current_dir(root)
-        .output()
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
         .with_context(|| format!("run build command {}", build.command))?;
-    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
-    if !output.status.success() {
-        return Err(anyhow::Error::new(SourceBuildCommandFailure {
+    let stdout = child.stdout.take().context("capture source-build stdout")?;
+    let stderr = child.stderr.take().context("capture source-build stderr")?;
+    let stdout_reader = std::thread::spawn(move || capture_bounded_stream(stdout));
+    let stderr_reader = std::thread::spawn(move || capture_bounded_stream(stderr));
+    let status = child
+        .wait()
+        .with_context(|| format!("wait for build command {}", build.command))?;
+    let stdout = join_captured_stream(stdout_reader, "stdout")?;
+    let stderr = join_captured_stream(stderr_reader, "stderr")?;
+    if !status.success() {
+        return Err(anyhow::Error::new(SourceBuildFailure {
             message: format!(
                 "build command failed: {} (status {})",
-                build.command, output.status
+                build.command, status
             ),
             stdout,
             stderr,
         }));
     }
     for output in build.outputs {
-        validate_repo_relative_path(&output, "build.outputs")?;
+        if let Err(error) = validate_repo_relative_path(&output, "build.outputs") {
+            return Err(anyhow::Error::new(SourceBuildFailure {
+                message: format!("{error:#}"),
+                stdout,
+                stderr,
+            }));
+        }
         if !root.join(&output).is_dir() {
-            bail!("build output missing: {output}");
+            return Err(anyhow::Error::new(SourceBuildFailure {
+                message: format!("build output missing: {output}"),
+                stdout,
+                stderr,
+            }));
         }
     }
     Ok(SourceBuildOutput { stdout, stderr })
+}
+
+fn capture_bounded_stream(mut reader: impl Read) -> std::io::Result<String> {
+    let mut retained = Vec::with_capacity(SOURCE_BUILD_STREAM_LIMIT);
+    let mut omitted = 0usize;
+    let mut buffer = [0u8; 16 * 1024];
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        let remaining = SOURCE_BUILD_STREAM_LIMIT.saturating_sub(retained.len());
+        let keep = remaining.min(read);
+        retained.extend_from_slice(&buffer[..keep]);
+        omitted = omitted.saturating_add(read - keep);
+    }
+    let mut output = String::from_utf8_lossy(&retained).into_owned();
+    if omitted > 0 {
+        output.push_str(&format!(
+            "\n[bloom: output truncated; {omitted} bytes omitted]\n"
+        ));
+    }
+    Ok(output)
+}
+
+fn join_captured_stream(
+    reader: std::thread::JoinHandle<std::io::Result<String>>,
+    stream: &str,
+) -> Result<String> {
+    reader
+        .join()
+        .map_err(|_| anyhow!("source-build {stream} reader panicked"))?
+        .with_context(|| format!("read source-build {stream}"))
 }
 
 fn read_source_manifest(root: &Path) -> Result<SourcePetalToml> {
@@ -1605,7 +1683,7 @@ mod tests {
         let daemon = Daemon::from_home(home_dir.clone()).unwrap();
 
         let error = install_github_source(&home_dir, &daemon, &repo, Some("v0.1.0")).unwrap_err();
-        let failure = source_build_failure(&error).expect("structured source-build failure");
+        let failure = source_install_failure(&error).expect("structured source-build failure");
         assert!(
             failure
                 .progress
@@ -1615,6 +1693,42 @@ mod tests {
         assert_eq!(failure.stdout, "partial build output\n");
         assert_eq!(failure.stderr, "build exploded\n");
         assert!(failure.message.contains("status exit status: 42"));
+        assert!(failure.completion_progress.is_empty());
+    }
+
+    #[test]
+    fn successful_build_retains_output_and_full_validation_error_chain() {
+        let fixture = source_repo_fixture(SourceRepoOptions {
+            repo: "bloom-petal-test-invalid-output",
+            tags: vec!["v0.1.0"],
+            include_manifest: true,
+            build_script: BuildScript::InvalidOutput,
+        })
+        .unwrap();
+        let repo = source_test_repo(fixture.bare.path(), "bloom-petal-test-invalid-output");
+        let home = tempfile::tempdir().unwrap();
+        let home_dir = HomeDir::at(home.path());
+        let daemon = Daemon::from_home(home_dir.clone()).unwrap();
+
+        let error = install_github_source(&home_dir, &daemon, &repo, Some("v0.1.0")).unwrap_err();
+        let failure = source_install_failure(&error).expect("structured source-install failure");
+        assert!(failure.stdout.contains("invalid package generated"));
+        assert!(failure.stderr.contains("validation should explain this"));
+        assert_eq!(failure.completion_progress, ["Validating Petal package..."]);
+        assert!(failure.message.contains("validate generated Petal package"));
+        assert!(
+            failure.message.contains("invalid wasm"),
+            "{}",
+            failure.message
+        );
+    }
+
+    #[test]
+    fn captured_build_stream_is_bounded_and_reports_omitted_bytes() {
+        let input = vec![b'x'; SOURCE_BUILD_STREAM_LIMIT + 17];
+        let output = capture_bounded_stream(std::io::Cursor::new(input)).unwrap();
+        assert!(output.starts_with(&"x".repeat(SOURCE_BUILD_STREAM_LIMIT)));
+        assert!(output.ends_with("[bloom: output truncated; 17 bytes omitted]\n"));
     }
 
     #[test]
@@ -2144,6 +2258,7 @@ mod tests {
         Success,
         Output,
         OutputFailure,
+        InvalidOutput,
         Failure,
     }
 
@@ -2260,6 +2375,9 @@ summary = "Demo app used by source install tests."
                 "#!/usr/bin/env bash\nset -euo pipefail\necho '{{\"routes\": 95}}'\necho 'build warning' >&2\nmkdir -p petal/{petal_name}\ncp components/route.wasm petal/{petal_name}/hello.txt.wasm\n"
             ),
             BuildScript::OutputFailure => "#!/usr/bin/env bash\nset -euo pipefail\necho 'partial build output'\necho 'build exploded' >&2\nexit 42\n".to_string(),
+            BuildScript::InvalidOutput => format!(
+                "#!/usr/bin/env bash\nset -euo pipefail\necho 'invalid package generated'\necho 'validation should explain this' >&2\nmkdir -p petal/{petal_name}\nprintf 'not wasm' > petal/{petal_name}/broken.wasm\n"
+            ),
             BuildScript::Failure => "#!/usr/bin/env bash\nset -euo pipefail\nexit 42\n".to_string(),
         };
         let script_path = work.path().join("scripts/build.sh");

--- a/crates/bloom/src/github_source.rs
+++ b/crates/bloom/src/github_source.rs
@@ -60,6 +60,58 @@ pub(crate) struct GitHubInstallOutput {
     pub index: RouteIndex,
     pub consent: PetalConsentSummary,
     pub provenance: PetalSourceProvenance,
+    pub progress: Vec<String>,
+    pub build_stdout: String,
+    pub build_stderr: String,
+    pub completion_progress: Vec<String>,
+}
+
+struct SourceBuildOutput {
+    stdout: String,
+    stderr: String,
+}
+
+#[derive(Clone, Debug)]
+struct SourceBuildCommandFailure {
+    message: String,
+    stdout: String,
+    stderr: String,
+}
+
+impl std::fmt::Display for SourceBuildCommandFailure {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "{}\nstdout:\n{}\nstderr:\n{}",
+            self.message, self.stdout, self.stderr
+        )
+    }
+}
+
+impl std::error::Error for SourceBuildCommandFailure {}
+
+#[derive(Debug)]
+pub(crate) struct GitHubSourceBuildFailure {
+    pub progress: Vec<String>,
+    pub stdout: String,
+    pub stderr: String,
+    pub message: String,
+}
+
+impl std::fmt::Display for GitHubSourceBuildFailure {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "{}\nstdout:\n{}\nstderr:\n{}",
+            self.message, self.stdout, self.stderr
+        )
+    }
+}
+
+impl std::error::Error for GitHubSourceBuildFailure {}
+
+pub(crate) fn source_build_failure(error: &anyhow::Error) -> Option<&GitHubSourceBuildFailure> {
+    error.downcast_ref()
 }
 
 #[derive(Debug, Deserialize)]
@@ -163,7 +215,7 @@ fn install_github_source_with_expectation(
     requested_ref: Option<&str>,
     expected: Option<&PreinstalledPetal>,
 ) -> Result<GitHubInstallOutput> {
-    println!("Resolving {}", repo.canonical_url);
+    let mut progress = vec![format!("Resolving {}", repo.canonical_url)];
     let cache = fetch_repo_cache(home, repo)?;
     let resolved = resolve_ref(&cache, repo, requested_ref)?;
     if let Some(expected) = expected
@@ -177,18 +229,31 @@ fn install_github_source_with_expectation(
         );
     }
     if let Some(tag) = &resolved.selected_tag {
-        println!("Selected tag: {tag}");
+        progress.push(format!("Selected tag: {tag}"));
     }
-    println!("Resolved commit: {}", resolved.commit);
+    progress.push(format!("Resolved commit: {}", resolved.commit));
 
     let tmp = tempfile::tempdir().context("create source checkout tempdir")?;
     checkout_source(&cache, tmp.path(), &resolved.commit)?;
     validate_source_manifest(tmp.path(), repo)?;
 
-    println!("Building source package...");
-    run_source_build(tmp.path())?;
+    progress.push("Building source package...".to_owned());
+    let build_output = match run_source_build(tmp.path()) {
+        Ok(output) => output,
+        Err(error) => {
+            if let Some(failure) = error.downcast_ref::<SourceBuildCommandFailure>() {
+                return Err(anyhow::Error::new(GitHubSourceBuildFailure {
+                    progress,
+                    stdout: failure.stdout.clone(),
+                    stderr: failure.stderr.clone(),
+                    message: failure.message.clone(),
+                }));
+            }
+            return Err(error);
+        }
+    };
 
-    println!("Validating Petal package...");
+    let completion_progress = vec!["Validating Petal package...".to_owned()];
     let package =
         PreparedPetalPackage::from_dir(tmp.path()).context("validate generated Petal package")?;
     if let Some(expected) = expected {
@@ -243,6 +308,10 @@ fn install_github_source_with_expectation(
         index,
         consent,
         provenance,
+        progress,
+        build_stdout: build_output.stdout,
+        build_stderr: build_output.stderr,
+        completion_progress,
     })
 }
 
@@ -553,6 +622,10 @@ fn install_prebuilt_petal_archive(
         index,
         consent,
         provenance,
+        progress: Vec::new(),
+        build_stdout: String::new(),
+        build_stderr: String::new(),
+        completion_progress: Vec::new(),
     })
 }
 
@@ -852,7 +925,7 @@ fn validate_source_manifest(root: &Path, repo: &GitHubRepo) -> Result<()> {
     Ok(())
 }
 
-fn run_source_build(root: &Path) -> Result<()> {
+fn run_source_build(root: &Path) -> Result<SourceBuildOutput> {
     let manifest = read_source_manifest(root)?;
     let build = manifest
         .build
@@ -862,12 +935,21 @@ fn run_source_build(root: &Path) -> Result<()> {
     if !command.is_file() {
         bail!("build command missing: {}", build.command);
     }
-    let status = Command::new(&command)
+    let output = Command::new(&command)
         .current_dir(root)
-        .status()
+        .output()
         .with_context(|| format!("run build command {}", build.command))?;
-    if !status.success() {
-        bail!("build command failed: {}", build.command);
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    if !output.status.success() {
+        return Err(anyhow::Error::new(SourceBuildCommandFailure {
+            message: format!(
+                "build command failed: {} (status {})",
+                build.command, output.status
+            ),
+            stdout,
+            stderr,
+        }));
     }
     for output in build.outputs {
         validate_repo_relative_path(&output, "build.outputs")?;
@@ -875,7 +957,7 @@ fn run_source_build(root: &Path) -> Result<()> {
             bail!("build output missing: {output}");
         }
     }
-    Ok(())
+    Ok(SourceBuildOutput { stdout, stderr })
 }
 
 fn read_source_manifest(root: &Path) -> Result<SourcePetalToml> {
@@ -1492,6 +1574,50 @@ mod tests {
     }
 
     #[test]
+    fn source_build_captures_stdout_and_stderr_instead_of_inheriting_daemon_stdio() {
+        let source = tempfile::tempdir().unwrap();
+        write_source_repo(
+            &source,
+            "bloom-petal-test-output",
+            true,
+            &BuildScript::Output,
+            "output",
+        )
+        .unwrap();
+
+        let output = run_source_build(source.path()).unwrap();
+        assert_eq!(output.stdout, "{\"routes\": 95}\n");
+        assert_eq!(output.stderr, "build warning\n");
+    }
+
+    #[test]
+    fn failed_source_build_retains_progress_and_both_output_streams() {
+        let fixture = source_repo_fixture(SourceRepoOptions {
+            repo: "bloom-petal-test-output-failure",
+            tags: vec!["v0.1.0"],
+            include_manifest: true,
+            build_script: BuildScript::OutputFailure,
+        })
+        .unwrap();
+        let repo = source_test_repo(fixture.bare.path(), "bloom-petal-test-output-failure");
+        let home = tempfile::tempdir().unwrap();
+        let home_dir = HomeDir::at(home.path());
+        let daemon = Daemon::from_home(home_dir.clone()).unwrap();
+
+        let error = install_github_source(&home_dir, &daemon, &repo, Some("v0.1.0")).unwrap_err();
+        let failure = source_build_failure(&error).expect("structured source-build failure");
+        assert!(
+            failure
+                .progress
+                .iter()
+                .any(|line| line == "Building source package...")
+        );
+        assert_eq!(failure.stdout, "partial build output\n");
+        assert_eq!(failure.stderr, "build exploded\n");
+        assert!(failure.message.contains("status exit status: 42"));
+    }
+
+    #[test]
     fn release_checksum_verification_is_name_bound_and_fail_closed() {
         let archive = tempfile::NamedTempFile::new().unwrap();
         std::fs::write(archive.path(), b"petal archive").unwrap();
@@ -1715,6 +1841,80 @@ mod tests {
             )
             .unwrap();
         assert_eq!(body, b"component");
+    }
+
+    #[tokio::test]
+    async fn source_build_output_is_returned_by_the_daemon_ipc_operation() {
+        #[derive(Clone)]
+        struct FixtureSourceInstaller {
+            home: HomeDir,
+            daemon: Daemon,
+            repo: GitHubRepo,
+        }
+
+        impl bloom_daemon::ipc::PetalSourceInstallService for FixtureSourceInstaller {
+            fn install_source(
+                &self,
+                _params: serde_json::Value,
+            ) -> Result<serde_json::Value, String> {
+                let installed =
+                    install_github_source(&self.home, &self.daemon, &self.repo, Some("v0.1.0"))
+                        .map_err(|error| error.to_string())?;
+                Ok(serde_json::json!({
+                    "build_stdout": installed.build_stdout,
+                    "build_stderr": installed.build_stderr,
+                }))
+            }
+        }
+
+        let fixture = source_repo_fixture(SourceRepoOptions {
+            repo: "bloom-petal-test-output-ipc",
+            tags: vec!["v0.1.0"],
+            include_manifest: true,
+            build_script: BuildScript::Output,
+        })
+        .unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let home_dir = HomeDir::at(home.path());
+        let daemon = Daemon::from_home(home_dir.clone()).unwrap();
+        let installer = FixtureSourceInstaller {
+            home: home_dir,
+            daemon: daemon.clone(),
+            repo: source_test_repo(fixture.bare.path(), "bloom-petal-test-output-ipc"),
+        };
+        let server = bloom_daemon::ipc::IpcServer::new(daemon.vfs.clone(), "0", vec![])
+            .with_petals(daemon.petals.clone())
+            .with_petal_source_installer(std::sync::Arc::new(installer));
+        let socket_dir = tempfile::tempdir().unwrap();
+        let socket = socket_dir.path().join("bloom.sock");
+        let serving = server.clone();
+        let serving_socket = socket.clone();
+        let task = tokio::spawn(async move { serving.serve(&serving_socket).await.unwrap() });
+        for _ in 0..100 {
+            if socket.exists() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        let result = bloom_daemon::ipc::IpcClient::new(&socket)
+            .call(
+                "petals.install",
+                serde_json::json!({
+                    "path": "https://github.com/bloom-directory/bloom-petal-test-output-ipc",
+                    "ref": "v0.1.0",
+                }),
+            )
+            .await
+            .unwrap();
+        assert_eq!(result["build_stdout"], "{\"routes\": 95}\n");
+        assert_eq!(result["build_stderr"], "build warning\n");
+
+        server.trigger_shutdown();
+        tokio::time::timeout(std::time::Duration::from_secs(2), task)
+            .await
+            .unwrap()
+            .unwrap();
     }
 
     #[test]
@@ -1942,6 +2142,8 @@ mod tests {
 
     enum BuildScript {
         Success,
+        Output,
+        OutputFailure,
         Failure,
     }
 
@@ -2054,6 +2256,10 @@ summary = "Demo app used by source install tests."
             BuildScript::Success => format!(
                 "#!/usr/bin/env bash\nset -euo pipefail\nmkdir -p petal/{petal_name}\ncp components/route.wasm petal/{petal_name}/hello.txt.wasm\n"
             ),
+            BuildScript::Output => format!(
+                "#!/usr/bin/env bash\nset -euo pipefail\necho '{{\"routes\": 95}}'\necho 'build warning' >&2\nmkdir -p petal/{petal_name}\ncp components/route.wasm petal/{petal_name}/hello.txt.wasm\n"
+            ),
+            BuildScript::OutputFailure => "#!/usr/bin/env bash\nset -euo pipefail\necho 'partial build output'\necho 'build exploded' >&2\nexit 42\n".to_string(),
             BuildScript::Failure => "#!/usr/bin/env bash\nset -euo pipefail\nexit 42\n".to_string(),
         };
         let script_path = work.path().join("scripts/build.sh");

--- a/crates/bloom/src/github_source.rs
+++ b/crates/bloom/src/github_source.rs
@@ -15,7 +15,7 @@ use sha2::{Digest, Sha256};
 use url::Url;
 
 const TRUSTED_GITHUB_OWNER: &str = "bloom-directory";
-// Two maximally JSON-escaped streams still fit within the 4 MiB IPC frame.
+// Retain a bounded diagnostic tail for reconciliation after streamed output.
 const SOURCE_BUILD_STREAM_LIMIT: usize = 256 * 1024;
 const NEAR_INTENTS_RELEASE_COMMIT: &str = "08e9bd83786425656bdd87e35031030cb7f3dc14";
 const ENSO_RELEASE_COMMIT: &str = "59e3c884f83c9c97b69b1b415becf8572791273b";
@@ -64,21 +64,21 @@ pub(crate) struct GitHubInstallOutput {
     pub consent: PetalConsentSummary,
     pub provenance: PetalSourceProvenance,
     pub progress: Vec<String>,
-    pub build_stdout: String,
-    pub build_stderr: String,
+    pub build_stdout: Vec<u8>,
+    pub build_stderr: Vec<u8>,
     pub completion_progress: Vec<String>,
 }
 
 struct SourceBuildOutput {
-    stdout: String,
-    stderr: String,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
 }
 
 #[derive(Clone, Debug)]
 struct SourceBuildFailure {
     message: String,
-    stdout: String,
-    stderr: String,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
 }
 
 impl std::fmt::Display for SourceBuildFailure {
@@ -86,7 +86,9 @@ impl std::fmt::Display for SourceBuildFailure {
         write!(
             formatter,
             "{}\nstdout:\n{}\nstderr:\n{}",
-            self.message, self.stdout, self.stderr
+            self.message,
+            String::from_utf8_lossy(&self.stdout),
+            String::from_utf8_lossy(&self.stderr)
         )
     }
 }
@@ -97,8 +99,8 @@ impl std::error::Error for SourceBuildFailure {}
 pub(crate) struct GitHubSourceInstallFailure {
     pub progress: Vec<String>,
     pub completion_progress: Vec<String>,
-    pub stdout: String,
-    pub stderr: String,
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
     pub message: String,
 }
 
@@ -107,7 +109,9 @@ impl std::fmt::Display for GitHubSourceInstallFailure {
         write!(
             formatter,
             "{}\nstdout:\n{}\nstderr:\n{}",
-            self.message, self.stdout, self.stderr
+            self.message,
+            String::from_utf8_lossy(&self.stdout),
+            String::from_utf8_lossy(&self.stderr)
         )
     }
 }
@@ -203,13 +207,24 @@ pub(crate) fn parse_github_install_url(input: &str) -> Result<Option<GitHubRepo>
     Ok(None)
 }
 
+#[cfg(test)]
 pub(crate) fn install_github_source(
     home: &HomeDir,
     daemon: &Daemon,
     repo: &GitHubRepo,
     requested_ref: Option<&str>,
 ) -> Result<GitHubInstallOutput> {
-    install_github_source_with_expectation(home, daemon, repo, requested_ref, None)
+    install_github_source_with_expectation(home, daemon, repo, requested_ref, None, None)
+}
+
+pub(crate) fn install_github_source_streaming(
+    home: &HomeDir,
+    daemon: &Daemon,
+    repo: &GitHubRepo,
+    requested_ref: Option<&str>,
+    context: &bloom_daemon::ipc::IpcOperationContext,
+) -> Result<GitHubInstallOutput> {
+    install_github_source_with_expectation(home, daemon, repo, requested_ref, None, Some(context))
 }
 
 fn install_github_source_with_expectation(
@@ -218,8 +233,14 @@ fn install_github_source_with_expectation(
     repo: &GitHubRepo,
     requested_ref: Option<&str>,
     expected: Option<&PreinstalledPetal>,
+    context: Option<&bloom_daemon::ipc::IpcOperationContext>,
 ) -> Result<GitHubInstallOutput> {
-    let mut progress = vec![format!("Resolving {}", repo.canonical_url)];
+    let mut progress = Vec::new();
+    record_source_progress(
+        &mut progress,
+        context,
+        format!("Resolving {}", repo.canonical_url),
+    )?;
     let cache = fetch_repo_cache(home, repo)?;
     let resolved = resolve_ref(&cache, repo, requested_ref)?;
     if let Some(expected) = expected
@@ -233,16 +254,24 @@ fn install_github_source_with_expectation(
         );
     }
     if let Some(tag) = &resolved.selected_tag {
-        progress.push(format!("Selected tag: {tag}"));
+        record_source_progress(&mut progress, context, format!("Selected tag: {tag}"))?;
     }
-    progress.push(format!("Resolved commit: {}", resolved.commit));
+    record_source_progress(
+        &mut progress,
+        context,
+        format!("Resolved commit: {}", resolved.commit),
+    )?;
 
     let tmp = tempfile::tempdir().context("create source checkout tempdir")?;
     checkout_source(&cache, tmp.path(), &resolved.commit)?;
     validate_source_manifest(tmp.path(), repo)?;
 
-    progress.push("Building source package...".to_owned());
-    let build_output = match run_source_build(tmp.path()) {
+    record_source_progress(
+        &mut progress,
+        context,
+        "Building source package...".to_owned(),
+    )?;
+    let build_output = match run_source_build_streaming(tmp.path(), context) {
         Ok(output) => output,
         Err(error) => {
             if let Some(failure) = error.downcast_ref::<SourceBuildFailure>() {
@@ -257,8 +286,8 @@ fn install_github_source_with_expectation(
             return Err(anyhow::Error::new(GitHubSourceInstallFailure {
                 progress,
                 completion_progress: Vec::new(),
-                stdout: String::new(),
-                stderr: String::new(),
+                stdout: Vec::new(),
+                stderr: Vec::new(),
                 message: format!("{error:#}"),
             }));
         }
@@ -266,7 +295,11 @@ fn install_github_source_with_expectation(
 
     let mut completion_progress = Vec::new();
     let installed = (|| -> Result<_> {
-        completion_progress.push("Validating Petal package...".to_owned());
+        record_source_progress(
+            &mut completion_progress,
+            context,
+            "Validating Petal package...".to_owned(),
+        )?;
         let package = PreparedPetalPackage::from_dir(tmp.path())
             .context("validate generated Petal package")?;
         if let Some(expected) = expected {
@@ -288,7 +321,11 @@ fn install_github_source_with_expectation(
                 );
             }
         }
-        completion_progress.push("Building Petal consent summary...".to_owned());
+        record_source_progress(
+            &mut completion_progress,
+            context,
+            "Building Petal consent summary...".to_owned(),
+        )?;
         let mut consent = petal_consent_summary(&package).context("build app consent summary")?;
         let bindings = daemon
             .config
@@ -310,7 +347,12 @@ fn install_github_source_with_expectation(
             selected_tag: resolved.selected_tag.clone(),
             package_hash: package.hash.clone(),
         };
-        completion_progress.push("Installing Petal package...".to_owned());
+        record_source_progress(
+            &mut completion_progress,
+            context,
+            "Installing Petal package...".to_owned(),
+        )?;
+        ensure_source_install_connected(context)?;
         let (result, meta, index) = daemon
             .petals
             .store()
@@ -649,8 +691,8 @@ fn install_prebuilt_petal_archive(
         consent,
         provenance,
         progress: Vec::new(),
-        build_stdout: String::new(),
-        build_stderr: String::new(),
+        build_stdout: Vec::new(),
+        build_stderr: Vec::new(),
         completion_progress: Vec::new(),
     })
 }
@@ -951,7 +993,41 @@ fn validate_source_manifest(root: &Path, repo: &GitHubRepo) -> Result<()> {
     Ok(())
 }
 
+fn record_source_progress(
+    retained: &mut Vec<String>,
+    context: Option<&bloom_daemon::ipc::IpcOperationContext>,
+    line: String,
+) -> Result<()> {
+    if let Some(context) = context
+        && !context.emit(
+            bloom_daemon::ipc::IpcOutputStream::Stdout,
+            format!("{line}\n").into_bytes(),
+        )
+    {
+        bail!("Petal source install cancelled by disconnected client");
+    }
+    retained.push(line);
+    Ok(())
+}
+
+fn ensure_source_install_connected(
+    context: Option<&bloom_daemon::ipc::IpcOperationContext>,
+) -> Result<()> {
+    if context.is_some_and(|context| context.is_cancelled()) {
+        bail!("Petal source install cancelled by disconnected client");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
 fn run_source_build(root: &Path) -> Result<SourceBuildOutput> {
+    run_source_build_streaming(root, None)
+}
+
+fn run_source_build_streaming(
+    root: &Path,
+    context: Option<&bloom_daemon::ipc::IpcOperationContext>,
+) -> Result<SourceBuildOutput> {
     let manifest = read_source_manifest(root)?;
     let build = manifest
         .build
@@ -961,19 +1037,58 @@ fn run_source_build(root: &Path) -> Result<SourceBuildOutput> {
     if !command.is_file() {
         bail!("build command missing: {}", build.command);
     }
-    let mut child = Command::new(&command)
+    let mut build_command = Command::new(&command);
+    build_command
         .current_dir(root)
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
+        .stderr(Stdio::piped());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt as _;
+        build_command.process_group(0);
+    }
+    let mut child = build_command
         .spawn()
         .with_context(|| format!("run build command {}", build.command))?;
     let stdout = child.stdout.take().context("capture source-build stdout")?;
     let stderr = child.stderr.take().context("capture source-build stderr")?;
-    let stdout_reader = std::thread::spawn(move || capture_bounded_stream(stdout));
-    let stderr_reader = std::thread::spawn(move || capture_bounded_stream(stderr));
-    let status = child
-        .wait()
-        .with_context(|| format!("wait for build command {}", build.command))?;
+    let stdout_context = context.cloned();
+    let stderr_context = context.cloned();
+    let stdout_reader = std::thread::spawn(move || {
+        capture_bounded_stream(
+            stdout,
+            stdout_context.as_ref(),
+            bloom_daemon::ipc::IpcOutputStream::Stdout,
+        )
+    });
+    let stderr_reader = std::thread::spawn(move || {
+        capture_bounded_stream(
+            stderr,
+            stderr_context.as_ref(),
+            bloom_daemon::ipc::IpcOutputStream::Stderr,
+        )
+    });
+    let status = loop {
+        if context.is_some_and(|context| context.is_cancelled()) {
+            #[cfg(unix)]
+            if let Some(pid) = rustix::process::Pid::from_raw(child.id() as i32) {
+                let _ = rustix::process::kill_process_group(pid, rustix::process::Signal::KILL);
+            }
+            #[cfg(not(unix))]
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = join_captured_stream(stdout_reader, "stdout");
+            let _ = join_captured_stream(stderr_reader, "stderr");
+            bail!("Petal source build cancelled by disconnected client");
+        }
+        if let Some(status) = child
+            .try_wait()
+            .with_context(|| format!("wait for build command {}", build.command))?
+        {
+            break status;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    };
     let stdout = join_captured_stream(stdout_reader, "stdout")?;
     let stderr = join_captured_stream(stderr_reader, "stderr")?;
     if !status.success() {
@@ -1005,7 +1120,11 @@ fn run_source_build(root: &Path) -> Result<SourceBuildOutput> {
     Ok(SourceBuildOutput { stdout, stderr })
 }
 
-fn capture_bounded_stream(mut reader: impl Read) -> std::io::Result<String> {
+fn capture_bounded_stream(
+    mut reader: impl Read,
+    context: Option<&bloom_daemon::ipc::IpcOperationContext>,
+    stream: bloom_daemon::ipc::IpcOutputStream,
+) -> std::io::Result<Vec<u8>> {
     let mut retained = Vec::with_capacity(SOURCE_BUILD_STREAM_LIMIT);
     let mut omitted = 0usize;
     let mut buffer = [0u8; 16 * 1024];
@@ -1014,24 +1133,31 @@ fn capture_bounded_stream(mut reader: impl Read) -> std::io::Result<String> {
         if read == 0 {
             break;
         }
+        if let Some(context) = context
+            && !context.emit(stream, buffer[..read].to_vec())
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Interrupted,
+                "Petal source output client disconnected",
+            ));
+        }
         let remaining = SOURCE_BUILD_STREAM_LIMIT.saturating_sub(retained.len());
         let keep = remaining.min(read);
         retained.extend_from_slice(&buffer[..keep]);
         omitted = omitted.saturating_add(read - keep);
     }
-    let mut output = String::from_utf8_lossy(&retained).into_owned();
     if omitted > 0 {
-        output.push_str(&format!(
-            "\n[bloom: output truncated; {omitted} bytes omitted]\n"
-        ));
+        retained.extend_from_slice(
+            format!("\n[bloom: output truncated; {omitted} bytes omitted]\n").as_bytes(),
+        );
     }
-    Ok(output)
+    Ok(retained)
 }
 
 fn join_captured_stream(
-    reader: std::thread::JoinHandle<std::io::Result<String>>,
+    reader: std::thread::JoinHandle<std::io::Result<Vec<u8>>>,
     stream: &str,
-) -> Result<String> {
+) -> Result<Vec<u8>> {
     reader
         .join()
         .map_err(|_| anyhow!("source-build {stream} reader panicked"))?
@@ -1664,8 +1790,8 @@ mod tests {
         .unwrap();
 
         let output = run_source_build(source.path()).unwrap();
-        assert_eq!(output.stdout, "{\"routes\": 95}\n");
-        assert_eq!(output.stderr, "build warning\n");
+        assert_eq!(output.stdout, b"{\"routes\": 95}\n");
+        assert_eq!(output.stderr, b"build warning\n");
     }
 
     #[test]
@@ -1690,8 +1816,8 @@ mod tests {
                 .iter()
                 .any(|line| line == "Building source package...")
         );
-        assert_eq!(failure.stdout, "partial build output\n");
-        assert_eq!(failure.stderr, "build exploded\n");
+        assert_eq!(failure.stdout, b"partial build output\n");
+        assert_eq!(failure.stderr, b"build exploded\n");
         assert!(failure.message.contains("status exit status: 42"));
         assert!(failure.completion_progress.is_empty());
     }
@@ -1712,8 +1838,10 @@ mod tests {
 
         let error = install_github_source(&home_dir, &daemon, &repo, Some("v0.1.0")).unwrap_err();
         let failure = source_install_failure(&error).expect("structured source-install failure");
-        assert!(failure.stdout.contains("invalid package generated"));
-        assert!(failure.stderr.contains("validation should explain this"));
+        assert!(String::from_utf8_lossy(&failure.stdout).contains("invalid package generated"));
+        assert!(
+            String::from_utf8_lossy(&failure.stderr).contains("validation should explain this")
+        );
         assert_eq!(failure.completion_progress, ["Validating Petal package..."]);
         assert!(failure.message.contains("validate generated Petal package"));
         assert!(
@@ -1726,9 +1854,14 @@ mod tests {
     #[test]
     fn captured_build_stream_is_bounded_and_reports_omitted_bytes() {
         let input = vec![b'x'; SOURCE_BUILD_STREAM_LIMIT + 17];
-        let output = capture_bounded_stream(std::io::Cursor::new(input)).unwrap();
-        assert!(output.starts_with(&"x".repeat(SOURCE_BUILD_STREAM_LIMIT)));
-        assert!(output.ends_with("[bloom: output truncated; 17 bytes omitted]\n"));
+        let output = capture_bounded_stream(
+            std::io::Cursor::new(input),
+            None,
+            bloom_daemon::ipc::IpcOutputStream::Stdout,
+        )
+        .unwrap();
+        assert!(output.starts_with(&vec![b'x'; SOURCE_BUILD_STREAM_LIMIT]));
+        assert!(output.ends_with(b"[bloom: output truncated; 17 bytes omitted]\n"));
     }
 
     #[test]
@@ -1958,7 +2091,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn source_build_output_is_returned_by_the_daemon_ipc_operation() {
+    async fn source_build_output_streams_early_without_utf8_or_capture_truncation() {
         #[derive(Clone)]
         struct FixtureSourceInstaller {
             home: HomeDir,
@@ -1970,13 +2103,25 @@ mod tests {
             fn install_source(
                 &self,
                 _params: serde_json::Value,
+                context: bloom_daemon::ipc::IpcOperationContext,
             ) -> Result<serde_json::Value, String> {
-                let installed =
-                    install_github_source(&self.home, &self.daemon, &self.repo, Some("v0.1.0"))
-                        .map_err(|error| error.to_string())?;
+                let installed = install_github_source_streaming(
+                    &self.home,
+                    &self.daemon,
+                    &self.repo,
+                    Some("v0.1.0"),
+                    &context,
+                )
+                .map_err(|error| error.to_string())?;
                 Ok(serde_json::json!({
-                    "build_stdout": installed.build_stdout,
-                    "build_stderr": installed.build_stderr,
+                    "build_stdout_b64": base64::Engine::encode(
+                        &base64::engine::general_purpose::STANDARD,
+                        &installed.build_stdout,
+                    ),
+                    "build_stderr_b64": base64::Engine::encode(
+                        &base64::engine::general_purpose::STANDARD,
+                        &installed.build_stderr,
+                    ),
                 }))
             }
         }
@@ -1985,7 +2130,7 @@ mod tests {
             repo: "bloom-petal-test-output-ipc",
             tags: vec!["v0.1.0"],
             include_manifest: true,
-            build_script: BuildScript::Output,
+            build_script: BuildScript::StreamingBinaryOutput,
         })
         .unwrap();
         let home = tempfile::tempdir().unwrap();
@@ -2011,21 +2156,196 @@ mod tests {
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }
 
-        let result = bloom_daemon::ipc::IpcClient::new(&socket)
-            .call(
-                "petals.install",
-                serde_json::json!({
-                    "path": "https://github.com/bloom-directory/bloom-petal-test-output-ipc",
-                    "ref": "v0.1.0",
-                }),
-            )
-            .await
-            .unwrap();
-        assert_eq!(result["build_stdout"], "{\"routes\": 95}\n");
-        assert_eq!(result["build_stderr"], "build warning\n");
+        let (output_tx, mut output_rx) = tokio::sync::mpsc::unbounded_channel();
+        let client = bloom_daemon::ipc::IpcClient::new(&socket);
+        let call = tokio::spawn(async move {
+            client
+                .call_streaming(
+                    "petals.install",
+                    serde_json::json!({
+                        "path": "https://github.com/bloom-directory/bloom-petal-test-output-ipc",
+                        "ref": "v0.1.0",
+                    }),
+                    move |event| {
+                        output_tx.send(event).map_err(|_| {
+                            std::io::Error::new(
+                                std::io::ErrorKind::BrokenPipe,
+                                "test output receiver closed",
+                            )
+                        })
+                    },
+                )
+                .await
+        });
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let marker = b"\xffbinary-start\n";
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while !stdout.windows(marker.len()).any(|window| window == marker) {
+                let event = output_rx.recv().await.expect("streaming output event");
+                match event.stream {
+                    bloom_daemon::ipc::IpcOutputStream::Stdout => {
+                        stdout.extend_from_slice(&event.bytes)
+                    }
+                    bloom_daemon::ipc::IpcOutputStream::Stderr => {
+                        stderr.extend_from_slice(&event.bytes)
+                    }
+                }
+            }
+        })
+        .await
+        .unwrap();
+        assert!(
+            !call.is_finished(),
+            "the first build bytes must arrive while the build is still running"
+        );
+
+        let result = call.await.unwrap().unwrap();
+        while let Ok(event) = output_rx.try_recv() {
+            match event.stream {
+                bloom_daemon::ipc::IpcOutputStream::Stdout => {
+                    stdout.extend_from_slice(&event.bytes)
+                }
+                bloom_daemon::ipc::IpcOutputStream::Stderr => {
+                    stderr.extend_from_slice(&event.bytes)
+                }
+            }
+        }
+        assert!(stdout.windows(marker.len()).any(|window| window == marker));
+        assert!(stdout.len() > SOURCE_BUILD_STREAM_LIMIT);
+        assert!(stderr.windows(2).any(|window| window == b"\xfew"));
+        let retained = base64::Engine::decode(
+            &base64::engine::general_purpose::STANDARD,
+            result.result["build_stdout_b64"].as_str().unwrap(),
+        )
+        .unwrap();
+        assert!(retained.starts_with(marker));
+        assert!(retained.len() < stdout.len());
 
         server.trigger_shutdown();
         tokio::time::timeout(std::time::Duration::from_secs(2), task)
+            .await
+            .unwrap()
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn disconnect_cancels_a_blocked_source_build_without_installing() {
+        #[derive(Clone)]
+        struct BlockingFixtureInstaller {
+            home: HomeDir,
+            daemon: Daemon,
+            repo: GitHubRepo,
+            finished: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        }
+
+        impl bloom_daemon::ipc::PetalSourceInstallService for BlockingFixtureInstaller {
+            fn install_source(
+                &self,
+                _params: serde_json::Value,
+                context: bloom_daemon::ipc::IpcOperationContext,
+            ) -> Result<serde_json::Value, String> {
+                let result = install_github_source_streaming(
+                    &self.home,
+                    &self.daemon,
+                    &self.repo,
+                    Some("v0.1.0"),
+                    &context,
+                )
+                .map(|_| serde_json::json!({"installed": true}))
+                .map_err(|error| error.to_string());
+                self.finished
+                    .store(true, std::sync::atomic::Ordering::SeqCst);
+                result
+            }
+        }
+
+        let fixture = source_repo_fixture(SourceRepoOptions {
+            repo: "bloom-petal-test-blocked-ipc",
+            tags: vec!["v0.1.0"],
+            include_manifest: true,
+            build_script: BuildScript::BlockingOutput,
+        })
+        .unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let home_dir = HomeDir::at(home.path());
+        let daemon = Daemon::from_home(home_dir.clone()).unwrap();
+        let finished = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let installer = BlockingFixtureInstaller {
+            home: home_dir,
+            daemon: daemon.clone(),
+            repo: source_test_repo(fixture.bare.path(), "bloom-petal-test-blocked-ipc"),
+            finished: finished.clone(),
+        };
+        let server = bloom_daemon::ipc::IpcServer::new(daemon.vfs.clone(), "0", vec![])
+            .with_petals(daemon.petals.clone())
+            .with_petal_source_installer(std::sync::Arc::new(installer));
+        let socket_dir = tempfile::tempdir().unwrap();
+        let socket = socket_dir.path().join("private-run/bloom.sock");
+        let serving = server.clone();
+        let serving_socket = socket.clone();
+        let server_task =
+            tokio::spawn(async move { serving.serve(&serving_socket).await.unwrap() });
+        for _ in 0..100 {
+            if socket.exists() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        let (output_tx, mut output_rx) = tokio::sync::mpsc::unbounded_channel();
+        let client = bloom_daemon::ipc::IpcClient::new(&socket);
+        let call = tokio::spawn(async move {
+            client
+                .call_streaming(
+                    "petals.install",
+                    serde_json::json!({
+                        "path": "https://github.com/bloom-directory/bloom-petal-test-blocked-ipc",
+                        "ref": "v0.1.0",
+                    }),
+                    move |event| {
+                        output_tx.send(event).map_err(|_| {
+                            std::io::Error::new(std::io::ErrorKind::BrokenPipe, "receiver closed")
+                        })
+                    },
+                )
+                .await
+        });
+        let marker = b"blocking-build-start";
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                let event = output_rx.recv().await.expect("build output event");
+                if event
+                    .bytes
+                    .windows(marker.len())
+                    .any(|window| window == marker)
+                {
+                    break;
+                }
+            }
+        })
+        .await
+        .unwrap();
+        call.abort();
+        let _ = call.await;
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while !finished.load(std::sync::atomic::Ordering::SeqCst) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        assert!(
+            daemon
+                .petals
+                .store()
+                .list_package_hashes()
+                .unwrap()
+                .is_empty()
+        );
+
+        server.trigger_shutdown();
+        tokio::time::timeout(std::time::Duration::from_secs(2), server_task)
             .await
             .unwrap()
             .unwrap();
@@ -2257,6 +2577,8 @@ mod tests {
     enum BuildScript {
         Success,
         Output,
+        StreamingBinaryOutput,
+        BlockingOutput,
         OutputFailure,
         InvalidOutput,
         Failure,
@@ -2373,6 +2695,12 @@ summary = "Demo app used by source install tests."
             ),
             BuildScript::Output => format!(
                 "#!/usr/bin/env bash\nset -euo pipefail\necho '{{\"routes\": 95}}'\necho 'build warning' >&2\nmkdir -p petal/{petal_name}\ncp components/route.wasm petal/{petal_name}/hello.txt.wasm\n"
+            ),
+            BuildScript::StreamingBinaryOutput => format!(
+                "#!/usr/bin/env bash\nset -euo pipefail\nprintf '\\377binary-start\\n'\nsleep 0.25\nhead -c 300000 /dev/zero | tr '\\000' x\nprintf '\\n'\nprintf '\\376warning\\n' >&2\nmkdir -p petal/{petal_name}\ncp components/route.wasm petal/{petal_name}/hello.txt.wasm\n"
+            ),
+            BuildScript::BlockingOutput => format!(
+                "#!/usr/bin/env bash\nset -euo pipefail\necho 'blocking-build-start'\nsleep 30\nmkdir -p petal/{petal_name}\ncp components/route.wasm petal/{petal_name}/hello.txt.wasm\n"
             ),
             BuildScript::OutputFailure => "#!/usr/bin/env bash\nset -euo pipefail\necho 'partial build output'\necho 'build exploded' >&2\nexit 42\n".to_string(),
             BuildScript::InvalidOutput => format!(

--- a/crates/bloom/src/main.rs
+++ b/crates/bloom/src/main.rs
@@ -2276,14 +2276,39 @@ fn print_vfs_stat_json(path: &str, entry: &serde_json::Value) -> Result<()> {
 }
 
 async fn ipc_read(endpoint: &ResolvedEndpoint, path: &str) -> Result<Vec<u8>> {
-    let result = try_ipc(
+    let mut streamed = Vec::new();
+    let reply = try_ipc_streaming(
         &IpcClient::new(&endpoint.socket),
         endpoint,
         "read",
         serde_json::json!({ "path": path }),
+        |event| match event.stream {
+            IpcOutputStream::Data => {
+                streamed.extend_from_slice(&event.bytes);
+                Ok(())
+            }
+            IpcOutputStream::Stdout | IpcOutputStream::Stderr => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "IPC read returned command output",
+            )),
+        },
     )
     .await
     .with_context(|| format!("ipc read {path} via {}", endpoint.display))?;
+    let result = reply.result;
+    if result.get("streamed").and_then(serde_json::Value::as_bool) == Some(true) {
+        let expected = result
+            .get("len")
+            .and_then(serde_json::Value::as_u64)
+            .context("ipc read: streamed response is missing len")?;
+        anyhow::ensure!(
+            streamed.len() as u64 == expected,
+            "ipc read: streamed byte count mismatch (expected {expected}, received {})",
+            streamed.len()
+        );
+        return Ok(streamed);
+    }
+    anyhow::ensure!(streamed.is_empty(), "ipc read: unexpected streamed data");
     let encoded = result
         .get("bytes_b64")
         .and_then(|value| value.as_str())
@@ -3180,6 +3205,10 @@ fn write_ipc_output_event(event: IpcOutputEvent) -> std::io::Result<()> {
             std::io::Write::write_all(&mut std::io::stderr(), &event.bytes)?;
             std::io::Write::flush(&mut std::io::stderr())
         }
+        IpcOutputStream::Data => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "command emitted an unexpected IPC data stream",
+        )),
     }
 }
 

--- a/crates/bloom/src/main.rs
+++ b/crates/bloom/src/main.rs
@@ -27,9 +27,10 @@ use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as B64;
 use bloom_daemon::Daemon;
 use bloom_daemon::ipc::{
-    IpcClient, IpcClientError, IpcProtocolRange, IpcServer, MachineCeremonyAction, MachineCommand,
-    MachineCommandFuture, MachineCommandOutput, MachineCommandService, MachineCustodyKind,
-    MachineError, MachineErrorKind, MachineOperationAction, default_socket_path,
+    IpcCallResult, IpcClient, IpcClientError, IpcOutputEvent, IpcOutputStream, IpcProtocolRange,
+    IpcServer, MachineCeremonyAction, MachineCommand, MachineCommandFuture, MachineCommandOutput,
+    MachineCommandService, MachineCustodyKind, MachineError, MachineErrorKind,
+    MachineOperationAction, default_socket_path,
 };
 use bloom_machine_client::MachineJournalHeadProvider;
 use bloom_proto::{AuditIdentity, AuditLog, HomeDir, HomeWritePermit};
@@ -2133,40 +2134,69 @@ async fn try_ipc(
 ) -> std::io::Result<serde_json::Value> {
     match client.call(method, params).await {
         Ok(v) => Ok(v),
-        Err(IpcClientError::Rpc(error)) => Err(std::io::Error::other(error)),
-        Err(IpcClientError::Transport(e)) if e.kind() == std::io::ErrorKind::NotFound => {
-            Err(std::io::Error::new(
+        Err(error) => Err(map_ipc_client_error(endpoint, error)),
+    }
+}
+
+async fn try_ipc_streaming<F>(
+    client: &IpcClient,
+    endpoint: &ResolvedEndpoint,
+    method: &str,
+    params: serde_json::Value,
+    on_output: F,
+) -> std::io::Result<IpcCallResult>
+where
+    F: FnMut(IpcOutputEvent) -> std::io::Result<()>,
+{
+    client
+        .call_streaming(method, params, on_output)
+        .await
+        .map_err(|error| map_ipc_client_error(endpoint, error))
+}
+
+fn map_ipc_client_error(endpoint: &ResolvedEndpoint, error: IpcClientError) -> std::io::Error {
+    match error {
+        IpcClientError::Rpc(error) => std::io::Error::other(error),
+        IpcClientError::Transport(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            std::io::Error::new(
                 e.kind(),
                 format!(
                     "Bloom daemon endpoint {} is not available: {e}; start it with 'bloom serve'",
                     endpoint.display
                 ),
-            ))
+            )
         }
-        Err(IpcClientError::Transport(e)) if is_endpoint_permission_denial(&e) => {
-            Err(endpoint_connection_error(&endpoint.display, e))
+        IpcClientError::Transport(e) if is_endpoint_permission_denial(&e) => {
+            endpoint_connection_error(&endpoint.display, e)
         }
-        Err(IpcClientError::Transport(e)) if e.kind() == std::io::ErrorKind::ConnectionRefused => {
-            Err(std::io::Error::other(format!(
+        IpcClientError::Transport(e) if e.kind() == std::io::ErrorKind::ConnectionRefused => {
+            std::io::Error::other(format!(
                 "Bloom daemon endpoint {} is not responding: {e}; start it with 'bloom serve'",
                 endpoint.display,
-            )))
+            ))
         }
-        Err(IpcClientError::Transport(e)) => Err(endpoint_connection_error(&endpoint.display, e)),
-        Err(IpcClientError::Protocol(message)) => Err(std::io::Error::new(
+        IpcClientError::Transport(e) => endpoint_connection_error(&endpoint.display, e),
+        IpcClientError::Protocol(message) => std::io::Error::new(
             std::io::ErrorKind::InvalidData,
             format!(
                 "Bloom daemon endpoint {} returned {message}",
                 endpoint.display
             ),
-        )),
-        Err(error @ IpcClientError::Incompatible { .. }) => Err(std::io::Error::new(
+        ),
+        IpcClientError::EndpointSecurity(message) => std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "Bloom daemon endpoint {} is insecure: {message}",
+                endpoint.display
+            ),
+        ),
+        error @ IpcClientError::Incompatible { .. } => std::io::Error::new(
             std::io::ErrorKind::Unsupported,
             format!(
                 "Bloom daemon endpoint {} rejected: {error}",
                 endpoint.display
             ),
-        )),
+        ),
     }
 }
 
@@ -2298,7 +2328,10 @@ async fn run(cli: Cli) -> Result<()> {
         !cli.version || cli.cmd.is_none(),
         "--version cannot be combined with a command"
     );
-    let (connect, ipc_socket) = if cli.connect.is_some() {
+    let lifecycle_command = matches!(cli.cmd.as_ref(), Some(Cmd::Init { .. } | Cmd::Serve { .. }));
+    let (connect, ipc_socket) = if lifecycle_command {
+        (None, None)
+    } else if cli.connect.is_some() {
         (cli.connect, None)
     } else if cli.ipc_socket.is_some() {
         (None, cli.ipc_socket)
@@ -2317,8 +2350,12 @@ async fn run(cli: Cli) -> Result<()> {
         }
         None => HomeDir::resolve("~/.bloom").context("resolving home dir")?,
     };
-    let client_endpoint = resolve_client_endpoint(&home, connect.as_deref(), ipc_socket.as_deref())
-        .context("resolve Bloom endpoint")?;
+    let client_endpoint = if lifecycle_command {
+        ResolvedEndpoint::default_for_home(&home)
+    } else {
+        resolve_client_endpoint(&home, connect.as_deref(), ipc_socket.as_deref())
+            .context("resolve Bloom endpoint")?
+    };
     trace!(cmd = ?cli.cmd, home = %home.root().display(), "cli.dispatch");
 
     if cli.version {
@@ -3025,7 +3062,11 @@ struct CanonicalPetalSourceInstaller {
 }
 
 impl bloom_daemon::ipc::PetalSourceInstallService for CanonicalPetalSourceInstaller {
-    fn install_source(&self, params: serde_json::Value) -> Result<serde_json::Value, String> {
+    fn install_source(
+        &self,
+        params: serde_json::Value,
+        context: bloom_daemon::ipc::IpcOperationContext,
+    ) -> Result<serde_json::Value, String> {
         let path = params
             .get("path")
             .and_then(serde_json::Value::as_str)
@@ -3036,19 +3077,20 @@ impl bloom_daemon::ipc::PetalSourceInstallService for CanonicalPetalSourceInstal
             .ok_or_else(|| {
                 "trusted source installer requires a GitHub repository URL".to_owned()
             })?;
-        let installed = match github_source::install_github_source(
+        let installed = match github_source::install_github_source_streaming(
             &self.home,
             &self.daemon,
             &repo,
             requested_ref,
+            &context,
         ) {
             Ok(installed) => installed,
             Err(error) => {
                 if let Some(failure) = github_source::source_install_failure(&error) {
                     return Ok(serde_json::json!({
                         "progress_lines": failure.progress,
-                        "build_stdout": failure.stdout,
-                        "build_stderr": failure.stderr,
+                        "build_stdout_b64": B64.encode(&failure.stdout),
+                        "build_stderr_b64": B64.encode(&failure.stderr),
                         "completion_progress_lines": failure.completion_progress,
                         "operation_error": failure.message,
                     }));
@@ -3071,8 +3113,8 @@ impl bloom_daemon::ipc::PetalSourceInstallService for CanonicalPetalSourceInstal
             "source": format!("{}/{}@{}", installed.provenance.owner, installed.provenance.repo, selected),
             "resolved_commit": installed.provenance.resolved_commit,
             "progress_lines": installed.progress,
-            "build_stdout": installed.build_stdout,
-            "build_stderr": installed.build_stderr,
+            "build_stdout_b64": B64.encode(&installed.build_stdout),
+            "build_stderr_b64": B64.encode(&installed.build_stderr),
             "completion_progress_lines": installed.completion_progress,
             "consent_lines": petal_consent_lines(&installed.consent),
         }))
@@ -3110,20 +3152,35 @@ fn print_ipc_lines(value: &serde_json::Value, field: &str) -> Result<()> {
 
 fn print_ipc_captured_build_output(value: &serde_json::Value) -> Result<()> {
     if let Some(stdout) = value
-        .get("build_stdout")
+        .get("build_stdout_b64")
         .and_then(serde_json::Value::as_str)
     {
-        std::io::Write::write_all(&mut std::io::stdout(), stdout.as_bytes())?;
+        let bytes = B64.decode(stdout).context("decode captured build stdout")?;
+        std::io::Write::write_all(&mut std::io::stdout(), &bytes)?;
         std::io::Write::flush(&mut std::io::stdout())?;
     }
     if let Some(stderr) = value
-        .get("build_stderr")
+        .get("build_stderr_b64")
         .and_then(serde_json::Value::as_str)
     {
-        std::io::Write::write_all(&mut std::io::stderr(), stderr.as_bytes())?;
+        let bytes = B64.decode(stderr).context("decode captured build stderr")?;
+        std::io::Write::write_all(&mut std::io::stderr(), &bytes)?;
         std::io::Write::flush(&mut std::io::stderr())?;
     }
     Ok(())
+}
+
+fn write_ipc_output_event(event: IpcOutputEvent) -> std::io::Result<()> {
+    match event.stream {
+        IpcOutputStream::Stdout => {
+            std::io::Write::write_all(&mut std::io::stdout(), &event.bytes)?;
+            std::io::Write::flush(&mut std::io::stdout())
+        }
+        IpcOutputStream::Stderr => {
+            std::io::Write::write_all(&mut std::io::stderr(), &event.bytes)?;
+            std::io::Write::flush(&mut std::io::stderr())
+        }
+    }
 }
 
 fn absolute_cli_path(path: &str) -> Result<PathBuf> {
@@ -3173,14 +3230,23 @@ async fn run_petals(endpoint: &ResolvedEndpoint, cmd: PetalsCmd) -> Result<()> {
                 let local = absolute_cli_path(&path)?;
                 serde_json::json!({ "path": local, "ref": null })
             };
-            let result = try_ipc(&client, endpoint, "petals.install", params)
-                .await
-                .with_context(|| format!("ipc petals install via {}", endpoint.display))?;
-            if result.get("progress_lines").is_some() {
+            let reply = try_ipc_streaming(
+                &client,
+                endpoint,
+                "petals.install",
+                params,
+                write_ipc_output_event,
+            )
+            .await
+            .with_context(|| format!("ipc petals install via {}", endpoint.display))?;
+            let result = reply.result;
+            if reply.output_events == 0 && result.get("progress_lines").is_some() {
                 print_ipc_lines(&result, "progress_lines")?;
             }
-            print_ipc_captured_build_output(&result)?;
-            if result.get("completion_progress_lines").is_some() {
+            if reply.output_events == 0 {
+                print_ipc_captured_build_output(&result)?;
+            }
+            if reply.output_events == 0 && result.get("completion_progress_lines").is_some() {
                 print_ipc_lines(&result, "completion_progress_lines")?;
             }
             if let Some(error) = result

--- a/crates/bloom/src/main.rs
+++ b/crates/bloom/src/main.rs
@@ -2955,15 +2955,16 @@ impl bloom_daemon::ipc::PetalSourceInstallService for CanonicalPetalSourceInstal
         ) {
             Ok(installed) => installed,
             Err(error) => {
-                if let Some(failure) = github_source::source_build_failure(&error) {
+                if let Some(failure) = github_source::source_install_failure(&error) {
                     return Ok(serde_json::json!({
                         "progress_lines": failure.progress,
                         "build_stdout": failure.stdout,
                         "build_stderr": failure.stderr,
+                        "completion_progress_lines": failure.completion_progress,
                         "operation_error": failure.message,
                     }));
                 }
-                return Err(error.to_string());
+                return Err(format!("{error:#}"));
             }
         };
         let selected = installed

--- a/crates/bloom/src/main.rs
+++ b/crates/bloom/src/main.rs
@@ -1706,25 +1706,6 @@ async fn main() -> ExitCode {
     }
 }
 
-fn reject_archive_output_inside_package(package_dir: &str, out: &str) -> Result<()> {
-    let package_dir = std::fs::canonicalize(package_dir)
-        .with_context(|| format!("canonicalize package dir {package_dir}"))?;
-    let out_path = std::path::Path::new(out);
-    let out_parent = out_path
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-        .unwrap_or_else(|| std::path::Path::new("."));
-    let out_parent = std::fs::canonicalize(out_parent)
-        .with_context(|| format!("canonicalize archive parent {out}"))?;
-    let out_abs = out_parent.join(out_path.file_name().unwrap_or_default());
-    if out_abs.starts_with(&package_dir) {
-        bail!(
-            "--out must be outside the package directory so archives are not packaged into future builds"
-        );
-    }
-    Ok(())
-}
-
 /// Returns `None` when no daemon socket is present (daemon not started),
 /// propagating all other errors normally. A stale socket (file exists but
 /// connection refused) is removed and surfaced as an error rather than
@@ -2571,6 +2552,18 @@ async fn run(cli: Cli) -> Result<()> {
             info!(home = %d.home.root().display(), chains = ?chains, endpoint = %endpoint.display, socket = %socket.display(), mount = ?mount, "cli.serve.starting");
             let server = IpcServer::new(d.vfs.clone(), env!("CARGO_PKG_VERSION"), chains)
                 .with_petals(d.petals.clone())
+                .with_petal_runtime_endpoints(
+                    d.config
+                        .petals
+                        .runtime
+                        .iter()
+                        .map(|(name, runtime)| (name.clone(), runtime.endpoints.clone()))
+                        .collect(),
+                )
+                .with_petal_source_installer(Arc::new(CanonicalPetalSourceInstaller {
+                    home: home.clone(),
+                    daemon: d.clone(),
+                }))
                 .with_batch_confirmation(
                     d.batch_confirmation_service().map_err(anyhow::Error::msg)?,
                 );
@@ -2612,10 +2605,7 @@ async fn run(cli: Cli) -> Result<()> {
             Ok(())
         }
         Cmd::Update(cmd) => handle_update(&home, cmd).await,
-        Cmd::Petals(cmd) => {
-            let _home_permit = HomeWritePermit::acquire(&home)?;
-            run_petals(home, cmd).await
-        }
+        Cmd::Petals(cmd) => run_petals(&client_endpoint, cmd).await,
 
         Cmd::Completions { shell } => {
             generate(shell, &mut Cli::command(), "bloom", &mut std::io::stdout());
@@ -2642,147 +2632,238 @@ async fn run(cli: Cli) -> Result<()> {
     }
 }
 
-async fn run_petals(home: HomeDir, cmd: PetalsCmd) -> Result<()> {
-    let cmd = match cmd {
-        PetalsCmd::Build { package_dir, out } => {
-            if let Some(out) = out.as_deref() {
-                reject_archive_output_inside_package(&package_dir, out)?;
-            }
-            let package = bloom_petals::package::build_petal_package_dir(&package_dir)
-                .with_context(|| format!("build Petal package {package_dir}"))?;
-            let consent = bloom_petals::package::petal_consent_summary(&package)
-                .context("build Petal consent summary")?;
-            println!("hash: {}", package.hash);
-            println!("contract: {}", bloom_petals::package::ROUTE_PACKAGE);
-            println!(
-                "wit_digest: {}",
-                bloom_petals::package::contract_wit_digest()
-            );
-            println!("petal_mount: petals/{}/", package.name);
-            println!("routes: {}", package.route_index.routes.len());
-            println!("artifacts: {package_dir}/artifacts");
-            print_petal_consent(&consent);
-            if let Some(out) = out {
-                let file =
-                    std::fs::File::create(&out).with_context(|| format!("create archive {out}"))?;
-                package
-                    .write_petal_tar(file)
-                    .with_context(|| format!("write archive {out}"))?;
-                println!("archive: {out}");
-            }
-            return Ok(());
-        }
-        other => other,
-    };
+#[derive(Clone)]
+struct CanonicalPetalSourceInstaller {
+    home: HomeDir,
+    daemon: Daemon,
+}
 
-    let d = build_authenticated_read_daemon(home.clone())?;
+impl bloom_daemon::ipc::PetalSourceInstallService for CanonicalPetalSourceInstaller {
+    fn install_source(&self, params: serde_json::Value) -> Result<serde_json::Value, String> {
+        let path = params
+            .get("path")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| "missing 'path'".to_owned())?;
+        let requested_ref = params.get("ref").and_then(serde_json::Value::as_str);
+        let repo = github_source::parse_github_install_url(path)
+            .map_err(|error| error.to_string())?
+            .ok_or_else(|| {
+                "trusted source installer requires a GitHub repository URL".to_owned()
+            })?;
+        let installed = match github_source::install_github_source(
+            &self.home,
+            &self.daemon,
+            &repo,
+            requested_ref,
+        ) {
+            Ok(installed) => installed,
+            Err(error) => {
+                if let Some(failure) = github_source::source_build_failure(&error) {
+                    return Ok(serde_json::json!({
+                        "progress_lines": failure.progress,
+                        "build_stdout": failure.stdout,
+                        "build_stderr": failure.stderr,
+                        "operation_error": failure.message,
+                    }));
+                }
+                return Err(error.to_string());
+            }
+        };
+        let selected = installed
+            .provenance
+            .selected_tag
+            .as_deref()
+            .unwrap_or(&installed.provenance.requested_ref);
+        Ok(serde_json::json!({
+            "hash": installed.result.hash,
+            "mode": "petal",
+            "size": installed.result.size,
+            "already_present": installed.result.already_present,
+            "petal_mount": installed.meta.petal.as_ref().map(|petal| format!("petals/{}/", petal.name)),
+            "routes": installed.index.routes.len(),
+            "source": format!("{}/{}@{}", installed.provenance.owner, installed.provenance.repo, selected),
+            "resolved_commit": installed.provenance.resolved_commit,
+            "progress_lines": installed.progress,
+            "build_stdout": installed.build_stdout,
+            "build_stderr": installed.build_stderr,
+            "completion_progress_lines": installed.completion_progress,
+            "consent_lines": petal_consent_lines(&installed.consent),
+        }))
+    }
+}
+
+fn required_petal_string<'a>(value: &'a serde_json::Value, field: &str) -> Result<&'a str> {
+    value
+        .get(field)
+        .and_then(serde_json::Value::as_str)
+        .with_context(|| format!("ipc petals response: missing {field}"))
+}
+
+fn required_petal_u64(value: &serde_json::Value, field: &str) -> Result<u64> {
+    value
+        .get(field)
+        .and_then(serde_json::Value::as_u64)
+        .with_context(|| format!("ipc petals response: missing {field}"))
+}
+
+fn print_ipc_lines(value: &serde_json::Value, field: &str) -> Result<()> {
+    for line in value
+        .get(field)
+        .and_then(serde_json::Value::as_array)
+        .with_context(|| format!("ipc petals response: missing {field}"))?
+    {
+        println!(
+            "{}",
+            line.as_str()
+                .with_context(|| format!("ipc petals response: non-string {field}"))?
+        );
+    }
+    Ok(())
+}
+
+fn print_ipc_captured_build_output(value: &serde_json::Value) -> Result<()> {
+    if let Some(stdout) = value
+        .get("build_stdout")
+        .and_then(serde_json::Value::as_str)
+    {
+        std::io::Write::write_all(&mut std::io::stdout(), stdout.as_bytes())?;
+        std::io::Write::flush(&mut std::io::stdout())?;
+    }
+    if let Some(stderr) = value
+        .get("build_stderr")
+        .and_then(serde_json::Value::as_str)
+    {
+        std::io::Write::write_all(&mut std::io::stderr(), stderr.as_bytes())?;
+        std::io::Write::flush(&mut std::io::stderr())?;
+    }
+    Ok(())
+}
+
+fn absolute_cli_path(path: &str) -> Result<PathBuf> {
+    let path = PathBuf::from(path);
+    if path.is_absolute() {
+        Ok(path)
+    } else {
+        Ok(std::env::current_dir()
+            .context("resolve CLI working directory")?
+            .join(path))
+    }
+}
+
+async fn run_petals(endpoint: &ResolvedEndpoint, cmd: PetalsCmd) -> Result<()> {
+    let client = IpcClient::new(&endpoint.socket);
     match cmd {
         PetalsCmd::Install { path, ref_ } => {
-            if let Some(repo) = github_source::parse_github_install_url(&path)? {
-                let installed =
-                    github_source::install_github_source(&home, &d, &repo, ref_.as_deref())?;
-                println!();
-                println!("hash: {}", installed.result.hash);
-                println!("mode: petal");
-                println!("size: {} bytes", installed.result.size);
-                if installed.result.already_present {
-                    println!("note: already installed");
-                }
-                if let Some(app) = &installed.meta.petal {
-                    println!("petal_mount: petals/{}/", app.name);
-                }
-                println!("routes: {}", installed.index.routes.len());
-                println!(
-                    "source: {}/{}@{}",
-                    installed.provenance.owner,
-                    installed.provenance.repo,
-                    installed
-                        .provenance
-                        .selected_tag
-                        .as_deref()
-                        .unwrap_or(&installed.provenance.requested_ref)
-                );
-                println!("resolved_commit: {}", installed.provenance.resolved_commit);
-                print_petal_consent(&installed.consent);
-                return Ok(());
-            }
-
-            if ref_.is_some() {
-                bail!("--ref is only supported for trusted GitHub source installs");
-            }
-            let path_meta = std::fs::metadata(&path).with_context(|| format!("stat {path}"))?;
-            let is_petal_dir = path_meta.is_dir();
-            if !is_petal_dir && !path.ends_with(".petal.tar") {
-                bail!(
-                    "petals install only accepts Petal package directories, .petal.tar archives, or trusted GitHub source repositories"
-                );
-            }
-            let consent_package = if is_petal_dir {
-                bloom_petals::package::PreparedPetalPackage::from_dir(&path)
-                    .with_context(|| format!("read Petal package dir {path}"))?
+            let rpc_path = if path.contains("://") || path.starts_with("git@github.com:") {
+                path.clone()
             } else {
-                bloom_petals::package::PreparedPetalPackage::from_petal_tar(&path)
-                    .with_context(|| format!("read Petal package archive {path}"))?
+                absolute_cli_path(&path)?.to_string_lossy().into_owned()
             };
-            let mut consent = bloom_petals::package::petal_consent_summary(&consent_package)
-                .context("build app consent summary")?;
-            apply_configured_petal_endpoints(&d, &mut consent)?;
-            let (result, meta, index) = if is_petal_dir {
-                d.petals
-                    .store()
-                    .install_petal_package_dir(&path)
-                    .with_context(|| format!("install Petal package dir {path}"))?
-            } else {
-                d.petals
-                    .store()
-                    .install_petal_package_tar(&path)
-                    .with_context(|| format!("install Petal package archive {path}"))?
-            };
-            println!("hash: {}", result.hash);
+            let result = client
+                .call(
+                    "petals.install",
+                    serde_json::json!({ "path": rpc_path, "ref": ref_ }),
+                )
+                .await
+                .with_context(|| format!("ipc petals install via {}", endpoint.display))?;
+            if result.get("progress_lines").is_some() {
+                print_ipc_lines(&result, "progress_lines")?;
+            }
+            print_ipc_captured_build_output(&result)?;
+            if result.get("completion_progress_lines").is_some() {
+                print_ipc_lines(&result, "completion_progress_lines")?;
+            }
+            if let Some(error) = result
+                .get("operation_error")
+                .and_then(serde_json::Value::as_str)
+            {
+                bail!("{error}");
+            }
+            println!("hash: {}", required_petal_string(&result, "hash")?);
             println!("mode: petal");
-            println!("size: {} bytes", result.size);
-            if result.already_present {
+            println!("size: {} bytes", required_petal_u64(&result, "size")?);
+            if result["already_present"].as_bool() == Some(true) {
                 println!("note: already installed");
             }
-            if let Some(app) = &meta.petal {
-                println!("petal_mount: petals/{}/", app.name);
+            if let Some(mount) = result["petal_mount"].as_str() {
+                println!("petal_mount: {mount}");
             }
-            println!("routes: {}", index.routes.len());
-            print_petal_consent(&consent);
+            println!("routes: {}", required_petal_u64(&result, "routes")?);
+            if let Some(source) = result["source"].as_str() {
+                println!("source: {source}");
+            }
+            if let Some(commit) = result["resolved_commit"].as_str() {
+                println!("resolved_commit: {commit}");
+            }
+            print_ipc_lines(&result, "consent_lines")?;
             Ok(())
         }
-        PetalsCmd::Build { .. } => {
-            unreachable!("Petal build commands are handled before daemon startup")
+        PetalsCmd::Build { package_dir, out } => {
+            let rpc_package_dir = absolute_cli_path(&package_dir)?;
+            let rpc_out = out.as_deref().map(absolute_cli_path).transpose()?;
+            let result = client
+                .call(
+                    "petals.build",
+                    serde_json::json!({ "package_dir": rpc_package_dir, "out": rpc_out }),
+                )
+                .await
+                .with_context(|| format!("ipc petals build via {}", endpoint.display))?;
+            for field in ["hash", "contract", "wit_digest", "petal_mount", "routes"] {
+                let value = result
+                    .get(field)
+                    .context("ipc petals build: missing response field")?;
+                println!(
+                    "{field}: {}",
+                    value
+                        .as_str()
+                        .map_or_else(|| value.to_string(), str::to_owned)
+                );
+            }
+            println!("artifacts: {package_dir}/artifacts");
+            print_ipc_lines(&result, "consent_lines")?;
+            if let Some(archive) = out {
+                println!("archive: {archive}");
+            }
+            Ok(())
         }
         PetalsCmd::Ls => {
-            let package_hashes = d
-                .petals
-                .store()
-                .list_package_hashes()
-                .context("list Petal packages")?;
-            if package_hashes.is_empty() {
+            let result = client
+                .call("petals.list", serde_json::Value::Null)
+                .await
+                .with_context(|| format!("ipc petals list via {}", endpoint.display))?;
+            let entries = result
+                .as_array()
+                .context("ipc petals list: expected array")?;
+            if entries.is_empty() {
                 println!("(no petals installed)");
                 return Ok(());
             }
-            for h in package_hashes {
-                let meta = d.petals.store().load_meta(&h).context("load meta")?;
-                let app = meta
-                    .petal
-                    .as_ref()
-                    .map(|app| format!("  app=petals/{}/", app.name))
+            for entry in entries {
+                let hash = required_petal_string(entry, "hash")?;
+                let app = entry["petal_mount"]
+                    .as_str()
+                    .map(|mount| format!("  app={mount}"))
                     .unwrap_or_default();
-                let source = meta.source.as_ref().map_or_else(String::new, |source| {
-                    let selected = source
-                        .selected_tag
-                        .as_deref()
-                        .unwrap_or(&source.requested_ref);
-                    format!("  source={}/{}@{}", source.owner, source.repo, selected)
-                });
+                let source = entry["source"]
+                    .as_object()
+                    .map_or_else(String::new, |source| {
+                        let selected = source
+                            .get("selected_tag")
+                            .and_then(|v| v.as_str())
+                            .or_else(|| source.get("requested_ref").and_then(|v| v.as_str()))
+                            .unwrap_or("?");
+                        format!(
+                            "  source={}/{}@{}",
+                            source.get("owner").and_then(|v| v.as_str()).unwrap_or("?"),
+                            source.get("repo").and_then(|v| v.as_str()).unwrap_or("?"),
+                            selected
+                        )
+                    });
                 println!(
                     "{}  {:<7}  {:>7}  caps=[]  name=-{}{}",
-                    &meta.hash[..bloom_petals::store::HASH_PREFIX_LEN],
+                    &hash[..bloom_petals::store::HASH_PREFIX_LEN.min(hash.len())],
                     "app",
-                    meta.size,
+                    required_petal_u64(entry, "size")?,
                     app,
                     source
                 );
@@ -2790,7 +2871,13 @@ async fn run_petals(home: HomeDir, cmd: PetalsCmd) -> Result<()> {
             Ok(())
         }
         PetalsCmd::Uninstall { target } => {
-            let removed = d.petals.uninstall(&target).context("uninstall petal")?;
+            let result = client
+                .call("petals.uninstall", serde_json::json!({ "hash": target }))
+                .await
+                .with_context(|| format!("ipc petals uninstall via {}", endpoint.display))?;
+            let removed = result["removed"]
+                .as_bool()
+                .context("ipc petals uninstall: missing removed")?;
             if removed {
                 println!("removed {target}");
             } else {
@@ -2801,33 +2888,39 @@ async fn run_petals(home: HomeDir, cmd: PetalsCmd) -> Result<()> {
     }
 }
 
-fn print_petal_consent(summary: &bloom_petals::package::PetalConsentSummary) {
-    println!("consent:");
+fn petal_consent_lines(summary: &bloom_petals::package::PetalConsentSummary) -> Vec<String> {
+    let mut lines = vec!["consent:".to_owned()];
     if let Some(package_summary) = &summary.package_summary {
-        println!("  summary: {package_summary}");
+        lines.push(format!("  summary: {package_summary}"));
     }
-    println!("  docs: {}", summary.docs.join(", "));
+    lines.push(format!("  docs: {}", summary.docs.join(", ")));
     if !summary.capabilities.is_empty() {
-        println!("  capabilities: {}", summary.capabilities.join(", "));
+        lines.push(format!(
+            "  capabilities: {}",
+            summary.capabilities.join(", ")
+        ));
     }
     if !summary.network.is_empty() {
-        println!("  network:");
+        lines.push("  network:".to_owned());
         for rule in &summary.network {
-            println!("{}", format_petal_consent_net_rule(rule));
+            lines.push(format_petal_consent_net_rule(rule));
         }
     }
     if !summary.sign_intents.is_empty() {
-        println!("  signing_intents: {}", summary.sign_intents.join(", "));
+        lines.push(format!(
+            "  signing_intents: {}",
+            summary.sign_intents.join(", ")
+        ));
     }
     if !summary.store_namespaces.is_empty() {
-        println!("  private_store:");
+        lines.push("  private_store:".to_owned());
         for ns in &summary.store_namespaces {
             let visibility = if ns.secret { "secret" } else { "private" };
-            println!("    - {} {}", ns.namespace, visibility);
+            lines.push(format!("    - {} {}", ns.namespace, visibility));
         }
     }
     if !summary.routes.is_empty() {
-        println!("  routes:");
+        lines.push("  routes:".to_owned());
         for route in &summary.routes {
             let ops = route
                 .ops
@@ -2851,34 +2944,22 @@ fn print_petal_consent(summary: &bloom_petals::package::PetalConsentSummary) {
                 route.required_caps.join(",")
             };
             if flags.is_empty() {
-                println!("    - {} ops=[{}] caps=[{}]", route.path, ops, caps);
+                lines.push(format!(
+                    "    - {} ops=[{}] caps=[{}]",
+                    route.path, ops, caps
+                ));
             } else {
-                println!(
+                lines.push(format!(
                     "    - {} ops=[{}] caps=[{}] flags=[{}]",
                     route.path,
                     ops,
                     caps,
                     flags.join(",")
-                );
+                ));
             }
         }
     }
-}
-
-fn apply_configured_petal_endpoints(
-    daemon: &Daemon,
-    summary: &mut bloom_petals::package::PetalConsentSummary,
-) -> Result<()> {
-    let bindings = daemon
-        .config
-        .petals
-        .runtime
-        .get(&summary.name)
-        .map(|app| &app.endpoints)
-        .cloned()
-        .unwrap_or_default();
-    bloom_petals::package::apply_petal_consent_endpoint_bindings(summary, &bindings)
-        .context("apply configured Petal endpoint bindings")
+    lines
 }
 
 fn format_petal_consent_net_rule(rule: &bloom_petals::package::PetalConsentNetRule) -> String {

--- a/crates/bloom/src/main.rs
+++ b/crates/bloom/src/main.rs
@@ -26,13 +26,13 @@ use anyhow::{Context, Result, bail};
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as B64;
 use bloom_daemon::Daemon;
-use bloom_daemon::ipc::{IpcClient, IpcServer, default_socket_path};
-use bloom_machine_client::{MachineJournalHeadProvider, WalletProjectionReader as _};
-use bloom_proto::{AuditIdentity, AuditLog, HomeDir, HomeWritePermit};
-use bloom_vfs::{
-    VfsPath,
-    handler::{Entry, EntryKind, Handler},
+use bloom_daemon::ipc::{
+    IpcClient, IpcClientError, IpcServer, MachineCeremonyAction, MachineCommand,
+    MachineCommandFuture, MachineCommandOutput, MachineCommandService, MachineCustodyKind,
+    MachineError, MachineErrorKind, MachineOperationAction, default_socket_path,
 };
+use bloom_machine_client::MachineJournalHeadProvider;
+use bloom_proto::{AuditIdentity, AuditLog, HomeDir, HomeWritePermit};
 use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::{Shell, generate};
 use tracing::{debug, info, trace};
@@ -46,16 +46,9 @@ const DEFAULT_MOUNT_PATH: &str = "/Volumes/bloom";
 const DEFAULT_MOUNT_PATH: &str = "/bloom";
 
 const ALPHA_DISCLOSURE: &str = "⚠️  Bloom is experimental, unaudited alpha software. Do not use with funds you cannot afford to lose. Review every generated transaction plan before signing.";
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum EndpointSource {
-    Default,
-    Explicit,
-}
-
 #[derive(Debug, Clone)]
 struct ResolvedEndpoint {
     socket: PathBuf,
-    source: EndpointSource,
     display: String,
 }
 
@@ -65,7 +58,6 @@ impl ResolvedEndpoint {
         Self {
             display: format!("unix:{}", socket.display()),
             socket,
-            source: EndpointSource::Default,
         }
     }
 
@@ -74,7 +66,6 @@ impl ResolvedEndpoint {
         Ok(Self {
             display: format!("unix:{}", path.display()),
             socket: path,
-            source: EndpointSource::Explicit,
         })
     }
 
@@ -82,12 +73,7 @@ impl ResolvedEndpoint {
         Self {
             display: format!("unix:{}", path.display()),
             socket: path,
-            source: EndpointSource::Explicit,
         }
-    }
-
-    fn is_explicit(&self) -> bool {
-        matches!(self.source, EndpointSource::Explicit)
     }
 }
 
@@ -127,25 +113,6 @@ fn resolve_server_endpoint(home: &HomeDir, endpoint: Option<&str>) -> Result<Res
 
 fn configured_broker_client(home: &HomeDir) -> Result<bloom_machine_client::MachineBrokerClient> {
     configured_broker_client_with_activation(home, false)
-}
-
-fn configured_wallet_projection_reader(
-    home: &HomeDir,
-) -> Result<bloom_machine_client::CachedWalletProjectionReader> {
-    let broker = match configured_broker_client(home) {
-        Ok(client) => Some(client),
-        Err(error) => {
-            debug!(error = %error, "wallet projection using stale cache until Broker is available");
-            None
-        }
-    };
-    bloom_machine_client::CachedWalletProjectionReader::new(
-        broker,
-        bloom_machine_client::FileProjectionStore::new(
-            home.cache_dir().join("wallet-projections.json"),
-        ),
-    )
-    .context("open Machine wallet projection cache")
 }
 
 fn validate_wallet_name(name: &str) -> Result<()> {
@@ -554,37 +521,6 @@ fn build_write_daemon(home: HomeDir) -> Result<(Arc<HomeWritePermit>, Daemon)> {
     Ok((permit, daemon))
 }
 
-fn build_authenticated_read_daemon(home: HomeDir) -> Result<Daemon> {
-    // Reads may still execute effectful VFS routes (for example provider
-    // refreshes), so production never constructs the unsigned developer
-    // composition merely because the long-running Machine socket is absent.
-    match configured_broker_connection(&home) {
-        Ok((broker, catalog)) => Daemon::from_home_with_broker(home, broker, catalog)
-            .context("build authenticated read daemon"),
-        Err(error) => {
-            #[cfg(debug_assertions)]
-            {
-                debug!(error = %error, "authenticated Broker edge absent; using key-free debug read composition");
-                Daemon::from_home_without_broker_for_debug(home)
-                    .context("build key-free debug read daemon")
-            }
-            #[cfg(not(debug_assertions))]
-            {
-                Err(error).context("load authenticated Machine identity and Broker edge")
-            }
-        }
-    }
-}
-
-fn configured_machine_audit(home: &HomeDir) -> Result<AuditLog> {
-    let client = configured_raw_broker_client_with_activation(false)
-        .context("load authenticated Machine identity for local audit operation")?;
-    let identity = client
-        .local_application_identity()
-        .context("authenticated Machine client did not retain its application identity")?;
-    open_configured_machine_audit(home, identity)
-}
-
 fn machine_audit_status(audit: &AuditLog) -> serde_json::Value {
     let (pending, pending_read_error) = match audit.pending_effect_correlations() {
         Ok(pending) => (pending, None),
@@ -626,13 +562,6 @@ fn execute_audit_command(command: &AuditCmd, audit: &AuditLog) -> Result<String>
             &audit.reconcile_pending_effect(correlation_id, outcome, confirm)?,
         )?),
     }
-}
-
-fn open_configured_machine_audit(
-    home: &HomeDir,
-    identity: bloom_triad_local_transport::LocalIdentity,
-) -> Result<AuditLog> {
-    open_configured_machine_audit_with_activation(home, identity, false)
 }
 
 fn open_configured_machine_audit_with_activation(
@@ -756,16 +685,29 @@ async fn launch_custody_ceremony(
     wallet_id: Option<bloom_broker_api::Token>,
     expected_input_class: &str,
     legacy_migration: Option<LegacyMigrationLaunch>,
-) -> Result<()> {
+) -> Result<String> {
     use rand::RngCore as _;
     use sha2::Digest as _;
 
-    validate_wallet_name(requested_name)
-        .context("requested wallet name must be a safe single path segment")?;
-    let requested_wallet_id = bloom_broker_api::Token::new(requested_name.to_owned())
-        .context("requested wallet name must be a protocol token")?;
-    let client = configured_broker_client(home)
-        .context("custody requires the authenticated Machine-to-Broker edge")?;
+    validate_wallet_name(requested_name).map_err(|error| {
+        machine_error(
+            MachineErrorKind::InvalidParams,
+            format!("requested wallet name must be a safe single path segment: {error:#}"),
+        )
+    })?;
+    let requested_wallet_id =
+        bloom_broker_api::Token::new(requested_name.to_owned()).map_err(|error| {
+            machine_error(
+                MachineErrorKind::InvalidParams,
+                format!("requested wallet name must be a protocol token: {error}"),
+            )
+        })?;
+    let client = configured_broker_client(home).map_err(|error| {
+        machine_error(
+            MachineErrorKind::Unavailable,
+            format!("custody requires the authenticated Machine-to-Broker edge: {error:#}"),
+        )
+    })?;
     let (operation_id, exact_terms_digest, legacy_passkey_migration) =
         if let Some(migration) = legacy_migration {
             (
@@ -820,15 +762,14 @@ async fn launch_custody_ceremony(
     .map_err(anyhow::Error::new)
     .context("construct Machine custody projection")?;
     let projection_path = persist_ceremony_projection(home, &projection)?;
-    println!("operation_id: {}", response.custody_operation_id);
-    println!("ceremony_kind: {:?}", response.ceremony_kind);
-    println!("ceremony_url: {}", response.ceremony_url);
-    println!(
-        "ceremony_expires_at_ms: {}",
-        response.ceremony_expires_at_ms.get()
-    );
-    println!("projection: {}", projection_path.display());
-    Ok(())
+    Ok(format!(
+        "operation_id: {}\nceremony_kind: {:?}\nceremony_url: {}\nceremony_expires_at_ms: {}\nprojection: {}\n",
+        response.custody_operation_id,
+        response.ceremony_kind,
+        response.ceremony_url,
+        response.ceremony_expires_at_ms.get(),
+        projection_path.display(),
+    ))
 }
 
 struct LegacyMigrationLaunch {
@@ -837,7 +778,439 @@ struct LegacyMigrationLaunch {
     public_terms: bloom_broker_api::LegacyPasskeyMigrationPublic,
 }
 
-#[derive(serde::Deserialize)]
+#[derive(Clone)]
+struct DaemonMachineCommands {
+    home: HomeDir,
+    daemon: Daemon,
+}
+
+impl MachineCommandService for DaemonMachineCommands {
+    fn execute(&self, command: MachineCommand) -> MachineCommandFuture<'_> {
+        Box::pin(async move {
+            execute_machine_command(&self.home, &self.daemon, command)
+                .await
+                .map_err(machine_error_from_anyhow)
+        })
+    }
+}
+
+fn machine_error_from_anyhow(error: anyhow::Error) -> MachineError {
+    let message = format!("{error:#}");
+    for cause in error.chain() {
+        if let Some(error) = cause.downcast_ref::<MachineError>() {
+            return MachineError::new(error.kind, error.code.clone(), message);
+        }
+        if let Some(error) = cause.downcast_ref::<bloom_broker_api::ProtocolError>() {
+            return machine_error_from_protocol(error, message);
+        }
+        if let Some(error) = cause.downcast_ref::<bloom_vfs::HandlerError>() {
+            return machine_error_from_handler(error, message);
+        }
+        if cause.downcast_ref::<bloom_vfs::path::PathError>().is_some() {
+            return machine_error(MachineErrorKind::InvalidParams, message);
+        }
+        if let Some(error) = cause.downcast_ref::<std::io::Error>() {
+            return machine_error_from_io(error, message);
+        }
+    }
+    machine_error(MachineErrorKind::Internal, message)
+}
+
+fn machine_error_from_protocol(
+    error: &bloom_broker_api::ProtocolError,
+    message: String,
+) -> MachineError {
+    use bloom_broker_api::ProtocolErrorCode as Code;
+    let kind = match error.code {
+        Code::MalformedFrame
+        | Code::LimitExceededFrame
+        | Code::UnknownField
+        | Code::UnknownMethod
+        | Code::UnsupportedVersion
+        | Code::BackendInvalidRequest => MachineErrorKind::InvalidParams,
+        Code::ApprovalNotFound => MachineErrorKind::NotFound,
+        Code::OperationIdConflict | Code::PolicyBaselineStale | Code::CeremonyReplay => {
+            MachineErrorKind::Conflict
+        }
+        Code::ServiceUnavailable
+        | Code::AssuranceUnavailable
+        | Code::ClockUntrusted
+        | Code::ClockRollback
+        | Code::BackendUnsupported => MachineErrorKind::Unavailable,
+        Code::AmbiguousProviderEffect => MachineErrorKind::Internal,
+        Code::UnauthenticatedPeer
+        | Code::ApprovalExpired
+        | Code::ApprovalRevoked
+        | Code::ApprovalRearmRequired
+        | Code::RevocationEpochUnreconciled
+        | Code::SelectorMismatch
+        | Code::SuiteNotAllowed
+        | Code::KeyrefMismatch
+        | Code::LimitExceededOperations
+        | Code::LimitExceededSignatures
+        | Code::LimitExceededValue
+        | Code::LimitExceededRate
+        | Code::SignerRateBackstopDenied
+        | Code::ClaimInvalid
+        | Code::ProvenanceMismatch
+        | Code::CeremonyRateLimited
+        | Code::CeremonyKindMismatch
+        | Code::QuotaExceeded => MachineErrorKind::PermissionDenied,
+    };
+    machine_error(kind, message)
+}
+
+fn machine_wallet_lookup_error(error: bloom_broker_api::ProtocolError) -> MachineError {
+    use bloom_broker_api::ProtocolErrorCode as Code;
+    let message = error.to_string();
+    match error.code {
+        // The projection reader currently uses BackendInvalidRequest for a
+        // well-formed wallet identifier absent from the authoritative list.
+        // At this operation boundary that is a missing resource, not malformed
+        // command input.
+        Code::BackendInvalidRequest => machine_error(MachineErrorKind::NotFound, message),
+        _ => machine_error_from_protocol(&error, message),
+    }
+}
+
+fn machine_error_from_handler(error: &bloom_vfs::HandlerError, message: String) -> MachineError {
+    let kind = match error {
+        bloom_vfs::HandlerError::NotFound(_) => MachineErrorKind::NotFound,
+        bloom_vfs::HandlerError::PermissionDenied
+        | bloom_vfs::HandlerError::OperationNotPermitted => MachineErrorKind::PermissionDenied,
+        bloom_vfs::HandlerError::Invalid(_)
+        | bloom_vfs::HandlerError::NotADir(_)
+        | bloom_vfs::HandlerError::NotAFile(_)
+        | bloom_vfs::HandlerError::Unsupported(_) => MachineErrorKind::InvalidParams,
+        bloom_vfs::HandlerError::Backend(_) => MachineErrorKind::Internal,
+        bloom_vfs::HandlerError::Io(error) => return machine_error_from_io(error, message),
+    };
+    machine_error(kind, message)
+}
+
+fn machine_error_from_io(error: &std::io::Error, message: String) -> MachineError {
+    let kind = match error.kind() {
+        std::io::ErrorKind::NotFound => MachineErrorKind::NotFound,
+        std::io::ErrorKind::PermissionDenied => MachineErrorKind::PermissionDenied,
+        std::io::ErrorKind::AlreadyExists | std::io::ErrorKind::WouldBlock => {
+            MachineErrorKind::Conflict
+        }
+        std::io::ErrorKind::ConnectionRefused
+        | std::io::ErrorKind::ConnectionReset
+        | std::io::ErrorKind::ConnectionAborted
+        | std::io::ErrorKind::NotConnected
+        | std::io::ErrorKind::TimedOut
+        | std::io::ErrorKind::BrokenPipe => MachineErrorKind::Unavailable,
+        std::io::ErrorKind::InvalidInput | std::io::ErrorKind::InvalidData => {
+            MachineErrorKind::InvalidParams
+        }
+        _ => MachineErrorKind::Internal,
+    };
+    machine_error(kind, message)
+}
+
+fn machine_error(kind: MachineErrorKind, message: impl Into<String>) -> MachineError {
+    let code = match kind {
+        MachineErrorKind::InvalidParams => "INVALID_ARGUMENT",
+        MachineErrorKind::PermissionDenied => "PERMISSION_DENIED",
+        MachineErrorKind::Unavailable => "UNAVAILABLE",
+        MachineErrorKind::Conflict => "CONFLICT",
+        MachineErrorKind::NotFound => "NOT_FOUND",
+        MachineErrorKind::Internal => "INTERNAL",
+    };
+    MachineError::new(kind, code, message)
+}
+
+async fn execute_machine_command(
+    home: &HomeDir,
+    daemon: &Daemon,
+    command: MachineCommand,
+) -> Result<MachineCommandOutput> {
+    let output = match command {
+        MachineCommand::Status => {
+            let wallets = match daemon.wallet_projections.list_wallets().await {
+                Ok(wallets) => Some(wallets),
+                Err(error)
+                    if error.code == bloom_broker_api::ProtocolErrorCode::ServiceUnavailable =>
+                {
+                    None
+                }
+                Err(error) => return Err(error.into()),
+            };
+            let mut output = format!(
+                "version: {}\nhome: {}\nchains: {:?}\ndefault_chain: {}\ndefault_wallet: {}\ntry: bloom vfs ls /\n",
+                env!("CARGO_PKG_VERSION"),
+                home.root().display(),
+                daemon.chains.list_names(),
+                daemon.config.default_chain,
+                daemon.config.default_wallet.as_deref().unwrap_or("<none>"),
+            );
+            match wallets {
+                Some(wallets) if wallets.is_empty() => output.push_str("no wallets yet — create one with bloom wallet new main\n"),
+                Some(_) => output.push_str("deposit: bloom wallet address <wallet> --qr\nagent workflow: browse the mounted VFS or use bloom vfs cat/ls/write\n"),
+                None => output.push_str("wallets: unavailable (Broker offline and no cached public projection)\n"),
+            }
+            let mut stderr = String::new();
+            let checker =
+                bloom_update::UpdateChecker::new(env!("CARGO_PKG_VERSION"), home.cache_dir())?;
+            if let Some(snapshot) = checker.quick_check_cached() {
+                let latest = snapshot.latest.as_deref().unwrap_or("?");
+                let available = match snapshot.available() {
+                    bloom_update::UpdateAvailable::OutOfDate => "out_of_date",
+                    bloom_update::UpdateAvailable::UpToDate => "up_to_date",
+                    bloom_update::UpdateAvailable::Unknown => "unknown",
+                };
+                output.push_str(&format!(
+                    "latest_release: {latest}\nupdate_available: {available}\n"
+                ));
+                if matches!(
+                    snapshot.available(),
+                    bloom_update::UpdateAvailable::OutOfDate
+                ) {
+                    let latest_display = latest.strip_prefix('v').unwrap_or(latest);
+                    stderr.push_str(&format!(
+                        "hint: bloom v{latest_display} is available (you have v{}); see /status/update\n",
+                        env!("CARGO_PKG_VERSION")
+                    ));
+                }
+            }
+            return Ok(MachineCommandOutput {
+                stdout: output,
+                stderr,
+                exit_code: 0,
+            });
+        }
+        MachineCommand::AuditStatus => {
+            format!("{}\n", machine_audit_status_output(daemon.audit.as_ref())?)
+        }
+        MachineCommand::AuditReconcile {
+            correlation_id,
+            outcome,
+            confirm,
+        } => format!(
+            "{}\n",
+            execute_audit_command(
+                &AuditCmd::Reconcile {
+                    correlation_id,
+                    outcome,
+                    confirm,
+                },
+                daemon.audit.as_ref(),
+            )?
+        ),
+        MachineCommand::WalletList => {
+            let mut output = String::new();
+            for projection in daemon.wallet_projections.list_wallets().await? {
+                output.push_str(&format!(
+                    "{}\t{}\t{}\n",
+                    projection.wallet.wallet_id,
+                    projection.primary_address()?,
+                    projection.wallet.wallet_kind
+                ));
+            }
+            output
+        }
+        MachineCommand::WalletProjection { name } => {
+            let wallet_id = bloom_broker_api::Token::new(name)?;
+            let projection = daemon
+                .wallet_projections
+                .get_wallet(&wallet_id)
+                .await
+                .map_err(machine_wallet_lookup_error)?;
+            format!("{}\n", serde_json::to_string_pretty(&projection)?)
+        }
+        MachineCommand::WalletAddress { name } => {
+            let wallet_id = bloom_broker_api::Token::new(name)?;
+            let projection = daemon
+                .wallet_projections
+                .get_wallet(&wallet_id)
+                .await
+                .map_err(machine_wallet_lookup_error)?;
+            let address: alloy::primitives::Address = projection.primary_address()?.parse()?;
+            bloom_proto::checksum_address(&address)
+        }
+        MachineCommand::WalletUnlock { name } => {
+            return Err(machine_error(
+                MachineErrorKind::PermissionDenied,
+                format!(
+                    "wallet unlock for '{}' is fail-closed: §17.1 defines wallet.unlock_prepare but §13.1 has no wallet_unlock ceremony_kind",
+                    name
+                ),
+            )
+            .into());
+        }
+        MachineCommand::WalletCustody { name, kind } => {
+            let (method, ceremony_kind, wallet_id, input_class) = match kind {
+                MachineCustodyKind::New => (
+                    bloom_machine_client::CustodyPrepareMethod::WalletRegistration,
+                    bloom_broker_api::CeremonyKind::WalletRegistration,
+                    None,
+                    "passkey-prf",
+                ),
+                MachineCustodyKind::Import => (
+                    bloom_machine_client::CustodyPrepareMethod::WalletImport,
+                    bloom_broker_api::CeremonyKind::WalletImport,
+                    None,
+                    "raw-wallet-import",
+                ),
+                MachineCustodyKind::Rebind => (
+                    bloom_machine_client::CustodyPrepareMethod::CredentialReplace,
+                    bloom_broker_api::CeremonyKind::CredentialReplace,
+                    Some(bloom_broker_api::Token::new(name.clone())?),
+                    "credential-prf",
+                ),
+                MachineCustodyKind::Delete => (
+                    bloom_machine_client::CustodyPrepareMethod::WalletDelete,
+                    bloom_broker_api::CeremonyKind::WalletDelete,
+                    Some(bloom_broker_api::Token::new(name.clone())?),
+                    "none",
+                ),
+            };
+            launch_custody_ceremony(
+                home,
+                &name,
+                method,
+                ceremony_kind,
+                wallet_id,
+                input_class,
+                None,
+            )
+            .await?
+        }
+        MachineCommand::WalletMigrate { receipt } => {
+            let receipt: LegacyMigrationReceiptFile =
+                serde_json::from_value(serde_json::to_value(receipt)?)?;
+            let (name, migration) = receipt.into_launch()?;
+            launch_custody_ceremony(
+                home,
+                &name,
+                bloom_machine_client::CustodyPrepareMethod::WalletImport,
+                bloom_broker_api::CeremonyKind::WalletImport,
+                None,
+                "legacy_passkey_v1_prf",
+                Some(migration),
+            )
+            .await?
+        }
+        MachineCommand::WalletPolicyPrepare {
+            name,
+            policy,
+            assurance_level,
+        } => prepare_policy_update(home, &name, &policy, &assurance_level).await?,
+        MachineCommand::WalletPolicyCommit { operation_id } => {
+            commit_policy_update(home, operation_id).await?
+        }
+        MachineCommand::WalletOutboxCancel {
+            wallet,
+            chain,
+            id,
+            text,
+        } => {
+            execute_wallet_outbox_action(
+                &daemon.vfs,
+                &wallet,
+                &chain,
+                &id,
+                "cancel",
+                text.as_bytes(),
+            )
+            .await?;
+            format!("cancel submitted for {id}\n")
+        }
+        MachineCommand::WalletOutboxReplace {
+            wallet,
+            chain,
+            id,
+            intent,
+        } => {
+            execute_wallet_outbox_action(
+                &daemon.vfs,
+                &wallet,
+                &chain,
+                &id,
+                "replace",
+                intent.as_bytes(),
+            )
+            .await?;
+            format!("replacement submitted for {id}\n")
+        }
+        MachineCommand::Ceremony {
+            action,
+            operation_id,
+        } => {
+            let command = match action {
+                MachineCeremonyAction::Status => CeremonyCmd::Status { operation_id },
+                MachineCeremonyAction::Cancel => CeremonyCmd::Cancel { operation_id },
+                MachineCeremonyAction::Result => CeremonyCmd::Result { operation_id },
+            };
+            handle_ceremony(home, command).await?
+        }
+        MachineCommand::Operation {
+            action,
+            operation_id,
+        } => {
+            let command = match action {
+                MachineOperationAction::Status => OperationCmd::Status { operation_id },
+                MachineOperationAction::Cancel => OperationCmd::Cancel { operation_id },
+            };
+            handle_operation(home, command).await?
+        }
+        MachineCommand::UpdateStatus => handle_update(home, UpdateCmd::Status).await?.0,
+        MachineCommand::UpdateCheck => {
+            let (output, code) = handle_update(home, UpdateCmd::Check).await?;
+            return Ok(MachineCommandOutput {
+                stdout: output,
+                stderr: String::new(),
+                exit_code: code,
+            });
+        }
+        MachineCommand::Completions { shell } => {
+            let shell: Shell = shell
+                .parse()
+                .map_err(|_| machine_error(MachineErrorKind::InvalidParams, "invalid shell"))?;
+            let mut bytes = Vec::new();
+            generate(shell, &mut Cli::command(), "bloom", &mut bytes);
+            String::from_utf8(bytes)?
+        }
+    };
+    Ok(MachineCommandOutput {
+        stdout: output,
+        stderr: String::new(),
+        exit_code: 0,
+    })
+}
+
+async fn execute_wallet_outbox_action(
+    vfs: &bloom_vfs::Vfs,
+    wallet: &str,
+    chain: &str,
+    id: &str,
+    action: &str,
+    body: &[u8],
+) -> Result<()> {
+    for (label, value) in [("wallet", wallet), ("chain", chain), ("id", id)] {
+        if value.is_empty()
+            || value == "."
+            || value == ".."
+            || value
+                .chars()
+                .any(|character| matches!(character, '/' | '\\' | '\0'))
+        {
+            return Err(machine_error(
+                MachineErrorKind::InvalidParams,
+                format!("invalid wallet outbox {label}"),
+            )
+            .into());
+        }
+    }
+    let path = bloom_vfs::VfsPath::parse(&format!(
+        "/wallets/{wallet}/chains/{chain}/outbox/pending/{id}/{action}"
+    ))?;
+    bloom_vfs::Handler::write(vfs, &path, body).await?;
+    Ok(())
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
 #[serde(deny_unknown_fields)]
 struct LegacyMigrationReceiptFile {
     schema: String,
@@ -889,42 +1262,54 @@ const MAX_POLICY_DOCUMENT_BYTES: u64 = 1024 * 1024;
 async fn prepare_policy_update(
     home: &HomeDir,
     requested_name: &str,
-    policy_file: &Path,
+    input: &[u8],
     assurance_level: &str,
-) -> Result<()> {
+) -> Result<String> {
     use rand::RngCore as _;
     use sha2::Digest as _;
 
-    validate_wallet_name(requested_name)
-        .context("wallet name must be a safe single path segment")?;
+    validate_wallet_name(requested_name).map_err(|error| {
+        machine_error(
+            MachineErrorKind::InvalidParams,
+            format!("wallet name must be a safe single path segment: {error:#}"),
+        )
+    })?;
     let wallet_id = bloom_broker_api::Token::new(requested_name.to_owned())
         .context("wallet name must be a protocol token")?;
     let assurance_level = bloom_broker_api::Token::new(assurance_level.to_owned())
         .context("assurance level must be a protocol token")?;
-    let metadata = std::fs::metadata(policy_file)
-        .with_context(|| format!("inspect proposed policy {}", policy_file.display()))?;
-    anyhow::ensure!(
-        metadata.is_file() && metadata.len() <= MAX_POLICY_DOCUMENT_BYTES,
-        "proposed policy must be a regular file no larger than {MAX_POLICY_DOCUMENT_BYTES} bytes"
-    );
-    let input = std::fs::read(policy_file)
-        .with_context(|| format!("read proposed policy {}", policy_file.display()))?;
-    let proposed: bloom_broker_api::CanonicalWalletPolicy = serde_json::from_slice(&input)
-        .with_context(|| {
+    if input.len() as u64 > MAX_POLICY_DOCUMENT_BYTES {
+        return Err(machine_error(
+            MachineErrorKind::InvalidParams,
             format!(
-                "parse proposed policy {} as canonical policy JSON",
-                policy_file.display()
+                "proposed policy must be a regular file no larger than {MAX_POLICY_DOCUMENT_BYTES} bytes"
+            ),
+        )
+        .into());
+    }
+    let proposed: bloom_broker_api::CanonicalWalletPolicy =
+        serde_json::from_slice(input).map_err(|error| {
+            machine_error(
+                MachineErrorKind::InvalidParams,
+                format!("parse proposed policy as canonical policy JSON: {error}"),
             )
         })?;
-    anyhow::ensure!(
-        proposed.wallet_id == wallet_id,
-        "proposed policy wallet_id does not match requested wallet"
-    );
+    if proposed.wallet_id != wallet_id {
+        return Err(machine_error(
+            MachineErrorKind::InvalidParams,
+            "proposed policy wallet_id does not match requested wallet",
+        )
+        .into());
+    }
     let proposed_bytes =
         serde_jcs::to_vec(&proposed).context("canonicalize proposed policy document")?;
 
-    let client = configured_broker_client(home)
-        .context("policy update requires the authenticated Machine-to-Broker edge")?;
+    let client = configured_broker_client(home).map_err(|error| {
+        machine_error(
+            MachineErrorKind::Unavailable,
+            format!("policy update requires the authenticated Machine-to-Broker edge: {error:#}"),
+        )
+    })?;
     let baseline = client
         .policy(wallet_id.clone())
         .await
@@ -977,26 +1362,26 @@ async fn prepare_policy_update(
             .map_err(anyhow::Error::new)
             .context("construct Machine policy-update projection")?;
     let projection_path = persist_ceremony_projection(home, &projection)?;
-    println!("operation_id: {}", response.operation_id);
-    println!("ceremony_kind: {:?}", response.ceremony_kind);
-    println!(
-        "review_manifest_digest: {}",
-        response.review_manifest_digest
-    );
-    println!("ceremony_url: {}", response.ceremony_url);
-    println!(
-        "ceremony_expires_at_ms: {}",
-        response.ceremony_expires_at_ms.get()
-    );
-    println!("projection: {}", projection_path.display());
-    Ok(())
+    Ok(format!(
+        "operation_id: {}\nceremony_kind: {:?}\nreview_manifest_digest: {}\nceremony_url: {}\nceremony_expires_at_ms: {}\nprojection: {}\n",
+        response.operation_id,
+        response.ceremony_kind,
+        response.review_manifest_digest,
+        response.ceremony_url,
+        response.ceremony_expires_at_ms.get(),
+        projection_path.display(),
+    ))
 }
 
-async fn commit_policy_update(home: &HomeDir, operation_id: String) -> Result<()> {
+async fn commit_policy_update(home: &HomeDir, operation_id: String) -> Result<String> {
     let operation_id = bloom_broker_api::OperationId::new(operation_id)
         .context("operation ID must be 64 lowercase hexadecimal characters")?;
-    let client = configured_broker_client(home)
-        .context("policy commit requires the authenticated Machine-to-Broker edge")?;
+    let client = configured_broker_client(home).map_err(|error| {
+        machine_error(
+            MachineErrorKind::Unavailable,
+            format!("policy commit requires the authenticated Machine-to-Broker edge: {error:#}"),
+        )
+    })?;
     let ceremony_receipt = client
         .custody_result(bloom_broker_api::OperationRequest {
             operation_id: operation_id.clone(),
@@ -1040,11 +1425,10 @@ async fn commit_policy_update(home: &HomeDir, operation_id: String) -> Result<()
         persist_ceremony_projection(home, &projection)?;
     }
 
-    println!(
-        "{}",
+    Ok(format!(
+        "{}\n",
         serde_json::to_string_pretty(&receipt).context("encode policy commit receipt")?
-    );
-    Ok(())
+    ))
 }
 
 fn is_completed_policy_update_receipt(
@@ -1131,7 +1515,7 @@ fn load_ceremony_projection(
     }
 }
 
-async fn handle_ceremony(home: &HomeDir, command: CeremonyCmd) -> Result<()> {
+async fn handle_ceremony(home: &HomeDir, command: CeremonyCmd) -> Result<String> {
     let (operation_id, action) = match command {
         CeremonyCmd::Status { operation_id } => (operation_id, "status"),
         CeremonyCmd::Cancel { operation_id } => (operation_id, "cancel"),
@@ -1139,8 +1523,14 @@ async fn handle_ceremony(home: &HomeDir, command: CeremonyCmd) -> Result<()> {
     };
     let operation_id = bloom_broker_api::OperationId::new(operation_id)
         .context("operation ID must be 64 lowercase hexadecimal characters")?;
-    let client = configured_broker_client(home)
-        .context("ceremony operations require the authenticated Machine-to-Broker edge")?;
+    let client = configured_broker_client(home).map_err(|error| {
+        machine_error(
+            MachineErrorKind::Unavailable,
+            format!(
+                "ceremony operations require the authenticated Machine-to-Broker edge: {error:#}"
+            ),
+        )
+    })?;
     if action == "result" {
         let result = client
             .custody_result(bloom_broker_api::OperationRequest {
@@ -1153,8 +1543,8 @@ async fn handle_ceremony(home: &HomeDir, command: CeremonyCmd) -> Result<()> {
             result.custody_operation_id == operation_id,
             "Broker custody result operation identity mismatch"
         );
-        println!(
-            "{}",
+        return Ok(format!(
+            "{}\n",
             serde_json::to_string_pretty(&serde_json::json!({
                 "ceremony_kind": result.ceremony_kind,
                 "operation_id": result.custody_operation_id,
@@ -1166,8 +1556,7 @@ async fn handle_ceremony(home: &HomeDir, command: CeremonyCmd) -> Result<()> {
                 "has_encrypted_browser_result": result.encrypted_browser_result.is_some(),
             }))
             .context("encode public custody result")?
-        );
-        return Ok(());
+        ));
     }
 
     let status = if action == "cancel" {
@@ -1202,23 +1591,28 @@ async fn handle_ceremony(home: &HomeDir, command: CeremonyCmd) -> Result<()> {
     };
     projection.expire_launch_secret(now_ms);
     let path = persist_ceremony_projection(home, &projection)?;
-    println!(
-        "{}",
-        serde_json::to_string_pretty(&projection).context("encode ceremony projection")?
-    );
-    println!("projection: {}", path.display());
-    Ok(())
+    Ok(format!(
+        "{}\nprojection: {}\n",
+        serde_json::to_string_pretty(&projection).context("encode ceremony projection")?,
+        path.display(),
+    ))
 }
 
-async fn handle_operation(home: &HomeDir, command: OperationCmd) -> Result<()> {
+async fn handle_operation(home: &HomeDir, command: OperationCmd) -> Result<String> {
     let (raw_operation_id, cancel) = match command {
         OperationCmd::Status { operation_id } => (operation_id, false),
         OperationCmd::Cancel { operation_id } => (operation_id, true),
     };
     let operation_id = bloom_broker_api::OperationId::new(raw_operation_id)
         .context("operation ID must be 64 lowercase hexadecimal characters")?;
-    let client = configured_broker_client(home)
-        .context("operation lifecycle requires the authenticated Machine-to-Broker edge")?;
+    let client = configured_broker_client(home).map_err(|error| {
+        machine_error(
+            MachineErrorKind::Unavailable,
+            format!(
+                "operation lifecycle requires the authenticated Machine-to-Broker edge: {error:#}"
+            ),
+        )
+    })?;
     let status = if cancel {
         client
             .cancel_operation(operation_id.clone())
@@ -1236,20 +1630,25 @@ async fn handle_operation(home: &HomeDir, command: OperationCmd) -> Result<()> {
         status.operation_id == operation_id,
         "Broker operation status identity mismatch"
     );
-    serde_json::to_writer_pretty(std::io::stdout().lock(), &status)
-        .context("encode Broker operation status")?;
-    println!();
-    Ok(())
+    Ok(format!(
+        "{}\n",
+        serde_json::to_string_pretty(&status).context("encode Broker operation status")?
+    ))
 }
 
 #[derive(Parser, Debug)]
 #[command(
     name = "bloom",
-    version,
+    disable_version_flag = true,
+    arg_required_else_help = true,
     about = "Bloom — an agentic Ethereum wallet as a virtual filesystem",
     long_about = "Bloom mounts an agentic Ethereum wallet as a directory for agents. EXPERIMENTAL / UNAUDITED ALPHA: do not use with funds you cannot afford to lose, and review every generated transaction plan before signing. Read balances, contracts, ENS, prices, and status with cat/ls; stage wallet actions by writing intents into an outbox; confirm only after reviewing the generated plan. New agents should read https://bloom.directory/SKILL.md, then run bloom init and bloom serve --mount ~/bloom. Use bloom vfs only as a fallback when mounting is unavailable."
 )]
 struct Cli {
+    /// Show the version reported by the running Bloom daemon.
+    #[arg(long)]
+    version: bool,
+
     /// Override home directory (default: ~/.bloom).
     #[arg(long, env = "BLOOM_HOME")]
     home: Option<PathBuf>,
@@ -1272,7 +1671,43 @@ struct Cli {
     quiet: bool,
 
     #[command(subcommand)]
-    cmd: Cmd,
+    cmd: Option<Cmd>,
+}
+
+#[derive(Subcommand, Debug)]
+enum InitInternal {
+    #[cfg(feature = "triad-dev-harness")]
+    #[command(name = "triad-render-developer-enrollment", hide = true)]
+    TriadRenderDeveloperEnrollment {
+        template_dir: PathBuf,
+        output_dir: PathBuf,
+        release_digest: String,
+    },
+    #[command(name = "triad-render-macos-enrollment", hide = true)]
+    TriadRenderMacosEnrollment {
+        template_dir: PathBuf,
+        output_dir: PathBuf,
+        login_uid: u32,
+        broker_uid: u32,
+        signer_uid: u32,
+        session_socket_gid: u32,
+        release_digest: String,
+    },
+    #[command(name = "triad-render-macos-identity-rotation", hide = true)]
+    TriadRenderMacosIdentityRotation {
+        current_identity: PathBuf,
+        replacement_identity: PathBuf,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum ServeInternal {
+    #[command(name = "triad-health-check", hide = true)]
+    TriadHealthCheck { expected_build: String },
+    #[command(name = "triad-pf-monitor-once", hide = true)]
+    TriadPfMonitorOnce,
+    #[command(name = "session-sentinel", hide = true)]
+    SessionSentinel,
 }
 
 #[derive(Subcommand, Debug)]
@@ -1317,6 +1752,9 @@ enum Cmd {
             default_missing_value = DEFAULT_MOUNT_PATH
         )]
         mount: Option<PathBuf>,
+
+        #[command(subcommand)]
+        internal: Option<ServeInternal>,
     },
     /// Talk to a running `bloom serve` over its UDS JSON-RPC socket.
     #[command(subcommand)]
@@ -1329,7 +1767,10 @@ enum Cmd {
     #[command(subcommand)]
     Update(UpdateCmd),
     /// Initialise ~/.bloom with default config + dirs.
-    Init,
+    Init {
+        #[command(subcommand)]
+        internal: Option<InitInternal>,
+    },
 
     /// Print a shell completion script.
     Completions { shell: Shell },
@@ -1587,97 +2028,6 @@ enum WalletCmd {
 
 #[tokio::main]
 async fn main() -> ExitCode {
-    #[cfg(feature = "triad-dev-harness")]
-    if std::env::args_os().len() == 5
-        && std::env::args_os().nth(1).as_deref()
-            == Some(std::ffi::OsStr::new("--triad-render-developer-enrollment"))
-    {
-        return match triad_enrollment::run_developer_from_process_args() {
-            Ok(()) => ExitCode::SUCCESS,
-            Err(error) => {
-                eprintln!("Bloom developer triad enrollment generation failed: {error:#}");
-                ExitCode::FAILURE
-            }
-        };
-    }
-    if std::env::args_os().len() == 4
-        && std::env::args_os().nth(1).as_deref()
-            == Some(std::ffi::OsStr::new(
-                "--triad-render-macos-identity-rotation",
-            ))
-    {
-        return match triad_enrollment::run_identity_rotation_from_process_args() {
-            Ok(()) => ExitCode::SUCCESS,
-            Err(error) => {
-                eprintln!("Bloom macOS identity rotation generation failed: {error:#}");
-                ExitCode::FAILURE
-            }
-        };
-    }
-    if std::env::args_os().len() == 9
-        && std::env::args_os().nth(1).as_deref()
-            == Some(std::ffi::OsStr::new("--triad-render-macos-enrollment"))
-    {
-        return match triad_enrollment::run_from_process_args() {
-            Ok(()) => ExitCode::SUCCESS,
-            Err(error) => {
-                eprintln!("Bloom macOS enrollment generation failed: {error:#}");
-                ExitCode::FAILURE
-            }
-        };
-    }
-    if std::env::args_os().len() == 3
-        && std::env::args_os().nth(1).as_deref()
-            == Some(std::ffi::OsStr::new("--triad-health-check"))
-    {
-        let expected_build = match std::env::args_os().nth(2) {
-            Some(value) => match value.into_string() {
-                Ok(value) => value,
-                Err(_) => {
-                    eprintln!("Bloom triad health check failed: build digest is not UTF-8");
-                    return ExitCode::FAILURE;
-                }
-            },
-            None => return ExitCode::FAILURE,
-        };
-        return match installed_triad_health_check(&expected_build).await {
-            Ok(()) => ExitCode::SUCCESS,
-            Err(error) => {
-                eprintln!("Bloom triad health check failed: {error:#}");
-                ExitCode::FAILURE
-            }
-        };
-    }
-    if std::env::args_os().len() == 2
-        && std::env::args_os().nth(1).as_deref()
-            == Some(std::ffi::OsStr::new("--triad-pf-monitor-once"))
-    {
-        return match pf_monitor::run_once() {
-            Ok(()) => ExitCode::SUCCESS,
-            Err(error) => {
-                eprintln!("Bloom packet-filter monitor failed: {error:#}");
-                ExitCode::FAILURE
-            }
-        };
-    }
-    if std::env::args_os().len() == 2
-        && std::env::args_os().nth(1).as_deref() == Some(std::ffi::OsStr::new("--session-sentinel"))
-    {
-        let _ = tracing_subscriber::fmt()
-            .with_env_filter(
-                EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
-            )
-            .with_target(false)
-            .with_writer(std::io::stderr)
-            .try_init();
-        return match session_sentinel::run().await {
-            Ok(()) => ExitCode::SUCCESS,
-            Err(error) => {
-                eprintln!("Bloom session sentinel failed: {error:#}");
-                ExitCode::FAILURE
-            }
-        };
-    }
     let cli = Cli::parse();
 
     // RUST_LOG wins when set; otherwise default to `info`, or `error`
@@ -1706,85 +2056,56 @@ async fn main() -> ExitCode {
     }
 }
 
-/// Returns `None` when no daemon socket is present (daemon not started),
-/// propagating all other errors normally. A stale socket (file exists but
-/// connection refused) is removed and surfaced as an error rather than
-/// silently falling back to in-process — a stale socket almost always
-/// means the daemon crashed and the caller should restart it explicitly.
+/// Calls the configured daemon endpoint. A missing daemon is always an error:
+/// `init` and `serve` are the only CLI commands allowed to execute without the
+/// long-running Machine process.
 async fn try_ipc(
     client: &IpcClient,
     endpoint: &ResolvedEndpoint,
     method: &str,
     params: serde_json::Value,
-) -> std::io::Result<Option<serde_json::Value>> {
+) -> std::io::Result<serde_json::Value> {
     match client.call(method, params).await {
-        Ok(v) => Ok(Some(v)),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            if endpoint.is_explicit() {
-                return Err(std::io::Error::new(
-                    e.kind(),
-                    format!(
-                        "explicit Bloom endpoint {} is not available: {e}",
-                        endpoint.display
-                    ),
-                ));
-            }
-            debug!(error = %e, "ipc.no_daemon_fallback");
-            Ok(None)
+        Ok(v) => Ok(v),
+        Err(IpcClientError::Rpc(error)) => Err(std::io::Error::other(error)),
+        Err(IpcClientError::Transport(e)) if e.kind() == std::io::ErrorKind::NotFound => {
+            Err(std::io::Error::new(
+                e.kind(),
+                format!(
+                    "Bloom daemon endpoint {} is not available: {e}; start it with 'bloom serve'",
+                    endpoint.display
+                ),
+            ))
         }
-        Err(e) if is_endpoint_permission_denial(&e) => {
-            if endpoint.is_explicit() {
-                return Err(std::io::Error::new(
-                    e.kind(),
-                    format!("explicit Bloom endpoint {} failed: {e}", endpoint.display),
-                ));
-            }
-            debug!(endpoint = %endpoint.display, error = %e, "ipc.permission_fallback");
-            Ok(None)
+        Err(IpcClientError::Transport(e)) if is_endpoint_permission_denial(&e) => {
+            Err(endpoint_connection_error(&endpoint.display, e))
         }
-        Err(e) if e.kind() == std::io::ErrorKind::ConnectionRefused => {
-            if endpoint.is_explicit() {
-                return Err(std::io::Error::new(
-                    e.kind(),
-                    format!(
-                        "explicit Bloom endpoint {} is not responding: {e}",
-                        endpoint.display
-                    ),
-                ));
-            }
-            // Only remove if it is actually a socket, not a regular
-            // file or symlink placed by another process.
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::FileTypeExt;
-                let removed = std::fs::symlink_metadata(client.socket())
-                    .is_ok_and(|m| m.file_type().is_socket())
-                    && std::fs::remove_file(client.socket()).is_ok();
-                let detail = if removed {
-                    "stale socket removed"
-                } else {
-                    "socket not responding"
-                };
-                Err(std::io::Error::other(format!(
-                    "daemon socket exists but is not responding ({detail}); \
-                     start the daemon with 'bloom serve'",
-                )))
-            }
-            #[cfg(not(unix))]
-            {
-                let _ = std::fs::remove_file(client.socket());
-                return Err(std::io::Error::other(
-                    "daemon socket exists but is not responding (stale socket removed); \
-                     start the daemon with 'bloom serve'",
-                ));
-            }
+        Err(IpcClientError::Transport(e)) if e.kind() == std::io::ErrorKind::ConnectionRefused => {
+            Err(std::io::Error::other(format!(
+                "Bloom daemon endpoint {} is not responding: {e}; start it with 'bloom serve'",
+                endpoint.display,
+            )))
         }
-        Err(e) => Err(e),
+        Err(IpcClientError::Transport(e)) => Err(endpoint_connection_error(&endpoint.display, e)),
+        Err(IpcClientError::Protocol(message)) => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "Bloom daemon endpoint {} returned {message}",
+                endpoint.display
+            ),
+        )),
     }
 }
 
 fn is_endpoint_permission_denial(e: &std::io::Error) -> bool {
     e.kind() == std::io::ErrorKind::PermissionDenied || e.raw_os_error() == Some(1)
+}
+
+fn endpoint_connection_error(endpoint: &str, error: std::io::Error) -> std::io::Error {
+    std::io::Error::new(
+        error.kind(),
+        format!("Bloom daemon endpoint {endpoint} failed: {error}; start it with 'bloom serve'"),
+    )
 }
 
 fn system_time_to_unix_ms(time: SystemTime) -> u128 {
@@ -1796,14 +2117,6 @@ fn system_time_to_unix_ms(time: SystemTime) -> u128 {
 fn unix_ms_to_system_time(ms: u128) -> SystemTime {
     let ms = ms.min(u64::MAX as u128) as u64;
     UNIX_EPOCH + std::time::Duration::from_millis(ms)
-}
-
-fn entry_kind_label(kind: EntryKind) -> &'static str {
-    match kind {
-        EntryKind::Dir => "dir",
-        EntryKind::File => "file",
-        EntryKind::Symlink => "symlink",
-    }
 }
 
 fn print_vfs_stat(
@@ -1833,18 +2146,6 @@ fn print_vfs_stat(
     }
 }
 
-fn print_vfs_stat_entry(path: &str, entry: &Entry) {
-    print_vfs_stat(
-        path,
-        &entry.name,
-        entry_kind_label(entry.kind),
-        entry.mode,
-        entry.size,
-        entry.link_target.as_deref(),
-        entry.modified,
-    )
-}
-
 fn print_vfs_stat_json(path: &str, entry: &serde_json::Value) -> Result<()> {
     let name = entry
         .get("name")
@@ -1871,7 +2172,59 @@ fn print_vfs_stat_json(path: &str, entry: &serde_json::Value) -> Result<()> {
     Ok(())
 }
 
+async fn ipc_read(endpoint: &ResolvedEndpoint, path: &str) -> Result<Vec<u8>> {
+    let result = try_ipc(
+        &IpcClient::new(&endpoint.socket),
+        endpoint,
+        "read",
+        serde_json::json!({ "path": path }),
+    )
+    .await
+    .with_context(|| format!("ipc read {path} via {}", endpoint.display))?;
+    let encoded = result
+        .get("bytes_b64")
+        .and_then(|value| value.as_str())
+        .context("ipc read: missing bytes_b64")?;
+    B64.decode(encoded).context("ipc read: bad base64")
+}
+
+async fn ipc_read_to_stdout(endpoint: &ResolvedEndpoint, path: &str, context: &str) -> Result<()> {
+    let bytes = ipc_read(endpoint, path)
+        .await
+        .with_context(|| context.to_owned())?;
+    std::io::Write::write_all(&mut std::io::stdout(), &bytes)?;
+    Ok(())
+}
+
+async fn machine_command(
+    endpoint: &ResolvedEndpoint,
+    command: MachineCommand,
+) -> Result<MachineCommandOutput> {
+    let result = try_ipc(
+        &IpcClient::new(&endpoint.socket),
+        endpoint,
+        "machine.execute",
+        serde_json::to_value(command)?,
+    )
+    .await?;
+    serde_json::from_value(result).context("decode daemon Machine command response")
+}
+
+async fn call_machine_command(endpoint: &ResolvedEndpoint, command: MachineCommand) -> Result<()> {
+    let output = machine_command(endpoint, command).await?;
+    std::io::Write::write_all(&mut std::io::stdout(), output.stdout.as_bytes())?;
+    std::io::Write::write_all(&mut std::io::stderr(), output.stderr.as_bytes())?;
+    if output.exit_code != 0 {
+        UPDATE_EXIT_CODE.store(output.exit_code, std::sync::atomic::Ordering::SeqCst);
+    }
+    Ok(())
+}
+
 async fn run(cli: Cli) -> Result<()> {
+    anyhow::ensure!(
+        !cli.version || cli.cmd.is_none(),
+        "--version cannot be combined with a command"
+    );
     let (connect, ipc_socket) = if cli.connect.is_some() {
         (cli.connect, None)
     } else if cli.ipc_socket.is_some() {
@@ -1895,8 +2248,65 @@ async fn run(cli: Cli) -> Result<()> {
         .context("resolve Bloom endpoint")?;
     trace!(cmd = ?cli.cmd, home = %home.root().display(), "cli.dispatch");
 
-    match cli.cmd {
-        Cmd::Init => {
+    if cli.version {
+        let version = try_ipc(
+            &IpcClient::new(&client_endpoint.socket),
+            &client_endpoint,
+            "version",
+            serde_json::Value::Null,
+        )
+        .await
+        .with_context(|| format!("ipc version via {}", client_endpoint.display))?;
+        println!(
+            "bloom {}",
+            version
+                .as_str()
+                .context("daemon version response is not a string")?
+        );
+        return Ok(());
+    }
+
+    match cli.cmd.context("a command is required")? {
+        Cmd::Init { internal } => {
+            if let Some(internal) = internal {
+                return match internal {
+                    #[cfg(feature = "triad-dev-harness")]
+                    InitInternal::TriadRenderDeveloperEnrollment {
+                        template_dir,
+                        output_dir,
+                        release_digest,
+                    } => {
+                        triad_enrollment::run_developer(&template_dir, &output_dir, release_digest)
+                            .context("Bloom developer triad enrollment generation failed")
+                    }
+                    InitInternal::TriadRenderMacosEnrollment {
+                        template_dir,
+                        output_dir,
+                        login_uid,
+                        broker_uid,
+                        signer_uid,
+                        session_socket_gid,
+                        release_digest,
+                    } => triad_enrollment::run(
+                        template_dir,
+                        output_dir,
+                        login_uid,
+                        broker_uid,
+                        signer_uid,
+                        session_socket_gid,
+                        release_digest,
+                    )
+                    .context("Bloom macOS enrollment generation failed"),
+                    InitInternal::TriadRenderMacosIdentityRotation {
+                        current_identity,
+                        replacement_identity,
+                    } => triad_enrollment::run_identity_rotation(
+                        &current_identity,
+                        &replacement_identity,
+                    )
+                    .context("Bloom macOS identity rotation generation failed"),
+                };
+            }
             eprintln!("{ALPHA_DISCLOSURE}");
             let (_home_permit, d) = build_write_daemon(home.clone()).context("init daemon")?;
             let preinstalled = github_source::ensure_preinstalled_petals(&home, &d)
@@ -1912,85 +2322,25 @@ async fn run(cli: Cli) -> Result<()> {
             println!("agent setup: https://bloom.directory/SKILL.md");
             Ok(())
         }
-        Cmd::Status => {
-            // Status is a public, projection-only surface. Do not construct a
-            // Daemon here: that composition still opens legacy authority
-            // stores while the extraction milestones are in progress.
-            let config = if home.config_path().is_file() {
-                bloom_proto::Config::load(&home.config_path()).context("load config")?
-            } else {
-                bloom_proto::Config::local_default()
-            };
-            let projected_wallets = match configured_wallet_projection_reader(&home)?
-                .list_wallets()
-                .await
-            {
-                Ok(wallets) => Some(wallets),
-                Err(error)
-                    if error.code == bloom_broker_api::ProtocolErrorCode::ServiceUnavailable =>
-                {
-                    None
-                }
-                Err(error) => return Err(error.into()),
-            };
-            println!("version: {}", env!("CARGO_PKG_VERSION"));
-            println!("home: {}", home.root().display());
-            println!(
-                "chains: {:?}",
-                config.chains.keys().cloned().collect::<Vec<_>>()
-            );
-            println!("default_chain: {}", config.default_chain);
-            println!(
-                "default_wallet: {}",
-                config.default_wallet.as_deref().unwrap_or("<none>")
-            );
-            println!("try: bloom vfs ls /");
-            match projected_wallets {
-                Some(wallets) if wallets.is_empty() => {
-                    println!("no wallets yet — create one with bloom wallet new main");
-                }
-                Some(_) => {
-                    println!("deposit: bloom wallet address <wallet> --qr");
-                    println!(
-                        "agent workflow: browse the mounted VFS or use bloom vfs cat/ls/write"
-                    );
-                }
-                None => println!(
-                    "wallets: unavailable (Broker offline and no cached public projection)"
-                ),
-            }
-            let update_checker =
-                bloom_update::UpdateChecker::new(env!("CARGO_PKG_VERSION"), home.cache_dir())
-                    .context("build update checker")?;
-            if let Some(snap) = update_checker.quick_check_cached() {
-                let latest = snap.latest.as_deref().unwrap_or("?");
-                let latest_display = latest.strip_prefix('v').unwrap_or(latest);
-                let available = match snap.available() {
-                    bloom_update::UpdateAvailable::OutOfDate => "out_of_date",
-                    bloom_update::UpdateAvailable::UpToDate => "up_to_date",
-                    bloom_update::UpdateAvailable::Unknown => "unknown",
-                };
-                println!("latest_release: {}", latest);
-                println!("update_available: {}", available);
-                if matches!(snap.available(), bloom_update::UpdateAvailable::OutOfDate) {
-                    eprintln!(
-                        "hint: bloom v{} is available (you have v{}); see /status/update",
-                        latest_display,
-                        env!("CARGO_PKG_VERSION")
-                    );
-                }
-            }
-            Ok(())
-        }
+        Cmd::Status => call_machine_command(&client_endpoint, MachineCommand::Status).await,
         Cmd::Audit(command) => {
-            let audit = configured_machine_audit(&home)?;
-            println!("{}", execute_audit_command(&command, &audit)?);
-            Ok(())
+            let command = match command {
+                AuditCmd::Status => MachineCommand::AuditStatus,
+                AuditCmd::Reconcile {
+                    correlation_id,
+                    outcome,
+                    confirm,
+                } => MachineCommand::AuditReconcile {
+                    correlation_id,
+                    outcome,
+                    confirm,
+                },
+            };
+            call_machine_command(&client_endpoint, command).await
         }
         Cmd::Vfs(VfsCmd::Cat { path }) => {
-            let p = VfsPath::parse(&path).context("parse path")?;
             let client = IpcClient::new(&client_endpoint.socket);
-            let ipc_res = try_ipc(
+            let res = try_ipc(
                 &client,
                 &client_endpoint,
                 "read",
@@ -1998,25 +2348,18 @@ async fn run(cli: Cli) -> Result<()> {
             )
             .await
             .with_context(|| format!("ipc read via {}", client_endpoint.display))?;
-            let bytes = if let Some(res) = ipc_res {
-                debug!(endpoint = %client_endpoint.display, "cli.vfs.cat.via_ipc");
-                let b64 = res
-                    .get("bytes_b64")
-                    .and_then(|v| v.as_str())
-                    .context("ipc read: missing bytes_b64")?;
-                B64.decode(b64).context("ipc read: bad base64")?
-            } else {
-                debug!("cli.vfs.cat.via_inproc: no daemon socket present");
-                let d = build_authenticated_read_daemon(home)?;
-                d.vfs.read(&p).await.context("vfs read")?
-            };
+            debug!(endpoint = %client_endpoint.display, "cli.vfs.cat.via_ipc");
+            let b64 = res
+                .get("bytes_b64")
+                .and_then(|v| v.as_str())
+                .context("ipc read: missing bytes_b64")?;
+            let bytes = B64.decode(b64).context("ipc read: bad base64")?;
             std::io::Write::write_all(&mut std::io::stdout(), &bytes)?;
             Ok(())
         }
         Cmd::Vfs(VfsCmd::Ls { path }) => {
-            let p = VfsPath::parse(&path).context("parse path")?;
             let client = IpcClient::new(&client_endpoint.socket);
-            let ipc_res = try_ipc(
+            let res = try_ipc(
                 &client,
                 &client_endpoint,
                 "list",
@@ -2024,32 +2367,22 @@ async fn run(cli: Cli) -> Result<()> {
             )
             .await
             .with_context(|| format!("ipc list via {}", client_endpoint.display))?;
-            if let Some(res) = ipc_res {
-                debug!(endpoint = %client_endpoint.display, "cli.vfs.ls.via_ipc");
-                let arr = res.as_array().context("ipc list: expected array")?;
-                for e in arr {
-                    let name = e.get("name").and_then(|v| v.as_str()).unwrap_or("?");
-                    let kind = match e.get("kind").and_then(|v| v.as_str()).unwrap_or("file") {
-                        "dir" => "Dir",
-                        "symlink" => "Symlink",
-                        _ => "File",
-                    };
-                    println!("{}\t{}", name, kind);
-                }
-            } else {
-                debug!("cli.vfs.ls.via_inproc: no daemon socket present");
-                let d = build_authenticated_read_daemon(home)?;
-                let entries = d.vfs.list(&p).await.context("vfs list")?;
-                for e in entries {
-                    println!("{}\t{:?}", e.name, e.kind);
-                }
+            debug!(endpoint = %client_endpoint.display, "cli.vfs.ls.via_ipc");
+            let arr = res.as_array().context("ipc list: expected array")?;
+            for e in arr {
+                let name = e.get("name").and_then(|v| v.as_str()).unwrap_or("?");
+                let kind = match e.get("kind").and_then(|v| v.as_str()).unwrap_or("file") {
+                    "dir" => "Dir",
+                    "symlink" => "Symlink",
+                    _ => "File",
+                };
+                println!("{}\t{}", name, kind);
             }
             Ok(())
         }
         Cmd::Vfs(VfsCmd::Stat { path }) => {
-            let p = VfsPath::parse(&path).context("parse path")?;
             let client = IpcClient::new(&client_endpoint.socket);
-            let ipc_res = try_ipc(
+            let res = try_ipc(
                 &client,
                 &client_endpoint,
                 "lookup",
@@ -2057,19 +2390,11 @@ async fn run(cli: Cli) -> Result<()> {
             )
             .await
             .with_context(|| format!("ipc lookup via {}", client_endpoint.display))?;
-            if let Some(res) = ipc_res {
-                debug!(endpoint = %client_endpoint.display, "cli.vfs.stat.via_ipc");
-                print_vfs_stat_json(&path, &res)?;
-            } else {
-                debug!("cli.vfs.stat.via_inproc: no daemon socket present");
-                let d = build_authenticated_read_daemon(home)?;
-                let entry = d.vfs.lookup(&p).await.context("vfs lookup")?;
-                print_vfs_stat_entry(&path, &entry);
-            }
+            debug!(endpoint = %client_endpoint.display, "cli.vfs.stat.via_ipc");
+            print_vfs_stat_json(&path, &res)?;
             Ok(())
         }
         Cmd::Vfs(VfsCmd::Write { path, data }) => {
-            let p = VfsPath::parse(&path).context("parse path")?;
             let body = match data {
                 Some(s) => s.into_bytes(),
                 None => {
@@ -2079,7 +2404,7 @@ async fn run(cli: Cli) -> Result<()> {
                 }
             };
             let client = IpcClient::new(&client_endpoint.socket);
-            let ipc_res = try_ipc(
+            try_ipc(
                 &client,
                 &client_endpoint,
                 "write",
@@ -2087,13 +2412,7 @@ async fn run(cli: Cli) -> Result<()> {
             )
             .await
             .with_context(|| format!("ipc write via {}", client_endpoint.display))?;
-            if ipc_res.is_some() {
-                debug!(endpoint = %client_endpoint.display, "cli.vfs.write.via_ipc");
-            } else {
-                debug!("cli.vfs.write.via_inproc: no daemon socket present");
-                let (_home_permit, d) = build_write_daemon(home)?;
-                d.vfs.write(&p, &body).await.context("vfs write")?;
-            }
+            debug!(endpoint = %client_endpoint.display, "cli.vfs.write.via_ipc");
             Ok(())
         }
         Cmd::Request(RequestCmd::New {
@@ -2108,49 +2427,43 @@ async fn run(cli: Cli) -> Result<()> {
                 "/requests/new"
             };
             let client = IpcClient::new(&client_endpoint.socket);
-            let ipc_res = try_ipc(
+            try_ipc(
                 &client,
                 &client_endpoint,
-                "write",
-                serde_json::json!({ "path": path, "bytes_b64": B64.encode(body.as_bytes()) }),
+                "write_with_lookup",
+                serde_json::json!({
+                    "path": path,
+                    "bytes_b64": B64.encode(body.as_bytes()),
+                    "projection_path": "/requests/latest",
+                }),
             )
             .await
-            .with_context(|| format!("ipc request new via {}", client_endpoint.display))?;
-            if ipc_res.is_some() {
-                debug!(endpoint = %client_endpoint.display, "cli.request.new.via_ipc");
-                if dry_run {
-                    println!("dry_run: true (unpaid probe/staging only; no spend/signing)");
-                }
-                return Ok(());
-            }
-            debug!("cli.request.new.via_inproc: no daemon socket present");
-            let (_home_permit, d) = build_write_daemon(home)?;
-            d.vfs
-                .write(&VfsPath::parse(path)?, body.as_bytes())
-                .await
-                .context("request new")?;
-            let latest = d
-                .vfs
-                .read(&VfsPath::parse("/requests/latest")?)
-                .await
-                .context("read latest request")?;
-            let latest = String::from_utf8_lossy(&latest);
-            println!("request: {}", latest.trim());
+            .with_context(|| format!("ipc request new via {}", client_endpoint.display))
+            .and_then(|entry| {
+                let target = entry
+                    .get("link_target")
+                    .and_then(serde_json::Value::as_str)
+                    .context("ipc request new: latest projection is missing link_target")?;
+                println!("request: {target}");
+                Ok(entry)
+            })?;
+            debug!(endpoint = %client_endpoint.display, "cli.request.new.via_ipc");
             if dry_run {
                 println!("dry_run: true (unpaid probe/staging only; no spend/signing)");
             }
             Ok(())
         }
         Cmd::Request(RequestCmd::Plan { id }) => {
-            let d = build_authenticated_read_daemon(home)?;
-            let path = VfsPath::parse(&format!("/requests/{id}/plan.md"))?;
-            let bytes = d.vfs.read(&path).await.context("request plan")?;
-            std::io::Write::write_all(&mut std::io::stdout(), &bytes)?;
+            ipc_read_to_stdout(
+                &client_endpoint,
+                &format!("/requests/{id}/plan.md"),
+                "request plan",
+            )
+            .await?;
             Ok(())
         }
         Cmd::Request(RequestCmd::Confirm { id, text }) => {
             let path = format!("/requests/{id}/confirm");
-            let p = VfsPath::parse(&path)?;
             let body = text.into_bytes();
             let client = IpcClient::new(&client_endpoint.socket);
             // Confirmation uses the ordinary Machine VFS lane. Any signing
@@ -2160,60 +2473,47 @@ async fn run(cli: Cli) -> Result<()> {
                 "path": path,
                 "bytes_b64": B64.encode(&body),
             });
-            match try_ipc(&client, &client_endpoint, "write", confirm_params.clone()).await {
-                Ok(Some(_)) => {
-                    debug!(endpoint = %client_endpoint.display, "cli.request.confirm.via_ipc");
-                    return Ok(());
-                }
-                Ok(None) => {
-                    debug!("cli.request.confirm.via_inproc: no daemon socket present");
-                    // Fall through to the in-process fallback below.
-                }
-                Err(e) => {
-                    return Err(anyhow::Error::new(e)).with_context(|| {
-                        format!("ipc request confirm via {}", client_endpoint.display)
-                    });
-                }
-            }
-            let (_home_permit, d) = build_write_daemon(home)?;
-            d.vfs.write(&p, &body).await.context("request confirm")?;
+            try_ipc(&client, &client_endpoint, "write", confirm_params)
+                .await
+                .with_context(|| format!("ipc request confirm via {}", client_endpoint.display))?;
+            debug!(endpoint = %client_endpoint.display, "cli.request.confirm.via_ipc");
             Ok(())
         }
         Cmd::Request(RequestCmd::Body { id }) => {
-            let d = build_authenticated_read_daemon(home)?;
-            let path = VfsPath::parse(&format!("/requests/{id}/response/body"))?;
-            let bytes = d.vfs.read(&path).await.context("request body")?;
-            std::io::Write::write_all(&mut std::io::stdout(), &bytes)?;
+            ipc_read_to_stdout(
+                &client_endpoint,
+                &format!("/requests/{id}/response/body"),
+                "request body",
+            )
+            .await?;
             Ok(())
         }
         Cmd::Request(RequestCmd::Receipt { id }) => {
-            let d = build_authenticated_read_daemon(home)?;
-            let path = VfsPath::parse(&format!("/requests/{id}/receipt.json"))?;
-            let bytes = d.vfs.read(&path).await.context("request receipt")?;
-            std::io::Write::write_all(&mut std::io::stdout(), &bytes)?;
+            ipc_read_to_stdout(
+                &client_endpoint,
+                &format!("/requests/{id}/receipt.json"),
+                "request receipt",
+            )
+            .await?;
             Ok(())
         }
         Cmd::Wallet(WalletCmd::New { name }) => {
-            launch_custody_ceremony(
-                &home,
-                &name,
-                bloom_machine_client::CustodyPrepareMethod::WalletRegistration,
-                bloom_broker_api::CeremonyKind::WalletRegistration,
-                None,
-                "passkey-prf",
-                None,
+            call_machine_command(
+                &client_endpoint,
+                MachineCommand::WalletCustody {
+                    name,
+                    kind: MachineCustodyKind::New,
+                },
             )
             .await
         }
         Cmd::Wallet(WalletCmd::Import { name }) => {
-            launch_custody_ceremony(
-                &home,
-                &name,
-                bloom_machine_client::CustodyPrepareMethod::WalletImport,
-                bloom_broker_api::CeremonyKind::WalletImport,
-                None,
-                "raw-wallet-import",
-                None,
+            call_machine_command(
+                &client_endpoint,
+                MachineCommand::WalletCustody {
+                    name,
+                    kind: MachineCustodyKind::Import,
+                },
             )
             .await
         }
@@ -2245,52 +2545,24 @@ async fn run(cli: Cli) -> Result<()> {
             }
             let receipt: LegacyMigrationReceiptFile =
                 serde_json::from_slice(&encoded).context("parse legacy migration receipt")?;
-            let (name, migration) = receipt.into_launch()?;
-            launch_custody_ceremony(
-                &home,
-                &name,
-                bloom_machine_client::CustodyPrepareMethod::WalletImport,
-                bloom_broker_api::CeremonyKind::WalletImport,
-                None,
-                "legacy_passkey_v1_prf",
-                Some(migration),
+            call_machine_command(
+                &client_endpoint,
+                MachineCommand::WalletMigrate {
+                    receipt: serde_json::from_value(serde_json::to_value(receipt)?)?,
+                },
             )
             .await
         }
         Cmd::Wallet(WalletCmd::List) => {
-            let reader = configured_wallet_projection_reader(&home)?;
-            for projection in reader.list_wallets().await? {
-                println!(
-                    "{}\t{}\t{}",
-                    projection.wallet.wallet_id,
-                    projection.primary_address()?,
-                    projection.wallet.wallet_kind
-                );
-            }
-            Ok(())
+            call_machine_command(&client_endpoint, MachineCommand::WalletList).await
         }
         Cmd::Wallet(WalletCmd::Projection { name }) => {
-            let reader = configured_wallet_projection_reader(&home)?;
-            let wallet_id =
-                bloom_broker_api::Token::new(name).context("wallet ID must be a protocol token")?;
-            let projection = reader.get_wallet(&wallet_id).await?;
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&projection)
-                    .context("encode public wallet projection")?
-            );
-            Ok(())
+            call_machine_command(&client_endpoint, MachineCommand::WalletProjection { name }).await
         }
         Cmd::Wallet(WalletCmd::Address { name, qr, qr_out }) => {
-            let reader = configured_wallet_projection_reader(&home)?;
-            let wallet_id =
-                bloom_broker_api::Token::new(name).context("wallet ID must be a protocol token")?;
-            let projection = reader.get_wallet(&wallet_id).await?;
-            let address: alloy::primitives::Address = projection
-                .primary_address()?
-                .parse()
-                .context("Broker wallet projection contains an invalid address")?;
-            let address = bloom_proto::checksum_address(&address);
+            let result =
+                machine_command(&client_endpoint, MachineCommand::WalletAddress { name }).await?;
+            let address = result.stdout;
             if let Some(path) = qr_out {
                 match commands::qr::render_qr_svg(&address) {
                     Some(svg) => {
@@ -2308,44 +2580,55 @@ async fn run(cli: Cli) -> Result<()> {
             Ok(())
         }
         Cmd::Wallet(WalletCmd::Unlock { name }) => {
-            bail!(
-                "wallet unlock for '{name}' is fail-closed: §17.1 defines \
-                 wallet.unlock_prepare but §13.1 has no wallet_unlock ceremony_kind"
-            )
+            call_machine_command(&client_endpoint, MachineCommand::WalletUnlock { name }).await
         }
         Cmd::Wallet(WalletCmd::UpdatePolicy {
             name,
             file,
             assurance_level,
-        }) => prepare_policy_update(&home, &name, &file, &assurance_level).await,
+        }) => {
+            let metadata = std::fs::metadata(&file)
+                .with_context(|| format!("inspect proposed policy {}", file.display()))?;
+            anyhow::ensure!(
+                metadata.is_file() && metadata.len() <= MAX_POLICY_DOCUMENT_BYTES,
+                "proposed policy must be a regular file no larger than {MAX_POLICY_DOCUMENT_BYTES} bytes"
+            );
+            let policy = std::fs::read(&file)
+                .with_context(|| format!("read proposed policy {}", file.display()))?;
+            call_machine_command(
+                &client_endpoint,
+                MachineCommand::WalletPolicyPrepare {
+                    name,
+                    policy,
+                    assurance_level,
+                },
+            )
+            .await
+        }
         Cmd::Wallet(WalletCmd::CommitPolicy { operation_id }) => {
-            commit_policy_update(&home, operation_id).await
+            call_machine_command(
+                &client_endpoint,
+                MachineCommand::WalletPolicyCommit { operation_id },
+            )
+            .await
         }
         Cmd::Wallet(WalletCmd::RebindPasskey { name }) => {
-            let wallet_id = bloom_broker_api::Token::new(name.clone())
-                .context("wallet ID must be a protocol token")?;
-            launch_custody_ceremony(
-                &home,
-                &name,
-                bloom_machine_client::CustodyPrepareMethod::CredentialReplace,
-                bloom_broker_api::CeremonyKind::CredentialReplace,
-                Some(wallet_id),
-                "credential-prf",
-                None,
+            call_machine_command(
+                &client_endpoint,
+                MachineCommand::WalletCustody {
+                    name,
+                    kind: MachineCustodyKind::Rebind,
+                },
             )
             .await
         }
         Cmd::Wallet(WalletCmd::Delete { name }) => {
-            let wallet_id = bloom_broker_api::Token::new(name.clone())
-                .context("wallet ID must be a protocol token")?;
-            launch_custody_ceremony(
-                &home,
-                &name,
-                bloom_machine_client::CustodyPrepareMethod::WalletDelete,
-                bloom_broker_api::CeremonyKind::WalletDelete,
-                Some(wallet_id),
-                "none",
-                None,
+            call_machine_command(
+                &client_endpoint,
+                MachineCommand::WalletCustody {
+                    name,
+                    kind: MachineCustodyKind::Delete,
+                },
             )
             .await
         }
@@ -2364,53 +2647,27 @@ async fn run(cli: Cli) -> Result<()> {
             };
             let path = format!("/wallets/{wallet}/chains/{chain}/outbox/new.tx");
             let client = IpcClient::new(&client_endpoint.socket);
-            let ipc_res = try_ipc(
+            let projection = try_ipc(
                 &client,
                 &client_endpoint,
-                "write",
-                serde_json::json!({ "path": path, "bytes_b64": B64.encode(body.as_bytes()) }),
+                "write_with_lookup",
+                serde_json::json!({
+                    "path": path,
+                    "bytes_b64": B64.encode(body.as_bytes()),
+                    "projection_path": format!("/wallets/{wallet}/chains/{chain}/outbox/latest"),
+                }),
             )
             .await
             .with_context(|| format!("ipc wallet stage via {}", client_endpoint.display))?;
-            if ipc_res.is_some() {
-                debug!(endpoint = %client_endpoint.display, "cli.wallet.stage.via_ipc");
-                return Ok(());
-            }
-            debug!("cli.wallet.stage.via_inproc: no daemon socket present");
-            let (home_permit, d) = build_write_daemon(home)?;
-            let parsed = bloom_tx::intent_parser::parse(&body).context("parse intent")?;
-            let wallet_id = bloom_broker_api::Token::new(wallet.clone())
-                .context("wallet ID must be a protocol token")?;
-            let projection = d
-                .wallet_projections
-                .get_wallet(&wallet_id)
-                .await
-                .context("load authenticated or cached public wallet projection")?;
-            let address = projection
-                .primary_address()
-                .context("projected wallet has no primary address")?
-                .parse()
-                .context("parse projected wallet address")?;
-            let policy = bloom_vfs::advisory_evm_policy(&projection, &chain)
-                .map_err(anyhow::Error::msg)
-                .context("derive key-free advisory staging policy")?;
-            let client = d
-                .chains
-                .get(&chain)
-                .with_context(|| format!("chain '{}'", chain))?;
-            let staged = d
-                .tx_engine
-                .stage(
-                    &home_permit,
-                    &wallet,
-                    address,
-                    parsed,
-                    &client,
-                    &policy,
-                    Some(&d.address_book),
-                )
-                .await?;
-            println!("{}", staged.id);
+            debug!(endpoint = %client_endpoint.display, "cli.wallet.stage.via_ipc");
+            let target = projection
+                .get("link_target")
+                .and_then(serde_json::Value::as_str)
+                .context("ipc wallet stage: latest projection is missing link_target")?;
+            let id = target
+                .strip_prefix("pending/")
+                .context("ipc wallet stage: invalid latest target")?;
+            println!("{id}");
             Ok(())
         }
         Cmd::Wallet(WalletCmd::Confirm {
@@ -2422,7 +2679,7 @@ async fn run(cli: Cli) -> Result<()> {
             let path = format!("/wallets/{wallet}/chains/{chain}/outbox/pending/{id}/confirm");
             let body = text.into_bytes();
             let client = IpcClient::new(&client_endpoint.socket);
-            let ipc_res = try_ipc(
+            try_ipc(
                 &client,
                 &client_endpoint,
                 "write",
@@ -2433,16 +2690,7 @@ async fn run(cli: Cli) -> Result<()> {
             )
             .await
             .with_context(|| format!("ipc wallet confirm via {}", client_endpoint.display))?;
-            if ipc_res.is_some() {
-                debug!(endpoint = %client_endpoint.display, "cli.wallet.confirm.via_ipc");
-                return Ok(());
-            }
-            debug!("cli.wallet.confirm.via_inproc: no daemon socket present");
-            let (_home_permit, d) = build_write_daemon(home)?;
-            d.vfs
-                .write(&VfsPath::parse(&path)?, &body)
-                .await
-                .context("wallet confirm")?;
+            debug!(endpoint = %client_endpoint.display, "cli.wallet.confirm.via_ipc");
             Ok(())
         }
         Cmd::Wallet(WalletCmd::Cancel {
@@ -2451,18 +2699,16 @@ async fn run(cli: Cli) -> Result<()> {
             id,
             text,
         }) => {
-            wallet_outbox_action_vfs_write(WalletOutboxActionWrite {
-                home,
-                client_endpoint: &client_endpoint,
-                wallet: wallet.clone(),
-                chain,
-                id: id.clone(),
-                action: "cancel",
-                body: text.into_bytes(),
-            })
-            .await?;
-            println!("cancel submitted for {id}");
-            Ok(())
+            call_machine_command(
+                &client_endpoint,
+                MachineCommand::WalletOutboxCancel {
+                    wallet,
+                    chain,
+                    id,
+                    text,
+                },
+            )
+            .await
         }
         Cmd::Wallet(WalletCmd::Replace {
             wallet,
@@ -2478,18 +2724,16 @@ async fn run(cli: Cli) -> Result<()> {
                     buf
                 }
             };
-            wallet_outbox_action_vfs_write(WalletOutboxActionWrite {
-                home,
-                client_endpoint: &client_endpoint,
-                wallet,
-                chain,
-                id: id.clone(),
-                action: "replace",
-                body: body.into_bytes(),
-            })
-            .await?;
-            println!("replacement submitted for {id}");
-            Ok(())
+            call_machine_command(
+                &client_endpoint,
+                MachineCommand::WalletOutboxReplace {
+                    wallet,
+                    chain,
+                    id,
+                    intent: body,
+                },
+            )
+            .await
         }
         Cmd::Wallet(WalletCmd::ConfirmBatch { wallet, txs, text }) => {
             if txs.is_empty() {
@@ -2500,36 +2744,77 @@ async fn run(cli: Cli) -> Result<()> {
             }
             let request = bloom_daemon::ipc::BatchConfirmIpcRequest { wallet, txs, text };
             let client = IpcClient::new(&client_endpoint.socket);
-            let result = match try_ipc(
+            let result = try_ipc(
                 &client,
                 &client_endpoint,
                 "confirm_batch",
                 serde_json::to_value(&request)?,
             )
             .await
-            .with_context(|| format!("ipc wallet confirm-batch via {}", client_endpoint.display))?
-            {
-                Some(result) => {
-                    debug!(endpoint = %client_endpoint.display, "cli.wallet.confirm_batch.via_ipc");
-                    result
-                }
-                None => {
-                    debug!("cli.wallet.confirm_batch.via_inproc: no daemon socket present");
-                    let (_home_permit, daemon) = build_write_daemon(home)?;
-                    daemon
-                        .batch_confirmation_service()
-                        .map_err(anyhow::Error::msg)?
-                        .confirm_batch(request)
-                        .await
-                        .map_err(anyhow::Error::msg)?
-                }
-            };
+            .with_context(|| format!("ipc wallet confirm-batch via {}", client_endpoint.display))?;
+            debug!(endpoint = %client_endpoint.display, "cli.wallet.confirm_batch.via_ipc");
             println!("{}", serde_json::to_string_pretty(&result)?);
             Ok(())
         }
-        Cmd::Ceremony(command) => handle_ceremony(&home, command).await,
-        Cmd::Operation(command) => handle_operation(&home, command).await,
-        Cmd::Serve { endpoint, mount } => {
+        Cmd::Ceremony(command) => {
+            let (action, operation_id) = match command {
+                CeremonyCmd::Status { operation_id } => {
+                    (MachineCeremonyAction::Status, operation_id)
+                }
+                CeremonyCmd::Cancel { operation_id } => {
+                    (MachineCeremonyAction::Cancel, operation_id)
+                }
+                CeremonyCmd::Result { operation_id } => {
+                    (MachineCeremonyAction::Result, operation_id)
+                }
+            };
+            call_machine_command(
+                &client_endpoint,
+                MachineCommand::Ceremony {
+                    action,
+                    operation_id,
+                },
+            )
+            .await
+        }
+        Cmd::Operation(command) => {
+            let (action, operation_id) = match command {
+                OperationCmd::Status { operation_id } => {
+                    (MachineOperationAction::Status, operation_id)
+                }
+                OperationCmd::Cancel { operation_id } => {
+                    (MachineOperationAction::Cancel, operation_id)
+                }
+            };
+            call_machine_command(
+                &client_endpoint,
+                MachineCommand::Operation {
+                    action,
+                    operation_id,
+                },
+            )
+            .await
+        }
+        Cmd::Serve {
+            endpoint,
+            mount,
+            internal,
+        } => {
+            if let Some(internal) = internal {
+                return match internal {
+                    ServeInternal::TriadHealthCheck { expected_build } => {
+                        installed_triad_health_check(&expected_build)
+                            .await
+                            .context("Bloom triad health check failed")
+                    }
+                    ServeInternal::TriadPfMonitorOnce => {
+                        pf_monitor::run_once().context("Bloom packet-filter monitor failed")
+                    }
+                    ServeInternal::SessionSentinel => session_sentinel::run()
+                        .await
+                        .context("Bloom session sentinel failed"),
+                };
+            }
             eprintln!("{ALPHA_DISCLOSURE}");
             let (_home_permit, d) = build_write_daemon(home.clone())?;
             github_source::ensure_preinstalled_petals(&home, &d)
@@ -2566,7 +2851,11 @@ async fn run(cli: Cli) -> Result<()> {
                 }))
                 .with_batch_confirmation(
                     d.batch_confirmation_service().map_err(anyhow::Error::msg)?,
-                );
+                )
+                .with_machine_commands(Arc::new(DaemonMachineCommands {
+                    home: home.clone(),
+                    daemon: d.clone(),
+                }));
             // Start audited and durable background effects only after every
             // fallible serve setup step has succeeded. The handle is shut
             // down and awaited before the runtime can return.
@@ -2604,12 +2893,23 @@ async fn run(cli: Cli) -> Result<()> {
             println!("shutting down");
             Ok(())
         }
-        Cmd::Update(cmd) => handle_update(&home, cmd).await,
+        Cmd::Update(cmd) => {
+            let command = match cmd {
+                UpdateCmd::Status => MachineCommand::UpdateStatus,
+                UpdateCmd::Check => MachineCommand::UpdateCheck,
+            };
+            call_machine_command(&client_endpoint, command).await
+        }
         Cmd::Petals(cmd) => run_petals(&client_endpoint, cmd).await,
 
         Cmd::Completions { shell } => {
-            generate(shell, &mut Cli::command(), "bloom", &mut std::io::stdout());
-            Ok(())
+            call_machine_command(
+                &client_endpoint,
+                MachineCommand::Completions {
+                    shell: shell.to_string(),
+                },
+            )
+            .await
         }
         Cmd::Ipc(IpcCmd::Call { method, params }) => {
             let endpoint = client_endpoint;
@@ -2622,10 +2922,7 @@ async fn run(cli: Cli) -> Result<()> {
                 None => serde_json::Value::Null,
             };
             debug!(%method, endpoint = %endpoint.display, "cli.ipc.call");
-            let result = client
-                .call(&method, v)
-                .await
-                .with_context(|| format!("ipc call to {}", endpoint.display))?;
+            let result = try_ipc(&client, &endpoint, &method, v).await?;
             println!("{}", serde_json::to_string_pretty(&result)?);
             Ok(())
         }
@@ -2750,20 +3047,43 @@ fn absolute_cli_path(path: &str) -> Result<PathBuf> {
     }
 }
 
+fn validate_petal_archive_output(package_dir: &str, out: &str) -> Result<()> {
+    let package_dir = std::fs::canonicalize(package_dir)
+        .with_context(|| format!("resolve Petal package directory {package_dir}"))?;
+    let out_path = Path::new(out);
+    let parent = out_path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let output = std::fs::canonicalize(parent)
+        .with_context(|| format!("resolve Petal archive parent {}", parent.display()))?
+        .join(
+            out_path
+                .file_name()
+                .context("Petal archive path has no file name")?,
+        );
+    anyhow::ensure!(
+        !output.starts_with(package_dir),
+        "--out must be outside the package directory so archives are not packaged into future builds"
+    );
+    Ok(())
+}
+
 async fn run_petals(endpoint: &ResolvedEndpoint, cmd: PetalsCmd) -> Result<()> {
     let client = IpcClient::new(&endpoint.socket);
     match cmd {
         PetalsCmd::Install { path, ref_ } => {
-            let rpc_path = if path.contains("://") || path.starts_with("git@github.com:") {
-                path.clone()
+            let params = if path.contains("://") || path.starts_with("git@github.com:") {
+                serde_json::json!({ "path": path, "ref": ref_ })
             } else {
-                absolute_cli_path(&path)?.to_string_lossy().into_owned()
+                anyhow::ensure!(
+                    ref_.is_none(),
+                    "--ref is only supported for trusted GitHub source installs"
+                );
+                let local = absolute_cli_path(&path)?;
+                serde_json::json!({ "path": local, "ref": null })
             };
-            let result = client
-                .call(
-                    "petals.install",
-                    serde_json::json!({ "path": rpc_path, "ref": ref_ }),
-                )
+            let result = try_ipc(&client, endpoint, "petals.install", params)
                 .await
                 .with_context(|| format!("ipc petals install via {}", endpoint.display))?;
             if result.get("progress_lines").is_some() {
@@ -2799,15 +3119,19 @@ async fn run_petals(endpoint: &ResolvedEndpoint, cmd: PetalsCmd) -> Result<()> {
             Ok(())
         }
         PetalsCmd::Build { package_dir, out } => {
+            if let Some(out) = out.as_deref() {
+                validate_petal_archive_output(&package_dir, out)?;
+            }
             let rpc_package_dir = absolute_cli_path(&package_dir)?;
             let rpc_out = out.as_deref().map(absolute_cli_path).transpose()?;
-            let result = client
-                .call(
-                    "petals.build",
-                    serde_json::json!({ "package_dir": rpc_package_dir, "out": rpc_out }),
-                )
-                .await
-                .with_context(|| format!("ipc petals build via {}", endpoint.display))?;
+            let result = try_ipc(
+                &client,
+                endpoint,
+                "petals.build",
+                serde_json::json!({ "package_dir": rpc_package_dir, "out": rpc_out }),
+            )
+            .await
+            .with_context(|| format!("ipc petals build via {}", endpoint.display))?;
             for field in ["hash", "contract", "wit_digest", "petal_mount", "routes"] {
                 let value = result
                     .get(field)
@@ -2827,8 +3151,7 @@ async fn run_petals(endpoint: &ResolvedEndpoint, cmd: PetalsCmd) -> Result<()> {
             Ok(())
         }
         PetalsCmd::Ls => {
-            let result = client
-                .call("petals.list", serde_json::Value::Null)
+            let result = try_ipc(&client, endpoint, "petals.list", serde_json::Value::Null)
                 .await
                 .with_context(|| format!("ipc petals list via {}", endpoint.display))?;
             let entries = result
@@ -2871,10 +3194,14 @@ async fn run_petals(endpoint: &ResolvedEndpoint, cmd: PetalsCmd) -> Result<()> {
             Ok(())
         }
         PetalsCmd::Uninstall { target } => {
-            let result = client
-                .call("petals.uninstall", serde_json::json!({ "hash": target }))
-                .await
-                .with_context(|| format!("ipc petals uninstall via {}", endpoint.display))?;
+            let result = try_ipc(
+                &client,
+                endpoint,
+                "petals.uninstall",
+                serde_json::json!({ "hash": target }),
+            )
+            .await
+            .with_context(|| format!("ipc petals uninstall via {}", endpoint.display))?;
             let removed = result["removed"]
                 .as_bool()
                 .context("ipc petals uninstall: missing removed")?;
@@ -2998,60 +3325,6 @@ async fn mount_bloom(
     }
 }
 
-struct WalletOutboxActionWrite<'a> {
-    home: HomeDir,
-    client_endpoint: &'a ResolvedEndpoint,
-    wallet: String,
-    chain: String,
-    id: String,
-    action: &'a str,
-    body: Vec<u8>,
-}
-
-async fn wallet_outbox_action_vfs_write(input: WalletOutboxActionWrite<'_>) -> Result<()> {
-    let WalletOutboxActionWrite {
-        home,
-        client_endpoint,
-        wallet,
-        chain,
-        id,
-        action,
-        body,
-    } = input;
-    if !matches!(action, "cancel" | "replace") {
-        bail!("unsupported wallet outbox action '{action}'");
-    }
-    let path = format!("/wallets/{wallet}/chains/{chain}/outbox/pending/{id}/{action}");
-    let client = IpcClient::new(&client_endpoint.socket);
-    let ipc_res = try_ipc(
-        &client,
-        client_endpoint,
-        "write",
-        serde_json::json!({
-            "path": path,
-            "bytes_b64": B64.encode(&body),
-        }),
-    )
-    .await
-    .with_context(|| format!("ipc wallet outbox {action} via {}", client_endpoint.display))?;
-    if ipc_res.is_some() {
-        debug!(endpoint = %client_endpoint.display, action, "cli.wallet.outbox_action.via_ipc");
-        return Ok(());
-    }
-
-    debug!(
-        action,
-        "cli.wallet.outbox_action.via_inproc: no daemon socket present"
-    );
-    let p = VfsPath::parse(&path)?;
-    let (_home_permit, d) = build_write_daemon(home)?;
-    d.vfs
-        .write(&p, &body)
-        .await
-        .with_context(|| format!("wallet outbox {action}"))?;
-    Ok(())
-}
-
 fn request_body_with_wallet(mut request: String, wallet: Option<&str>) -> String {
     let Some(wallet) = wallet else {
         return request;
@@ -3089,14 +3362,13 @@ fn parse_batch_tx_ref(s: &str) -> Result<(String, String)> {
     Ok((chain.to_string(), id.to_string()))
 }
 
-async fn handle_update(home: &HomeDir, cmd: UpdateCmd) -> Result<()> {
+async fn handle_update(home: &HomeDir, cmd: UpdateCmd) -> Result<(String, i32)> {
     match cmd {
         UpdateCmd::Status => {
             let installed = env!("CARGO_PKG_VERSION");
             let snap = bloom_update::read_cache_only(installed, &home.cache_dir());
             let json = serde_json::to_string_pretty(&snap).context("serialise update snapshot")?;
-            println!("{json}");
-            Ok(())
+            Ok((format!("{json}\n"), 0))
         }
         UpdateCmd::Check => {
             // An explicit check needs only a checker; avoid constructing
@@ -3106,16 +3378,12 @@ async fn handle_update(home: &HomeDir, cmd: UpdateCmd) -> Result<()> {
                     .context("build update checker")?;
             let snap = checker.refresh().await;
             let json = serde_json::to_string_pretty(&snap).context("serialise update snapshot")?;
-            println!("{json}");
             let code = match snap.available() {
                 bloom_update::UpdateAvailable::OutOfDate => 1,
                 bloom_update::UpdateAvailable::UpToDate => 0,
                 bloom_update::UpdateAvailable::Unknown => 2,
             };
-            if code != 0 {
-                UPDATE_EXIT_CODE.store(code, std::sync::atomic::Ordering::SeqCst);
-            }
-            Ok(())
+            Ok((format!("{json}\n"), code))
         }
     }
 }
@@ -3150,14 +3418,157 @@ async fn unmount_bloom(handle: Option<()>) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
+    use async_trait::async_trait;
     use clap::Parser as _;
 
     use super::{
         Cli, Cmd, LegacyMigrationReceiptFile, WalletCmd, ceremony_projection_path,
-        enrollment_state_is_usable, execute_audit_command, format_petal_consent_net_rule,
-        is_completed_policy_update_receipt, load_ceremony_projection,
-        open_machine_audit_with_history, persist_ceremony_projection, request_body_with_wallet,
+        endpoint_connection_error, enrollment_state_is_usable, execute_audit_command,
+        execute_wallet_outbox_action, format_petal_consent_net_rule,
+        is_completed_policy_update_receipt, load_ceremony_projection, machine_error_from_anyhow,
+        machine_wallet_lookup_error, open_machine_audit_with_history, persist_ceremony_projection,
+        request_body_with_wallet,
     };
+
+    #[derive(Default)]
+    struct RecordingOutboxHandler(Mutex<Vec<(String, Vec<u8>)>>);
+
+    #[async_trait]
+    impl bloom_vfs::Handler for RecordingOutboxHandler {
+        async fn lookup(
+            &self,
+            path: &bloom_vfs::VfsPath,
+        ) -> Result<bloom_vfs::Entry, bloom_vfs::HandlerError> {
+            Ok(bloom_vfs::Entry::writable_file(
+                path.segments().last().map(String::as_str).unwrap_or(""),
+            ))
+        }
+
+        async fn write(
+            &self,
+            path: &bloom_vfs::VfsPath,
+            data: &[u8],
+        ) -> Result<(), bloom_vfs::HandlerError> {
+            self.0
+                .lock()
+                .unwrap()
+                .push((path.to_string_path(), data.to_vec()));
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn daemon_owned_wallet_outbox_actions_use_the_canonical_vfs_handler() {
+        let handler = std::sync::Arc::new(RecordingOutboxHandler::default());
+        let vfs = bloom_vfs::Vfs::builder()
+            .mount("wallets", handler.clone())
+            .build();
+
+        execute_wallet_outbox_action(&vfs, "alice", "base", "tx-1", "cancel", b"approve")
+            .await
+            .unwrap();
+        execute_wallet_outbox_action(
+            &vfs,
+            "alice",
+            "base",
+            "tx-1",
+            "replace",
+            b"replacement intent",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            *handler.0.lock().unwrap(),
+            vec![
+                (
+                    "/alice/chains/base/outbox/pending/tx-1/cancel".into(),
+                    b"approve".to_vec(),
+                ),
+                (
+                    "/alice/chains/base/outbox/pending/tx-1/replace".into(),
+                    b"replacement intent".to_vec(),
+                ),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn daemon_owned_wallet_outbox_actions_reject_path_shaping_params() {
+        let vfs = bloom_vfs::Vfs::new();
+        for invalid in ["bad/segment", "bad\\segment", "bad\0segment"] {
+            for (wallet, chain, id) in [
+                (invalid, "base", "tx-1"),
+                ("alice", invalid, "tx-1"),
+                ("alice", "base", invalid),
+            ] {
+                let error =
+                    execute_wallet_outbox_action(&vfs, wallet, chain, id, "cancel", b"approve")
+                        .await
+                        .unwrap_err();
+                let error = error
+                    .downcast_ref::<bloom_daemon::ipc::MachineError>()
+                    .unwrap();
+                assert_eq!(
+                    error.kind,
+                    bloom_daemon::ipc::MachineErrorKind::InvalidParams,
+                    "{wallet:?} {chain:?} {id:?}"
+                );
+                assert_eq!(error.code, "INVALID_ARGUMENT");
+            }
+        }
+    }
+
+    #[test]
+    fn machine_error_mapping_uses_concrete_causes_not_context_words() {
+        use bloom_broker_api::ProtocolErrorCode as Code;
+        use bloom_daemon::ipc::MachineErrorKind as Kind;
+
+        let cases = [
+            (Code::MalformedFrame, Kind::InvalidParams),
+            (Code::UnauthenticatedPeer, Kind::PermissionDenied),
+            (Code::OperationIdConflict, Kind::Conflict),
+            (Code::ServiceUnavailable, Kind::Unavailable),
+        ];
+        for (code, expected) in cases {
+            let source = bloom_broker_api::ProtocolError::new(code, "typed cause");
+            let mapped = machine_error_from_anyhow(anyhow::Error::new(source));
+            assert_eq!(mapped.kind, expected, "{code:?}");
+        }
+
+        let missing = machine_wallet_lookup_error(bloom_broker_api::ProtocolError::new(
+            Code::BackendInvalidRequest,
+            "wallet absent",
+        ));
+        assert_eq!(missing.kind, Kind::NotFound);
+
+        let refused = machine_error_from_anyhow(anyhow::Error::new(std::io::Error::new(
+            std::io::ErrorKind::ConnectionRefused,
+            "Broker socket refused",
+        )));
+        assert_eq!(refused.kind, Kind::Unavailable);
+
+        let misleading = anyhow::Error::new(bloom_broker_api::ProtocolError::new(
+            Code::ServiceUnavailable,
+            "Broker socket refused",
+        ))
+        .context("permission denied and invalid words in outer context");
+        assert_eq!(
+            machine_error_from_anyhow(misleading).kind,
+            Kind::Unavailable
+        );
+
+        let unexpected = machine_error_from_anyhow(anyhow::anyhow!("unexpected failure"));
+        assert_eq!(unexpected.kind, Kind::Internal);
+
+        let invalid_path = machine_error_from_anyhow(anyhow::Error::new(
+            bloom_vfs::path::PathError::InvalidSegment("bad\\segment".into()),
+        ));
+        assert_eq!(invalid_path.kind, Kind::InvalidParams);
+        assert_eq!(invalid_path.code, "INVALID_ARGUMENT");
+    }
 
     #[test]
     fn legacy_migration_receipt_is_digest_bound_and_cli_is_explicit() {
@@ -3208,7 +3619,7 @@ mod tests {
             Cli::try_parse_from(["bloom", "wallet", "migrate-passkey", "receipt.json"]).unwrap();
         assert!(matches!(
             cli.cmd,
-            Cmd::Wallet(WalletCmd::MigratePasskey { receipt })
+            Some(Cmd::Wallet(WalletCmd::MigratePasskey { receipt }))
                 if receipt.as_os_str() == "receipt.json"
         ));
     }
@@ -3260,7 +3671,7 @@ mod tests {
         file.sync_all().unwrap();
 
         let cli = Cli::try_parse_from(["bloom", "audit", "status"]).unwrap();
-        let Cmd::Audit(command) = cli.cmd else {
+        let Some(Cmd::Audit(command)) = cli.cmd else {
             panic!("audit status must parse to the audit command handler");
         };
         let output = execute_audit_command(&command, &audit).unwrap();
@@ -3451,11 +3862,11 @@ mod tests {
         .unwrap();
         assert!(matches!(
             prepared.cmd,
-            Cmd::Wallet(WalletCmd::UpdatePolicy {
+            Some(Cmd::Wallet(WalletCmd::UpdatePolicy {
                 name,
                 file,
                 assurance_level,
-            }) if name == "wallet"
+            })) if name == "wallet"
                 && file.as_os_str() == "proposed.json"
                 && assurance_level == "user_verified"
         ));
@@ -3464,7 +3875,7 @@ mod tests {
             Cli::try_parse_from(["bloom", "wallet", "commit-policy", &"ab".repeat(32)]).unwrap();
         assert!(matches!(
             committed.cmd,
-            Cmd::Wallet(WalletCmd::CommitPolicy { .. })
+            Some(Cmd::Wallet(WalletCmd::CommitPolicy { .. }))
         ));
         assert!(
             Cli::try_parse_from(["bloom", "wallet", "update-policy", "wallet"]).is_err(),
@@ -3502,14 +3913,38 @@ mod tests {
     }
 
     #[test]
-    fn production_cli_has_no_unsigned_daemon_fallback_call_site() {
+    fn production_cli_has_no_in_process_daemon_fallback_call_site() {
         let source = include_str!("main.rs");
-        let forbidden = concat!("Daemon::", "from_home(");
+        let read_fallback = concat!("build_authenticated_", "read_daemon");
+        let in_process_log = concat!("via_", "inproc");
+        let fallback_log = concat!("ipc.no_daemon_", "fallback");
+        let write_builder = concat!("build_write_", "daemon(home.clone())");
         assert!(
-            !source.contains(forbidden),
-            "production CLI fallbacks must retain the authenticated Machine identity"
+            !source.contains(read_fallback),
+            "production CLI commands must never construct a read fallback daemon"
         );
-        assert!(source.contains("build_authenticated_read_daemon(home)"));
-        assert!(source.contains("Daemon::from_home_with_broker(home, broker, catalog)"));
+        assert_eq!(
+            source.matches(write_builder).count(),
+            2,
+            "only init and serve may construct the daemon"
+        );
+        assert!(!source.contains(fallback_log));
+        assert!(!source.contains(in_process_log));
+        let raw_process_args = concat!("std::env::", "args_os()");
+        assert!(
+            !source.contains(raw_process_args),
+            "internal lifecycle protocols must be parsed below init or serve, not before Clap"
+        );
+    }
+
+    #[test]
+    fn permission_denied_endpoint_error_includes_daemon_recovery_instruction() {
+        let error = endpoint_connection_error(
+            "unix:/restricted/bloom.sock",
+            std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied"),
+        );
+        let message = error.to_string();
+        assert!(message.contains("unix:/restricted/bloom.sock"), "{message}");
+        assert!(message.contains("bloom serve"), "{message}");
     }
 }

--- a/crates/bloom/src/main.rs
+++ b/crates/bloom/src/main.rs
@@ -772,6 +772,71 @@ async fn launch_custody_ceremony(
     ))
 }
 
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WalletRegistrationLaunchProjection {
+    schema: String,
+    requested_name: String,
+    operation_id: bloom_broker_api::OperationId,
+    ceremony_kind: bloom_broker_api::CeremonyKind,
+    ceremony_state: bloom_broker_api::CeremonyState,
+    ceremony_url: Option<String>,
+    ceremony_expires_at_ms: Option<bloom_broker_api::DecimalU64>,
+    signer_contribution_digest: bloom_broker_api::Digest32,
+}
+
+async fn launch_wallet_registration_via_vfs(
+    vfs: &bloom_vfs::Vfs,
+    requested_name: &str,
+) -> Result<String> {
+    validate_wallet_name(requested_name).map_err(|error| {
+        machine_error(
+            MachineErrorKind::InvalidParams,
+            format!("requested wallet name must be a safe single path segment: {error:#}"),
+        )
+    })?;
+    let write_path = bloom_vfs::VfsPath::parse("/wallets/new")?;
+    bloom_vfs::Handler::write(vfs, &write_path, requested_name.as_bytes()).await?;
+
+    let projection_path = format!("/wallets/registrations/{requested_name}/status.json");
+    let projection_path_parsed = bloom_vfs::VfsPath::parse(&projection_path)?;
+    let projection: WalletRegistrationLaunchProjection =
+        serde_json::from_slice(&bloom_vfs::Handler::read(vfs, &projection_path_parsed).await?)
+            .context("decode mounted wallet registration projection")?;
+    let _ = &projection.signer_contribution_digest;
+    if projection.schema != "bloom.machine-wallet-registration-projection.1"
+        || projection.requested_name != requested_name
+        || projection.ceremony_kind != bloom_broker_api::CeremonyKind::WalletRegistration
+        || projection.ceremony_state != bloom_broker_api::CeremonyState::AwaitingUser
+    {
+        return Err(machine_error(
+            MachineErrorKind::Internal,
+            "mounted wallet registration returned a mismatched or non-actionable projection",
+        )
+        .into());
+    }
+    let ceremony_url = projection.ceremony_url.ok_or_else(|| {
+        machine_error(
+            MachineErrorKind::Internal,
+            "mounted wallet registration omitted its ceremony URL",
+        )
+    })?;
+    let ceremony_expires_at_ms = projection.ceremony_expires_at_ms.ok_or_else(|| {
+        machine_error(
+            MachineErrorKind::Internal,
+            "mounted wallet registration omitted its ceremony expiry",
+        )
+    })?;
+    Ok(format!(
+        "operation_id: {}\nceremony_kind: {:?}\nceremony_url: {}\nceremony_expires_at_ms: {}\nprojection: {}\n",
+        projection.operation_id,
+        projection.ceremony_kind,
+        ceremony_url,
+        ceremony_expires_at_ms.get(),
+        projection_path,
+    ))
+}
+
 struct LegacyMigrationLaunch {
     operation_id: bloom_broker_api::OperationId,
     exact_terms_digest: bloom_broker_api::Digest32,
@@ -1040,42 +1105,43 @@ async fn execute_machine_command(
             .into());
         }
         MachineCommand::WalletCustody { name, kind } => {
-            let (method, ceremony_kind, wallet_id, input_class) = match kind {
-                MachineCustodyKind::New => (
-                    bloom_machine_client::CustodyPrepareMethod::WalletRegistration,
-                    bloom_broker_api::CeremonyKind::WalletRegistration,
+            if kind == MachineCustodyKind::New {
+                launch_wallet_registration_via_vfs(&daemon.vfs, &name).await?
+            } else {
+                let (method, ceremony_kind, wallet_id, input_class) = match kind {
+                    MachineCustodyKind::New => {
+                        unreachable!("wallet registration uses the VFS adapter")
+                    }
+                    MachineCustodyKind::Import => (
+                        bloom_machine_client::CustodyPrepareMethod::WalletImport,
+                        bloom_broker_api::CeremonyKind::WalletImport,
+                        None,
+                        "raw-wallet-import",
+                    ),
+                    MachineCustodyKind::Rebind => (
+                        bloom_machine_client::CustodyPrepareMethod::CredentialReplace,
+                        bloom_broker_api::CeremonyKind::CredentialReplace,
+                        Some(bloom_broker_api::Token::new(name.clone())?),
+                        "credential-prf",
+                    ),
+                    MachineCustodyKind::Delete => (
+                        bloom_machine_client::CustodyPrepareMethod::WalletDelete,
+                        bloom_broker_api::CeremonyKind::WalletDelete,
+                        Some(bloom_broker_api::Token::new(name.clone())?),
+                        "none",
+                    ),
+                };
+                launch_custody_ceremony(
+                    home,
+                    &name,
+                    method,
+                    ceremony_kind,
+                    wallet_id,
+                    input_class,
                     None,
-                    "passkey-prf",
-                ),
-                MachineCustodyKind::Import => (
-                    bloom_machine_client::CustodyPrepareMethod::WalletImport,
-                    bloom_broker_api::CeremonyKind::WalletImport,
-                    None,
-                    "raw-wallet-import",
-                ),
-                MachineCustodyKind::Rebind => (
-                    bloom_machine_client::CustodyPrepareMethod::CredentialReplace,
-                    bloom_broker_api::CeremonyKind::CredentialReplace,
-                    Some(bloom_broker_api::Token::new(name.clone())?),
-                    "credential-prf",
-                ),
-                MachineCustodyKind::Delete => (
-                    bloom_machine_client::CustodyPrepareMethod::WalletDelete,
-                    bloom_broker_api::CeremonyKind::WalletDelete,
-                    Some(bloom_broker_api::Token::new(name.clone())?),
-                    "none",
-                ),
-            };
-            launch_custody_ceremony(
-                home,
-                &name,
-                method,
-                ceremony_kind,
-                wallet_id,
-                input_class,
-                None,
-            )
-            .await?
+                )
+                .await?
+            }
         }
         MachineCommand::WalletMigrate { receipt } => {
             let receipt: LegacyMigrationReceiptFile =
@@ -3427,13 +3493,82 @@ mod tests {
         Cli, Cmd, LegacyMigrationReceiptFile, WalletCmd, ceremony_projection_path,
         endpoint_connection_error, enrollment_state_is_usable, execute_audit_command,
         execute_wallet_outbox_action, format_petal_consent_net_rule,
-        is_completed_policy_update_receipt, load_ceremony_projection, machine_error_from_anyhow,
-        machine_wallet_lookup_error, open_machine_audit_with_history, persist_ceremony_projection,
-        request_body_with_wallet,
+        is_completed_policy_update_receipt, launch_wallet_registration_via_vfs,
+        load_ceremony_projection, machine_error_from_anyhow, machine_wallet_lookup_error,
+        open_machine_audit_with_history, persist_ceremony_projection, request_body_with_wallet,
     };
 
     #[derive(Default)]
     struct RecordingOutboxHandler(Mutex<Vec<(String, Vec<u8>)>>);
+
+    #[derive(Default)]
+    struct RecordingRegistrationHandler(Mutex<Vec<(String, Vec<u8>)>>);
+
+    #[async_trait]
+    impl bloom_vfs::Handler for RecordingRegistrationHandler {
+        async fn lookup(
+            &self,
+            path: &bloom_vfs::VfsPath,
+        ) -> Result<bloom_vfs::Entry, bloom_vfs::HandlerError> {
+            match path.segments() {
+                [name] if name == "new" => Ok(bloom_vfs::Entry::writable_file("new")),
+                [_, _, leaf] if leaf == "status.json" => Ok(bloom_vfs::Entry::file("status.json")),
+                _ => Err(bloom_vfs::HandlerError::NotFound(path.to_string_path())),
+            }
+        }
+
+        async fn read(
+            &self,
+            path: &bloom_vfs::VfsPath,
+        ) -> Result<Vec<u8>, bloom_vfs::HandlerError> {
+            if path.to_string_path() != "/registrations/gavin/status.json" {
+                return Err(bloom_vfs::HandlerError::NotFound(path.to_string_path()));
+            }
+            Ok(serde_json::to_vec(&serde_json::json!({
+                "schema": "bloom.machine-wallet-registration-projection.1",
+                "requested_name": "gavin",
+                "operation_id": "11".repeat(32),
+                "ceremony_kind": "wallet_registration",
+                "ceremony_state": "AWAITING_USER",
+                "ceremony_url": "http://localhost:18734/ceremony/test-token",
+                "ceremony_expires_at_ms": u64::MAX.to_string(),
+                "signer_contribution_digest": "22".repeat(32),
+            }))
+            .unwrap())
+        }
+
+        async fn write(
+            &self,
+            path: &bloom_vfs::VfsPath,
+            data: &[u8],
+        ) -> Result<(), bloom_vfs::HandlerError> {
+            self.0
+                .lock()
+                .unwrap()
+                .push((path.to_string_path(), data.to_vec()));
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn wallet_new_machine_command_uses_the_mounted_registration_projection() {
+        let handler = std::sync::Arc::new(RecordingRegistrationHandler::default());
+        let vfs = bloom_vfs::Vfs::builder()
+            .mount("wallets", handler.clone())
+            .build();
+
+        let output = launch_wallet_registration_via_vfs(&vfs, "gavin")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            *handler.0.lock().unwrap(),
+            vec![("/new".into(), b"gavin".to_vec())]
+        );
+        assert!(output.contains("operation_id: "));
+        assert!(output.contains("ceremony_url: http://localhost:18734/ceremony/test-token\n"));
+        assert!(output.contains("projection: /wallets/registrations/gavin/status.json\n"));
+    }
 
     #[async_trait]
     impl bloom_vfs::Handler for RecordingOutboxHandler {

--- a/crates/bloom/src/main.rs
+++ b/crates/bloom/src/main.rs
@@ -27,7 +27,7 @@ use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as B64;
 use bloom_daemon::Daemon;
 use bloom_daemon::ipc::{
-    IpcClient, IpcClientError, IpcServer, MachineCeremonyAction, MachineCommand,
+    IpcClient, IpcClientError, IpcProtocolRange, IpcServer, MachineCeremonyAction, MachineCommand,
     MachineCommandFuture, MachineCommandOutput, MachineCommandService, MachineCustodyKind,
     MachineError, MachineErrorKind, MachineOperationAction, default_socket_path,
 };
@@ -1711,7 +1711,7 @@ async fn handle_operation(home: &HomeDir, command: OperationCmd) -> Result<Strin
     long_about = "Bloom mounts an agentic Ethereum wallet as a directory for agents. EXPERIMENTAL / UNAUDITED ALPHA: do not use with funds you cannot afford to lose, and review every generated transaction plan before signing. Read balances, contracts, ENS, prices, and status with cat/ls; stage wallet actions by writing intents into an outbox; confirm only after reviewing the generated plan. New agents should read https://bloom.directory/SKILL.md, then run bloom init and bloom serve --mount ~/bloom. Use bloom vfs only as a fallback when mounting is unavailable."
 )]
 struct Cli {
-    /// Show the version reported by the running Bloom daemon.
+    /// Show CLI, daemon, and negotiated IPC protocol versions.
     #[arg(long)]
     version: bool,
 
@@ -2160,6 +2160,13 @@ async fn try_ipc(
                 endpoint.display
             ),
         )),
+        Err(error @ IpcClientError::Incompatible { .. }) => Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            format!(
+                "Bloom daemon endpoint {} rejected: {error}",
+                endpoint.display
+            ),
+        )),
     }
 }
 
@@ -2315,20 +2322,36 @@ async fn run(cli: Cli) -> Result<()> {
     trace!(cmd = ?cli.cmd, home = %home.root().display(), "cli.dispatch");
 
     if cli.version {
-        let version = try_ipc(
-            &IpcClient::new(&client_endpoint.socket),
-            &client_endpoint,
-            "version",
-            serde_json::Value::Null,
-        )
-        .await
-        .with_context(|| format!("ipc version via {}", client_endpoint.display))?;
-        println!(
-            "bloom {}",
-            version
-                .as_str()
-                .context("daemon version response is not a string")?
-        );
+        let client_protocol = IpcProtocolRange::supported();
+        println!("bloom {}", env!("CARGO_PKG_VERSION"));
+        match IpcClient::new(&client_endpoint.socket)
+            .call_with_protocol("version", serde_json::Value::Null)
+            .await
+        {
+            Ok(reply) => {
+                let daemon_version = reply
+                    .result
+                    .as_str()
+                    .context("daemon version response is not a string")?;
+                println!("bloom-daemon {daemon_version}");
+                println!(
+                    "bloom-ipc {} (compatible; cli {}, daemon {})",
+                    reply.negotiated_protocol, client_protocol, reply.daemon_protocol
+                );
+            }
+            Err(IpcClientError::Transport(_)) => {
+                println!("bloom-daemon unavailable");
+                println!("bloom-ipc {client_protocol} (not negotiated)");
+            }
+            Err(IpcClientError::Incompatible { client, daemon }) => {
+                println!("bloom-daemon incompatible");
+                println!("bloom-ipc incompatible (cli {client}, daemon {daemon})");
+            }
+            Err(error) => {
+                println!("bloom-daemon incompatible");
+                println!("bloom-ipc {client_protocol} (not negotiated: {error})");
+            }
+        }
         return Ok(());
     }
 

--- a/crates/bloom/src/triad_enrollment.rs
+++ b/crates/bloom/src/triad_enrollment.rs
@@ -22,33 +22,34 @@ const MAX_TEMPLATE_BYTES: u64 = 1024 * 1024;
 const PUBLIC_TEMPLATE_FILES: [&str; 3] =
     ["edge-manifest.json.in", "broker.json.in", "signer.json.in"];
 
-pub fn run_from_process_args() -> Result<()> {
+pub fn run(
+    template_dir: PathBuf,
+    output_dir: PathBuf,
+    login_uid: u32,
+    broker_uid: u32,
+    signer_uid: u32,
+    session_socket_gid: u32,
+    release_digest: String,
+) -> Result<()> {
     if rustix::process::geteuid().as_raw() != 0 {
         bail!("macOS enrollment material generation requires root");
     }
     if std::env::consts::OS != "macos" {
         bail!("macOS enrollment material generation requires Darwin");
     }
-    let args = std::env::args_os().collect::<Vec<_>>();
-    if args.len() != 9 {
-        bail!("invalid macOS enrollment material invocation");
-    }
     generate(&EnrollmentPlan {
-        template_dir: PathBuf::from(&args[2]),
-        output_dir: PathBuf::from(&args[3]),
-        login_uid: decimal_arg(&args[4], "login UID")?,
-        broker_uid: decimal_arg(&args[5], "Broker UID")?,
-        signer_uid: decimal_arg(&args[6], "Signer UID")?,
-        session_socket_gid: decimal_arg(&args[7], "session socket GID")?,
-        release_digest: args[8]
-            .to_str()
-            .ok_or_else(|| anyhow::anyhow!("release digest is not UTF-8"))?
-            .to_owned(),
+        template_dir,
+        output_dir,
+        login_uid,
+        broker_uid,
+        signer_uid,
+        session_socket_gid,
+        release_digest,
     })
 }
 
 #[cfg(feature = "triad-dev-harness")]
-pub fn run_developer_from_process_args() -> Result<()> {
+pub fn run_developer(template_dir: &Path, output_dir: &Path, release_digest: String) -> Result<()> {
     let uid = rustix::process::geteuid().as_raw();
     let gid = rustix::process::getegid().as_raw();
     if uid == 0 {
@@ -57,18 +58,10 @@ pub fn run_developer_from_process_args() -> Result<()> {
     if std::env::consts::OS != "macos" {
         bail!("developer enrollment material generation requires Darwin");
     }
-    let args = std::env::args_os().collect::<Vec<_>>();
-    if args.len() != 5 {
-        bail!("invalid developer enrollment material invocation");
-    }
-    let template_dir = fs::canonicalize(Path::new(&args[2]))
+    let template_dir = fs::canonicalize(template_dir)
         .context("canonicalize developer enrollment template directory")?;
-    let output_dir = fs::canonicalize(Path::new(&args[3]))
+    let output_dir = fs::canonicalize(output_dir)
         .context("canonicalize developer enrollment output directory")?;
-    let release_digest = args[4]
-        .to_str()
-        .context("developer release digest is not UTF-8")?
-        .to_owned();
     let plan = EnrollmentPlan {
         template_dir,
         output_dir,
@@ -156,18 +149,14 @@ fn rewrite_private_json(path: &Path, value: &serde_json::Value) -> Result<()> {
     result
 }
 
-pub fn run_identity_rotation_from_process_args() -> Result<()> {
+pub fn run_identity_rotation(current_identity: &Path, replacement_identity: &Path) -> Result<()> {
     if rustix::process::geteuid().as_raw() != 0 {
         bail!("macOS identity rotation generation requires root");
     }
     if std::env::consts::OS != "macos" {
         bail!("macOS identity rotation generation requires Darwin");
     }
-    let args = std::env::args_os().collect::<Vec<_>>();
-    if args.len() != 4 {
-        bail!("invalid macOS identity rotation invocation");
-    }
-    generate_identity_rotation_for_owner(Path::new(&args[2]), Path::new(&args[3]), 0)
+    generate_identity_rotation_for_owner(current_identity, replacement_identity, 0)
 }
 
 #[derive(Clone, Debug)]
@@ -587,19 +576,6 @@ fn write_new_private(path: &Path, bytes: &[u8]) -> Result<()> {
         .with_context(|| format!("write {}", path.display()))?;
     file.sync_all()
         .with_context(|| format!("sync {}", path.display()))
-}
-
-fn decimal_arg(value: &std::ffi::OsStr, name: &str) -> Result<u32> {
-    let value = value
-        .to_str()
-        .ok_or_else(|| anyhow::anyhow!("{name} is not UTF-8"))?;
-    let parsed = value
-        .parse::<u32>()
-        .with_context(|| format!("{name} is not a decimal 32-bit ID"))?;
-    if parsed == 0 || parsed.to_string() != value {
-        bail!("{name} is not a canonical positive decimal ID");
-    }
-    Ok(parsed)
 }
 
 struct ApplicationIdentity {

--- a/crates/bloom/tests/cli.rs
+++ b/crates/bloom/tests/cli.rs
@@ -18,6 +18,7 @@ use std::time::{Duration, UNIX_EPOCH};
 
 use assert_cmd::Command;
 use async_trait::async_trait;
+use base64::Engine as _;
 use bloom_broker_api::{
     Base64UrlBytes, CanonicalWalletPolicy, CryptoSuite, DecimalU64, Digest32, KeyPublic, KeyRef,
     KeyRole, KeySpec, SignedPolicySnapshot, Token, WalletPublic,
@@ -625,7 +626,11 @@ fn spawn_petals_ipc_server(
 struct TestPetalSourceInstaller;
 
 impl bloom_daemon::ipc::PetalSourceInstallService for TestPetalSourceInstaller {
-    fn install_source(&self, params: serde_json::Value) -> Result<serde_json::Value, String> {
+    fn install_source(
+        &self,
+        params: serde_json::Value,
+        _context: bloom_daemon::ipc::IpcOperationContext,
+    ) -> Result<serde_json::Value, String> {
         let path = params["path"].as_str().unwrap_or_default();
         if path.contains("github.com/not-bloom/") {
             return Err("unsupported GitHub owner".to_owned());
@@ -649,8 +654,8 @@ impl bloom_daemon::ipc::PetalSourceInstallService for TestPetalSourceInstaller {
                     "Resolved commit: 0123456789abcdef",
                     "Building source package..."
                 ],
-                "build_stdout": "{\"routes\": 95}\n",
-                "build_stderr": "build warning\n",
+                "build_stdout_b64": base64::engine::general_purpose::STANDARD.encode(b"{\"routes\": 95}\n"),
+                "build_stderr_b64": base64::engine::general_purpose::STANDARD.encode(b"build warning\n"),
                 "completion_progress_lines": ["Validating Petal package..."],
                 "consent_lines": ["consent:", "  docs: README.md"]
             }));
@@ -669,8 +674,8 @@ impl bloom_daemon::ipc::PetalSourceInstallService for TestPetalSourceInstaller {
                     "Resolved commit: deadbeef",
                     "Building source package..."
                 ],
-                "build_stdout": String::from_utf8_lossy(&output.stdout),
-                "build_stderr": String::from_utf8_lossy(&output.stderr),
+                "build_stdout_b64": base64::engine::general_purpose::STANDARD.encode(&output.stdout),
+                "build_stderr_b64": base64::engine::general_purpose::STANDARD.encode(&output.stderr),
                 "operation_error": format!("build command failed: scripts/build.sh (status {})", output.status),
             }));
         }
@@ -1385,12 +1390,14 @@ fn vfs_explicit_missing_endpoint_fails_closed() {
 #[cfg(unix)]
 #[test]
 fn refused_endpoint_is_never_unlinked_by_a_client() {
+    use std::os::unix::fs::PermissionsExt as _;
     use std::os::unix::net::UnixListener;
 
     let home = fresh_home();
     let socket = home.path().join("run/refused.sock");
     std::fs::create_dir_all(socket.parent().unwrap()).unwrap();
     let listener = UnixListener::bind(&socket).unwrap();
+    std::fs::set_permissions(&socket, std::fs::Permissions::from_mode(0o600)).unwrap();
     drop(listener);
     let endpoint = format!("unix:{}", socket.display());
 
@@ -1461,6 +1468,50 @@ fn connect_flag_beats_rpc_endpoint_env() {
             predicate::str::contains(flag_socket.display().to_string())
                 .and(predicate::str::contains(env_socket.display().to_string()).not()),
         );
+}
+
+#[test]
+fn lifecycle_commands_ignore_invalid_client_endpoint_configuration() {
+    let home = fresh_home();
+    let home_dir = bloom_proto::HomeDir::at(home.path());
+    let mut config = bloom_proto::Config::local_default();
+    config.petals.preinstalled.clear();
+    config.save(&home_dir.config_path()).unwrap();
+    bloom_cmd(home.path())
+        .env("BLOOM_RPC_ENDPOINT", "tcp:invalid")
+        .arg("init")
+        .assert()
+        .success();
+
+    let binary = Command::cargo_bin("bloom").expect("locate bloom binary");
+    let mut child = std::process::Command::new(binary.get_program())
+        .env("BLOOM_HOME", home.path())
+        .env("BLOOM_RPC_ENDPOINT", "tcp:invalid")
+        .env("RUST_LOG", "error")
+        .env(bloom_update::DISABLE_AUTO_CHECK_ENV, "1")
+        .arg("serve")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("start Bloom daemon with invalid client endpoint configuration");
+    let socket = bloom_daemon::ipc::default_socket_path(home.path());
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    while std::time::Instant::now() < deadline && !ipc_endpoint_accepting(&socket) {
+        if child.try_wait().unwrap().is_some() {
+            let mut stderr = String::new();
+            child
+                .stderr
+                .take()
+                .unwrap()
+                .read_to_string(&mut stderr)
+                .unwrap();
+            panic!("lifecycle daemon exited before binding its socket: {stderr}");
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert!(ipc_endpoint_accepting(&socket));
+    child.kill().unwrap();
+    child.wait().unwrap();
 }
 
 #[test]

--- a/crates/bloom/tests/cli.rs
+++ b/crates/bloom/tests/cli.rs
@@ -87,7 +87,8 @@ impl RunningBloom {
         }
         let mut child = command.spawn().expect("start Bloom daemon for CLI test");
         let socket = bloom_daemon::ipc::default_socket_path(home);
-        for _ in 0..200 {
+        let deadline = std::time::Instant::now() + Duration::from_secs(30);
+        while std::time::Instant::now() < deadline {
             if ipc_endpoint_accepting(&socket) {
                 return Self(child);
             }
@@ -108,7 +109,14 @@ impl RunningBloom {
         }
         let _ = child.kill();
         let _ = child.wait();
-        panic!("Bloom daemon did not create {}", socket.display());
+        let mut stderr = String::new();
+        if let Some(mut pipe) = child.stderr.take() {
+            let _ = pipe.read_to_string(&mut stderr);
+        }
+        panic!(
+            "Bloom daemon did not accept connections at {} within 30 seconds: {stderr}",
+            socket.display()
+        );
     }
 }
 
@@ -2254,7 +2262,8 @@ fn github_source_install_polymarket_dispatches_route_contract() {
     if std::env::var_os("BLOOM_RUN_NETWORK_TESTS").as_deref() != Some(std::ffi::OsStr::new("1")) {
         return;
     }
-    let petal_ref = "e2e898b69046c9f5d905dd2cd66b3a57ef195542";
+    // This commit uses the same canonical Petal contract revision as Bloom.
+    let petal_ref = "f92a800ce21ac594e3158c93e390aade683327c5";
     let home = fresh_home();
     let home_dir = bloom_proto::HomeDir::at(home.path());
     let mut config = bloom_proto::Config::local_default();
@@ -2284,8 +2293,8 @@ fn github_source_install_polymarket_dispatches_route_contract() {
         )))
         .stdout(predicate::str::contains("Building source package..."))
         .stdout(predicate::str::contains("Validating Petal package..."))
-        .stdout(predicate::str::contains("\"routes\": 95"))
-        .stdout(predicate::str::contains("routes: 95"));
+        .stdout(predicate::str::contains("\"routes\": 97"))
+        .stdout(predicate::str::contains("routes: 97"));
 
     bloom_cmd(home.path())
         .args(["petals", "ls"])

--- a/crates/bloom/tests/cli.rs
+++ b/crates/bloom/tests/cli.rs
@@ -132,7 +132,6 @@ fn every_non_lifecycle_command_family_requires_the_daemon_endpoint() {
     let home = fresh_home();
     let operation_id = "11".repeat(32);
     let commands: Vec<Vec<&str>> = vec![
-        vec!["--version"],
         vec!["status"],
         vec!["audit", "status"],
         vec!["vfs", "ls", "/"],
@@ -157,15 +156,36 @@ fn every_non_lifecycle_command_family_requires_the_daemon_endpoint() {
 }
 
 #[test]
-fn version_is_reported_by_the_running_daemon() {
+fn version_reports_the_cli_when_the_daemon_is_unavailable() {
     let home = fresh_home();
-    let (server, server_thread) = spawn_ipc_server(home.path(), bloom_vfs::Vfs::new());
+    let expected = format!(
+        "bloom {}\nbloom-daemon unavailable\nbloom-ipc {} (not negotiated)\n",
+        env!("CARGO_PKG_VERSION"),
+        bloom_daemon::ipc::IPC_PROTOCOL_CURRENT,
+    );
 
     bloom_cmd(home.path())
         .arg("--version")
         .assert()
         .success()
-        .stdout(predicate::eq("bloom ipc-test-version\n"));
+        .stdout(predicate::eq(expected));
+}
+
+#[test]
+fn version_reports_cli_daemon_and_negotiated_ipc_versions() {
+    let home = fresh_home();
+    let (server, server_thread) = spawn_ipc_server(home.path(), bloom_vfs::Vfs::new());
+    let protocol = bloom_daemon::ipc::IPC_PROTOCOL_CURRENT;
+    let expected = format!(
+        "bloom {}\nbloom-daemon ipc-test-version\nbloom-ipc {protocol} (compatible; cli {protocol}, daemon {protocol})\n",
+        env!("CARGO_PKG_VERSION"),
+    );
+
+    bloom_cmd(home.path())
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(predicate::eq(expected));
 
     stop_ipc_server(server, server_thread);
 }

--- a/crates/bloom/tests/cli.rs
+++ b/crates/bloom/tests/cli.rs
@@ -355,6 +355,104 @@ fn spawn_batch_ipc_server(
     (server, server_thread)
 }
 
+fn spawn_petals_ipc_server(
+    home: &Path,
+) -> (bloom_daemon::ipc::IpcServer, std::thread::JoinHandle<()>) {
+    use bloom_daemon::ipc::{IpcServer, default_socket_path};
+
+    let socket = default_socket_path(home);
+    std::fs::create_dir_all(socket.parent().unwrap()).unwrap();
+    let store = bloom_petals::PetalStore::open(home.join("petals/store")).unwrap();
+    let registry =
+        Arc::new(bloom_petals::NameRegistry::open(home.join("petals/registry")).unwrap());
+    let runner =
+        bloom_petals::PetalRunner::new(store, registry, bloom_petals::PetalVm::new().unwrap());
+    let server = IpcServer::new(
+        bloom_vfs::Vfs::builder().build(),
+        "ipc-test-version",
+        vec![],
+    )
+    .with_petals(runner)
+    .with_petal_source_installer(Arc::new(TestPetalSourceInstaller));
+    let server_for_thread = server.clone();
+    let socket_for_thread = socket.clone();
+    let server_thread = std::thread::spawn(move || {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async move {
+                server_for_thread.serve(&socket_for_thread).await.unwrap();
+            });
+    });
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while !socket.exists() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "Petal IPC server never created socket at {}",
+            socket.display()
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    (server, server_thread)
+}
+
+struct TestPetalSourceInstaller;
+
+impl bloom_daemon::ipc::PetalSourceInstallService for TestPetalSourceInstaller {
+    fn install_source(&self, params: serde_json::Value) -> Result<serde_json::Value, String> {
+        let path = params["path"].as_str().unwrap_or_default();
+        if path.contains("github.com/not-bloom/") {
+            return Err("unsupported GitHub owner".to_owned());
+        }
+        if path.contains("/raw/") || path.ends_with(".wasm") {
+            return Err("raw remote .wasm installs are not supported".to_owned());
+        }
+        if path == "https://github.com/bloom-directory/demo" {
+            return Ok(serde_json::json!({
+            "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "mode": "petal",
+            "size": 42,
+            "already_present": false,
+            "petal_mount": "petals/demo/",
+            "routes": 1,
+            "source": "bloom-directory/demo@v1.0.0",
+            "resolved_commit": "0123456789abcdef",
+                "progress_lines": [
+                    "Resolving https://github.com/bloom-directory/demo",
+                    "Selected tag: v1.0.0",
+                    "Resolved commit: 0123456789abcdef",
+                    "Building source package..."
+                ],
+                "build_stdout": "{\"routes\": 95}\n",
+                "build_stderr": "build warning\n",
+                "completion_progress_lines": ["Validating Petal package..."],
+                "consent_lines": ["consent:", "  docs: README.md"]
+            }));
+        }
+        if path == "https://github.com/bloom-directory/failing-demo" {
+            let output = std::process::Command::new("sh")
+                .args([
+                    "-c",
+                    "echo 'partial build output'; echo 'build exploded' >&2; exit 42",
+                ])
+                .output()
+                .map_err(|error| error.to_string())?;
+            return Ok(serde_json::json!({
+                "progress_lines": [
+                    "Resolving https://github.com/bloom-directory/failing-demo",
+                    "Resolved commit: deadbeef",
+                    "Building source package..."
+                ],
+                "build_stdout": String::from_utf8_lossy(&output.stdout),
+                "build_stderr": String::from_utf8_lossy(&output.stderr),
+                "operation_error": format!("build command failed: scripts/build.sh (status {})", output.status),
+            }));
+        }
+        Err("network source installs are disabled in CLI tests".to_owned())
+    }
+}
+
 fn stop_ipc_server(
     server: bloom_daemon::ipc::IpcServer,
     server_thread: std::thread::JoinHandle<()>,
@@ -368,6 +466,55 @@ fn stop_ipc_server(
         std::thread::sleep(Duration::from_millis(20));
     }
     server_thread.join().expect("ipc server thread panicked");
+}
+
+fn spawn_bloom_serve(home: &Path) -> std::process::Child {
+    let binary = Command::cargo_bin("bloom")
+        .expect("locate bloom binary")
+        .get_program()
+        .to_owned();
+    let mut child = std::process::Command::new(binary)
+        .env("BLOOM_HOME", home)
+        .env("RUST_LOG", "error")
+        .arg("serve")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn bloom serve");
+    let socket = bloom_daemon::ipc::default_socket_path(home);
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    while !socket.exists() {
+        assert!(
+            child.try_wait().unwrap().is_none(),
+            "bloom serve exited before binding {}",
+            socket.display()
+        );
+        assert!(
+            std::time::Instant::now() < deadline,
+            "bloom serve did not bind {}",
+            socket.display()
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    child
+}
+
+fn stop_bloom_serve(home: &Path, mut child: std::process::Child) {
+    bloom_cmd(home)
+        .args(["ipc", "call", "shutdown"])
+        .assert()
+        .success();
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if child.try_wait().unwrap().is_some() {
+            return;
+        }
+        if std::time::Instant::now() >= deadline {
+            child.kill().expect("kill stuck bloom serve");
+            panic!("bloom serve did not stop after shutdown RPC");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
 }
 
 fn http_fixture(
@@ -437,11 +584,13 @@ fn init_respects_persistent_preinstalled_petal_opt_out_without_network() {
         .success()
         .stdout(predicate::str::contains("preinstalled_petals: []"));
 
+    let (server, server_thread) = spawn_petals_ipc_server(home.path());
     bloom_cmd(home.path())
         .args(["petals", "ls"])
         .assert()
         .success()
         .stdout(predicate::str::contains("(no petals installed)"));
+    stop_ipc_server(server, server_thread);
 }
 
 #[test]
@@ -546,10 +695,12 @@ fn docs_petals_discovers_installed_package_from_manifest() {
     let home = fresh_home();
     let package = home.path().join("demo-petal");
     write_demo_petal_package(&package);
+    let (server, server_thread) = spawn_petals_ipc_server(home.path());
     bloom_cmd(home.path())
         .args(["petals", "install", package.to_str().unwrap()])
         .assert()
         .success();
+    stop_ipc_server(server, server_thread);
 
     bloom_cmd(home.path())
         .args(["vfs", "cat", "/docs/petals.md"])
@@ -560,6 +711,171 @@ fn docs_petals_discovers_installed_package_from_manifest() {
         .stdout(predicate::str::contains("Demo app used by CLI tests."))
         .stdout(predicate::str::contains("Declared capabilities: none"))
         .stdout(predicate::str::contains("`petals/demo/README.md`"));
+}
+
+#[test]
+fn petals_commands_route_through_ipc_while_home_write_lock_is_live() {
+    let home = fresh_home();
+    let package = home.path().join("demo-petal");
+    let archive = home.path().join("demo.petal.tar");
+    write_demo_petal_package(&package);
+    let _permit = bloom_proto::HomeWritePermit::acquire(&bloom_proto::HomeDir::at(home.path()))
+        .expect("hold home write permit as the running daemon would");
+    let (server, server_thread) = spawn_petals_ipc_server(home.path());
+
+    bloom_cmd(home.path())
+        .args(["petals", "install", package.to_str().unwrap()])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("already open for writing").not())
+        .stdout(predicate::str::contains("petal_mount: petals/demo/"));
+
+    bloom_cmd(home.path())
+        .args(["petals", "ls"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("already open for writing").not())
+        .stdout(predicate::str::contains("app=petals/demo/"));
+
+    bloom_cmd(home.path())
+        .args([
+            "petals",
+            "build",
+            package.to_str().unwrap(),
+            "--out",
+            archive.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("already open for writing").not())
+        .stdout(predicate::str::contains("archive:"));
+    assert!(
+        archive.is_file(),
+        "daemon should write the requested archive"
+    );
+
+    bloom_cmd(home.path())
+        .args(["petals", "uninstall", "demo"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("already open for writing").not())
+        .stdout(predicate::str::contains("removed demo"));
+
+    stop_ipc_server(server, server_thread);
+}
+
+#[test]
+fn petals_commands_fail_against_an_explicit_missing_endpoint() {
+    let home = fresh_home();
+    let package = home.path().join("demo-petal");
+    write_demo_petal_package(&package);
+    let socket = home.path().join("run/missing-petals.sock");
+    let endpoint = format!("unix:{}", socket.display());
+
+    for args in [
+        vec!["petals", "ls"],
+        vec!["petals", "install", package.to_str().unwrap()],
+        vec!["petals", "build", package.to_str().unwrap()],
+        vec!["petals", "uninstall", "demo"],
+    ] {
+        bloom_cmd(home.path())
+            .args(["--connect", &endpoint])
+            .args(args)
+            .assert()
+            .failure()
+            .stderr(
+                predicate::str::contains("ipc")
+                    .and(predicate::str::contains(socket.display().to_string())),
+            );
+    }
+}
+
+#[test]
+fn petals_relative_package_paths_are_resolved_from_the_cli_working_directory() {
+    let home = fresh_home();
+    let work = tempfile::tempdir().expect("create caller workdir");
+    let package = work.path().join("demo-package");
+    let archive = work.path().join("demo.petal.tar");
+    write_demo_petal_package(&package);
+    let (server, server_thread) = spawn_petals_ipc_server(home.path());
+
+    bloom_cmd(home.path())
+        .current_dir(work.path())
+        .args(["petals", "build", "demo-package", "--out", "demo.petal.tar"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("archive: demo.petal.tar"));
+    assert!(
+        archive.is_file(),
+        "relative --out must be written under the CLI working directory"
+    );
+
+    bloom_cmd(home.path())
+        .current_dir(work.path())
+        .args(["petals", "install", "demo.petal.tar"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("petal_mount: petals/demo/"));
+
+    stop_ipc_server(server, server_thread);
+}
+
+#[test]
+fn petals_source_install_prints_daemon_progress() {
+    let home = fresh_home();
+    let (server, server_thread) = spawn_petals_ipc_server(home.path());
+
+    bloom_cmd(home.path())
+        .args([
+            "petals",
+            "install",
+            "https://github.com/bloom-directory/demo",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Resolving https://github.com/bloom-directory/demo",
+        ))
+        .stdout(predicate::str::contains("Selected tag: v1.0.0"))
+        .stdout(predicate::str::contains(
+            "Resolved commit: 0123456789abcdef",
+        ))
+        .stdout(predicate::str::contains("Building source package..."))
+        .stdout(predicate::str::contains("{\"routes\": 95}"))
+        .stderr(predicate::str::contains("build warning"))
+        .stdout(predicate::str::contains("Validating Petal package..."));
+
+    stop_ipc_server(server, server_thread);
+}
+
+#[test]
+fn petals_source_build_failure_replays_output_before_returning_an_error() {
+    let home = fresh_home();
+    let (server, server_thread) = spawn_petals_ipc_server(home.path());
+
+    let assert = bloom_cmd(home.path())
+        .args([
+            "petals",
+            "install",
+            "https://github.com/bloom-directory/failing-demo",
+        ])
+        .assert()
+        .failure();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    let resolving = stdout
+        .find("Resolving https://github.com/bloom-directory/failing-demo")
+        .unwrap();
+    let building = stdout.find("Building source package...").unwrap();
+    let build_output = stdout.find("partial build output").unwrap();
+    assert!(resolving < building && building < build_output, "{stdout}");
+    let build_stderr = stderr.find("build exploded").unwrap();
+    let final_error = stderr
+        .find("build command failed: scripts/build.sh")
+        .unwrap();
+    assert!(build_stderr < final_error, "{stderr}");
+
+    stop_ipc_server(server, server_thread);
 }
 
 #[test]
@@ -1382,6 +1698,7 @@ fn petal_cli_build_install_list_and_vfs_read_happy_path() {
 
     let package_arg = package.to_str().unwrap();
     let archive_arg = archive.to_str().unwrap();
+    let (server, server_thread) = spawn_petals_ipc_server(home.path());
     bloom_cmd(home.path())
         .args(["petals", "build", package_arg, "--out", archive_arg])
         .assert()
@@ -1408,6 +1725,8 @@ fn petal_cli_build_install_list_and_vfs_read_happy_path() {
         .assert()
         .success()
         .stdout(predicate::str::contains("app=petals/demo/"));
+
+    stop_ipc_server(server, server_thread);
 
     bloom_cmd(home.path())
         .args(["vfs", "cat", "/petals/demo/hello.txt"])
@@ -1440,6 +1759,8 @@ fn github_source_install_polymarket_dispatches_route_contract() {
         .success()
         .stdout(predicate::str::contains("preinstalled_petals: []"));
 
+    let daemon = spawn_bloom_serve(home.path());
+
     bloom_cmd(home.path())
         .args([
             "petals",
@@ -1453,13 +1774,10 @@ fn github_source_install_polymarket_dispatches_route_contract() {
         .stdout(predicate::str::contains(format!(
             "Resolved commit: {petal_ref}"
         )))
-        .stdout(predicate::str::contains("\"routes\": 95"));
-
-    bloom_cmd(home.path())
-        .arg("init")
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("preinstalled_petals: []"));
+        .stdout(predicate::str::contains("Building source package..."))
+        .stdout(predicate::str::contains("Validating Petal package..."))
+        .stdout(predicate::str::contains("\"routes\": 95"))
+        .stdout(predicate::str::contains("routes: 95"));
 
     bloom_cmd(home.path())
         .args(["petals", "ls"])
@@ -1482,11 +1800,14 @@ fn github_source_install_polymarket_dispatches_route_contract() {
         .assert()
         .success()
         .stdout(predicate::str::contains("# Polymarket Petal"));
+
+    stop_bloom_serve(home.path(), daemon);
 }
 
 #[test]
 fn petals_install_rejects_untrusted_owner_and_raw_remote_wasm() {
     let home = fresh_home();
+    let (server, server_thread) = spawn_petals_ipc_server(home.path());
     bloom_cmd(home.path())
         .args(["petals", "install", "https://github.com/not-bloom/petal"])
         .assert()
@@ -1504,4 +1825,5 @@ fn petals_install_rejects_untrusted_owner_and_raw_remote_wasm() {
         .stderr(predicate::str::contains(
             "raw remote .wasm installs are not supported",
         ));
+    stop_ipc_server(server, server_thread);
 }

--- a/crates/bloom/tests/cli.rs
+++ b/crates/bloom/tests/cli.rs
@@ -3,10 +3,9 @@
 //! CLI smoke tests for the `bloom` binary.
 //!
 //! Each test allocates a fresh `tempfile::tempdir()` home and invokes the
-//! built `bloom` binary via `assert_cmd::Command::cargo_bin`. We exercise
-//! the local one-shot path for status / vfs / wallet, and stand up an
-//! in-process `IpcServer` to verify the "socket exists → route via IPC"
-//! branch in the CLI's vfs subcommand.
+//! built `bloom` binary via `assert_cmd::Command::cargo_bin`. Runtime command
+//! tests either start a real `bloom serve` process or a focused in-process IPC
+//! fixture; missing-endpoint tests prove there is no one-shot fallback.
 
 use std::io::{Read, Write};
 use std::net::TcpListener;
@@ -42,7 +41,125 @@ fn bloom_cmd(home: &Path) -> Command {
 }
 
 fn fresh_home() -> TempDir {
+    #[cfg(target_os = "macos")]
+    return tempfile::Builder::new()
+        .prefix("bloom-cli-test-")
+        .tempdir_in("/private/tmp")
+        .expect("create temp home");
+    #[cfg(not(target_os = "macos"))]
     tempfile::tempdir().expect("create temp home")
+}
+
+fn ipc_endpoint_accepting(socket: &Path) -> bool {
+    std::os::unix::net::UnixStream::connect(socket).is_ok()
+}
+
+struct RunningBloom(std::process::Child);
+
+impl RunningBloom {
+    fn start(home: &Path) -> Self {
+        Self::start_with_automatic_update_checks(home, true)
+    }
+
+    fn start_without_automatic_update_checks(home: &Path) -> Self {
+        Self::start_with_automatic_update_checks(home, false)
+    }
+
+    fn start_with_automatic_update_checks(home: &Path, automatic_update_checks: bool) -> Self {
+        let home_dir = bloom_proto::HomeDir::at(home);
+        let mut config = if home_dir.config_path().is_file() {
+            bloom_proto::Config::load(&home_dir.config_path()).unwrap()
+        } else {
+            bloom_proto::Config::local_default()
+        };
+        config.petals.preinstalled.clear();
+        config.save(&home_dir.config_path()).unwrap();
+        let binary = Command::cargo_bin("bloom").expect("locate bloom binary");
+        let mut command = std::process::Command::new(binary.get_program());
+        command
+            .env("BLOOM_HOME", home)
+            .env("RUST_LOG", "error")
+            .arg("serve")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped());
+        if !automatic_update_checks {
+            command.env(bloom_update::DISABLE_AUTO_CHECK_ENV, "1");
+        }
+        let mut child = command.spawn().expect("start Bloom daemon for CLI test");
+        let socket = bloom_daemon::ipc::default_socket_path(home);
+        for _ in 0..200 {
+            if ipc_endpoint_accepting(&socket) {
+                return Self(child);
+            }
+            if child.try_wait().expect("poll Bloom daemon").is_some() {
+                let mut stderr = String::new();
+                child
+                    .stderr
+                    .take()
+                    .unwrap()
+                    .read_to_string(&mut stderr)
+                    .unwrap();
+                panic!(
+                    "Bloom daemon exited before creating {}: {stderr}",
+                    socket.display()
+                );
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        let _ = child.kill();
+        let _ = child.wait();
+        panic!("Bloom daemon did not create {}", socket.display());
+    }
+}
+
+impl Drop for RunningBloom {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+#[test]
+fn every_non_lifecycle_command_family_requires_the_daemon_endpoint() {
+    let home = fresh_home();
+    let operation_id = "11".repeat(32);
+    let commands: Vec<Vec<&str>> = vec![
+        vec!["--version"],
+        vec!["status"],
+        vec!["audit", "status"],
+        vec!["vfs", "ls", "/"],
+        vec!["wallet", "unlock", "alice"],
+        vec!["ceremony", "status", &operation_id],
+        vec!["operation", "status", &operation_id],
+        vec!["request", "plan", "latest"],
+        vec!["ipc", "call", "version"],
+        vec!["petals", "ls"],
+        vec!["update", "status"],
+        vec!["completions", "bash"],
+    ];
+    for args in commands {
+        bloom_cmd(home.path())
+            .args(&args)
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("Bloom daemon endpoint"))
+            .stderr(predicate::str::contains("bloom serve"))
+            .stderr(predicate::str::contains("already open for writing").not());
+    }
+}
+
+#[test]
+fn version_is_reported_by_the_running_daemon() {
+    let home = fresh_home();
+    let (server, server_thread) = spawn_ipc_server(home.path(), bloom_vfs::Vfs::new());
+
+    bloom_cmd(home.path())
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(predicate::eq("bloom ipc-test-version\n"));
+
+    stop_ipc_server(server, server_thread);
 }
 
 #[cfg(target_os = "macos")]
@@ -51,7 +168,7 @@ fn global_session_agent_exits_successfully_for_an_unenrolled_login() {
     let root = tempfile::tempdir().expect("create isolated sentinel roots");
     let home = fresh_home();
     bloom_cmd(home.path())
-        .arg("--session-sentinel")
+        .args(["serve", "session-sentinel"])
         .env("BLOOM_ENROLLMENT_ROOT", root.path().join("enrollments"))
         .env("BLOOM_CONFIG_ROOT", root.path().join("config"))
         .env("BLOOM_RUNTIME_ROOT", root.path().join("runtime"))
@@ -215,6 +332,18 @@ impl Handler for RecordingWriteHandler {
         if p.is_root() {
             return Ok(Entry::dir(""));
         }
+        if p.segments()
+            .last()
+            .is_some_and(|segment| segment == "latest")
+        {
+            let sequence = self.writes.lock().unwrap().len();
+            let target = if p.segments().iter().any(|segment| segment == "outbox") {
+                format!("pending/tx-{sequence}")
+            } else {
+                format!("pending/request-{sequence}")
+            };
+            return Ok(Entry::symlink("latest", &target));
+        }
         Ok(Entry::writable_file(
             p.segments().last().map(String::as_str).unwrap_or("write"),
         ))
@@ -268,7 +397,6 @@ fn spawn_ipc_server(
     use bloom_daemon::ipc::{IpcServer, default_socket_path};
 
     let socket = default_socket_path(home);
-    std::fs::create_dir_all(socket.parent().unwrap()).unwrap();
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -286,7 +414,7 @@ fn spawn_ipc_server(
     });
 
     let deadline = std::time::Instant::now() + Duration::from_secs(5);
-    while !socket.exists() {
+    while !ipc_endpoint_accepting(&socket) {
         if std::time::Instant::now() >= deadline {
             panic!("ipc server never created socket at {}", socket.display());
         }
@@ -297,6 +425,42 @@ fn spawn_ipc_server(
 }
 
 struct FixedBatchConfirmation;
+
+#[derive(Default)]
+struct RecordingMachineCommands {
+    commands: Mutex<Vec<bloom_daemon::ipc::MachineCommand>>,
+}
+
+impl RecordingMachineCommands {
+    fn commands(&self) -> Vec<bloom_daemon::ipc::MachineCommand> {
+        self.commands.lock().unwrap().clone()
+    }
+}
+
+impl bloom_daemon::ipc::MachineCommandService for RecordingMachineCommands {
+    fn execute(
+        &self,
+        command: bloom_daemon::ipc::MachineCommand,
+    ) -> bloom_daemon::ipc::MachineCommandFuture<'_> {
+        let stdout = match &command {
+            bloom_daemon::ipc::MachineCommand::WalletOutboxCancel { id, .. } => {
+                format!("cancel submitted for {id}\n")
+            }
+            bloom_daemon::ipc::MachineCommand::WalletOutboxReplace { id, .. } => {
+                format!("replacement submitted for {id}\n")
+            }
+            _ => String::new(),
+        };
+        self.commands.lock().unwrap().push(command);
+        Box::pin(async move {
+            Ok(bloom_daemon::ipc::MachineCommandOutput {
+                stdout,
+                stderr: String::new(),
+                exit_code: 0,
+            })
+        })
+    }
+}
 
 impl bloom_daemon::ipc::BatchConfirmationService for FixedBatchConfirmation {
     fn confirm_batch<'a>(
@@ -322,7 +486,6 @@ fn spawn_batch_ipc_server(
     use bloom_daemon::ipc::{IpcServer, default_socket_path};
 
     let socket = default_socket_path(home);
-    std::fs::create_dir_all(socket.parent().unwrap()).unwrap();
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -344,10 +507,45 @@ fn spawn_batch_ipc_server(
         });
     });
     let deadline = std::time::Instant::now() + Duration::from_secs(5);
-    while !socket.exists() {
+    while !ipc_endpoint_accepting(&socket) {
         assert!(
             std::time::Instant::now() < deadline,
             "batch IPC server never created socket at {}",
+            socket.display()
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    (server, server_thread)
+}
+
+fn spawn_machine_ipc_server(
+    home: &Path,
+    service: Arc<RecordingMachineCommands>,
+) -> (bloom_daemon::ipc::IpcServer, std::thread::JoinHandle<()>) {
+    use bloom_daemon::ipc::{IpcServer, default_socket_path};
+
+    let socket = default_socket_path(home);
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio runtime");
+    let server = IpcServer::new(bloom_vfs::Vfs::new(), "ipc-test-version", vec![])
+        .with_machine_commands(service);
+    let server_for_thread = server.clone();
+    let socket_for_thread = socket.clone();
+    let server_thread = std::thread::spawn(move || {
+        rt.block_on(async move {
+            server_for_thread
+                .serve(&socket_for_thread)
+                .await
+                .expect("ipc serve");
+        });
+    });
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while !ipc_endpoint_accepting(&socket) {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "Machine IPC server never created socket at {}",
             socket.display()
         );
         std::thread::sleep(Duration::from_millis(20));
@@ -361,7 +559,6 @@ fn spawn_petals_ipc_server(
     use bloom_daemon::ipc::{IpcServer, default_socket_path};
 
     let socket = default_socket_path(home);
-    std::fs::create_dir_all(socket.parent().unwrap()).unwrap();
     let store = bloom_petals::PetalStore::open(home.join("petals/store")).unwrap();
     let registry =
         Arc::new(bloom_petals::NameRegistry::open(home.join("petals/registry")).unwrap());
@@ -386,7 +583,7 @@ fn spawn_petals_ipc_server(
             });
     });
     let deadline = std::time::Instant::now() + Duration::from_secs(5);
-    while !socket.exists() {
+    while !ipc_endpoint_accepting(&socket) {
         assert!(
             std::time::Instant::now() < deadline,
             "Petal IPC server never created socket at {}",
@@ -483,7 +680,7 @@ fn spawn_bloom_serve(home: &Path) -> std::process::Child {
         .expect("spawn bloom serve");
     let socket = bloom_daemon::ipc::default_socket_path(home);
     let deadline = std::time::Instant::now() + Duration::from_secs(10);
-    while !socket.exists() {
+    while !ipc_endpoint_accepting(&socket) {
         assert!(
             child.try_wait().unwrap().is_none(),
             "bloom serve exited before binding {}",
@@ -619,6 +816,7 @@ fn wallet_help_lists_outbox_cancel_and_replace() {
 #[test]
 fn status_prints_version_and_chain_summary() {
     let home = fresh_home();
+    let _daemon = RunningBloom::start(home.path());
     bloom_cmd(home.path())
         .arg("status")
         .assert()
@@ -632,6 +830,7 @@ fn status_prints_version_and_chain_summary() {
 #[test]
 fn vfs_ls_root_lists_top_level_handlers() {
     let home = fresh_home();
+    let _daemon = RunningBloom::start(home.path());
     let assert = bloom_cmd(home.path())
         .args(["vfs", "ls", "/"])
         .assert()
@@ -663,6 +862,7 @@ fn vfs_ls_root_lists_top_level_handlers() {
 #[test]
 fn vfs_cat_root_agent_guidance_returns_identical_content() {
     let home = fresh_home();
+    let _daemon = RunningBloom::start(home.path());
     let agents = bloom_cmd(home.path())
         .args(["vfs", "cat", "/AGENTS.md"])
         .assert()
@@ -701,6 +901,7 @@ fn docs_petals_discovers_installed_package_from_manifest() {
         .assert()
         .success();
     stop_ipc_server(server, server_thread);
+    let _daemon = RunningBloom::start(home.path());
 
     bloom_cmd(home.path())
         .args(["vfs", "cat", "/docs/petals.md"])
@@ -719,6 +920,19 @@ fn petals_commands_route_through_ipc_while_home_write_lock_is_live() {
     let package = home.path().join("demo-petal");
     let archive = home.path().join("demo.petal.tar");
     write_demo_petal_package(&package);
+    write_file(&package, "artifacts/routes/stale.wasm", b"stale route");
+    write_file(&package, "artifacts/build-manifest.json", b"stale manifest");
+    write_file(&package, "artifacts/keep.txt", b"preserve me");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(
+            package.join("artifacts/keep.txt"),
+            std::fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+    }
+    let keep_before = std::fs::metadata(package.join("artifacts/keep.txt")).unwrap();
     let _permit = bloom_proto::HomeWritePermit::acquire(&bloom_proto::HomeDir::at(home.path()))
         .expect("hold home write permit as the running daemon would");
     let (server, server_thread) = spawn_petals_ipc_server(home.path());
@@ -753,6 +967,31 @@ fn petals_commands_route_through_ipc_while_home_write_lock_is_live() {
         archive.is_file(),
         "daemon should write the requested archive"
     );
+    assert_eq!(
+        std::fs::read(package.join("artifacts/routes/r000001.wasm")).unwrap(),
+        std::fs::read(package.join("petal/demo/hello.txt.wasm")).unwrap(),
+        "daemon-generated route artifact must be materialized into the caller package"
+    );
+    assert!(
+        !package.join("artifacts/routes/stale.wasm").exists(),
+        "stale generated routes must be replaced"
+    );
+    assert_eq!(
+        std::fs::read(package.join("artifacts/keep.txt")).unwrap(),
+        b"preserve me",
+        "unrelated artifact files must retain the builder's replacement semantics"
+    );
+    let keep_after = std::fs::metadata(package.join("artifacts/keep.txt")).unwrap();
+    assert_eq!(
+        keep_after.modified().unwrap(),
+        keep_before.modified().unwrap()
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+        assert_eq!(keep_after.ino(), keep_before.ino());
+        assert_eq!(keep_after.permissions().mode() & 0o777, 0o600);
+    }
 
     bloom_cmd(home.path())
         .args(["petals", "uninstall", "demo"])
@@ -788,6 +1027,28 @@ fn petals_commands_fail_against_an_explicit_missing_endpoint() {
                     .and(predicate::str::contains(socket.display().to_string())),
             );
     }
+}
+
+#[cfg(unix)]
+#[test]
+fn petals_build_preserves_builder_symlink_rejection_semantics() {
+    let home = fresh_home();
+    let package = home.path().join("demo-petal");
+    let outside = home.path().join("outside-artifacts");
+    write_demo_petal_package(&package);
+    std::fs::create_dir(&outside).unwrap();
+    std::fs::write(outside.join("sentinel"), b"keep").unwrap();
+    std::os::unix::fs::symlink(&outside, package.join("artifacts")).unwrap();
+    let (server, server_thread) = spawn_petals_ipc_server(home.path());
+
+    bloom_cmd(home.path())
+        .args(["petals", "build", package.to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("artifacts"));
+    assert_eq!(std::fs::read(outside.join("sentinel")).unwrap(), b"keep");
+
+    stop_ipc_server(server, server_thread);
 }
 
 #[test]
@@ -881,6 +1142,7 @@ fn petals_source_build_failure_replays_output_before_returning_an_error() {
 #[test]
 fn vfs_ls_status_lists_known_files() {
     let home = fresh_home();
+    let _daemon = RunningBloom::start(home.path());
     let assert = bloom_cmd(home.path())
         .args(["vfs", "ls", "/status"])
         .assert()
@@ -897,6 +1159,7 @@ fn vfs_ls_status_lists_known_files() {
 #[test]
 fn vfs_cat_status_version_returns_pkg_version() {
     let home = fresh_home();
+    let _daemon = RunningBloom::start(home.path());
     let expected = format!("{}\n", env!("CARGO_PKG_VERSION"));
     bloom_cmd(home.path())
         .args(["vfs", "cat", "/status/version"])
@@ -908,6 +1171,7 @@ fn vfs_cat_status_version_returns_pkg_version() {
 #[test]
 fn vfs_stat_reports_metadata_without_mount() {
     let home = fresh_home();
+    let _daemon = RunningBloom::start(home.path());
     let out = bloom_cmd(home.path())
         .args(["vfs", "stat", "/status/version"])
         .assert()
@@ -952,7 +1216,7 @@ fn vfs_stat_via_ipc_preserves_entry_modified_ms() {
 }
 
 #[test]
-fn vfs_default_missing_socket_falls_back_in_process() {
+fn vfs_default_missing_socket_fails_closed() {
     let home = fresh_home();
     let socket = home.path().join("run").join("bloom.sock");
     assert!(
@@ -963,13 +1227,14 @@ fn vfs_default_missing_socket_falls_back_in_process() {
     bloom_cmd(home.path())
         .args(["vfs", "cat", "/status/version"])
         .assert()
-        .success()
-        .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
+        .failure()
+        .stderr(predicate::str::contains("Bloom daemon endpoint"));
 }
 
 #[test]
 fn vfs_ls_status_includes_update_subtree() {
     let home = fresh_home();
+    let _daemon = RunningBloom::start(home.path());
     let out = bloom_cmd(home.path())
         .args(["vfs", "ls", "/status"])
         .assert()
@@ -984,6 +1249,7 @@ fn vfs_ls_status_includes_update_subtree() {
 #[test]
 fn vfs_cat_status_update_installed_matches_pkg_version() {
     let home = fresh_home();
+    let _daemon = RunningBloom::start(home.path());
     let expected = format!("{}\n", env!("CARGO_PKG_VERSION"));
     bloom_cmd(home.path())
         .args(["vfs", "cat", "/status/update/installed"])
@@ -995,6 +1261,9 @@ fn vfs_cat_status_update_installed_matches_pkg_version() {
 #[test]
 fn vfs_cat_status_update_when_no_cache_reports_unknown() {
     let home = fresh_home();
+    // This fixture asserts the empty-cache projection before any refresh.
+    // Keep only this child daemon offline from automatic update checks.
+    let _daemon = RunningBloom::start_without_automatic_update_checks(home.path());
     bloom_cmd(home.path())
         .args(["vfs", "cat", "/status/update/available"])
         .assert()
@@ -1017,19 +1286,19 @@ fn vfs_cat_status_update_with_seed_cache_reports_behind() {
     let home = fresh_home();
     let cache_dir = home.path().join("cache");
     std::fs::create_dir_all(&cache_dir).unwrap();
-    let cache = serde_json::json!({
-        "version": 1,
-        "installed": "0.1.0",
-        "latest": "0.2.0",
-        "release_url": "https://github.com/bloom-directory/bloom/releases/tag/v0.2.0",
-        "checked_at": null,
-        "status": "ok"
-    });
-    std::fs::write(
-        cache_dir.join("update_cache.json"),
-        serde_json::to_vec_pretty(&cache).unwrap(),
+    bloom_update::cache::write(
+        &cache_dir,
+        &bloom_update::UpdateSnapshot::ok(
+            "0.1.0".into(),
+            Some("0.2.0".into()),
+            Some("https://github.com/bloom-directory/bloom/releases/tag/v0.2.0".into()),
+        ),
     )
     .unwrap();
+    // This fixture asserts the daemon's seeded-cache rendering, not GitHub
+    // refresh behavior. Disable only this child process's automatic check so
+    // a parallel startup refresh cannot replace the deterministic snapshot.
+    let _daemon = RunningBloom::start_without_automatic_update_checks(home.path());
     bloom_cmd(home.path())
         .args(["vfs", "cat", "/status/update/latest"])
         .assert()
@@ -1048,11 +1317,19 @@ fn vfs_cat_status_update_with_seed_cache_reports_behind() {
                 "up_to_date\n"
             },
         ));
+    bloom_cmd(home.path())
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("latest_release: 0.2.0"))
+        .stdout(predicate::str::contains("update_available: out_of_date"))
+        .stderr(predicate::str::contains("hint: bloom v0.2.0 is available"));
 }
 
 #[test]
 fn bloom_update_status_prints_cached_snapshot() {
     let home = fresh_home();
+    let _daemon = RunningBloom::start(home.path());
     bloom_cmd(home.path())
         .args(["update", "status"])
         .assert()
@@ -1072,9 +1349,36 @@ fn vfs_explicit_missing_endpoint_fails_closed() {
         .assert()
         .failure()
         .stderr(
-            predicate::str::contains("explicit Bloom endpoint")
+            predicate::str::contains("Bloom daemon endpoint")
                 .and(predicate::str::contains(socket.display().to_string())),
         );
+}
+
+#[cfg(unix)]
+#[test]
+fn refused_endpoint_is_never_unlinked_by_a_client() {
+    use std::os::unix::net::UnixListener;
+
+    let home = fresh_home();
+    let socket = home.path().join("run/refused.sock");
+    std::fs::create_dir_all(socket.parent().unwrap()).unwrap();
+    let listener = UnixListener::bind(&socket).unwrap();
+    drop(listener);
+    let endpoint = format!("unix:{}", socket.display());
+
+    bloom_cmd(home.path())
+        .args(["--connect", &endpoint, "vfs", "cat", "/status/version"])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("not responding")
+                .and(predicate::str::contains("start it with 'bloom serve'")),
+        );
+
+    assert!(
+        std::fs::symlink_metadata(&socket).is_ok(),
+        "a client must never unlink an endpoint during a daemon restart race"
+    );
 }
 
 #[test]
@@ -1088,7 +1392,7 @@ fn vfs_legacy_ipc_socket_env_fails_closed() {
         .assert()
         .failure()
         .stderr(
-            predicate::str::contains("explicit Bloom endpoint")
+            predicate::str::contains("Bloom daemon endpoint")
                 .and(predicate::str::contains(socket.display().to_string())),
         );
 }
@@ -1236,6 +1540,7 @@ fn request_new_routes_via_ipc_when_home_write_lock_is_live() {
         .assert()
         .success()
         .stderr(predicate::str::contains("already open for writing").not())
+        .stdout(predicate::str::contains("request: pending/request-1"))
         .stdout(predicate::str::contains("dry_run: true"));
 
     stop_ipc_server(server, server_thread);
@@ -1246,6 +1551,51 @@ fn request_new_routes_via_ipc_when_home_write_lock_is_live() {
         String::from_utf8_lossy(&writes[0].1),
         "GET https://example.com wallet=alice"
     );
+}
+
+#[test]
+fn concurrent_request_clients_receive_the_identity_from_their_own_atomic_write() {
+    use bloom_vfs::Vfs;
+
+    let home = fresh_home();
+    let requests = RecordingWriteHandler::new();
+    let vfs = Vfs::builder().mount("requests", requests).build();
+    let (server, server_thread) = spawn_ipc_server(home.path(), vfs);
+    let home_path = home.path().to_path_buf();
+    let clients = (0..2)
+        .map(|index| {
+            let home_path = home_path.clone();
+            std::thread::spawn(move || {
+                let output = bloom_cmd(&home_path)
+                    .args([
+                        "request",
+                        "new",
+                        &format!("GET https://example.com/{index}"),
+                    ])
+                    .output()
+                    .expect("run concurrent request client");
+                assert!(
+                    output.status.success(),
+                    "{}",
+                    String::from_utf8_lossy(&output.stderr)
+                );
+                String::from_utf8(output.stdout).unwrap()
+            })
+        })
+        .collect::<Vec<_>>();
+    let mut outputs = clients
+        .into_iter()
+        .map(|client| client.join().expect("request client panicked"))
+        .collect::<Vec<_>>();
+    outputs.sort();
+    assert_eq!(
+        outputs,
+        vec![
+            "request: pending/request-1\n".to_owned(),
+            "request: pending/request-2\n".to_owned(),
+        ]
+    );
+    stop_ipc_server(server, server_thread);
 }
 
 #[test]
@@ -1264,6 +1614,7 @@ fn wallet_stage_routes_via_ipc_when_home_write_lock_is_live() {
         .args(["wallet", "stage", "alice", "anvil", "--intent", intent])
         .assert()
         .success()
+        .stdout(predicate::eq("tx-1\n"))
         .stderr(predicate::str::contains("already open for writing").not());
 
     stop_ipc_server(server, server_thread);
@@ -1274,7 +1625,7 @@ fn wallet_stage_routes_via_ipc_when_home_write_lock_is_live() {
 }
 
 #[test]
-fn wallet_stage_without_daemon_uses_in_process_parser() {
+fn wallet_stage_without_daemon_fails_before_local_parsing() {
     let home = fresh_home();
     bloom_cmd(home.path())
         .args([
@@ -1287,7 +1638,8 @@ fn wallet_stage_without_daemon_uses_in_process_parser() {
         ])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("parse intent"))
+        .stderr(predicate::str::contains("Bloom daemon endpoint"))
+        .stderr(predicate::str::contains("parse intent").not())
         .stderr(predicate::str::contains("already open for writing").not());
 }
 
@@ -1295,6 +1647,7 @@ fn wallet_stage_without_daemon_uses_in_process_parser() {
 fn wallet_list_ignores_legacy_keystore_without_a_broker_projection() {
     let home = fresh_home();
     seed_legacy_wallet_fixture(home.path(), "alice");
+    let _daemon = RunningBloom::start(home.path());
     bloom_cmd(home.path())
         .args(["wallet", "list"])
         .assert()
@@ -1309,6 +1662,7 @@ fn wallet_list_ignores_legacy_keystore_without_a_broker_projection() {
 fn wallet_projection_prints_only_the_authenticated_key_free_cache() {
     let home = fresh_home();
     seed_wallet_projection_fixture(home.path(), "alice");
+    let _daemon = RunningBloom::start(home.path());
     let output = bloom_cmd(home.path())
         .args(["wallet", "projection", "alice"])
         .assert()
@@ -1333,6 +1687,7 @@ fn wallet_projection_prints_only_the_authenticated_key_free_cache() {
 fn wallet_projection_ignores_a_legacy_keystore_record() {
     let home = fresh_home();
     seed_legacy_wallet_fixture(home.path(), "alice");
+    let _daemon = RunningBloom::start(home.path());
     bloom_cmd(home.path())
         .args(["wallet", "projection", "alice"])
         .assert()
@@ -1344,14 +1699,58 @@ fn wallet_projection_ignores_a_legacy_keystore_record() {
 #[test]
 fn wallet_new_requires_broker_and_never_creates_machine_key_material() {
     let home = fresh_home();
+    let _daemon = RunningBloom::start(home.path());
     bloom_cmd(home.path())
         .args(["wallet", "new", "alice"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains(
-            "custody requires the authenticated Machine-to-Broker edge",
-        ));
+        .stderr(
+            predicate::str::contains("custody requires the authenticated Machine-to-Broker edge")
+                .and(predicate::str::contains("jsonrpc").not())
+                .and(predicate::str::contains("\"code\"").not())
+                .and(predicate::str::contains("ipc machine.execute").not()),
+        );
     assert!(!home.path().join("keystore").join("alice").exists());
+}
+
+#[test]
+fn machine_operation_errors_are_clean_and_preserve_cli_text() {
+    let home = fresh_home();
+    let _daemon = RunningBloom::start(home.path());
+    bloom_cmd(home.path())
+        .args(["wallet", "unlock", "alice"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::is_empty())
+        .stderr(
+            predicate::str::contains("wallet unlock for 'alice' is fail-closed")
+                .and(predicate::str::contains("jsonrpc").not())
+                .and(predicate::str::contains("\"code\"").not())
+                .and(predicate::str::contains("ipc machine.execute").not()),
+        );
+}
+
+#[test]
+fn raw_ipc_call_reports_invalid_machine_params_without_json_error_wrappers() {
+    let home = fresh_home();
+    let _daemon = RunningBloom::start(home.path());
+    bloom_cmd(home.path())
+        .args([
+            "ipc",
+            "call",
+            "machine.execute",
+            "--params",
+            r#"{"command":"status","extra":true}"#,
+        ])
+        .assert()
+        .failure()
+        .stdout(predicate::str::is_empty())
+        .stderr(
+            predicate::str::contains("invalid params: unknown fields")
+                .and(predicate::str::contains("jsonrpc").not())
+                .and(predicate::str::contains("\"code\"").not())
+                .and(predicate::str::contains("ipc call to").not()),
+        );
 }
 
 #[test]
@@ -1368,14 +1767,20 @@ fn wallet_import_accepts_no_machine_private_key_argument() {
 #[test]
 fn wallet_import_rejects_path_names_before_broker_contact() {
     let home = fresh_home();
+    let _daemon = RunningBloom::start(home.path());
     for name in ["../escape", "../../escape", "a/b", "..", "/etc/passwd"] {
         bloom_cmd(home.path())
             .args(["wallet", "import", name])
             .assert()
             .failure()
-            .stderr(predicate::str::contains(
-                "requested wallet name must be a safe single path segment",
-            ));
+            .stderr(
+                predicate::str::contains(
+                    "requested wallet name must be a safe single path segment",
+                )
+                .and(predicate::str::contains("jsonrpc").not())
+                .and(predicate::str::contains("\"code\"").not())
+                .and(predicate::str::contains("ipc machine.execute").not()),
+            );
     }
     assert!(!home.path().join("keystore").join("escape").exists());
 }
@@ -1384,6 +1789,7 @@ fn wallet_import_rejects_path_names_before_broker_contact() {
 fn request_cli_dry_run_uses_vfs_lifecycle_and_body_receipt_helpers() {
     let home = fresh_home();
     seed_wallet_projection_fixture(home.path(), "alice");
+    let _daemon = RunningBloom::start(home.path());
 
     let (url, hits) = http_fixture(200, &[("content-type", "text/plain")], b"cli-body\n");
     let new = bloom_cmd(home.path())
@@ -1428,6 +1834,7 @@ fn request_cli_dry_run_uses_vfs_lifecycle_and_body_receipt_helpers() {
 #[test]
 fn status_without_broker_or_projection_reports_wallets_unavailable() {
     let home = fresh_home();
+    let _daemon = RunningBloom::start(home.path());
     let assert = bloom_cmd(home.path()).args(["status"]).assert().success();
     let out = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
     assert!(
@@ -1439,16 +1846,8 @@ fn status_without_broker_or_projection_reports_wallets_unavailable() {
         "status must not falsely claim that no wallets exist:\n{out}"
     );
     assert!(
-        !home.path().join("keystore").exists(),
-        "public status must not create the legacy keystore"
-    );
-    assert!(
-        !home.path().join("auth").exists(),
-        "public status must not create the legacy approval store"
-    );
-    assert!(
-        !home.path().join("outbox").exists(),
-        "public status must not construct the legacy daemon composition"
+        !home.path().join("keystore").join("default").exists(),
+        "public status must not create wallet key material"
     );
 }
 
@@ -1456,6 +1855,7 @@ fn status_without_broker_or_projection_reports_wallets_unavailable() {
 fn wallet_address_ignores_legacy_keystore_without_a_broker_projection() {
     let home = fresh_home();
     seed_legacy_wallet_fixture(home.path(), "alice");
+    let _daemon = RunningBloom::start(home.path());
 
     bloom_cmd(home.path())
         .args(["wallet", "address", "alice"])
@@ -1474,6 +1874,7 @@ fn wallet_address_ignores_legacy_keystore_without_a_broker_projection() {
 fn wallet_address_qr_out_does_not_use_legacy_keystore() {
     let home = fresh_home();
     seed_legacy_wallet_fixture(home.path(), "alice");
+    let _daemon = RunningBloom::start(home.path());
     let svg_path = home.path().join("deposit.svg");
     bloom_cmd(home.path())
         .args([
@@ -1491,9 +1892,8 @@ fn wallet_address_qr_out_does_not_use_legacy_keystore() {
 
 /// Spin up an in-process `IpcServer` bound to the home's default socket
 /// path, then invoke the CLI so its `vfs` subcommand routes through IPC.
-/// The CLI's local-vs-IPC selection keys solely off `socket.exists()`, so
-/// proving the IPC branch reduces to seeing data we know only the server
-/// would produce.
+/// Seeing data only this server can produce proves the command used the
+/// configured IPC authority plane.
 #[test]
 fn vfs_routes_via_ipc_when_socket_exists() {
     use bloom_daemon::ipc::{IpcServer, default_socket_path};
@@ -1559,8 +1959,6 @@ fn vfs_routes_via_ipc_when_socket_exists() {
 
     let home = fresh_home();
     let socket = default_socket_path(home.path());
-    std::fs::create_dir_all(socket.parent().unwrap()).unwrap();
-
     let vfs = Vfs::builder()
         .mount("probe", std::sync::Arc::new(probe))
         .build();
@@ -1587,7 +1985,7 @@ fn vfs_routes_via_ipc_when_socket_exists() {
     // accepting connections; this is the same pattern used by the daemon's
     // own ipc tests).
     let deadline = std::time::Instant::now() + Duration::from_secs(5);
-    while !socket.exists() {
+    while !ipc_endpoint_accepting(&socket) {
         if std::time::Instant::now() >= deadline {
             panic!("ipc server never created socket at {}", socket.display());
         }
@@ -1608,8 +2006,8 @@ fn vfs_routes_via_ipc_when_socket_exists() {
     );
 
     // `vfs cat` exercises the IPC `read` method + base64 decode in the
-    // CLI. Asserting on the unique payload also rules out an accidental
-    // local-path fallback.
+    // CLI. Asserting on the unique payload also proves the daemon response is
+    // the source of client output.
     bloom_cmd(home.path())
         .args(["vfs", "cat", "/probe/marker"])
         .assert()
@@ -1663,6 +2061,115 @@ fn wallet_confirm_uses_plain_ipc_write_when_socket_exists() {
         "/alice/chains/base/outbox/pending/0001-deadbeef/confirm"
     );
     assert_eq!(writes[0].1, b"y");
+}
+
+#[test]
+fn wallet_cancel_uses_daemon_owned_machine_command_while_home_lock_is_live() {
+    let home = fresh_home();
+    let _permit = bloom_proto::HomeWritePermit::acquire(&bloom_proto::HomeDir::at(home.path()))
+        .expect("hold home write permit");
+    let commands = Arc::new(RecordingMachineCommands::default());
+    let (server, server_thread) = spawn_machine_ipc_server(home.path(), commands.clone());
+
+    bloom_cmd(home.path())
+        .args([
+            "wallet",
+            "cancel",
+            "alice",
+            "base",
+            "0001-deadbeef",
+            "--text",
+            "approve",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::eq("cancel submitted for 0001-deadbeef\n"))
+        .stderr(predicate::str::contains("already open for writing").not());
+
+    stop_ipc_server(server, server_thread);
+    assert_eq!(
+        serde_json::to_value(commands.commands()).unwrap(),
+        serde_json::json!([{
+            "command": "wallet_outbox_cancel",
+            "wallet": "alice",
+            "chain": "base",
+            "id": "0001-deadbeef",
+            "text": "approve"
+        }])
+    );
+}
+
+#[test]
+fn wallet_replace_uses_daemon_owned_machine_command_while_home_lock_is_live() {
+    let home = fresh_home();
+    let _permit = bloom_proto::HomeWritePermit::acquire(&bloom_proto::HomeDir::at(home.path()))
+        .expect("hold home write permit");
+    let commands = Arc::new(RecordingMachineCommands::default());
+    let (server, server_thread) = spawn_machine_ipc_server(home.path(), commands.clone());
+    let intent = "send 0.002 eth to 0x0000000000000000000000000000000000000000 on base";
+
+    bloom_cmd(home.path())
+        .args([
+            "wallet",
+            "replace",
+            "alice",
+            "base",
+            "0001-deadbeef",
+            "--intent",
+            intent,
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::eq("replacement submitted for 0001-deadbeef\n"))
+        .stderr(predicate::str::contains("already open for writing").not());
+
+    stop_ipc_server(server, server_thread);
+    assert_eq!(
+        serde_json::to_value(commands.commands()).unwrap(),
+        serde_json::json!([{
+            "command": "wallet_outbox_replace",
+            "wallet": "alice",
+            "chain": "base",
+            "id": "0001-deadbeef",
+            "intent": intent
+        }])
+    );
+}
+
+#[test]
+fn wallet_outbox_machine_command_reports_invalid_path_params_cleanly() {
+    let home = fresh_home();
+    let _daemon = RunningBloom::start(home.path());
+
+    for invalid_wallet in ["alice/other", "alice\\other"] {
+        bloom_cmd(home.path())
+            .args(["wallet", "cancel", invalid_wallet, "base", "0001-deadbeef"])
+            .assert()
+            .failure()
+            .stdout(predicate::str::is_empty())
+            .stderr(
+                predicate::str::contains("invalid wallet outbox wallet")
+                    .and(predicate::str::contains("jsonrpc").not())
+                    .and(predicate::str::contains("ipc machine.execute").not()),
+            );
+    }
+
+    bloom_cmd(home.path())
+        .args([
+            "ipc",
+            "call",
+            "machine.execute",
+            "--params",
+            r#"{"command":"wallet_outbox_cancel","wallet":"alice\u0000other","chain":"base","id":"0001-deadbeef","text":"approve"}"#,
+        ])
+        .assert()
+        .failure()
+        .stdout(predicate::str::is_empty())
+        .stderr(
+            predicate::str::contains("invalid wallet outbox wallet")
+                .and(predicate::str::contains("jsonrpc").not())
+                .and(predicate::str::contains("\"code\"").not()),
+        );
 }
 
 #[test]
@@ -1727,6 +2234,7 @@ fn petal_cli_build_install_list_and_vfs_read_happy_path() {
         .stdout(predicate::str::contains("app=petals/demo/"));
 
     stop_ipc_server(server, server_thread);
+    let _daemon = RunningBloom::start(home.path());
 
     bloom_cmd(home.path())
         .args(["vfs", "cat", "/petals/demo/hello.txt"])

--- a/docs/architecture/Interaction Modes.md
+++ b/docs/architecture/Interaction Modes.md
@@ -12,13 +12,21 @@ Bloom exposes actions through three client interaction modes:
 The `bloom` CLI has exactly two local lifecycle commands: `bloom init` creates
 the home, and `bloom serve` owns the long-running Machine. Every other command,
 including `status`, `completions`, `update`, `petals`, and the `bloom vfs`
-facade—and `bloom --version`—is only a client proxy to that running Machine over the configured IPC
+facade is only a client proxy to that running Machine over the configured IPC
 endpoint. A missing, refused, or inaccessible default or explicit endpoint is
 an error which names the endpoint and tells the user to start `bloom serve`.
+`bloom --version` is the diagnostic exception: it always reports the local CLI
+version and, when reachable, the daemon version and negotiated IPC protocol;
+it reports the daemon as unavailable without constructing a one-shot Machine.
 There is no one-shot Machine construction or local Broker fallback.
 Hidden platform bootstrap and supervision helpers are submodes of `init` or
 `serve`; the binary has no pre-parser execution modes outside those lifecycle
 namespaces.
+
+Every IPC request advertises the client's current and supported Bloom protocol
+range, and every response advertises the daemon's. Both peers fail closed when
+the ranges do not overlap or the metadata is absent; package versions are
+reported for diagnosis but are not used as the compatibility contract.
 
 The daemon publishes its socket without exposing a permissive bind-to-chmod
 window. It creates a unique `0700` staging directory inside the endpoint's

--- a/docs/architecture/Interaction Modes.md
+++ b/docs/architecture/Interaction Modes.md
@@ -9,7 +9,35 @@ Bloom exposes actions through three client interaction modes:
 2. the foreground `bloom vfs` facade; and
 3. a VFS mounted by a long-running Bloom Machine.
 
-All three modes use the same production authority plane. Machine stages,
+The `bloom` CLI has exactly two local lifecycle commands: `bloom init` creates
+the home, and `bloom serve` owns the long-running Machine. Every other command,
+including `status`, `completions`, `update`, `petals`, and the `bloom vfs`
+facade—and `bloom --version`—is only a client proxy to that running Machine over the configured IPC
+endpoint. A missing, refused, or inaccessible default or explicit endpoint is
+an error which names the endpoint and tells the user to start `bloom serve`.
+There is no one-shot Machine construction or local Broker fallback.
+Hidden platform bootstrap and supervision helpers are submodes of `init` or
+`serve`; the binary has no pre-parser execution modes outside those lifecycle
+namespaces.
+
+The daemon publishes its socket without exposing a permissive bind-to-chmod
+window. It creates a unique `0700` staging directory inside the endpoint's
+resolved parent, binds the listener there, changes the socket to `0600`, verifies
+its owner, type, mode, and inode, then atomically renames that secured inode to
+the endpoint and verifies it again. Before inspecting or publishing the endpoint,
+`bloom serve` acquires a nonblocking exclusive lock on a persistent, regular,
+same-owner, owner-only lock file beside it and holds that lock for the listener's
+full lifetime. A second server therefore fails without replacing the live
+listener. The parent itself only needs to be a real writable and traversable
+directory; Bloom neither changes its permissions nor requires it to be private,
+so conventional `/tmp` and `0755` runtime directories remain compatible. Kernel
+peer credentials must match the daemon's effective UID before it reads any
+request. Clients never remove or replace an endpoint, including after
+`ConnectionRefused`. Shutdown leaves an inert socket in place; on the next
+startup, the lock-owning server validates that it is a same-owner socket and
+atomically replaces it. Invalid endpoint paths are refused without deletion.
+
+All three client surfaces use the same production authority plane. Machine stages,
 simulates, executes Petals, and projects public status. Broker is the only
 Machine-facing authorization service and owns Sealed Approvals and ceremony
 HTTP. Signer is the only process that holds wallet or delegated private keys
@@ -44,8 +72,8 @@ subsequent operation with its own operation identity.
 
 | Mode | Machine execution state | Ceremony launch UX | Authority behavior |
 |---|---|---|---|
-| Foreground CLI | Key-free Machine composition in the foreground command | The deliberate command may open the Broker-provided URL | Broker and Signer remain separate authenticated services |
-| Foreground `bloom vfs` | Same key-free Machine composition used by the CLI | The deliberate facade command may open or print the Broker-provided URL | Identical Broker/Signer protocol; no local approval path |
+| Foreground CLI | IPC proxy to the running Machine | The deliberate command may open the Broker-provided URL | Broker and Signer remain separate authenticated services |
+| Foreground `bloom vfs` | IPC proxy to the same running Machine VFS | The deliberate facade command may open or print the Broker-provided URL | Identical Broker/Signer protocol; no local approval path |
 | Mounted VFS | Long-running Bloom Machine | The mount never opens a browser; the expecting client reads and opens or forwards the URL | Identical Broker/Signer protocol; Machine projects status only |
 
 Broker or Signer unavailability leaves cached public reads, staging, and
@@ -54,6 +82,17 @@ policy mutation, and custody fail closed. No interaction mode restores legacy
 authority.
 
 ## Foreground clients
+
+Foreground clients may parse presentation flags, read bounded policy or
+migration inputs for transport, format an authoritative daemon response, or
+write presentation outputs such as QR files. For local Petal install and build,
+the client resolves caller paths to absolute paths; the daemon reads the package,
+generates artifacts, and writes any requested archive under its serialized Petal
+mutation lane. Foreground clients do not acquire the home write lock, open
+Machine state, contact Broker directly, or infer an operation identity from a
+later mutable `latest` read. Creation RPCs return the identity projection
+under the same VFS mutation gate used by ordinary IPC and mounted writes, so a
+concurrent mutation cannot replace the identity before it is captured.
 
 A foreground command may make ceremony UX convenient, but it does not own the
 ceremony. When fresh approval is required it:

--- a/docs/examples-domain/03-wallets-simulate-watch.md
+++ b/docs/examples-domain/03-wallets-simulate-watch.md
@@ -16,15 +16,24 @@ Writing a plain name to `new` starts an asynchronous Broker custody ceremony;
 it never creates or imports key material in Machine.
 
 ```sh
+BEFORE_REGISTRATIONS="$(mktemp)"
+ls /bloom/wallets/registrations > "$BEFORE_REGISTRATIONS"
 printf 'alice\n' > /bloom/wallets/new
-cat /bloom/wallets/registrations/alice/status.json
-cat /bloom/wallets/registrations/alice/ceremony_url
+AFTER_REGISTRATIONS="$(mktemp)"
+ls /bloom/wallets/registrations > "$AFTER_REGISTRATIONS"
+comm -13 "$BEFORE_REGISTRATIONS" "$AFTER_REGISTRATIONS"
+REGISTRATION_ID='<candidate-operation-id>'
+cat /bloom/wallets/registrations/"$REGISTRATION_ID"/status.json
 ```
 
-Wallet names must match `[A-Za-z0-9_-]{1,64}`. Complete the projected browser
-ceremony and wait for `status.json` to report `completed` before reading the
-wallet. Import, recovery, rebind, and deletion are likewise Broker custody
-operations; sensitive inputs belong only in the Broker-hosted ceremony.
+Wallet names must match `[A-Za-z0-9_-]{1,64}`. Compare the before and after
+listings and verify each candidate's `requested_name` before opening its
+`ceremony_url`, polling it, or cancelling it. Concurrent registrations for the
+same requested name remain ambiguous through this write-only sink, so serialize
+same-name writes. Complete the projected browser ceremony and wait for
+`ceremony_state` to report `COMPLETED` before reading the wallet. Import,
+recovery, rebind, and deletion are likewise Broker custody operations; sensitive
+inputs belong only in the Broker-hosted ceremony.
 
 ### Per-wallet leaves
 

--- a/docs/operations/release-process.md
+++ b/docs/operations/release-process.md
@@ -89,7 +89,7 @@ git diff -- Cargo.toml Cargo.lock
 
 # 4. Build and verify the binary.
 cargo build --release -p bloom --all-features --locked
-./target/release/bloom --version    # must print "bloom $VERSION"
+./target/release/bloom --version    # first line must print "bloom $VERSION"
 
 # 5. Commit the bump on a release-prep branch and open a PR. Do not
 #    push directly to master; the default branch requires its status
@@ -108,7 +108,7 @@ git switch master
 git pull --ff-only origin master
 test "$(sed -n -E 's/^version = "([0-9]+\.[0-9]+\.[0-9]+)"/\1/p' Cargo.toml | head -n 1)" = "$VERSION"
 cargo build --release -p bloom --all-features --locked
-./target/release/bloom --version    # must print "bloom $VERSION"
+./target/release/bloom --version    # first line must print "bloom $VERSION"
 git tag "v$VERSION"
 git push origin "v$VERSION"
 ```

--- a/docs/reviews/2026-08-06-triad-migration-audit-update.md
+++ b/docs/reviews/2026-08-06-triad-migration-audit-update.md
@@ -30,7 +30,7 @@ There is also one low-severity contract pin drift and one AWS multi-key concern 
   - The embedded README repeats the same invalid workflow: `crates/bloom-vfs/src/docs/README.md:129`.
   - Domain examples do likewise: `docs/examples-domain/03-wallets-simulate-watch.md:15`.
 - **Why existing tests failed to catch it:** The handler test uses correct JSON and discovers the operation ID by listing `registrations`. Documentation tests merely assert that the text contains `wallets/registrations/` and `status.json`; `crates/bloom-vfs/src/router.rs:573` explicitly enshrines the incorrect `<name>` terminology.
-- **Smallest appropriate fix:** Correct all mounted examples to write the documented JSON schema, list `wallets/registrations`, select the operation whose `status.json.requested_name` matches, and read the URL from `status.json`. Document `cancel` as accepting exactly `cancel`.
+- **Smallest appropriate fix:** Correct all mounted examples to write the documented JSON schema, list `wallets/registrations`, select the operation whose `status.json.requested_name` matches, and read the URL from `status.json`. Document the `cancel` confirmation values explicitly.
 - **Focused regression test:** Execute every documented registration command against the real handler and prove preparation, operation discovery, status read, cancellation, and result recovery.
 
 ### Medium — Expired exact Petal approvals cannot be restaged under the same action identity

--- a/docs/superpowers/plans/2026-08-07-triad-vfs-cli-regression-repairs.md
+++ b/docs/superpowers/plans/2026-08-07-triad-vfs-cli-regression-repairs.md
@@ -1,0 +1,87 @@
+# Triad VFS and CLI Regression Repairs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Repair the approved VFS metadata, wallet sink, daemon-only CLI, and phantom lookup regressions without changing ceremony or approval protocols.
+
+**Architecture:** Keep VFS behavior in `WalletsHandler`, route runtime CLI work through the existing daemon IPC endpoint, and extend IPC only with typed, narrow operations required by current CLI commands. Preserve documented workflows and remove one-shot fallbacks rather than introducing replacement local execution paths.
+
+**Tech Stack:** Rust 2024, Tokio Unix sockets, JSON-RPC 2.0, Clap, serde, cargo test.
+
+---
+
+### Task 1: Advertise `new.tx` as writable
+
+**Files:**
+- Modify: `crates/bloom-vfs/src/handlers/wallets.rs`
+
+- [ ] Add a test that lists a wallet chain outbox and asserts `new.tx` has mode `0o644`.
+- [ ] Run the focused test and observe the current `0o444` failure.
+- [ ] Change `outbox_dir_entries()` to construct a writable file entry.
+- [ ] Run the focused wallet handler tests and verify they pass.
+- [ ] Commit only this fix and its test as `fix(vfs): advertise wallet outbox sink as writable`.
+
+### Task 2: Route Petal CLI operations through daemon IPC
+
+**Files:**
+- Modify: `crates/bloom/src/main.rs`
+- Modify: `crates/bloom-daemon/src/ipc.rs`
+- Modify: `crates/bloom/tests/cli.rs`
+- Modify additional focused Petal IPC files only if required by the existing typed API.
+
+- [ ] Add tests proving `petals ls`, install, uninstall, and build work while `serve` owns the home lock and fail against an explicit missing endpoint.
+- [ ] Run the focused CLI tests and observe lock acquisition or endpoint-bypass failures.
+- [ ] Reuse existing `petals.*` IPC methods and add the narrow build RPC required to eliminate local execution.
+- [ ] Remove Petal command home-lock acquisition and in-process daemon construction from client dispatch.
+- [ ] Verify focused daemon IPC and CLI Petal tests.
+- [ ] Commit only this change as `fix(cli): proxy petal commands through daemon IPC`.
+
+### Task 3: Restore the plain-name wallet registration sink
+
+**Files:**
+- Modify: `crates/bloom-vfs/src/handlers/wallets.rs`
+- Modify: registration examples in `crates/bloom-vfs/src/docs/`, `QUICKSTART.md`, `EXAMPLES.md`, and `docs/examples-domain/03-wallets-simulate-watch.md` only where necessary to describe the existing operation-ID projection honestly.
+
+- [ ] Replace the JSON-body registration test with a plain-name test and add rejection coverage for empty, unsafe, and JSON bodies.
+- [ ] Run the focused test and observe the JSON-deserialization failure.
+- [ ] Parse a trimmed UTF-8 wallet name and feed it into the unchanged Broker custody preparation path.
+- [ ] Make the readable `wallets/new` help advertise the plain-name body.
+- [ ] Align examples with the existing operation-ID registration directories and status fields without changing that process.
+- [ ] Run wallet registration and embedded-documentation tests.
+- [ ] Commit only this change as `fix(vfs): restore plain-name wallet registration sink`.
+
+### Task 4: Make the CLI a strict daemon proxy
+
+**Files:**
+- Modify: `crates/bloom/src/main.rs`
+- Modify: `crates/bloom-daemon/src/ipc.rs`
+- Modify: `crates/bloom-daemon/src/lib.rs` where a running-daemon service seam is required.
+- Modify: `crates/bloom/tests/cli.rs`
+- Modify: `docs/architecture/Interaction Modes.md`
+
+- [ ] Add source and integration tests proving every command family except `init` and `serve` contacts the configured IPC endpoint, rejects a missing explicit endpoint, and never acquires the home lock or constructs a fallback daemon.
+- [ ] Add output tests for request creation and wallet staging over IPC.
+- [ ] Run the focused tests and observe current direct-local/direct-Broker successes and missing output.
+- [ ] Route VFS, request, wallet, audit, status, ceremony, operation, update, Petal, and remaining runtime commands through typed daemon IPC; remove fallback branches.
+- [ ] Remove or daemonize static one-shot commands so `init` and `serve` are the only commands that execute without a running daemon.
+- [ ] Preserve client-side presentation and explicit output-file writes only after authoritative daemon responses.
+- [ ] Document the daemon-only CLI rule and failure behavior in Interaction Modes.
+- [ ] Run CLI and daemon IPC suites.
+- [ ] Commit only this change as `refactor(cli): require daemon IPC for all commands`.
+
+### Task 5: Reject phantom outbox artifacts
+
+**Files:**
+- Modify: `crates/bloom-vfs/src/handlers/wallets.rs`
+
+- [ ] Add a test showing lookup succeeds for real artifacts and virtual pending controls but returns `NotFound` for an absent filename.
+- [ ] Run the focused test and observe the phantom lookup success.
+- [ ] Validate artifact existence in `lookup_outbox` while retaining the four virtual pending controls.
+- [ ] Run focused wallet handler tests.
+- [ ] Commit only this change as `fix(vfs): reject phantom wallet outbox artifacts`.
+
+### Final verification
+
+- [ ] Run formatting and workspace tests.
+- [ ] Confirm the only accepted baseline failure is `tests::exact_petal_approval_is_owner_only_and_retries_the_frozen_payload_after_activation` with `PROVENANCE_MISMATCH`.
+- [ ] Review the complete branch against this plan and the approved exclusions.

--- a/docs/superpowers/specs/2026-08-07-triad-vfs-cli-regression-repairs-design.md
+++ b/docs/superpowers/specs/2026-08-07-triad-vfs-cli-regression-repairs-design.md
@@ -1,0 +1,62 @@
+# Triad VFS and CLI Regression Repairs
+
+## Scope
+
+This branch repairs the user-approved subset of the triad migration audit. Work
+is committed in issue order, one behavior change per commit:
+
+1. Advertise `wallets/<wallet>/chains/<chain>/outbox/new.tx` as writable in
+   directory listings as well as direct lookup.
+2. Make every `bloom petals` operation use the running daemon instead of
+   acquiring the Machine home lock or constructing another daemon.
+3. Restore the documented plain-name body for `wallets/new`. The existing
+   asynchronous Broker registration, random operation identity, and projection
+   layout remain unchanged.
+4. Make the CLI, except for `serve` and `init`, a strict proxy to the configured
+   running daemon. Remove in-process and direct-Broker fallbacks. Preserve useful
+   command output, including request and staged-transaction identities, across
+   IPC. Document this boundary in Interaction Modes.
+5. Make wallet outbox lookup reject nonexistent artifact names instead of
+   returning phantom file metadata.
+
+The existing `ceremony.json` behavior is intentionally unchanged. The
+capability and `next.md` projections are intentionally unchanged. Sealed
+Approval request sinks and the Petal contract pin are explanation-only items.
+
+## Architecture
+
+VFS fixes stay in `WalletsHandler` and retain the existing handler contract.
+The registration parser accepts one trimmed wallet name and constructs the
+same internal registration request used today; no Broker protocol or operation
+discovery changes are included.
+
+The daemon is the sole runtime owner. Existing narrow VFS and Petal IPC methods
+remain preferred where they already fit. Additional typed IPC methods or a
+narrow command-service seam may be added for commands currently implemented in
+the CLI process, but execution must happen inside the running `serve` process.
+Client-side formatting and writing explicitly requested output files may remain
+in the CLI after the daemon returns authoritative data.
+
+An explicit endpoint failure is terminal. No non-`init`/`serve` command may
+silently construct a daemon, acquire the Machine home lock, read Machine-owned
+runtime state directly, or connect directly to Broker as a fallback.
+
+## Error handling
+
+- Missing or unreachable daemon endpoints fail closed with the endpoint in the
+  error context.
+- Daemon RPC errors retain their structured JSON-RPC code and message.
+- Plain wallet names are trimmed and validated using the existing wallet-name
+  constraints; JSON and legacy wallet descriptors are rejected.
+- Outbox lookup returns `NotFound` for absent artifacts while preserving the
+  four virtual pending controls.
+
+## Testing
+
+Every change follows red-green TDD. Focused tests cover list/lookup mode parity,
+Petal commands with the daemon lock held, plain-name registration, explicit
+missing-endpoint behavior for every CLI family, IPC output parity, Interaction
+Modes documentation, and phantom-file rejection. Each commit runs its focused
+suite before the next task begins. Final verification runs the workspace suite,
+with the pre-existing deterministic `bloom-daemon` provenance test failure
+reported separately.

--- a/packaging/triad/macos/README.md
+++ b/packaging/triad/macos/README.md
@@ -40,7 +40,7 @@ status because the confined Broker cannot initiate even a loopback SYN. A
 successful retry removes the stale diagnostic.
 
 The global `com.bloom.session` LaunchAgent invokes only Machine's
-`--session-sentinel` mode. It exits successfully for an unenrolled login,
+`serve session-sentinel` mode. It exits successfully for an unenrolled login,
 keeps no custody or signing authority, and is destroyed with its GUI login
 domain. It owns `session/session.sock` as the login UID and authenticates a
 separately pinned `bloom-session` identity. The socket reuses the already

--- a/packaging/triad/macos/launchagents/com.bloom.session.plist.in
+++ b/packaging/triad/macos/launchagents/com.bloom.session.plist.in
@@ -8,7 +8,8 @@
   <key>ProgramArguments</key>
   <array>
     <string>@BLOOM_MACHINE_BINARY@</string>
-    <string>--session-sentinel</string>
+    <string>serve</string>
+    <string>session-sentinel</string>
   </array>
   <key>EnvironmentVariables</key>
   <dict>

--- a/packaging/triad/macos/launchdaemons/com.bloom.containment.plist.in
+++ b/packaging/triad/macos/launchdaemons/com.bloom.containment.plist.in
@@ -14,7 +14,8 @@
   <key>ProgramArguments</key>
   <array>
     <string>@BLOOM_MACHINE_BINARY@</string>
-    <string>--triad-pf-monitor-once</string>
+    <string>serve</string>
+    <string>triad-pf-monitor-once</string>
   </array>
   <key>RunAtLoad</key>
   <true/>

--- a/packaging/triad/macos/w0/run-disposable.sh
+++ b/packaging/triad/macos/w0/run-disposable.sh
@@ -399,7 +399,7 @@ assert_substitution_rejected hard-link
 assert_metadata "$edge_manifest" "0:0:644"
 sudo -u "$login_user" \
   "$machine_binary" \
-  --triad-health-check \
+  serve triad-health-check \
   "$release_digest"
 
 unrelated_user="nobody"
@@ -514,7 +514,7 @@ wait "$hostile_session_pid" 2>/dev/null || true
 hostile_session_pid=""
 sudo -u "$login_user" \
   "$machine_binary" \
-  --triad-health-check \
+  serve triad-health-check \
   "$release_digest"
 
 launchctl bootout "$session_label"
@@ -545,7 +545,7 @@ while [[ $SECONDS -lt $deadline ]]; do
   if [[ -S "$session_socket" ]] &&
     sudo -u "$login_user" \
       "$machine_binary" \
-      --triad-health-check \
+      serve triad-health-check \
       "$release_digest"
   then
     break
@@ -554,7 +554,7 @@ while [[ $SECONDS -lt $deadline ]]; do
 done
 sudo -u "$login_user" \
   "$machine_binary" \
-  --triad-health-check \
+  serve triad-health-check \
   "$release_digest"
 
 ceremony_headers=""
@@ -640,7 +640,7 @@ assert_metadata \
 if foreign_machine_failure="$(
   sudo -u "$login_user" \
     "$machine_binary" \
-    --triad-health-check "$release_digest" 2>&1
+    serve triad-health-check "$release_digest" 2>&1
 )"
 then
   echo "Machine reported healthy while a foreign process owned the ceremony port" >&2
@@ -684,7 +684,7 @@ deadline=$((SECONDS + 60))
 while [[ $SECONDS -lt $deadline ]]; do
   if sudo -u "$login_user" \
     "$machine_binary" \
-    --triad-health-check \
+    serve triad-health-check \
     "$release_digest"
   then
     break
@@ -693,7 +693,7 @@ while [[ $SECONDS -lt $deadline ]]; do
 done
 sudo -u "$login_user" \
   "$machine_binary" \
-  --triad-health-check \
+  serve triad-health-check \
   "$release_digest"
 [[ ! -e "$broker_startup_status" ]] || {
   echo "Broker retained a stale startup diagnostic after acquiring the listener" >&2
@@ -780,7 +780,7 @@ deadline=$((SECONDS + 20))
 while [[ $SECONDS -lt $deadline ]]; do
   if sudo -u "$login_user" \
     "$machine_binary" \
-    --triad-health-check \
+    serve triad-health-check \
     "$release_digest"
   then
     break
@@ -789,7 +789,7 @@ while [[ $SECONDS -lt $deadline ]]; do
 done
 sudo -u "$login_user" \
   "$machine_binary" \
-  --triad-health-check \
+  serve triad-health-check \
   "$release_digest"
 
 pfctl -a "com.bloom.triad/$login_uid" -F rules
@@ -808,7 +808,7 @@ done
 }
 if sudo -u "$login_user" \
   "$machine_binary" \
-  --triad-health-check \
+  serve triad-health-check \
   "$release_digest"
 then
   echo "Broker remained ready after its packet-filter anchor disappeared" >&2
@@ -817,10 +817,10 @@ fi
 pfctl \
   -a "com.bloom.triad/$login_uid" \
   -f "/etc/pf.anchors/com.bloom.triad.$login_uid"
-"$machine_binary" --triad-pf-monitor-once
+"$machine_binary" serve triad-pf-monitor-once
 sudo -u "$login_user" \
   "$machine_binary" \
-  --triad-health-check \
+  serve triad-health-check \
   "$release_digest"
 
 current_good_payload="$payload"

--- a/packaging/triad/macos/w0/run-installed-acceptance.sh
+++ b/packaging/triad/macos/w0/run-installed-acceptance.sh
@@ -158,7 +158,7 @@ signer_uid="$(plutil -extract signer_uid raw -o - "$enrollment")"
 assert_installed_process bloom-broker "$broker_uid" "$release_root/bloom-broker"
 assert_installed_process bloom-signer "$signer_uid" "$release_root/bloom-signer"
 sudo -u "$login_user" \
-  "$release_root/bloom" --triad-health-check "$release_digest"
+  "$release_root/bloom" serve triad-health-check "$release_digest"
 
 machine_identity="/Library/Application Support/BloomTriad/config/$login_uid/machine/identity.json"
 edge_manifest="/Library/Application Support/BloomTriad/config/$login_uid/edge-manifest.json"
@@ -176,14 +176,14 @@ edge_manifest="/Library/Application Support/BloomTriad/config/$login_uid/edge-ma
 deadline=$((SECONDS + 20))
 while [[ $SECONDS -lt $deadline ]]; do
   if sudo -u "$login_user" \
-    "$release_root/bloom" --triad-health-check "$release_digest"
+    "$release_root/bloom" serve triad-health-check "$release_digest"
   then
     break
   fi
   sleep 1
 done
 sudo -u "$login_user" \
-  "$release_root/bloom" --triad-health-check "$release_digest"
+  "$release_root/bloom" serve triad-health-check "$release_digest"
 
 source_revision() {
   key="$1"
@@ -294,7 +294,7 @@ assert_source "$signer_root" BLOOM_SIGNER_SHA
 assert_installed_process bloom-broker "$broker_uid" "$release_root/bloom-broker"
 assert_installed_process bloom-signer "$signer_uid" "$release_root/bloom-signer"
 sudo -u "$login_user" \
-  "$release_root/bloom" --triad-health-check "$release_digest"
+  "$release_root/bloom" serve triad-health-check "$release_digest"
 
 subject_digest="$(
   "$main_root/packaging/triad/release/macos-conformance-subject.sh" "$payload"

--- a/packaging/triad/macos/w0/run-two-login.sh
+++ b/packaging/triad/macos/w0/run-two-login.sh
@@ -168,7 +168,7 @@ installed_a=true
 release_digest="$(field "$login_uid_a" release_digest)"
 [[ "$(field "$login_uid_a" state)" == "active" ]]
 sudo -u "$login_user_a" \
-  "$machine_binary" --triad-health-check "$release_digest"
+  "$machine_binary" serve triad-health-check "$release_digest"
 
 # Leave A enrolled and its socket-activated LaunchDaemons loaded, but remove its
 # login-session sentinel so B can become the first canonical-listener owner.
@@ -184,7 +184,7 @@ installed_b=true
 [[ "$(field "$login_uid_b" release_digest)" == "$release_digest" ]]
 [[ "$(field "$login_uid_b" state)" == "active" ]]
 sudo -u "$login_user_b" \
-  "$machine_binary" --triad-health-check "$release_digest"
+  "$machine_binary" serve triad-health-check "$release_digest"
 
 launchctl bootstrap "gui/$login_uid_a" "$session_plist"
 session_socket_a="/private/var/run/bloom/$login_uid_a/session/session.sock"
@@ -259,14 +259,14 @@ if [[ -n "$upgrade_payload" ]]; then
   deadline=$((SECONDS + 20))
   while [[ $SECONDS -lt $deadline ]]; do
     if sudo -u "$login_user_b" \
-      "$machine_binary" --triad-health-check "$release_digest"
+      "$machine_binary" serve triad-health-check "$release_digest"
     then
       break
     fi
     sleep 1
   done
   sudo -u "$login_user_b" \
-    "$machine_binary" --triad-health-check "$release_digest"
+    "$machine_binary" serve triad-health-check "$release_digest"
   launchctl bootstrap system "$broker_plist_a"
 fi
 
@@ -281,7 +281,7 @@ done
 
 if machine_failure="$(
   sudo -u "$login_user_a" \
-    "$machine_binary" --triad-health-check "$release_digest" 2>&1
+    "$machine_binary" serve triad-health-check "$release_digest" 2>&1
 )"
 then
   echo "second Broker reported healthy while login B owned the canonical listener" >&2
@@ -307,7 +307,7 @@ then
   exit 1
 fi
 sudo -u "$login_user_b" \
-  "$machine_binary" --triad-health-check "$release_digest"
+  "$machine_binary" serve triad-health-check "$release_digest"
 
 # End B's complete GUI launchd domain. A's already-failed Broker must acquire
 # the freed port through failure-only KeepAlive before any new Machine request.
@@ -346,7 +346,7 @@ lsof -nP -a -u "bloom-broker-$login_uid_a" \
   exit 1
 }
 sudo -u "$login_user_a" \
-  "$machine_binary" --triad-health-check "$release_digest"
+  "$machine_binary" serve triad-health-check "$release_digest"
 
 if [[ -n "${BLOOM_MACOS_W0_EVIDENCE_DIR:-}" ]]; then
   evidence_dir="$BLOOM_MACOS_W0_EVIDENCE_DIR"

--- a/packaging/triad/release/install-macos.sh
+++ b/packaging/triad/release/install-macos.sh
@@ -249,7 +249,7 @@ install_config() {
     if $live; then
       scratch="$(mktemp -d "$product/.material.XXXXXX")"; templates="$scratch/templates"; material="$scratch/material"
       mkdir -m 0700 "$templates" "$material"; cp "$payload/installer/macos/config/"* "$templates/"
-      "$machine_binary" --triad-render-macos-enrollment "$templates" "$material" "$login_uid" \
+      "$machine_binary" init triad-render-macos-enrollment "$templates" "$material" "$login_uid" \
         "$BLOOM_MACOS_BROKER_UID" "$BLOOM_MACOS_SIGNER_UID" "$BLOOM_MACOS_REVOKE_GID" "$BLOOM_RELEASE_DIGEST"
       source_config="$material"
     else source_config="$payload/config"; fi
@@ -294,12 +294,12 @@ secure_ownership() {
 start_and_check() {
   plutil -lint "$broker_plist" "$signer_plist" "$containment_plist" "$session_plist" >/dev/null; pfctl -nf "$pf_anchor"
   launchctl bootout system/com.bloom.containment 2>/dev/null || true; launchctl bootstrap system "$containment_plist"
-  "$machine_binary" --triad-pf-monitor-once
+  "$machine_binary" serve triad-pf-monitor-once
   for label in "gui/$login_uid/com.bloom.session" "system/com.bloom.broker.$login_uid" "system/com.bloom.signer.$login_uid"; do launchctl bootout "$label" 2>/dev/null || true; done
   launchctl bootstrap "gui/$login_uid" "$session_plist"; launchctl bootstrap system "$signer_plist"; launchctl bootstrap system "$broker_plist"
   health_output="$(mktemp "$scratch/health-check.XXXXXX")"
   for _ in {1..20}; do
-    if sudo -n -u "$login_user" -- "$machine_binary" --triad-health-check "$BLOOM_RELEASE_DIGEST" >"$health_output" 2>&1; then return; fi
+    if sudo -n -u "$login_user" -- "$machine_binary" serve triad-health-check "$BLOOM_RELEASE_DIGEST" >"$health_output" 2>&1; then return; fi
     sleep 1
   done
   cat "$health_output" >&2

--- a/scripts/triad-dev-launch.sh
+++ b/scripts/triad-dev-launch.sh
@@ -126,7 +126,7 @@ if [ ! -f "${config_dir}/edge-manifest.json" ]; then
   fi
   mkdir "$config_dir"
   chmod 0700 "$config_dir"
-  "$bloom_bin" --triad-render-developer-enrollment \
+  "$bloom_bin" init triad-render-developer-enrollment \
     "$template_dir" "$config_dir" "$release_digest"
   rm -rf -- "$template_dir"
 fi
@@ -300,7 +300,7 @@ supervise_services() {
 
 BLOOM_TRIAD_DEVELOPER_ROOT="$developer_root" \
 BLOOM_TRIAD_DEVELOPER_RUNTIME="$runtime_dir" \
-  "$bloom_bin" --session-sentinel >"${log_dir}/session.log" 2>&1 &
+  "$bloom_bin" serve session-sentinel >"${log_dir}/session.log" 2>&1 &
 session_pid=$!
 wait_for_socket "$session_socket" "$session_pid" session
 


### PR DESCRIPTION
## Summary

This PR repairs the approved VFS and CLI regressions found during the triad-architecture audit:

- advertise wallet outbox `new.tx` consistently as a writable sink;
- restore the documented plain-name `/wallets/new` body while leaving the asynchronous Broker registration protocol unchanged;
- route every Petal CLI operation through the running daemon;
- make every CLI operation other than `init` and `serve` a strict IPC proxy, including `--version`, wallet cancel/replace, request planning, update checks, and completions;
- preserve request and staged-transaction identities atomically across IPC;
- preserve CLI stdout, stderr, exit behavior, caller-relative Petal paths, generated artifacts, and source-build output;
- reject missing and non-regular wallet outbox artifacts consistently across list, lookup, and read;
- document the daemon-only boundary in Interaction Modes.

The IPC expansion also closes the local trust boundary around daemon-owned commands: Unix peers must have the daemon's effective UID, sockets are securely staged and atomically published under a persistent endpoint lock, raw signer-consuming writes remain denied, and Machine commands/errors use closed typed contracts.

## Why

The triad rewrite exposed Broker-oriented schemas and daemon internals directly through some VFS and CLI surfaces. In particular, wallet registration began requiring JSON, several commands silently constructed local daemons or talked directly to Broker, IPC responses lost operation identities or output, and some outbox metadata advertised impossible files.

The intended boundary is now explicit: `bloom init` initializes state, `bloom serve` owns runtime authority and state, and every other command is a client of that running daemon.

## Base-branch reconciliation

This branch now includes `triad-architecture` through `43ed476`.

- The base's petname registration work is combined with this PR's ergonomic sink: `/wallets/new` still accepts a plain wallet name, while status, cancellation, and results are projected at `wallets/registrations/<petname>/...`. The random Broker operation identity remains internal to the projection.
- The base's approval-contract alignment is adopted unchanged, including the updated Petal contract and Broker/runtime revisions.

## Further context / intentionally deferred findings

### EVM exact-approval expiry

EVM exact signing persists a ten-minute approval window together with its approval/signing operation IDs, request nonce, and approval ID in `ceremony.json`. When matching state is reloaded after expiry, the scalar and batch paths retain those terminal identities. Broker therefore continues rejecting an otherwise unchanged staged payload instead of starting a fresh exact-approval attempt.

The Petal exact-signing paths already demonstrate the recovery shape: rotate approval/signing operation IDs and the request nonce, refresh timestamps, and clear the old approval ID while retaining exact payload and provenance comparisons.

This PR deliberately does not change the EVM flow. Correcting it needs a dedicated scalar-and-batch identity-retirement design, atomic persistence rules, and protocol-level tests; folding it into CLI/VFS compatibility work would make the approval semantics much harder to review.

### Sealed Approval sinks

The Sealed Approval sinks are low-level Broker orchestration surfaces for reusable, bounded signing authority rather than ordinary transaction-staging endpoints:

- `sealed-approvals/new.json` accepts `ApprovalPrepareRequest` and prepares a new approval ceremony;
- `<approval-id>/renew` accepts `ApprovalRenewRequest` and prepares replacement terms;
- `<approval-id>/revoke` accepts `RevokeRequest` and revokes one approval with a reason;
- `revoke_all` accepts `WalletOperationRequest` and revokes wallet-scoped approvals.

They currently expose raw Broker request schemas. That is useful as a narrow orchestration layer, but it is not an ergonomic VFS builder API. This PR leaves those schemas unchanged so a later protocol/API change can address them deliberately.

### Petal contract alignment (resolved by the merged base)

The original audit found Bloom pinned to Petal commit `4f6fb570…` while newer payload-signing interfaces were being supported elsewhere, creating a risk that `contract_wit_digest()`, SDKs, builders, and conformance tooling would disagree about the canonical contract.

The latest `triad-architecture` now pins `bloom-petal-contract` to `eda6647c523bba161eaa22812aa0e75ec7782404` and updates the associated host-interface and approval-contract handling. This merge adopts that alignment, so the old-pin discrepancy is no longer deferred work in this PR. Keeping this note documents the audit finding and why no separate pin change appears in the feature commits.

## Validation

- `cargo test -p bloom --test cli` — 62 passed
- `cargo test -p bloom-daemon ipc::tests -- --test-threads=1` — 28 passed
- `cargo test -p bloom-vfs handlers::wallets::tests -- --test-threads=1` — 37 passed
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check triad-architecture...HEAD`

## Baseline and merge verification context

Before the base update, full-suite runs reproduced the exact-Petal `PROVENANCE_MISMATCH` family in the daemon approval retry and VFS exact-signing retry tests. The newly merged base aligns the Petal, Broker, and runtime contract dependencies that govern this area.

After resolving the merge, `cargo check -p bloom-vfs -p bloom-daemon -p bloom`, the CLI integration suite (62/62), and daemon IPC suite (28/28) passed. Per request, the remaining suites were not rerun after conflict resolution; the earlier focused wallet VFS suite was 37/37 before the base merge.


## Checklist

- [x] Tests added or updated for behavior changes
- [x] Architecture docs (`docs/architecture/`) updated if contracts or behavior changed
- [x] Sealed Approval invariants respected (no signing outside a grant or bounded capability, no PRF/grant persistence, execution from sealed bytes) — see `docs/architecture/Sealed Approvals.md`
- [x] Agent Documentation updated (`crates/bloom-vfs/src/docs/agent-guidance.md` and affected Petal READMEs) — see `docs/architecture/Agent-native Documentation.md`
