### PR TITLE
feat: add Privacy Pools private withdrawal ceremony

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2568,7 +2568,6 @@ dependencies = [
 [[package]]
 name = "bloom-petal-contract"
 version = "0.1.0"
-source = "git+https://github.com/bloom-directory/petal?rev=4f6fb57063a70f95cba288f68bdc139e3ecac7a5#4f6fb57063a70f95cba288f68bdc139e3ecac7a5"
 dependencies = [
  "sha2 0.10.9",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ bloom-ens      = { path = "crates/bloom-ens" }
 bloom-prices   = { path = "crates/bloom-prices" }
 bloom-revert   = { path = "crates/bloom-revert" }
 bloom-petals   = { path = "crates/bloom-petals" }
-bloom-petal-contract = { git = "https://github.com/bloom-directory/petal", rev = "4f6fb57063a70f95cba288f68bdc139e3ecac7a5" }
+bloom-petal-contract = { path = "../petal" }
 bloom-daemon   = { path = "crates/bloom-daemon" }
 bloom-auth-api = { path = "crates/bloom-auth-api" }
 bloom-auth     = { path = "crates/bloom-auth" }

--- a/crates/bloom-daemon/src/ceremony_server.rs
+++ b/crates/bloom-daemon/src/ceremony_server.rs
@@ -41,6 +41,7 @@ use tokio::task::JoinHandle;
 
 use crate::Daemon;
 
+mod private_input_ceremony;
 mod wallet_registration;
 
 const CEREMONY_HTML: &str = include_str!("sealed_ceremony.html");
@@ -68,7 +69,7 @@ fn sealed_review_session_id(challenge: &ApprovalChallenge) -> String {
 }
 
 #[derive(Clone)]
-struct CeremonyState {
+pub(super) struct CeremonyState {
     daemon: Daemon,
 }
 
@@ -165,8 +166,13 @@ fn router(state: CeremonyState) -> Router {
         .route("/ceremony/{token}/challenge", get(challenge_json))
         .route("/ceremony/{token}/complete", post(complete))
         .merge(wallet_registration::router())
+        .merge(private_input_ceremony::router())
         .layer(axum::middleware::from_fn(require_local_origin))
         .with_state(state)
+}
+
+pub(crate) fn private_input_url(token: &str) -> String {
+    format!("http://localhost:{LOCAL_CEREMONY_PORT}/private-input/{token}")
 }
 
 /// Reject cross-site POSTs. Loopback GETs carry no Origin; POSTs from the

--- a/crates/bloom-daemon/src/ceremony_server/private_input_ceremony.html
+++ b/crates/bloom-daemon/src/ceremony_server/private_input_ceremony.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="referrer" content="no-referrer">
+  <title>/bloom — Private Privacy Pools destination</title>
+  <style>
+    :root{color-scheme:light dark;font-family:system-ui,sans-serif;background:#f4efe6;color:#18140f}
+    body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(135deg,#f8f3ea,#e7dfd2)}
+    main{width:min(560px,calc(100% - 32px));padding:32px;border:1px solid #cbbda9;border-radius:18px;background:#fffaf2;box-shadow:0 24px 70px #4a38251f}
+    h1{margin:0 0 10px;font:italic 42px Georgia,serif}.muted{color:#6e6456;line-height:1.5}
+    label{display:block;margin:26px 0 8px;font-weight:650}input{width:100%;box-sizing:border-box;padding:14px;border:1px solid #aa9c88;border-radius:9px;background:white;color:#18140f;font:14px ui-monospace,monospace}
+    button{width:100%;margin-top:16px;padding:14px;border:0;border-radius:9px;background:#7a2230;color:white;font-weight:650;cursor:pointer}button:disabled{opacity:.55;cursor:wait}
+    #status{min-height:1.5em;margin-top:16px;color:#6e2430}.privacy{margin-top:24px;padding-top:18px;border-top:1px solid #d8ccba;font-size:13px;color:#6e6456}
+  </style>
+</head>
+<body><main>
+  <p class="muted" id="wallet">Loading ceremony…</p>
+  <h1 id="title">Private destination</h1>
+  <p class="muted" id="prompt"></p>
+  <form id="form">
+    <label for="destination">Ethereum withdrawal address</label>
+    <input id="destination" name="destination" inputmode="text" autocomplete="off" spellcheck="false" placeholder="0x…" required pattern="0x[0-9a-fA-F]{40}">
+    <button id="approve" type="submit">Verify with passkey</button>
+  </form>
+  <div id="status" role="status" aria-live="polite"></div>
+  <p class="privacy">The address is submitted directly to the local Bloom daemon. It is not returned through VFS. Your passkey approval is bound to its digest, so the prepared address cannot be swapped afterward.</p>
+</main><script>
+var PATH=location.pathname.replace(/\/$/,'');
+function dec(s){s=s.replace(/-/g,'+').replace(/_/g,'/');while(s.length%4)s+='=';var b=atob(s),a=new Uint8Array(b.length);for(var i=0;i<b.length;i++)a[i]=b.charCodeAt(i);return a.buffer}
+function enc(b){var a=new Uint8Array(b),s='';for(var i=0;i<a.length;i++)s+=String.fromCharCode(a[i]);return btoa(s).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'')}
+fetch(PATH+'/request.json').then(function(r){if(!r.ok)throw new Error('Ceremony unavailable');return r.json()}).then(function(v){
+  document.getElementById('title').textContent=v.title;document.getElementById('prompt').textContent=v.prompt;document.getElementById('wallet').textContent='Passkey wallet · '+v.approval_wallet+' · Note wallet · '+v.note_wallet;
+}).catch(function(e){document.getElementById('status').textContent=e.message;document.getElementById('approve').disabled=true});
+document.getElementById('form').addEventListener('submit',async function(event){
+  event.preventDefault();var button=document.getElementById('approve'),status=document.getElementById('status'),value=document.getElementById('destination').value.trim();button.disabled=true;status.textContent='Preparing an approval bound to this address…';
+  try{
+    var prepared=await fetch(PATH+'/prepare',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({value:value})});var opts=await prepared.json();if(!prepared.ok)throw new Error(opts.error||'Could not prepare ceremony');
+    opts.publicKey.challenge=dec(opts.publicKey.challenge);if(opts.publicKey.allowCredentials)opts.publicKey.allowCredentials=opts.publicKey.allowCredentials.map(function(c){return Object.assign({},c,{id:dec(c.id)})});
+    if(opts.publicKey.extensions&&opts.publicKey.extensions.prf&&opts.publicKey.extensions.prf.eval&&opts.publicKey.extensions.prf.eval.first)opts.publicKey.extensions.prf.eval.first=dec(opts.publicKey.extensions.prf.eval.first);
+    status.textContent='Confirm the exact address above with your passkey…';var cred=await navigator.credentials.get(opts);
+    var body={credential:{id:cred.id,response:{authenticatorData:enc(cred.response.authenticatorData),clientDataJSON:enc(cred.response.clientDataJSON),signature:enc(cred.response.signature),userHandle:cred.response.userHandle?enc(cred.response.userHandle):null}}};
+    var completed=await fetch(PATH+'/complete',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});var out=await completed.json();if(!completed.ok||!out.ok)throw new Error(out.error||'Approval failed');
+    status.textContent='Destination approved and held privately. You can close this tab.';document.getElementById('destination').value='';
+  }catch(e){status.textContent='Error: '+(e&&e.message?e.message:e);button.disabled=false}
+});
+</script></body></html>

--- a/crates/bloom-daemon/src/ceremony_server/private_input_ceremony.rs
+++ b/crates/bloom-daemon/src/ceremony_server/private_input_ceremony.rs
@@ -1,0 +1,416 @@
+//! Passkey-bound collection of Privacy Pools withdrawal destinations.
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::{Html, IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use base64::Engine as _;
+use bloom_auth_api::{
+    AssuranceLevel, CANONICAL_INTENT_HEADER_SCHEMA_V1, CanonicalEnvelope, CanonicalIntentHeader,
+    DaemonGrantTerms, ExecutorKind, PETAL_PETAL_ID_PREFIX, PetalPolicySnapshot, PolicyCheckClass,
+    PolicyCheckResult, SealedAction, SignerTransport, UnsignedApproval, WebAuthnAssertionRecord,
+};
+use rand::RngCore;
+use serde::Deserialize;
+
+use super::{CeremonyState, err_json, now_ms};
+
+const HTML: &str = include_str!("private_input_ceremony.html");
+const SURFACE: &str = "petal-private-input";
+
+pub(super) fn router() -> Router<CeremonyState> {
+    Router::new()
+        .route("/private-input/{token}", get(page))
+        .route("/private-input/{token}/request.json", get(request_json))
+        .route("/private-input/{token}/prepare", post(prepare))
+        .route("/private-input/{token}/complete", post(complete))
+        .layer(axum::middleware::from_fn(private_input_headers))
+}
+
+async fn private_input_headers(
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Response {
+    let mut response = next.run(req).await;
+    let headers = response.headers_mut();
+    headers.insert(
+        axum::http::header::CACHE_CONTROL,
+        axum::http::HeaderValue::from_static("no-store, no-cache, must-revalidate"),
+    );
+    headers.insert(
+        axum::http::header::CONTENT_SECURITY_POLICY,
+        axum::http::HeaderValue::from_static(
+            "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; connect-src 'self'; form-action 'none'; frame-ancestors 'none'; base-uri 'none'",
+        ),
+    );
+    headers.insert(
+        axum::http::header::REFERRER_POLICY,
+        axum::http::HeaderValue::from_static("no-referrer"),
+    );
+    headers.insert(
+        axum::http::header::X_CONTENT_TYPE_OPTIONS,
+        axum::http::HeaderValue::from_static("nosniff"),
+    );
+    headers.insert(
+        axum::http::header::HeaderName::from_static("x-frame-options"),
+        axum::http::HeaderValue::from_static("DENY"),
+    );
+    headers.insert(
+        axum::http::header::HeaderName::from_static("cross-origin-opener-policy"),
+        axum::http::HeaderValue::from_static("same-origin"),
+    );
+    response
+}
+
+fn private_error(error: bloom_petals::HostError) -> Response {
+    match error {
+        bloom_petals::HostError::NotFound(_) => err_json(StatusCode::NOT_FOUND, error.to_string()),
+        bloom_petals::HostError::Denied(_) => err_json(StatusCode::GONE, error.to_string()),
+        bloom_petals::HostError::Invalid(_) => err_json(StatusCode::BAD_REQUEST, error.to_string()),
+        bloom_petals::HostError::Backend(_) => err_json(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "private-input backend error",
+        ),
+    }
+}
+
+async fn page(State(state): State<CeremonyState>, Path(token): Path<String>) -> Response {
+    match state.daemon.private_inputs.metadata(&token, now_ms()) {
+        Ok(_) => Html(HTML).into_response(),
+        Err(error) => private_error(error),
+    }
+}
+
+async fn request_json(State(state): State<CeremonyState>, Path(token): Path<String>) -> Response {
+    match state.daemon.private_inputs.metadata(&token, now_ms()) {
+        Ok(metadata) => Json(serde_json::json!({
+            "title": metadata.title,
+            "prompt": metadata.prompt,
+            "note_wallet": metadata.wallet,
+            "approval_wallet": metadata.approval_wallet,
+            "kind": match metadata.kind {
+                bloom_petals::abi::PrivateInputKind::EvmAddress => "evm-address",
+            },
+            "expires_ms": metadata.expires_ms,
+        }))
+        .into_response(),
+        Err(error) => private_error(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bloom_petals::abi::{PetalRouteContext, PrivateInputKind};
+
+    fn metadata() -> crate::private_input::PrivateInputMetadata {
+        crate::private_input::PrivateInputMetadata {
+            token: "opaque-token".into(),
+            id: "privacy-pools/withdraw/dev/note-1".into(),
+            wallet: "dev".into(),
+            approval_wallet: "owner-passkey".into(),
+            title: "Private withdrawal".into(),
+            prompt: "Enter a destination".into(),
+            kind: PrivateInputKind::EvmAddress,
+            context: PetalRouteContext {
+                petal_root: "privacy-pools".into(),
+                package_hash: "ab".repeat(32),
+                route_id: "withdraw-private".into(),
+                op: "write".into(),
+                path: "withdrawals/dev/note-1.json".into(),
+                params: vec![],
+                actor: None,
+            },
+            expires_ms: 600_001,
+        }
+    }
+
+    #[test]
+    fn sealed_action_contains_digest_but_not_private_value() {
+        let private_value = "0x1111111111111111111111111111111111111111";
+        let digest = blake3::hash(private_value.as_bytes()).to_hex().to_string();
+        let action = private_input_action(&metadata(), &digest, 1).unwrap();
+        let encoded = serde_json::to_string(&action).unwrap();
+        assert!(encoded.contains(&digest));
+        assert_eq!(action.wallet(), "owner-passkey");
+        assert_eq!(action.envelope.header.account, "owner-passkey");
+        let subject = base64::engine::general_purpose::STANDARD
+            .decode(&action.envelope.subject_bytes_b64)
+            .unwrap();
+        let subject: serde_json::Value = serde_json::from_slice(&subject).unwrap();
+        assert_eq!(subject["note_wallet"], "dev");
+        assert_eq!(subject["approval_wallet"], "owner-passkey");
+        assert!(!encoded.contains(private_value));
+        assert!(!HTML.contains(private_value));
+    }
+
+    #[test]
+    fn page_posts_value_only_to_local_private_input_endpoint() {
+        assert!(HTML.contains("PATH+'/prepare'"));
+        assert!(HTML.contains("PATH+'/complete'"));
+        assert!(!HTML.contains("console.log"));
+        assert!(!HTML.contains("localStorage"));
+        assert!(HTML.contains("v.approval_wallet"));
+        assert!(HTML.contains("v.note_wallet"));
+        assert!(!HTML.contains("v.wallet"));
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PrepareBody {
+    value: String,
+}
+
+async fn prepare(
+    State(state): State<CeremonyState>,
+    Path(token): Path<String>,
+    Json(body): Json<PrepareBody>,
+) -> Response {
+    let now = now_ms();
+    let metadata = match state.daemon.private_inputs.metadata(&token, now) {
+        Ok(metadata) => metadata,
+        Err(error) => return private_error(error),
+    };
+    let value = match body.value.trim().parse::<alloy::primitives::Address>() {
+        Ok(address) if !address.is_zero() => format!("{address:#x}"),
+        _ => return err_json(StatusCode::BAD_REQUEST, "enter a non-zero Ethereum address"),
+    };
+    let value_digest = blake3::hash(value.as_bytes()).to_hex().to_string();
+    let action = match private_input_action(&metadata, &value_digest, now) {
+        Ok(action) => action,
+        Err(message) => return err_json(StatusCode::INTERNAL_SERVER_ERROR, message),
+    };
+    let writer = match state.daemon.auth_services.require_writer() {
+        Ok(writer) => writer,
+        Err(error) => return err_json(StatusCode::INTERNAL_SERVER_ERROR, error.to_string()),
+    };
+    if let Err(error) = writer.stage_action(action.clone(), now).await {
+        return err_json(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("stage private-input approval: {error}"),
+        );
+    }
+    let mut nonce = [0u8; 32];
+    rand::rngs::OsRng.fill_bytes(&mut nonce);
+    let challenge = match writer
+        .issue_challenge(
+            SURFACE,
+            action.action_id(),
+            &base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(nonce),
+            metadata.expires_ms,
+            now,
+        )
+        .await
+    {
+        Ok(challenge) => challenge,
+        Err(error) => {
+            return err_json(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("issue private-input approval challenge: {error}"),
+            );
+        }
+    };
+    let unsigned =
+        UnsignedApproval::for_challenge(&challenge, SignerTransport::BrowserWebauthn, None, None);
+    let prepared = match state
+        .daemon
+        .keystore
+        .sealed_ceremony_challenge(&metadata.approval_wallet, &unsigned)
+        .await
+    {
+        Ok(prepared) => prepared,
+        Err(error) => {
+            return err_json(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("prepare private-input passkey challenge: {error}"),
+            );
+        }
+    };
+    if let Err(error) = state
+        .daemon
+        .private_inputs
+        .set_prepared(&token, value, challenge, now)
+    {
+        return private_error(error);
+    }
+    match serde_json::from_str::<serde_json::Value>(&prepared.challenge_json) {
+        Ok(json) => Json(json).into_response(),
+        Err(_) => err_json(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "invalid private-input passkey challenge",
+        ),
+    }
+}
+
+#[derive(Deserialize)]
+struct BrowserCredentialResponse {
+    #[serde(rename = "authenticatorData")]
+    authenticator_data: String,
+    #[serde(rename = "clientDataJSON")]
+    client_data_json: String,
+    signature: String,
+    #[serde(rename = "userHandle", default)]
+    user_handle: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct BrowserCredential {
+    id: String,
+    response: BrowserCredentialResponse,
+}
+
+#[derive(Deserialize)]
+struct CompleteBody {
+    credential: BrowserCredential,
+}
+
+async fn complete(
+    State(state): State<CeremonyState>,
+    Path(token): Path<String>,
+    Json(body): Json<CompleteBody>,
+) -> Response {
+    let now = now_ms();
+    let challenge = match state.daemon.private_inputs.prepared_challenge(&token, now) {
+        Ok(challenge) => challenge,
+        Err(error) => return private_error(error),
+    };
+    let unsigned =
+        UnsignedApproval::for_challenge(&challenge, SignerTransport::BrowserWebauthn, None, None);
+    let assertion = WebAuthnAssertionRecord {
+        credential_id: body.credential.id,
+        authenticator_data_b64: body.credential.response.authenticator_data,
+        client_data_json_b64: body.credential.response.client_data_json,
+        signature_b64: body.credential.response.signature,
+        user_handle_b64: body.credential.response.user_handle,
+    };
+    if let Err(error) = assertion.validate_challenge(&unsigned) {
+        return err_json(
+            StatusCode::BAD_REQUEST,
+            format!("assertion challenge mismatch: {error}"),
+        );
+    }
+    let verifier = match state.daemon.auth_services.require_approval_verifier() {
+        Ok(verifier) => verifier,
+        Err(error) => return err_json(StatusCode::INTERNAL_SERVER_ERROR, error.to_string()),
+    };
+    let grants = match state.daemon.auth_services.require_grant_store() {
+        Ok(grants) => grants,
+        Err(error) => return err_json(StatusCode::INTERNAL_SERVER_ERROR, error.to_string()),
+    };
+    let signed = unsigned.into_signed(assertion);
+    let grant = match verifier
+        .verify_and_mint_grant(signed, grants.as_ref(), now)
+        .await
+    {
+        Ok(grant) => grant,
+        Err(error) => {
+            return err_json(
+                StatusCode::UNAUTHORIZED,
+                format!("verify private-input approval: {error}"),
+            );
+        }
+    };
+    if let Err(error) = state
+        .daemon
+        .private_inputs
+        .complete(&token, &challenge.action_id, now)
+    {
+        let _ = grants.revoke(&grant.grant_id, now).await;
+        return private_error(error);
+    }
+    // The grant authorizes no later signing operation; consume its nonce and
+    // revoke it immediately after promoting the private value.
+    if let Err(error) = grants.revoke(&grant.grant_id, now).await {
+        tracing::warn!(err = %error, "private_input.grant_revoke_failed");
+    }
+    Json(serde_json::json!({ "ok": true, "status": "ready" })).into_response()
+}
+
+fn private_input_action(
+    metadata: &crate::private_input::PrivateInputMetadata,
+    value_digest: &str,
+    now_ms: u64,
+) -> Result<SealedAction, String> {
+    let mut action_hasher = blake3::Hasher::new();
+    action_hasher.update(b"bloom.private_input.approval.v1");
+    action_hasher.update(metadata.token.as_bytes());
+    action_hasher.update(value_digest.as_bytes());
+    action_hasher.update(&metadata.expires_ms.to_be_bytes());
+    let action_id = format!("private-input-{}", action_hasher.finalize().to_hex());
+    let petal_id = format!("{PETAL_PETAL_ID_PREFIX}{}", metadata.context.petal_root);
+    let header = CanonicalIntentHeader {
+        schema: CANONICAL_INTENT_HEADER_SCHEMA_V1.into(),
+        wallet: metadata.approval_wallet.clone(),
+        surface: SURFACE.into(),
+        action_id,
+        petal_id,
+        petal_digest: metadata.context.package_hash.clone(),
+        petal_version: "v1-package".into(),
+        executor_kind: ExecutorKind::Wasm,
+        network: "eip155:1".into(),
+        account: metadata.approval_wallet.clone(),
+        action_kind: "petal.private_input".into(),
+        value_movement: true,
+        authority_change: false,
+        expires_ms: metadata.expires_ms,
+    };
+    let subject = serde_json::to_vec(&serde_json::json!({
+        "schema": "bloom.private_input.subject.v1",
+        "input_id": metadata.id,
+        "note_wallet": metadata.wallet,
+        "approval_wallet": metadata.approval_wallet,
+        "input_kind": "evm_address",
+        "value_digest": value_digest,
+        "petal_root": metadata.context.petal_root,
+        "package_hash": metadata.context.package_hash,
+        "route_id": metadata.context.route_id,
+        "path": metadata.context.path,
+    }))
+    .map_err(|error| format!("encode private-input approval: {error}"))?;
+    let envelope = CanonicalEnvelope::new(
+        header,
+        "petal_private_input",
+        "bloom.private_input.subject.v1",
+        subject,
+    );
+    let mut terms = DaemonGrantTerms::minimal(AssuranceLevel::Standard);
+    terms.max_ttl_secs = crate::private_input::PRIVATE_INPUT_TTL_MS / 1_000;
+    terms.max_signatures = 1;
+    terms.extra.insert(
+        "required.private_input_digest".into(),
+        serde_json::Value::String(value_digest.into()),
+    );
+    let mut snapshot = PetalPolicySnapshot::minimal(&envelope.header);
+    snapshot.config.insert(
+        "private_input_kind".into(),
+        serde_json::Value::String("evm_address".into()),
+    );
+    let plan = format!(
+        "# Approve private Privacy Pools destination\n\nPetal: `{}`\nRoute: `{}`\nNote wallet: `{}`\nApproval wallet: `{}`\nInput: `{}`\nValue digest: `{}`\n\nThe destination remains private to Bloom and the Privacy Pools helper. Verify the address shown in this browser before approving.",
+        metadata.context.petal_root,
+        metadata.context.route_id,
+        metadata.wallet,
+        metadata.approval_wallet,
+        metadata.id,
+        value_digest,
+    );
+    SealedAction::new(
+        envelope,
+        plan,
+        vec![PolicyCheckResult {
+            rule_id: "privacy-pools.private_destination".into(),
+            rule_class: PolicyCheckClass::Informational,
+            outcome: "pass".into(),
+            message:
+                "destination value is bound by digest and omitted from agent-visible projections"
+                    .into(),
+            step_up_ceiling: None,
+        }],
+        terms,
+        snapshot,
+        now_ms,
+    )
+    .map_err(|error| format!("seal private-input approval: {error}"))
+}

--- a/crates/bloom-daemon/src/lib.rs
+++ b/crates/bloom-daemon/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod ceremony_server;
 pub mod ipc;
+mod private_input;
 pub mod registration;
 pub mod sealed_ceremony;
 pub mod sign_hash;
@@ -18,7 +19,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use alloy::network::TransactionBuilder;
-use alloy::primitives::{Address, Bytes, U256};
+use alloy::primitives::{Address, B256, Bytes, U256};
 use alloy::rpc::types::eth::TransactionRequest;
 #[cfg(feature = "unsafe-debug-signer")]
 use alloy::signers::SignerSync;
@@ -37,11 +38,11 @@ use bloom_evm::{ChainClient, ChainRegistry};
 
 use bloom_ens::EnsClient;
 use bloom_etherscan::EtherscanClient;
-use bloom_keystore::{Keystore, KeystoreApprovalSignatureVerifier};
+use bloom_keystore::{Keystore, KeystoreApprovalSignatureVerifier, WalletKind};
 use bloom_paid_http::PaidHttpChainRpcResolver;
 use bloom_petals::abi::{
     ApprovalRequired, ChainRequest, ChainResponse, EvmOutboxInspection, EvmOutboxOutcome,
-    EvmTransactionRequest, PetalRouteContext,
+    EvmTransactionRequest, PetalRouteContext, PrivateInputOutcome, PrivateInputRequest,
 };
 use bloom_petals::{
     HostError, HostVfsEntry, HttpRequest, HttpResponse, LateVfsHost, NameRegistry, NetPolicy,
@@ -264,6 +265,8 @@ struct DaemonPetalHost {
     tx_stage_lock: tokio::sync::Mutex<()>,
     sign_batch_lock: tokio::sync::Mutex<()>,
     petal_action_identities: Mutex<PetalActionIdentityCache>,
+    private_inputs: Arc<private_input::PrivateInputManager>,
+    keystore: Option<Keystore>,
     #[cfg(feature = "unsafe-debug-signer")]
     unsafe_debug_signer: Option<(String, Arc<PrivateKeySigner>)>,
 }
@@ -293,9 +296,24 @@ impl DaemonPetalHost {
             tx_stage_lock: tokio::sync::Mutex::new(()),
             sign_batch_lock: tokio::sync::Mutex::new(()),
             petal_action_identities: Mutex::new(PetalActionIdentityCache::default()),
+            private_inputs: Arc::new(private_input::PrivateInputManager::default()),
+            keystore: None,
             #[cfg(feature = "unsafe-debug-signer")]
             unsafe_debug_signer: None,
         }
+    }
+
+    fn with_private_inputs(
+        mut self,
+        private_inputs: Arc<private_input::PrivateInputManager>,
+    ) -> Self {
+        self.private_inputs = private_inputs;
+        self
+    }
+
+    fn with_keystore(mut self, keystore: Keystore) -> Self {
+        self.keystore = Some(keystore);
+        self
     }
 
     fn with_tx_outbox(mut self, tx_outbox: PetalTxOutbox) -> Self {
@@ -973,6 +991,40 @@ impl PetalHost for DaemonPetalHost {
         unreachable!("bounded redirect loop returns before exhausting iterator")
     }
 
+    async fn private_input_request(
+        &self,
+        mut req: PrivateInputRequest,
+    ) -> Result<PrivateInputOutcome, HostError> {
+        let wallets = self
+            .keystore
+            .as_ref()
+            .ok_or_else(|| HostError::Backend("private-input keystore is unavailable".into()))?
+            .list()
+            .map_err(|error| HostError::Backend(format!("list approval wallets: {error}")))?;
+        req.approval_wallet = Some(choose_private_input_approval_wallet(
+            req.approval_wallet.as_deref(),
+            &req.wallet,
+            wallets.into_iter().map(|wallet| (wallet.name, wallet.kind)),
+        )?);
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_millis() as u64)
+            .unwrap_or(0);
+        self.private_inputs.request(req, now_ms)
+    }
+
+    async fn private_input_consume(
+        &self,
+        id: String,
+        context: Option<PetalRouteContext>,
+    ) -> Result<(), HostError> {
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_millis() as u64)
+            .unwrap_or(0);
+        self.private_inputs.consume(&id, context, now_ms)
+    }
+
     async fn sign_hash(&self, req: SignRequest) -> Result<Vec<u8>, HostError> {
         match self.sign_hash_outcome(req).await? {
             SignOutcome::Signature(signature) => Ok(signature),
@@ -1465,6 +1517,38 @@ impl PetalHost for DaemonPetalHost {
     }
 }
 
+fn choose_private_input_approval_wallet(
+    requested: Option<&str>,
+    note_wallet: &str,
+    wallets: impl IntoIterator<Item = (String, WalletKind)>,
+) -> Result<String, HostError> {
+    let passkeys = wallets
+        .into_iter()
+        .filter_map(|(name, kind)| (kind == WalletKind::PasskeyGated).then_some(name))
+        .collect::<Vec<_>>();
+    if let Some(requested) = requested {
+        return passkeys
+            .iter()
+            .find(|name| name.as_str() == requested)
+            .cloned()
+            .ok_or_else(|| {
+                HostError::Denied("approval_wallet does not name a passkey wallet".into())
+            });
+    }
+    if passkeys.iter().any(|name| name == note_wallet) {
+        return Ok(note_wallet.to_string());
+    }
+    match passkeys.as_slice() {
+        [] => Err(HostError::Denied(
+            "private input requires a passkey wallet; create one or set approval_wallet".into(),
+        )),
+        [only] => Ok(only.clone()),
+        _ => Err(HostError::Invalid(
+            "multiple passkey wallets exist; set approval_wallet explicitly".into(),
+        )),
+    }
+}
+
 #[derive(serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 struct PetalEthCall {
@@ -1487,13 +1571,13 @@ async fn daemon_petal_chain_read(
     let params: Vec<serde_json::Value> = serde_json::from_str(params_json)
         .map_err(|e| HostError::Invalid(format!("chain params-json must be an array: {e}")))?;
     let result = match method {
-        "eth_chainId" if params.is_empty() => format!(
+        "eth_chainId" if params.is_empty() => serde_json::Value::String(format!(
             "0x{:x}",
             chain
                 .chain_id()
                 .await
                 .map_err(|e| HostError::Backend(format!("chain id: {e}")))?
-        ),
+        )),
         "eth_getBalance" if matches!(params.len(), 1 | 2) => {
             require_latest_block_param(&params, 1)?;
             let address = parse_petal_address(&params[0], "eth_getBalance address")?;
@@ -1501,7 +1585,7 @@ async fn daemon_petal_chain_read(
                 .balance(address)
                 .await
                 .map_err(|e| HostError::Backend(format!("native balance: {e}")))?;
-            format!("{balance:#x}")
+            serde_json::Value::String(format!("{balance:#x}"))
         }
         "eth_getCode" if matches!(params.len(), 1 | 2) => {
             require_latest_block_param(&params, 1)?;
@@ -1510,7 +1594,7 @@ async fn daemon_petal_chain_read(
                 .code(address)
                 .await
                 .map_err(|e| HostError::Backend(format!("contract code: {e}")))?;
-            format!("0x{}", hex::encode(code))
+            serde_json::Value::String(format!("0x{}", hex::encode(code)))
         }
         "eth_call" if matches!(params.len(), 1 | 2) => {
             require_latest_block_param(&params, 1)?;
@@ -1541,9 +1625,27 @@ async fn daemon_petal_chain_read(
                 .eth_call_at_block(tx, Some("latest"))
                 .await
                 .map_err(|e| HostError::Backend(format!("eth_call: {e}")))?;
-            format!("0x{}", hex::encode(bytes))
+            serde_json::Value::String(format!("0x{}", hex::encode(bytes)))
         }
-        "eth_chainId" | "eth_getBalance" | "eth_getCode" | "eth_call" => {
+        "eth_getTransactionReceipt" if params.len() == 1 => {
+            let hash = params[0]
+                .as_str()
+                .ok_or_else(|| {
+                    HostError::Invalid("eth_getTransactionReceipt hash must be a string".into())
+                })?
+                .parse::<B256>()
+                .map_err(|e| HostError::Invalid(format!("eth_getTransactionReceipt hash: {e}")))?;
+            chain
+                .receipt_json(hash)
+                .await
+                .map_err(|e| HostError::Backend(format!("eth_getTransactionReceipt: {e}")))?
+                .unwrap_or(serde_json::Value::Null)
+        }
+        "eth_chainId"
+        | "eth_getBalance"
+        | "eth_getCode"
+        | "eth_call"
+        | "eth_getTransactionReceipt" => {
             return Err(HostError::Invalid(format!(
                 "invalid {method} parameters; only latest-block reads are allowed"
             )));
@@ -1736,6 +1838,7 @@ pub struct Daemon {
     pub audit: Arc<AuditLog>,
     pub auth_services: AuthServices,
     pub signer_cache: Arc<bloom_keystore::petal_host::SignerCache>,
+    pub(crate) private_inputs: Arc<private_input::PrivateInputManager>,
     pub vfs: Vfs,
     pub petals: PetalRunner,
     pub watch_registry: Arc<WatchRegistry>,
@@ -2289,11 +2392,14 @@ impl Daemon {
         let petal_vm = PetalVm::new().map_err(|e| DaemonError::Audit(format!("petals vm: {e}")))?;
         let petals = PetalRunner::new(petal_store.clone(), petal_registry.clone(), petal_vm);
         let petal_vfs_host = Arc::new(LateVfsHost::new());
+        let private_inputs = Arc::new(private_input::PrivateInputManager::default());
         let petal_app_host = DaemonPetalHost::new(
             petal_vfs_host.clone(),
             audit_arc.clone(),
             auth_services.clone(),
         )
+        .with_private_inputs(private_inputs.clone())
+        .with_keystore(keystore.clone())
         .with_tx_outbox(PetalTxOutbox {
             tx_engine: tx_engine.clone(),
             chains: chains.clone(),
@@ -2663,6 +2769,7 @@ impl Daemon {
             audit: audit_arc,
             auth_services,
             signer_cache,
+            private_inputs,
             vfs,
             petals,
             watch_registry,
@@ -2961,6 +3068,38 @@ mod tests {
     use bloom_vfs::handler::Handler;
 
     #[test]
+    fn private_input_approval_wallet_is_unambiguous_and_passkey_only() {
+        let wallets = || {
+            vec![
+                ("dev".to_string(), WalletKind::Local),
+                ("owner".to_string(), WalletKind::PasskeyGated),
+            ]
+        };
+        assert_eq!(
+            choose_private_input_approval_wallet(None, "dev", wallets()).unwrap(),
+            "owner"
+        );
+        assert_eq!(
+            choose_private_input_approval_wallet(Some("owner"), "dev", wallets()).unwrap(),
+            "owner"
+        );
+        assert!(choose_private_input_approval_wallet(Some("dev"), "dev", wallets()).is_err());
+    }
+
+    #[test]
+    fn private_input_prefers_passkey_note_wallet_but_rejects_ambiguous_fallback() {
+        let wallets = vec![
+            ("note".to_string(), WalletKind::PasskeyGated),
+            ("other".to_string(), WalletKind::PasskeyGated),
+        ];
+        assert_eq!(
+            choose_private_input_approval_wallet(None, "note", wallets.clone()).unwrap(),
+            "note"
+        );
+        assert!(choose_private_input_approval_wallet(None, "dev", wallets).is_err());
+    }
+
+    #[test]
     fn approval_error_display_text_cannot_trigger_ceremony_routing() {
         let error = bloom_tx::TxEngineError::ApprovalServiceUnavailable(
             "Sealed Approval is mentioned, but no ceremony can recover this".into(),
@@ -3143,7 +3282,10 @@ mod tests {
         // lifecycle cannot be revived.
         let (after_expiry, _) = host.petal_action(&req, ctx, start.expires_ms).unwrap();
         assert_ne!(start.action_id(), after_expiry.action_id());
-        assert_eq!(after_expiry.expires_ms, start.expires_ms + PETAL_ACTION_TTL_MS);
+        assert_eq!(
+            after_expiry.expires_ms,
+            start.expires_ms + PETAL_ACTION_TTL_MS
+        );
     }
 
     #[test]
@@ -3397,6 +3539,8 @@ mod tests {
                 "eth_call",
                 r#"[{"to":"0x0000000000000000000000000000000000000001","stateOverride":{}},"latest"]"#,
             ),
+            ("eth_getTransactionReceipt", "[]"),
+            ("eth_getTransactionReceipt", r#"["not-a-transaction-hash"]"#),
         ] {
             let error = host
                 .chain_read(ChainRequest {
@@ -3510,6 +3654,7 @@ mod tests {
             tx_hash: tx_hash.clone(),
             block_number: Some(42),
             revert_reason: None,
+            logs: None,
         };
         daemon
             .tx_engine

--- a/crates/bloom-daemon/src/private_input.rs
+++ b/crates/bloom-daemon/src/private_input.rs
@@ -1,0 +1,439 @@
+//! Daemon-owned, capability-gated private input sessions for Petal routes.
+//!
+//! Session values are held only in daemon memory. Public callers receive a
+//! bearer URL and lifecycle metadata; the value is released solely through the
+//! mediated Petal host call bound to the originating package and route.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use base64::Engine as _;
+use bloom_auth_api::ApprovalChallenge;
+use bloom_petals::HostError;
+use bloom_petals::abi::{
+    PendingPrivateInput, PetalRouteContext, PrivateInputKind, PrivateInputOutcome,
+    PrivateInputRequest,
+};
+use rand::RngCore;
+use zeroize::Zeroizing;
+
+use crate::ceremony_server::private_input_url;
+
+pub(crate) const PRIVATE_INPUT_TTL_MS: u64 = 10 * 60 * 1000;
+const MAX_ACTIVE_PRIVATE_INPUTS: usize = 64;
+const ALLOWED_PETAL_ROOT: &str = "privacy-pools";
+
+#[derive(Clone)]
+pub(crate) struct PrivateInputMetadata {
+    pub token: String,
+    pub id: String,
+    pub wallet: String,
+    pub approval_wallet: String,
+    pub title: String,
+    pub prompt: String,
+    pub kind: PrivateInputKind,
+    pub context: PetalRouteContext,
+    pub expires_ms: u64,
+}
+
+enum PrivateInputState {
+    Awaiting,
+    Prepared {
+        value: Zeroizing<String>,
+        challenge: Box<ApprovalChallenge>,
+    },
+    Ready {
+        value: Zeroizing<String>,
+    },
+}
+
+struct PrivateInputSession {
+    metadata: PrivateInputMetadata,
+    fingerprint: [u8; 32],
+    state: PrivateInputState,
+}
+
+#[derive(Default)]
+pub(crate) struct PrivateInputManager {
+    sessions: Mutex<HashMap<String, PrivateInputSession>>,
+}
+
+impl PrivateInputManager {
+    pub fn request(
+        &self,
+        request: PrivateInputRequest,
+        now_ms: u64,
+    ) -> Result<PrivateInputOutcome, HostError> {
+        let context = validate_request(&request)?;
+        let fingerprint = request_fingerprint(&request, &context)?;
+        let mut sessions = self
+            .sessions
+            .lock()
+            .map_err(|_| HostError::Backend("private-input session lock poisoned".into()))?;
+        sessions.retain(|_, session| session.metadata.expires_ms > now_ms);
+
+        if let Some(session) = sessions
+            .values()
+            .find(|session| session.fingerprint == fingerprint)
+        {
+            return Ok(outcome(session));
+        }
+        if sessions.len() >= MAX_ACTIVE_PRIVATE_INPUTS {
+            return Err(HostError::Backend(
+                "too many active private-input ceremonies".into(),
+            ));
+        }
+
+        let expires_ms = now_ms
+            .checked_add(PRIVATE_INPUT_TTL_MS)
+            .ok_or_else(|| HostError::Backend("private-input expiry overflow".into()))?;
+        let mut token_bytes = [0u8; 32];
+        rand::rngs::OsRng.fill_bytes(&mut token_bytes);
+        let token = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(token_bytes);
+        let metadata = PrivateInputMetadata {
+            token: token.clone(),
+            id: request.id,
+            wallet: request.wallet,
+            approval_wallet: request.approval_wallet.ok_or_else(|| {
+                HostError::Invalid("private-input approval wallet was not resolved".into())
+            })?,
+            title: request.title,
+            prompt: request.prompt,
+            kind: request.kind,
+            context,
+            expires_ms,
+        };
+        sessions.insert(
+            token,
+            PrivateInputSession {
+                metadata: metadata.clone(),
+                fingerprint,
+                state: PrivateInputState::Awaiting,
+            },
+        );
+        Ok(PrivateInputOutcome::Pending(PendingPrivateInput {
+            ceremony_url: private_input_url(&metadata.token),
+            expires_ms,
+        }))
+    }
+
+    pub fn metadata(&self, token: &str, now_ms: u64) -> Result<PrivateInputMetadata, HostError> {
+        let mut sessions = self
+            .sessions
+            .lock()
+            .map_err(|_| HostError::Backend("private-input session lock poisoned".into()))?;
+        let expired = sessions
+            .get(token)
+            .is_some_and(|session| session.metadata.expires_ms <= now_ms);
+        if expired {
+            sessions.remove(token);
+            return Err(HostError::Denied("private-input ceremony expired".into()));
+        }
+        sessions
+            .get(token)
+            .map(|session| session.metadata.clone())
+            .ok_or_else(|| HostError::NotFound("private-input ceremony".into()))
+    }
+
+    pub fn set_prepared(
+        &self,
+        token: &str,
+        value: String,
+        challenge: ApprovalChallenge,
+        now_ms: u64,
+    ) -> Result<(), HostError> {
+        let mut sessions = self
+            .sessions
+            .lock()
+            .map_err(|_| HostError::Backend("private-input session lock poisoned".into()))?;
+        let session = sessions
+            .get_mut(token)
+            .ok_or_else(|| HostError::NotFound("private-input ceremony".into()))?;
+        if session.metadata.expires_ms <= now_ms {
+            return Err(HostError::Denied("private-input ceremony expired".into()));
+        }
+        if matches!(session.state, PrivateInputState::Ready { .. }) {
+            return Err(HostError::Denied(
+                "private-input ceremony already completed".into(),
+            ));
+        }
+        session.state = PrivateInputState::Prepared {
+            value: Zeroizing::new(value),
+            challenge: Box::new(challenge),
+        };
+        Ok(())
+    }
+
+    pub fn prepared_challenge(
+        &self,
+        token: &str,
+        now_ms: u64,
+    ) -> Result<ApprovalChallenge, HostError> {
+        let sessions = self
+            .sessions
+            .lock()
+            .map_err(|_| HostError::Backend("private-input session lock poisoned".into()))?;
+        let session = sessions
+            .get(token)
+            .ok_or_else(|| HostError::NotFound("private-input ceremony".into()))?;
+        if session.metadata.expires_ms <= now_ms {
+            return Err(HostError::Denied("private-input ceremony expired".into()));
+        }
+        match &session.state {
+            PrivateInputState::Prepared { challenge, .. } => Ok(challenge.as_ref().clone()),
+            PrivateInputState::Awaiting => Err(HostError::Invalid(
+                "private-input value has not been prepared".into(),
+            )),
+            PrivateInputState::Ready { .. } => Err(HostError::Denied(
+                "private-input ceremony already completed".into(),
+            )),
+        }
+    }
+
+    pub fn complete(&self, token: &str, action_id: &str, now_ms: u64) -> Result<(), HostError> {
+        let mut sessions = self
+            .sessions
+            .lock()
+            .map_err(|_| HostError::Backend("private-input session lock poisoned".into()))?;
+        let session = sessions
+            .get_mut(token)
+            .ok_or_else(|| HostError::NotFound("private-input ceremony".into()))?;
+        if session.metadata.expires_ms <= now_ms {
+            return Err(HostError::Denied("private-input ceremony expired".into()));
+        }
+        let state = std::mem::replace(&mut session.state, PrivateInputState::Awaiting);
+        match state {
+            PrivateInputState::Prepared { value, challenge }
+                if challenge.action_id == action_id =>
+            {
+                session.state = PrivateInputState::Ready { value };
+                Ok(())
+            }
+            other => {
+                session.state = other;
+                Err(HostError::Denied(
+                    "private-input approval does not match the prepared value".into(),
+                ))
+            }
+        }
+    }
+
+    pub fn consume(
+        &self,
+        id: &str,
+        context: Option<PetalRouteContext>,
+        now_ms: u64,
+    ) -> Result<(), HostError> {
+        let context = context.ok_or_else(|| {
+            HostError::Denied("private-input consume requires trusted route context".into())
+        })?;
+        let mut sessions = self
+            .sessions
+            .lock()
+            .map_err(|_| HostError::Backend("private-input session lock poisoned".into()))?;
+        let token = sessions
+            .iter()
+            .find(|(_, session)| {
+                session.metadata.id == id
+                    && same_origin(&session.metadata.context, &context)
+                    && session.metadata.expires_ms > now_ms
+                    && matches!(session.state, PrivateInputState::Ready { .. })
+            })
+            .map(|(token, _)| token.clone())
+            .ok_or_else(|| HostError::NotFound("ready private-input session".into()))?;
+        sessions.remove(&token);
+        Ok(())
+    }
+}
+
+fn validate_request(request: &PrivateInputRequest) -> Result<PetalRouteContext, HostError> {
+    let context = request.context.clone().ok_or_else(|| {
+        HostError::Denied("private-input request requires trusted route context".into())
+    })?;
+    if context.petal_root != ALLOWED_PETAL_ROOT {
+        return Err(HostError::Denied(
+            "private-input ceremonies are restricted to the privacy-pools petal".into(),
+        ));
+    }
+    if request.id.is_empty()
+        || request.id.len() > 256
+        || request.id.starts_with('/')
+        || request.id.contains('\0')
+        || request
+            .id
+            .split('/')
+            .any(|part| part.is_empty() || part == "." || part == "..")
+    {
+        return Err(HostError::Invalid("invalid private-input id".into()));
+    }
+    if request.wallet.is_empty() || request.wallet.len() > 128 {
+        return Err(HostError::Invalid("invalid private-input wallet".into()));
+    }
+    if request
+        .approval_wallet
+        .as_ref()
+        .is_none_or(|wallet| wallet.is_empty() || wallet.len() > 64)
+    {
+        return Err(HostError::Invalid(
+            "private-input approval wallet must name a passkey wallet".into(),
+        ));
+    }
+    if request.title.is_empty() || request.title.len() > 120 {
+        return Err(HostError::Invalid("invalid private-input title".into()));
+    }
+    if request.prompt.is_empty() || request.prompt.len() > 500 {
+        return Err(HostError::Invalid("invalid private-input prompt".into()));
+    }
+    Ok(context)
+}
+
+fn request_fingerprint(
+    request: &PrivateInputRequest,
+    context: &PetalRouteContext,
+) -> Result<[u8; 32], HostError> {
+    let encoded = serde_json::to_vec(&serde_json::json!({
+        "domain": "bloom.private_input.request.v1",
+        "id": request.id,
+        "wallet": request.wallet,
+        "approval_wallet": request.approval_wallet,
+        "title": request.title,
+        "prompt": request.prompt,
+        "kind": match request.kind { PrivateInputKind::EvmAddress => "evm_address" },
+        "petal_root": context.petal_root,
+        "package_hash": context.package_hash,
+        "route_id": context.route_id,
+        "op": context.op,
+        "path": context.path,
+        "params": context.params,
+        "actor": context.actor,
+    }))
+    .map_err(|error| HostError::Backend(format!("encode private-input request: {error}")))?;
+    Ok(*blake3::hash(&encoded).as_bytes())
+}
+
+fn same_origin(left: &PetalRouteContext, right: &PetalRouteContext) -> bool {
+    left.petal_root == right.petal_root
+        && left.package_hash == right.package_hash
+        && left.route_id == right.route_id
+        && left.op == right.op
+        && left.path == right.path
+        && left.params == right.params
+        && left.actor == right.actor
+}
+
+fn outcome(session: &PrivateInputSession) -> PrivateInputOutcome {
+    match &session.state {
+        PrivateInputState::Ready { value } => PrivateInputOutcome::Ready(value.to_string()),
+        PrivateInputState::Awaiting | PrivateInputState::Prepared { .. } => {
+            PrivateInputOutcome::Pending(PendingPrivateInput {
+                ceremony_url: private_input_url(&session.metadata.token),
+                expires_ms: session.metadata.expires_ms,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bloom_auth_api::{APPROVAL_CHALLENGE_SCHEMA_V1, AssuranceLevel};
+
+    fn request() -> PrivateInputRequest {
+        PrivateInputRequest {
+            id: "privacy-pools/withdraw/dev/note-1".into(),
+            wallet: "dev".into(),
+            approval_wallet: Some("owner-passkey".into()),
+            title: "Private withdrawal destination".into(),
+            prompt: "Enter the destination address".into(),
+            kind: PrivateInputKind::EvmAddress,
+            context: Some(PetalRouteContext {
+                petal_root: "privacy-pools".into(),
+                package_hash: "ab".repeat(32),
+                route_id: "withdraw-private".into(),
+                op: "write".into(),
+                path: "private-withdrawals/dev/note-1.json".into(),
+                params: vec![],
+                actor: None,
+            }),
+        }
+    }
+
+    #[test]
+    fn request_is_stable_and_redacted() {
+        let manager = PrivateInputManager::default();
+        let first = manager.request(request(), 1).unwrap();
+        let second = manager.request(request(), 2).unwrap();
+        assert_eq!(first, second);
+        let json = format!("{first:?}");
+        assert!(!json.contains("0x"));
+    }
+
+    #[test]
+    fn rejects_other_petals() {
+        let manager = PrivateInputManager::default();
+        let mut request = request();
+        request.context.as_mut().unwrap().petal_root = "anything-else".into();
+        assert!(matches!(
+            manager.request(request, 1),
+            Err(HostError::Denied(_))
+        ));
+    }
+
+    fn challenge(action_id: &str) -> ApprovalChallenge {
+        ApprovalChallenge {
+            schema: APPROVAL_CHALLENGE_SCHEMA_V1.into(),
+            action_id: action_id.into(),
+            wallet: "dev".into(),
+            surface: "petal-private-input".into(),
+            petal_id: "pkg:privacy-pools".into(),
+            petal_digest: "ab".repeat(32),
+            intent_hash: "cd".repeat(32),
+            server_nonce: "nonce".into(),
+            assurance: AssuranceLevel::Standard,
+            daemon_terms_digest: "ef".repeat(32),
+            petal_policy_digest: "12".repeat(32),
+            policy_version: 0,
+            expiry_ms: 600_001,
+            ceremony_url: None,
+        }
+    }
+
+    #[test]
+    fn ready_value_is_origin_bound_and_single_use() {
+        let manager = PrivateInputManager::default();
+        let request = request();
+        let context = request.context.clone();
+        let pending = manager.request(request.clone(), 1).unwrap();
+        let PrivateInputOutcome::Pending(pending) = pending else {
+            panic!("expected pending");
+        };
+        let token = pending.ceremony_url.rsplit('/').next().unwrap();
+        manager
+            .set_prepared(
+                token,
+                "0x1111111111111111111111111111111111111111".into(),
+                challenge("action-1"),
+                2,
+            )
+            .unwrap();
+        assert!(manager.complete(token, "wrong-action", 3).is_err());
+        manager.complete(token, "action-1", 3).unwrap();
+        assert!(matches!(
+            manager.request(request, 4).unwrap(),
+            PrivateInputOutcome::Ready(value)
+                if value == "0x1111111111111111111111111111111111111111"
+        ));
+
+        let mut wrong_context = context.clone().unwrap();
+        wrong_context.package_hash = "ff".repeat(32);
+        assert!(
+            manager
+                .consume("privacy-pools/withdraw/dev/note-1", Some(wrong_context), 5,)
+                .is_err()
+        );
+        manager
+            .consume("privacy-pools/withdraw/dev/note-1", context, 5)
+            .unwrap();
+        assert!(manager.metadata(token, 6).is_err());
+    }
+}

--- a/crates/bloom-daemon/src/registration.rs
+++ b/crates/bloom-daemon/src/registration.rs
@@ -1546,8 +1546,15 @@ mod tests {
         // recovery-ack deadline (300_000ms out) outlives the original
         // SESSION_TTL_MS (also 300_000ms in these tests) only if we push
         // "now" past the original expiry but before the ack deadline.
-        stage_and_finalize_directly(&coordinator, "alice", "0xabc", "receipt-1", 1_000, SESSION_TTL_MS + 300_000)
-            .await;
+        stage_and_finalize_directly(
+            &coordinator,
+            "alice",
+            "0xabc",
+            "receipt-1",
+            1_000,
+            SESSION_TTL_MS + 300_000,
+        )
+        .await;
 
         // Past the original ceremony deadline, but still within the ack
         // window: must NOT be treated as dead.

--- a/crates/bloom-evm/src/lib.rs
+++ b/crates/bloom-evm/src/lib.rs
@@ -1086,11 +1086,15 @@ mod tests {
         let r = ChainRegistry::new();
         r.add(c);
         assert!(r.get("ethereum").is_some());
-        assert!(r.get("mainnet").is_some(), "'mainnet' must alias to 'ethereum'");
+        assert!(
+            r.get("mainnet").is_some(),
+            "'mainnet' must alias to 'ethereum'"
+        );
         assert!(r.get("eth").is_some(), "'eth' must alias to 'ethereum'");
         assert!(r.get("sepolia").is_none(), "unknown names still miss");
         assert_eq!(
-            r.get("mainnet").unwrap().spec().name, "ethereum",
+            r.get("mainnet").unwrap().spec().name,
+            "ethereum",
             "alias resolves to the ethereum client",
         );
     }

--- a/crates/bloom-petals/src/abi.rs
+++ b/crates/bloom-petals/src/abi.rs
@@ -121,6 +121,34 @@ pub struct ChainResponse {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrivateInputKind {
+    EvmAddress,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrivateInputRequest {
+    pub id: String,
+    pub wallet: String,
+    pub approval_wallet: Option<String>,
+    pub title: String,
+    pub prompt: String,
+    pub kind: PrivateInputKind,
+    pub context: Option<PetalRouteContext>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingPrivateInput {
+    pub ceremony_url: String,
+    pub expires_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PrivateInputOutcome {
+    Pending(PendingPrivateInput),
+    Ready(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DispatchOp {
     Lookup,
     List,

--- a/crates/bloom-petals/src/host.rs
+++ b/crates/bloom-petals/src/host.rs
@@ -10,8 +10,8 @@ use async_trait::async_trait;
 
 use crate::abi::{
     ChainRequest, ChainResponse, EvmOutboxInspection, EvmOutboxOutcome, EvmTransactionRequest,
-    HttpRequest, HttpResponse, PetalRouteContext, SignBatchOutcome, SignBatchRequest, SignOutcome,
-    SignRequest,
+    HttpRequest, HttpResponse, PetalRouteContext, PrivateInputOutcome, PrivateInputRequest,
+    SignBatchOutcome, SignBatchRequest, SignOutcome, SignRequest,
 };
 use crate::policy::NetPolicy;
 
@@ -140,6 +140,26 @@ pub trait PetalHost: Send + Sync {
     /// opt in explicitly so chain RPC access remains policy mediated.
     async fn chain_read(&self, _req: ChainRequest) -> Result<ChainResponse, HostError> {
         Err(HostError::Denied("chain_read".into()))
+    }
+
+    /// Request owner-supplied data through a daemon-owned private ceremony.
+    /// The value is returned only to the calling component and never projected
+    /// through the VFS by the host.
+    async fn private_input_request(
+        &self,
+        _req: PrivateInputRequest,
+    ) -> Result<PrivateInputOutcome, HostError> {
+        Err(HostError::Denied("private_input_request".into()))
+    }
+
+    /// Consume a ready private-input session after the component has durably
+    /// persisted the value in its secret namespace.
+    async fn private_input_consume(
+        &self,
+        _id: String,
+        _context: Option<PetalRouteContext>,
+    ) -> Result<(), HostError> {
+        Err(HostError::Denied("private_input_consume".into()))
     }
 }
 

--- a/crates/bloom-petals/src/meta.rs
+++ b/crates/bloom-petals/src/meta.rs
@@ -29,6 +29,9 @@ pub enum Capability {
     /// May stage and confirm generic EVM outbox entries.
     #[serde(rename = "tx.outbox")]
     TxOutbox,
+    /// May collect typed owner input through a private ceremony.
+    #[serde(rename = "private_input")]
+    PrivateInput,
 }
 
 impl Capability {
@@ -41,6 +44,7 @@ impl Capability {
             Capability::Store => "store",
             Capability::Chain => "chain",
             Capability::TxOutbox => "tx.outbox",
+            Capability::PrivateInput => "private_input",
         }
     }
 
@@ -53,6 +57,7 @@ impl Capability {
             "store" => Some(Capability::Store),
             "chain" => Some(Capability::Chain),
             "tx.outbox" => Some(Capability::TxOutbox),
+            "private_input" => Some(Capability::PrivateInput),
             _ => None,
         }
     }
@@ -150,6 +155,7 @@ pub fn validate_mode_caps(
                     | Capability::Store
                     | Capability::Chain
                     | Capability::TxOutbox
+                    | Capability::PrivateInput
             )
         );
         if !ok {
@@ -182,6 +188,10 @@ mod tests {
         assert_eq!(Capability::parse("store"), Some(Capability::Store));
         assert_eq!(Capability::parse("chain"), Some(Capability::Chain));
         assert_eq!(Capability::parse("tx.outbox"), Some(Capability::TxOutbox));
+        assert_eq!(
+            Capability::parse("private_input"),
+            Some(Capability::PrivateInput)
+        );
         assert_eq!(Capability::parse("nope"), None);
     }
 

--- a/crates/bloom-petals/src/package.rs
+++ b/crates/bloom-petals/src/package.rs
@@ -2291,6 +2291,7 @@ enum ComponentHostInterface {
     ChainRead,
     VfsReadwrite,
     EnvRuntime,
+    PrivateInputCeremony,
 }
 
 fn component_host_interface(name: &str) -> Option<ComponentHostInterface> {
@@ -2302,6 +2303,9 @@ fn component_host_interface(name: &str) -> Option<ComponentHostInterface> {
         ContractHostInterface::ChainRead => Some(ComponentHostInterface::ChainRead),
         ContractHostInterface::VfsReadwrite => Some(ComponentHostInterface::VfsReadwrite),
         ContractHostInterface::EnvRuntime => Some(ComponentHostInterface::EnvRuntime),
+        ContractHostInterface::PrivateInputCeremony => {
+            Some(ComponentHostInterface::PrivateInputCeremony)
+        }
         ContractHostInterface::RouteTypes => None,
     }
 }
@@ -2533,6 +2537,10 @@ enum HostTypeExport {
     SignResultStructured,
     SignRequestStructured,
     SignBatchResultStructured,
+    PrivateInputKind,
+    PrivateInputRequest,
+    PrivatePendingInput,
+    PrivateInputResult,
 }
 
 #[derive(Clone, Copy)]
@@ -2557,6 +2565,8 @@ enum HostFuncExport {
     EnvNowMs,
     EnvRandomBytes,
     EnvSetting,
+    PrivateInputRequest,
+    PrivateInputConsume,
 }
 
 fn is_host_interface_instance<'a>(
@@ -2683,6 +2693,18 @@ fn host_type_export(interface: ComponentHostInterface, name: &str) -> Option<Hos
         (ComponentHostInterface::SignSigning, "sign-batch-result") => {
             Some(HostTypeExport::SignBatchResultStructured)
         }
+        (ComponentHostInterface::PrivateInputCeremony, "input-kind") => {
+            Some(HostTypeExport::PrivateInputKind)
+        }
+        (ComponentHostInterface::PrivateInputCeremony, "request") => {
+            Some(HostTypeExport::PrivateInputRequest)
+        }
+        (ComponentHostInterface::PrivateInputCeremony, "pending-input") => {
+            Some(HostTypeExport::PrivatePendingInput)
+        }
+        (ComponentHostInterface::PrivateInputCeremony, "input-result") => {
+            Some(HostTypeExport::PrivateInputResult)
+        }
         _ => None,
     }
 }
@@ -2717,6 +2739,12 @@ fn host_func_export(interface: ComponentHostInterface, name: &str) -> Option<Hos
             Some(HostFuncExport::EnvRandomBytes)
         }
         (ComponentHostInterface::EnvRuntime, "setting") => Some(HostFuncExport::EnvSetting),
+        (ComponentHostInterface::PrivateInputCeremony, "request-input") => {
+            Some(HostFuncExport::PrivateInputRequest)
+        }
+        (ComponentHostInterface::PrivateInputCeremony, "consume") => {
+            Some(HostFuncExport::PrivateInputConsume)
+        }
         _ => None,
     }
 }
@@ -2742,6 +2770,10 @@ fn host_type_export_matches(
         HostTypeExport::SignResultStructured => is_sign_result_petal(&ty, types, 0),
         HostTypeExport::SignRequestStructured => is_sign_request_petal(&ty, types, 0),
         HostTypeExport::SignBatchResultStructured => is_sign_batch_result_petal(&ty, types, 0),
+        HostTypeExport::PrivateInputKind => is_private_input_kind(&ty, types, 0),
+        HostTypeExport::PrivateInputRequest => is_private_input_request(&ty, types, 0),
+        HostTypeExport::PrivatePendingInput => is_private_pending_input(&ty, types, 0),
+        HostTypeExport::PrivateInputResult => is_private_input_result(&ty, types, 0),
     }
 }
 
@@ -2897,6 +2929,14 @@ fn host_func_export_matches(
             params_match(params, types, &[("key", is_string_type)])
                 && result_matches(&ty.result, types, HostOkType::OptionalString)
         }
+        HostFuncExport::PrivateInputRequest => {
+            params_match(params, types, &[("request", is_private_input_request)])
+                && result_matches(&ty.result, types, HostOkType::PrivateInputResult)
+        }
+        HostFuncExport::PrivateInputConsume => {
+            params_match(params, types, &[("id", is_string_type)])
+                && result_matches(&ty.result, types, HostOkType::Unit)
+        }
     }
 }
 
@@ -2932,6 +2972,7 @@ enum HostOkType {
     SignBatchResultStructured,
     StagedTransaction,
     OutboxInspection,
+    PrivateInputResult,
 }
 
 fn result_matches(
@@ -2965,6 +3006,7 @@ fn result_matches(
             }
             (HostOkType::StagedTransaction, Some(ty)) => is_staged_transaction(ty, types, depth),
             (HostOkType::OutboxInspection, Some(ty)) => is_outbox_inspection(ty, types, depth),
+            (HostOkType::PrivateInputResult, Some(ty)) => is_private_input_result(ty, types, depth),
             _ => false,
         };
         ok_matches && err.is_some_and(|ty| is_string(&ty))
@@ -2991,6 +3033,81 @@ fn is_sign_result_petal(
                 .ty
                 .as_ref()
                 .is_some_and(|ty| is_approval_required(ty, types, depth))
+    })
+}
+
+fn is_private_input_kind(
+    ty: &ComponentValType,
+    types: &[ComponentTypeEntry<'_>],
+    depth: usize,
+) -> bool {
+    with_defined_type(
+        ty,
+        types,
+        depth,
+        |defined, _types, _depth| matches!(defined, ComponentDefinedType::Enum(tags) if tags.as_ref() == ["evm-address"]),
+    )
+}
+
+fn is_private_input_request(
+    ty: &ComponentValType,
+    types: &[ComponentTypeEntry<'_>],
+    depth: usize,
+) -> bool {
+    with_defined_type(ty, types, depth, |defined, types, depth| {
+        let ComponentDefinedType::Record(fields) = defined else {
+            return false;
+        };
+        fields.as_ref().len() == 6
+            && fields[0].0 == "id"
+            && is_string(&fields[0].1)
+            && fields[1].0 == "wallet"
+            && is_string(&fields[1].1)
+            && fields[2].0 == "approval-wallet"
+            && is_option_of(&fields[2].1, types, is_string_type, depth)
+            && fields[3].0 == "title"
+            && is_string(&fields[3].1)
+            && fields[4].0 == "prompt"
+            && is_string(&fields[4].1)
+            && fields[5].0 == "kind"
+            && is_private_input_kind(&fields[5].1, types, depth)
+    })
+}
+
+fn is_private_pending_input(
+    ty: &ComponentValType,
+    types: &[ComponentTypeEntry<'_>],
+    depth: usize,
+) -> bool {
+    with_defined_type(ty, types, depth, |defined, types, depth| {
+        let ComponentDefinedType::Record(fields) = defined else {
+            return false;
+        };
+        fields.as_ref().len() == 2
+            && fields[0].0 == "ceremony-url"
+            && is_string(&fields[0].1)
+            && fields[1].0 == "expires-ms"
+            && is_u64(&fields[1].1, types, depth)
+    })
+}
+
+fn is_private_input_result(
+    ty: &ComponentValType,
+    types: &[ComponentTypeEntry<'_>],
+    depth: usize,
+) -> bool {
+    with_defined_type(ty, types, depth, |defined, types, depth| {
+        let ComponentDefinedType::Variant(cases) = defined else {
+            return false;
+        };
+        cases.as_ref().len() == 2
+            && cases[0].name == "pending"
+            && cases[0]
+                .ty
+                .as_ref()
+                .is_some_and(|ty| is_private_pending_input(ty, types, depth))
+            && cases[1].name == "ready"
+            && cases[1].ty.as_ref().is_some_and(is_string)
     })
 }
 
@@ -5998,6 +6115,37 @@ paths = ["/*"]
     (export "read" (func (type 2)))
   ))
   (import "bloom:vfs/readwrite@0.1.0" (instance (type 0)))
+)
+"#,
+        ));
+        assert!(host_import_instance_matches(
+            ComponentHostInterface::PrivateInputCeremony,
+            r#"
+(component
+  (type (instance
+    (type (enum "evm-address"))
+    (type (option string))
+    (type (record
+      (field "id" string)
+      (field "wallet" string)
+      (field "approval-wallet" 1)
+      (field "title" string)
+      (field "prompt" string)
+      (field "kind" 0)
+    ))
+    (type (record
+      (field "ceremony-url" string)
+      (field "expires-ms" u64)
+    ))
+    (type (variant (case "pending" 3) (case "ready" string)))
+    (type (result 4 (error string)))
+    (type (func (param "request" 2) (result 5)))
+    (type (result (error string)))
+    (type (func (param "id" string) (result 7)))
+    (export "request-input" (func (type 6)))
+    (export "consume" (func (type 8)))
+  ))
+  (import "bloom:private-input/ceremony@0.1.0" (instance (type 0)))
 )
 "#,
         ));

--- a/crates/bloom-petals/src/runner.rs
+++ b/crates/bloom-petals/src/runner.rs
@@ -690,6 +690,7 @@ fn petal_capability(cap: &str) -> Option<Capability> {
         "bloom:sign" => Some(Capability::Sign),
         "bloom:chain" => Some(Capability::Chain),
         "bloom:tx.outbox" => Some(Capability::TxOutbox),
+        "bloom:private-input" => Some(Capability::PrivateInput),
         "bloom:vfs.read" => Some(Capability::VfsRead),
         "bloom:vfs.write" => Some(Capability::VfsWrite),
         _ => Capability::parse(cap),

--- a/crates/bloom-petals/src/store.rs
+++ b/crates/bloom-petals/src/store.rs
@@ -289,30 +289,30 @@ impl PetalStore {
         // migrate it to the new hash BEFORE committing the owner write.
         // Without this, reinstalling a petal silently orphans all secrets —
         // for privacy-pools that means locked deposits (unrecoverable).
-        if let Ok(Some(old_hash)) = self.resolve_petal_owner(&package.name) {
-            if old_hash != hash {
-                let data_root = self.private_data_root();
-                let old_dir = data_root.join(&old_hash);
-                let new_dir = data_root.join(&hash);
-                if old_dir.is_dir() {
-                    match migrate_private_store(&old_dir, &new_dir) {
-                        Ok(count) if count > 0 => {
-                            eprintln!(
-                                "[bloom] petal store migration: copied {} files from \
-                                 prior {} (hash {:.12}) to new hash {:.12} — secrets \
-                                 preserved across reinstall",
-                                count, package.name, old_hash, hash
-                            );
-                        }
-                        Ok(_) => {}
-                        Err(e) => {
-                            eprintln!(
-                                "[bloom] WARNING: could not migrate private store for \
-                                 {} ({:.12} → {:.12}): {}. \
-                                 Back up secrets via /recovery/ before proceeding.",
-                                package.name, old_hash, hash, e
-                            );
-                        }
+        if let Ok(Some(old_hash)) = self.resolve_petal_owner(&package.name)
+            && old_hash != hash
+        {
+            let data_root = self.private_data_root();
+            let old_dir = data_root.join(&old_hash);
+            let new_dir = data_root.join(&hash);
+            if old_dir.is_dir() {
+                match migrate_private_store(&old_dir, &new_dir) {
+                    Ok(count) if count > 0 => {
+                        eprintln!(
+                            "[bloom] petal store migration: copied {} files from \
+                             prior {} (hash {:.12}) to new hash {:.12} — secrets \
+                             preserved across reinstall",
+                            count, package.name, old_hash, hash
+                        );
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        eprintln!(
+                            "[bloom] WARNING: could not migrate private store for \
+                             {} ({:.12} → {:.12}): {}. \
+                             Back up secrets via /recovery/ before proceeding.",
+                            package.name, old_hash, hash, e
+                        );
                     }
                 }
             }
@@ -804,7 +804,6 @@ fn validate_owner(owner: &AppOwner) -> Result<(), PetalError> {
 /// permissions (secret files are 0600). Existing files in the target are
 /// not overwritten — a partial prior migration won't clobber fresh data.
 fn migrate_private_store(source: &Path, target: &Path) -> Result<usize, PetalError> {
-    use std::os::unix::fs::PermissionsExt;
     let mut count = 0;
     migrate_dir(source, target, &mut count)?;
     Ok(count)
@@ -1222,12 +1221,21 @@ name = "echo"
         assert_ne!(first_hash, second_hash);
 
         // The new hash's private store should have the migrated data.
-        let migrated_secret = data_root.join(&second_hash).join("secrets/deposit_note.json");
+        let migrated_secret = data_root
+            .join(&second_hash)
+            .join("secrets/deposit_note.json");
         assert!(migrated_secret.exists(), "secret file was not migrated");
-        assert_eq!(std::fs::read(&migrated_secret).unwrap(), b"{\"nullifier\":\"0xabc\"}");
+        assert_eq!(
+            std::fs::read(&migrated_secret).unwrap(),
+            b"{\"nullifier\":\"0xabc\"}"
+        );
 
         // File permissions preserved (0600 for secrets).
-        let mode = std::fs::metadata(&migrated_secret).unwrap().permissions().mode() & 0o777;
+        let mode = std::fs::metadata(&migrated_secret)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
         assert_eq!(mode, 0o600, "secret file permissions not preserved");
 
         // State files migrated too.

--- a/crates/bloom-petals/src/vm.rs
+++ b/crates/bloom-petals/src/vm.rs
@@ -845,6 +845,15 @@ fn link_component_host_imports(linker: &mut ComponentLinker<StoreData>) -> anyho
             Box::new(async move { component_env_setting(store, params, results).await })
         })?;
     }
+    {
+        let mut private_input = linker.instance("bloom:private-input/ceremony@0.1.0")?;
+        private_input.func_new_async("request-input", |store, params, results| {
+            Box::new(async move { component_private_input_request(store, params, results).await })
+        })?;
+        private_input.func_new_async("consume", |store, params, results| {
+            Box::new(async move { component_private_input_consume(store, params, results).await })
+        })?;
+    }
     Ok(())
 }
 
@@ -1821,6 +1830,90 @@ async fn component_env_setting(
             value.map(|value| Box::new(ComponentVal::String(value))),
         ))),
     )
+}
+
+async fn component_private_input_request(
+    store: StoreContextMut<'_, StoreData>,
+    params: &[ComponentVal],
+    results: &mut [ComponentVal],
+) -> anyhow::Result<()> {
+    if !store.data().caps.contains(&Capability::PrivateInput) {
+        log_denied(store.data(), "component_private_input_request");
+        return set_component_result(
+            results,
+            component_host_err(HostError::Denied("private_input".into())),
+        );
+    }
+    let [ComponentVal::Record(fields)] = params else {
+        return set_component_result(
+            results,
+            component_host_err(HostError::Invalid("invalid private-input request".into())),
+        );
+    };
+    let kind = match component_record_field(fields, "kind")? {
+        ComponentVal::Enum(name) if name == "evm-address" => {
+            crate::abi::PrivateInputKind::EvmAddress
+        }
+        _ => {
+            return set_component_result(
+                results,
+                component_host_err(HostError::Invalid("unsupported private-input kind".into())),
+            );
+        }
+    };
+    let request = crate::abi::PrivateInputRequest {
+        id: component_record_string(fields, "id")?,
+        wallet: component_record_string(fields, "wallet")?,
+        approval_wallet: component_optional_string_field(fields, "approval-wallet")?,
+        title: component_record_string(fields, "title")?,
+        prompt: component_record_string(fields, "prompt")?,
+        kind,
+        context: store.data().sign_context.clone(),
+    };
+    let host = store.data().host.clone();
+    let value = match host.private_input_request(request).await {
+        Ok(crate::abi::PrivateInputOutcome::Pending(pending)) => ComponentVal::Variant(
+            "pending".into(),
+            Some(Box::new(ComponentVal::Record(vec![
+                (
+                    "ceremony-url".into(),
+                    ComponentVal::String(pending.ceremony_url),
+                ),
+                ("expires-ms".into(), ComponentVal::U64(pending.expires_ms)),
+            ]))),
+        ),
+        Ok(crate::abi::PrivateInputOutcome::Ready(value)) => {
+            ComponentVal::Variant("ready".into(), Some(Box::new(ComponentVal::String(value))))
+        }
+        Err(err) => return set_component_result(results, component_host_err(err)),
+    };
+    set_component_result(results, component_ok(Some(value)))
+}
+
+async fn component_private_input_consume(
+    store: StoreContextMut<'_, StoreData>,
+    params: &[ComponentVal],
+    results: &mut [ComponentVal],
+) -> anyhow::Result<()> {
+    if !store.data().caps.contains(&Capability::PrivateInput) {
+        log_denied(store.data(), "component_private_input_consume");
+        return set_component_result(
+            results,
+            component_host_err(HostError::Denied("private_input".into())),
+        );
+    }
+    let id = match component_single_string_param(params, "id") {
+        Ok(id) => id,
+        Err(err) => return set_component_result(results, component_host_err(err)),
+    };
+    let host = store.data().host.clone();
+    match host
+        .private_input_consume(id, store.data().sign_context.clone())
+        .await
+    {
+        Ok(()) => set_component_result(results, component_ok(None)),
+        Err(err) => set_component_result(results, component_host_err(err)),
+    }
 }
 
 fn set_component_result(results: &mut [ComponentVal], val: ComponentVal) -> anyhow::Result<()> {

--- a/crates/bloom-tx/src/outbox.rs
+++ b/crates/bloom-tx/src/outbox.rs
@@ -1229,6 +1229,7 @@ mod tests {
             tx_hash: staged.tx_hash.clone().unwrap(),
             block_number: Some(123),
             revert_reason: None,
+            logs: None,
         };
         let se = &ob.walk_all_sent().unwrap()[0];
         ob.write_sent_sibling(se, RECEIPT_FILE, &serde_json::to_vec(&rec).unwrap())

--- a/crates/bloom-tx/src/reconcile.rs
+++ b/crates/bloom-tx/src/reconcile.rs
@@ -77,8 +77,7 @@ impl Reconciler {
                 tx_hash: format!("{:#x}", se.hash),
                 block_number: receipt.block_number,
                 revert_reason,
-                logs: serde_json::to_value(&receipt.inner.logs())
-                    .ok(),
+                logs: serde_json::to_value(receipt.inner.logs()).ok(),
             };
             match serde_json::to_vec_pretty(&record) {
                 Ok(bytes) => match self.outbox.write_sent_sibling(&se, RECEIPT_FILE, &bytes) {

--- a/crates/bloom-tx/src/tx_engine.rs
+++ b/crates/bloom-tx/src/tx_engine.rs
@@ -607,6 +607,34 @@ impl TxEngine {
         Ok(())
     }
 
+    fn private_rpc_provider(
+        &self,
+        chain_id: u64,
+        provider_id: &str,
+    ) -> Result<Arc<dyn bloom_mempool::PrivateRpcProvider>, TxEngineError> {
+        self.private_rpcs
+            .read()
+            .get(&(chain_id, provider_id.to_string()))
+            .cloned()
+            .ok_or_else(|| TxEngineError::PrivateProviderNotConfigured(provider_id.to_string()))
+    }
+
+    fn ensure_private_rpc_available(
+        &self,
+        staged: &StagedTx,
+        policy: &Policy,
+    ) -> Result<(), TxEngineError> {
+        if policy.private.enabled
+            && matches!(
+                staged.chain_id,
+                bloom_mempool::MAINNET_CHAIN_ID | bloom_mempool::SEPOLIA_CHAIN_ID
+            )
+        {
+            self.private_rpc_provider(staged.chain_id, &policy.private.provider)?;
+        }
+        Ok(())
+    }
+
     /// Submit a signed raw tx via the configured private RPC provider
     /// keyed by `(chain_id, provider_id)`. Returns the hash returned by
     /// the provider on success, or a typed error if the provider is not
@@ -621,12 +649,7 @@ impl TxEngine {
     ) -> Result<alloy::primitives::B256, TxEngineError> {
         // Take the lock, clone the Arc out, drop the guard before .await — no
         // lock is held across the network call.
-        let provider = self
-            .private_rpcs
-            .read()
-            .get(&(chain_id, provider_id.to_string()))
-            .cloned()
-            .ok_or_else(|| TxEngineError::PrivateProviderNotConfigured(provider_id.to_string()))?;
+        let provider = self.private_rpc_provider(chain_id, provider_id)?;
         provider
             .submit(raw)
             .await
@@ -1786,6 +1809,11 @@ impl TxEngine {
             self.simulate_or_reject(&staged, chain).await?;
         }
 
+        // Fail local private-routing misconfiguration before opening an owner
+        // approval ceremony. The selected provider must already be registered
+        // for this chain.
+        self.ensure_private_rpc_available(&staged, policy)?;
+
         let subject = self.authorization_subject(&staged);
         if self.session_store.covers(
             wallet,
@@ -1945,6 +1973,8 @@ impl TxEngine {
         if !override_warnings {
             self.simulate_or_reject(&staged, chain).await?;
         }
+
+        self.ensure_private_rpc_available(&staged, policy)?;
 
         // Authorization. The policy gates above (hard deny / unoverridden warn)
         // have already passed, so a bounded policy session may authorize this
@@ -2109,14 +2139,8 @@ impl TxEngine {
 
         match attempt.transport {
             BroadcastTransport::PrivateRpc => {
-                self.write_reconcile_ambiguous(
-                    entry,
-                    "private relay attempt absent from public RPC; refusing to leak to public mempool",
-                )?;
-                Err(TxEngineError::BroadcastAttemptAmbiguous {
-                    id: entry.staged.id.clone(),
-                    reason: "private relay attempt unresolved".into(),
-                })
+                self.resubmit_private_attempt(entry, &attempt, tx_hash, chain)
+                    .await
             }
             BroadcastTransport::PublicRpc => {
                 let spec = chain.spec();
@@ -2163,6 +2187,38 @@ impl TxEngine {
                 self.finalize_sent(entry, tx_hash, chain)
             }
         }
+    }
+
+    async fn resubmit_private_attempt(
+        &self,
+        entry: &crate::outbox::OutboxEntry,
+        attempt: &BroadcastAttempt,
+        tx_hash: B256,
+        chain: &ChainClient,
+    ) -> Result<StagedTx, TxEngineError> {
+        // Replaying identical signed bytes to the same private relay is
+        // idempotent and never leaks them to the public mempool. This closes
+        // the crash/error window between persisting the attempt and observing
+        // the relay response.
+        let provider = attempt.private_provider.as_deref().ok_or_else(|| {
+            TxEngineError::BroadcastAttemptAmbiguous {
+                id: entry.staged.id.clone(),
+                reason: "private attempt does not record its provider".into(),
+            }
+        })?;
+        let raw =
+            self.outbox
+                .read_broadcast_raw_tx(entry, BroadcastAttemptKind::Confirm, attempt)?;
+        let returned = self
+            .submit_via_private(attempt.chain_id, provider, &Bytes::from(raw))
+            .await?;
+        if returned != tx_hash {
+            return Err(TxEngineError::BroadcastHashMismatch {
+                expected: format!("{tx_hash:#x}"),
+                returned: format!("{returned:#x}"),
+            });
+        }
+        self.finalize_sent(entry, tx_hash, chain)
     }
 
     fn finalize_sent(
@@ -2579,6 +2635,13 @@ impl TxEngine {
                 staged.chain_id,
                 bloom_mempool::MAINNET_CHAIN_ID | bloom_mempool::SEPOLIA_CHAIN_ID
             );
+        // Resolve private routing before any owner ceremony or durable
+        // broadcast marker. A missing provider is a local configuration error,
+        // not an ambiguous network attempt, and must be reported while the
+        // transaction is still unsigned.
+        if private_eligible {
+            self.private_rpc_provider(staged.chain_id, &policy.private.provider)?;
+        }
         // Refuse to broadcast into a nonce gap (would be queued and never mine).
         // Do this before signing/marker writes so a refused attempt leaves no
         // half-broadcast state — just an advisory beside the pending entry.
@@ -2621,8 +2684,7 @@ impl TxEngine {
             } else {
                 BroadcastTransport::PublicRpc
             },
-            private_provider: private_eligible
-                .then(|| policy.private.provider.clone()),
+            private_provider: private_eligible.then(|| policy.private.provider.clone()),
         };
         self.outbox.write_broadcast_attempt(entry, kind, &attempt)?;
         let submitted = self
@@ -6381,6 +6443,7 @@ mod tests {
             tx_hash: dep.tx_hash.clone().unwrap(),
             block_number: Some(1),
             revert_reason: Some("ERC20: insufficient allowance".into()),
+            logs: None,
         };
         engine
             .outbox
@@ -6399,6 +6462,7 @@ mod tests {
             tx_hash: dep.tx_hash.clone().unwrap(),
             block_number: Some(1),
             revert_reason: None,
+            logs: None,
         };
         engine
             .outbox
@@ -7785,6 +7849,92 @@ mod tests {
         }
     }
 
+    #[test]
+    fn private_rpc_preflight_fails_before_signing_when_provider_is_missing() {
+        let (engine, _spec, _dir) = fake_engine(60_000);
+        let mut staged = fake_staged_1559("0001-private-preflight");
+        staged.chain_id = bloom_mempool::MAINNET_CHAIN_ID;
+        let mut policy = bloom_proto::Policy::default();
+        policy.private.enabled = true;
+        policy.private.provider = "mev_blocker".into();
+
+        assert!(matches!(
+            engine.ensure_private_rpc_available(&staged, &policy),
+            Err(TxEngineError::PrivateProviderNotConfigured(provider)) if provider == "mev_blocker"
+        ));
+
+        engine
+            .register_private_rpc(
+                bloom_mempool::MAINNET_CHAIN_ID,
+                Arc::new(bloom_mempool::MockPrivateRpcProvider::new("mev_blocker")),
+            )
+            .unwrap();
+        engine
+            .ensure_private_rpc_available(&staged, &policy)
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn private_rpc_reconciliation_replays_retained_bytes_to_same_provider() {
+        let (engine, mut spec, _dir) = fake_engine(60_000);
+        spec.chain_id = bloom_mempool::MAINNET_CHAIN_ID;
+        let chain = bloom_evm::ChainClient::new(spec).unwrap();
+        let provider = Arc::new(bloom_mempool::MockPrivateRpcProvider::new("mev_blocker"));
+        engine
+            .register_private_rpc(bloom_mempool::MAINNET_CHAIN_ID, provider.clone())
+            .unwrap();
+
+        let staged = fake_staged_1559("0001-private-replay");
+        engine
+            .outbox
+            .write_pending(&staged, "private replay")
+            .unwrap();
+        let entry = engine
+            .outbox
+            .read("alice", "anvil", "0001-private-replay")
+            .unwrap();
+        let raw = Bytes::from_static(b"retained signed transaction");
+        let tx_hash = alloy::primitives::keccak256(&raw);
+        let attempt = BroadcastAttempt {
+            schema: "bloom.broadcast_attempted.v1".into(),
+            tx_hash: format!("{tx_hash:#x}"),
+            raw_tx_blake3: blake3::hash(&raw).to_hex().to_string(),
+            raw_tx_path: BroadcastAttemptKind::Confirm.raw_name().into(),
+            from: staged.from.clone(),
+            to: staged.to.clone(),
+            nonce: staged.nonce,
+            chain_id: bloom_mempool::MAINNET_CHAIN_ID,
+            created_ms: now_ms(),
+            transport: BroadcastTransport::PrivateRpc,
+            private_provider: Some("mev_blocker".into()),
+        };
+        engine
+            .outbox
+            .write_broadcast_raw_tx(&entry, BroadcastAttemptKind::Confirm, &raw)
+            .unwrap();
+        engine
+            .outbox
+            .write_broadcast_attempt(&entry, BroadcastAttemptKind::Confirm, &attempt)
+            .unwrap();
+
+        let sent = engine
+            .resubmit_private_attempt(&entry, &attempt, tx_hash, &chain)
+            .await
+            .unwrap();
+        assert_eq!(sent.status, TxStatus::Sent);
+        assert_eq!(
+            sent.tx_hash.as_deref(),
+            Some(format!("{tx_hash:#x}").as_str())
+        );
+        assert_eq!(provider.submissions(), vec![raw]);
+        assert!(
+            engine
+                .outbox
+                .read_in_state("alice", "anvil", "0001-private-replay", OutboxState::Sent)
+                .is_ok()
+        );
+    }
+
     /// The registry is keyed by `(chain_id, provider_id)`, so two
     /// providers registered on the same chain must be reachable
     /// independently and only the one keyed by the requested id should
@@ -7893,11 +8043,8 @@ mod tests {
         // Must NOT be rejected for private-RPC support; instead it falls back
         // to the public RPC (which only fails here because `fake_engine` points
         // at a dummy RPC URL → a chain transport error).
-        match r {
-            Err(TxEngineError::PrivateNotSupportedOnChain(_)) => {
-                panic!("expected public-RPC fallback, got PrivateNotSupportedOnChain");
-            }
-            _ => {}
+        if let Err(TxEngineError::PrivateNotSupportedOnChain(_)) = r {
+            panic!("expected public-RPC fallback, got PrivateNotSupportedOnChain");
         }
     }
 

--- a/crates/bloom-vfs/src/handlers/wallets.rs
+++ b/crates/bloom-vfs/src/handlers/wallets.rs
@@ -2292,12 +2292,10 @@ impl WalletsHandler {
             let wallets = coordinator.list_wallets().await.map_err(err_be)?;
             let mut out = Vec::new();
             for wallet in wallets {
-                if let Ok(status) = self.registration_status(&wallet).await {
-                    if !status.state.is_terminal() {
-                        out.push(
-                            Entry::dir(&wallet).with_modified_ms(status.created_at_ms as u128),
-                        );
-                    }
+                if let Ok(status) = self.registration_status(&wallet).await
+                    && !status.state.is_terminal()
+                {
+                    out.push(Entry::dir(&wallet).with_modified_ms(status.created_at_ms as u128));
                 }
             }
             return Ok(out);

--- a/crates/bloom/src/github_source.rs
+++ b/crates/bloom/src/github_source.rs
@@ -19,7 +19,7 @@ const HYPERLIQUID_RELEASE_COMMIT: &str = "fa722a986c2a0a23977e9e00df54ebd291a686
 const NEAR_INTENTS_RELEASE_COMMIT: &str = "08e9bd83786425656bdd87e35031030cb7f3dc14";
 const ENSO_RELEASE_COMMIT: &str = "59e3c884f83c9c97b69b1b415becf8572791273b";
 const GASLESS_RELEASE_COMMIT: &str = "73ccf05b4f10d7993fbc8fa453e8f91987564aab";
-const PRIVACY_POOLS_RELEASE_COMMIT: &str = "ae01a7d398416af4fa38a985b684ac973e128208";
+const PRIVACY_POOLS_RELEASE_COMMIT: &str = "c661942fd07205221f9fff62c000ea01a55d67bd";
 const VENICE_X402_RELEASE_COMMIT: &str = "f8d6a1b287397b2c66fa11ca777fe2b762640964";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -96,9 +96,9 @@ const PREINSTALLED_PRIVACY_POOLS: PreinstalledPetal = PreinstalledPetal {
     name: "privacy-pools",
     repository: "https://github.com/bloom-directory/bloom-petal-privacy-pools",
     commit: PRIVACY_POOLS_RELEASE_COMMIT,
-    release_tag: "v0.1.2",
-    archive: "privacy-pools-v0.1.2.petal.tar.gz",
-    expected_hash: Some("f86cf4fac3dcd5dc86fa6d60daadeb2377b7d3a655774f64a109a7f5aca446b4"),
+    release_tag: "v0.1.3",
+    archive: "privacy-pools-v0.1.3.petal.tar.gz",
+    expected_hash: Some("5d665b7f0a74f9046f38bd39a3aa879eb455b3c17f7f34bf9b57c3b23071fc8f"),
     upgrade_policy: PreinstalledUpgradePolicy::Automatic,
 };
 
@@ -1088,7 +1088,15 @@ mod tests {
         let defaults = bloom_proto::Config::local_default().petals.preinstalled;
         assert_eq!(
             defaults,
-            ["polymarket", "near-intents", "enso", "hyperliquid"]
+            [
+                "polymarket",
+                "near-intents",
+                "enso",
+                "hyperliquid",
+                "gasless",
+                "privacy-pools",
+                "venice-x402",
+            ]
         );
         for name in defaults {
             let entry = preinstalled_petal(&name).unwrap();
@@ -1126,7 +1134,14 @@ mod tests {
             preinstalled_petal("hyperliquid").unwrap().upgrade_policy,
             PreinstalledUpgradePolicy::ManualStateMigration
         );
-        for name in ["polymarket", "near-intents", "enso"] {
+        for name in [
+            "polymarket",
+            "near-intents",
+            "enso",
+            "gasless",
+            "privacy-pools",
+            "venice-x402",
+        ] {
             assert_eq!(
                 preinstalled_petal(name).unwrap().upgrade_policy,
                 PreinstalledUpgradePolicy::Automatic

--- a/scripts/test-private-input-browser.mjs
+++ b/scripts/test-private-input-browser.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+
+const html = await readFile(new URL("../crates/bloom-daemon/src/ceremony_server/private_input_ceremony.html", import.meta.url), "utf8");
+const recipient = "0x1111111111111111111111111111111111111111";
+let preparedValue;
+let completion;
+
+async function body(request) {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+const server = createServer(async (request, response) => {
+  const url = new URL(request.url, "http://127.0.0.1");
+  response.setHeader("Content-Type", url.pathname.endsWith(".json") ? "application/json" : "text/html");
+  if (request.method === "GET" && url.pathname === "/private-input/test") {
+    response.end(html);
+  } else if (request.method === "GET" && url.pathname.endsWith("/request.json")) {
+    response.end(JSON.stringify({
+      title: "Private Privacy Pools withdrawal",
+      prompt: "Enter the destination privately.",
+      note_wallet: "dev",
+      approval_wallet: "owner-passkey",
+    }));
+  } else if (request.method === "POST" && url.pathname.endsWith("/prepare")) {
+    preparedValue = (await body(request)).value;
+    response.end(JSON.stringify({
+      publicKey: {
+        challenge: "AQIDBA",
+        allowCredentials: [{ type: "public-key", id: "BQYHCA" }],
+        timeout: 60_000,
+      },
+    }));
+  } else if (request.method === "POST" && url.pathname.endsWith("/complete")) {
+    completion = await body(request);
+    response.end(JSON.stringify({ ok: true }));
+  } else {
+    response.statusCode = 404;
+    response.end(JSON.stringify({ error: "not found" }));
+  }
+});
+
+await new Promise((resolvePromise) => server.listen(0, "127.0.0.1", resolvePromise));
+const driverPort = 19_515 + Math.floor(Math.random() * 1_000);
+const driver = spawn("chromedriver", [`--port=${driverPort}`, "--log-level=SEVERE"], { stdio: "ignore" });
+const driverUrl = `http://127.0.0.1:${driverPort}`;
+
+async function command(path, payload, method = "POST") {
+  const response = await fetch(`${driverUrl}${path}`, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: payload === undefined ? undefined : JSON.stringify(payload),
+  });
+  assert(response.ok, `WebDriver ${path} failed: HTTP ${response.status}`);
+  const result = await response.json();
+  if (result.value?.error) throw new Error(result.value.message ?? result.value.error);
+  return result.value;
+}
+
+async function waitForDriver() {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    try {
+      await command("/status", undefined, "GET");
+      return;
+    } catch {
+      await new Promise((resolvePromise) => setTimeout(resolvePromise, 100));
+    }
+  }
+  throw new Error("chromedriver did not start");
+}
+
+let sessionId;
+try {
+  await waitForDriver();
+  const session = await command("/session", {
+    capabilities: {
+      alwaysMatch: {
+        browserName: "chrome",
+        "goog:chromeOptions": {
+          binary: "/usr/bin/chromium",
+          args: ["--headless=new", "--no-sandbox", "--disable-dev-shm-usage"],
+        },
+      },
+    },
+  });
+  sessionId = session.sessionId;
+  await command(`/session/${sessionId}/goog/cdp/execute`, {
+    cmd: "Page.addScriptToEvaluateOnNewDocument",
+    params: {
+      source: `Object.defineProperty(navigator,'credentials',{configurable:true,value:{get:async()=>({id:'credential-id',response:{authenticatorData:new Uint8Array([1,2]).buffer,clientDataJSON:new Uint8Array([3,4]).buffer,signature:new Uint8Array([5,6]).buffer,userHandle:null}})}});`,
+    },
+  });
+  await command(`/session/${sessionId}/url`, { url: `http://127.0.0.1:${server.address().port}/private-input/test` });
+  await command(`/session/${sessionId}/execute/sync`, {
+    script: `document.getElementById('destination').value=arguments[0];document.getElementById('form').requestSubmit();`,
+    args: [recipient],
+  });
+  let view;
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    view = await command(`/session/${sessionId}/execute/sync`, {
+      script: `return {wallet:document.getElementById('wallet').textContent,status:document.getElementById('status').textContent,value:document.getElementById('destination').value};`,
+      args: [],
+    });
+    if (view.status.includes("held privately")) break;
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 100));
+  }
+  assert.equal(view.wallet, "Passkey wallet · owner-passkey · Note wallet · dev");
+  assert.match(view.status, /held privately/);
+  assert.equal(view.value, "");
+  assert.equal(preparedValue, recipient);
+  assert.equal(completion.credential.id, "credential-id");
+  assert.equal(completion.credential.response.authenticatorData, "AQI");
+  assert.equal(completion.credential.response.clientDataJSON, "AwQ");
+  assert.equal(completion.credential.response.signature, "BQY");
+  assert.equal(completion.credential.response.userHandle, null);
+  console.log(JSON.stringify({ browserCeremony: "complete", approvalIdentityCorrect: true, addressCleared: true }));
+} finally {
+  if (sessionId) await command(`/session/${sessionId}`, undefined, "DELETE").catch(() => {});
+  driver.kill("SIGTERM");
+  await new Promise((resolvePromise) => server.close(resolvePromise));
+}


### PR DESCRIPTION
## Summary

- add the capability-gated `bloom:private-input` component host interface
- add a local, expiring, passkey-gated recipient-input ceremony bound to Privacy Pools withdrawal context
- support single-use private input consumption without exposing recipient data via VFS
- preserve Petal private stores across package replacement and harden private-relay retry behavior
- pin the catalog to the published Privacy Pools v0.1.3 release (`c661942`, package `5d665b7f…71fc8f`)

## Verification

- `cargo fmt --check`
- `cargo clippy -p bloom-petals -p bloom-daemon -p bloom-tx -p bloom --all-targets -- -D warnings`
- `cargo test -p bloom-petals -p bloom-tx` (155 + 159 passed)
- `cargo test -p bloom-daemon` (96 passed)
- `cargo test -p bloom --test cli` (43 passed, 2 external ignored)
- Privacy Pools pinned SDK suite: 40 passed
- browser private-input ceremony test passed
- Privacy Pools v0.1.3 archive built, capability-validated, tagged, and released

No live fund movement or protocol action was performed.