### PR TITLE
ci: publish static aarch64 musl release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -330,6 +330,7 @@ jobs:
           \`\`\`
           https://github.com/$REPOSITORY/releases/download/$TAG/bloom-linux-x86_64.tar.gz
           https://github.com/$REPOSITORY/releases/download/$TAG/bloom-linux-aarch64.tar.gz
+          https://github.com/$REPOSITORY/releases/download/$TAG/bloom-linux-aarch64-musl.tar.gz
           https://github.com/$REPOSITORY/releases/download/$TAG/bloom-macos-x86_64.tar.gz
           https://github.com/$REPOSITORY/releases/download/$TAG/bloom-macos-aarch64.tar.gz
           \`\`\`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 # Tag-driven release workflow. Mirrors the structure of vibefi/client's
 # release.yml but adapted to this repo: no cargo-packager, four native
-# runners (no --target cross-compile), per-binary verify step, and a
+# runner platforms plus an aarch64 musl build, per-binary verification, and a
 # reviewed workspace version bump (no --config magic, no cargo-edit).
 #
 # Flow:
@@ -10,10 +10,10 @@ name: Release
 #      matching `vX.Y.Z` tag. `propose-release.yml` can open that PR.
 #   2. `prepare` resolves and validates the existing tag (vX.Y.Z).
 #   3. `build` checks out that exact SHA and runs `cargo build --locked`
-#      on each of the four native runners. A verify step asserts that
+#      for each release target. Verification asserts that
 #      `bloom --version` matches the tag.
 #   4. `publish` verifies the tag still resolves to the built SHA,
-#      downloads the four tarballs, generates SHA256SUMS and release notes
+#      downloads the five tarballs, generates SHA256SUMS and release notes
 #      from commits since the previous version tag, then creates or updates
 #      the GitHub release for that existing tag.
 #
@@ -139,15 +139,28 @@ jobs:
           - asset_name: bloom-linux-x86_64.tar.gz
             os: ubuntu-latest
             binary: bloom
+            target: x86_64-unknown-linux-gnu
+            static: false
           - asset_name: bloom-linux-aarch64.tar.gz
             os: ubuntu-24.04-arm
             binary: bloom
+            target: aarch64-unknown-linux-gnu
+            static: false
+          - asset_name: bloom-linux-aarch64-musl.tar.gz
+            os: ubuntu-24.04-arm
+            binary: bloom
+            target: aarch64-unknown-linux-musl
+            static: true
           - asset_name: bloom-macos-x86_64.tar.gz
             os: macos-26-intel
             binary: bloom
+            target: x86_64-apple-darwin
+            static: false
           - asset_name: bloom-macos-aarch64.tar.gz
             os: macos-26
             binary: bloom
+            target: aarch64-apple-darwin
+            static: false
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -157,7 +170,13 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        run: rustup show
+        run: rustup target add "${{ matrix.target }}"
+
+      - name: Install musl toolchain
+        if: matrix.static
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes make musl-tools perl
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -165,25 +184,45 @@ jobs:
           cache-targets: false
 
       - name: Build release binary (locked)
-        run: cargo build --release -p bloom --all-features --locked
+        env:
+          AR_aarch64_unknown_linux_musl: ar
+          CC_aarch64_unknown_linux_musl: musl-gcc
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: musl-gcc
+        run: cargo build --release -p bloom --all-features --locked --target "${{ matrix.target }}"
 
       - name: Verify binary version matches tag
         env:
           VERSION: ${{ needs.prepare.outputs.release_version }}
         run: |
           set -euo pipefail
-          ACTUAL="$(./target/release/${{ matrix.binary }} --version | awk '{print $2}')"
+          BINARY="./target/${{ matrix.target }}/release/${{ matrix.binary }}"
+          ACTUAL="$("$BINARY" --version | awk '{print $2}')"
           if [[ "$ACTUAL" != "$VERSION" ]]; then
             echo "::error::binary version '$ACTUAL' does not match tag '$VERSION'"
             exit 1
           fi
           echo "Verified: ${{ matrix.binary }} --version = $ACTUAL"
 
+      - name: Verify static linkage
+        if: matrix.static
+        run: |
+          set -euo pipefail
+          BINARY="./target/${{ matrix.target }}/release/${{ matrix.binary }}"
+          if readelf --program-headers "$BINARY" | grep -q 'Requesting program interpreter'; then
+            echo "::error::$BINARY has a dynamic program interpreter"
+            exit 1
+          fi
+          if readelf --dynamic "$BINARY" 2>/dev/null | grep -q '(NEEDED)'; then
+            echo "::error::$BINARY has dynamic library dependencies"
+            exit 1
+          fi
+          file "$BINARY"
+
       - name: Stage package
         run: |
           set -euo pipefail
           mkdir -p package dist
-          cp "target/release/${{ matrix.binary }}" package/
+          cp "target/${{ matrix.target }}/release/${{ matrix.binary }}" package/
           cp README.md LICENSE package/
           tar -czf "dist/${{ matrix.asset_name }}" -C package .
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2280,6 +2280,7 @@ dependencies = [
  "flate2",
  "hex",
  "humantime",
+ "openssl-sys",
  "predicates",
  "qrcode",
  "rand 0.8.6",
@@ -6252,6 +6253,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6259,6 +6269,7 @@ checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/crates/bloom/Cargo.toml
+++ b/crates/bloom/Cargo.toml
@@ -56,6 +56,11 @@ zeroize.workspace = true
 flate2.workspace = true
 sha2.workspace = true
 
+# WebAuthn attestation pulls in OpenSSL. Musl releases cannot link the host's
+# glibc OpenSSL, so build it from source only for musl targets.
+[target.'cfg(target_env = "musl")'.dependencies]
+openssl-sys = { version = "0.9", features = ["vendored"] }
+
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"

--- a/docs/operations/release-process.md
+++ b/docs/operations/release-process.md
@@ -10,12 +10,12 @@ The `release.yml` workflow:
 1. Validates the tag shape.
 2. Verifies that the tagged commit is reachable from the default branch and
    already has workspace version `X.Y.Z`.
-3. Builds the exact
-   commit SHA on four runners (Linux x86_64 + aarch64, macOS x86_64 +
-   aarch64) with `--locked`.
+3. Builds the exact commit SHA on four runner platforms (Linux x86_64 +
+   aarch64, macOS x86_64 + aarch64) with `--locked`, including both glibc
+   and static musl artifacts for Linux aarch64.
 4. Verifies the resulting binary's `bloom --version` matches the tag.
 5. Verifies the tag still resolves to the built SHA, then creates a
-   GitHub release `vX.Y.Z` with the four tarballs and a `SHA256SUMS`
+   GitHub release `vX.Y.Z` with the five tarballs and a `SHA256SUMS`
    file. It advances GitHub's latest-release alias only when this version is
    at least as new as the current latest release; failures resolving that
    release abort publication rather than treating the result as empty.
@@ -26,6 +26,11 @@ workflow. It is owned by the old (now-retired) branch-driven
 `latest` tag are removed in the cleanup step below. GitHub's
 `/releases/latest/download/...` route follows the release marked
 latest; it does not require a git tag literally named `latest`.
+
+Linux aarch64 releases include two variants. Use
+`bloom-linux-aarch64.tar.gz` on glibc distributions and
+`bloom-linux-aarch64-musl.tar.gz` on Termux/Android, Alpine Linux, and
+minimal Linux systems without glibc. The musl binary is statically linked.
 
 ## CI-proposed release
 
@@ -115,7 +120,7 @@ git push origin "v$VERSION"
 
 The tag push starts the workflow automatically. Because the tag already
 points at the reviewed version-bumped commit, the build jobs use that exact
-SHA and the publish job creates the `v$VERSION` release with the four
+SHA and the publish job creates the `v$VERSION` release with the five
 tarballs and `SHA256SUMS`. A manual `release.yml` run is available only to
 retry an existing tag and never creates commits or tags.
 
@@ -174,9 +179,10 @@ checks, set `BLOOM_DISABLE_UPDATE_CHECK=1` in the service environment.
 - **A floating `latest` git tag**: removed during legacy cleanup. The
   versioned URL is canonical, while GitHub's latest-release URL remains
   a stable convenience alias.
-- **Cross-compiled builds**: each runner builds natively (`cargo
-  build --release` without `--target`), matching the previous
-  workflow. Cross-compilation is a separate effort.
+- **Cross-architecture builds**: each artifact is built on a runner with the
+  matching CPU architecture. The release workflow selects explicit Rust
+  targets, including musl on the native aarch64 runner, but does not emulate
+  or cross-compile between CPU architectures.
 - **Windows builds**: intentionally out of scope. Historical commit
   `cce4250 remove Windows release builds` removed them; the current
   CI has no Windows tests.


### PR DESCRIPTION
## Summary

- add an `aarch64-unknown-linux-musl` release-matrix entry and publish `bloom-linux-aarch64-musl.tar.gz`
- vendor OpenSSL only for musl targets so the existing WebAuthn attestation feature links statically
- verify the musl ELF has no program interpreter or dynamic library dependencies
- document when to choose the glibc or musl aarch64 artifact

## Validation

- `cargo fmt --all -- --check`
- targeted `actionlint` on `release.yml`
- full `aarch64-unknown-linux-musl` release build in a musl cross-build container
- verified the result is an ARM aarch64, statically linked ELF with no interpreter or `NEEDED` entries
- `cargo test --workspace --locked`: all completed tests passed; two existing live-daemon tests could not acquire their fixed port because a local Bloom service already owns `127.0.0.1:18734`

## Checklist

- [x] Tests added or updated for behavior changes — N/A: release packaging only; build and linkage validation is listed above
- [x] Architecture docs updated — N/A: no architecture contract or runtime behavior changed
- [x] Sealed Approval invariants respected — N/A: no signing or approval code changed
- [x] Agent Documentation updated — N/A: no agent-facing behavior changed

Closes #154