### PR TITLE
research(private-input): preserve the pre-Triad ceremony prototype

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2588,7 +2588,7 @@ dependencies = [
 [[package]]
 name = "bloom-petal-contract"
 version = "0.1.0"
-source = "git+https://github.com/bloom-directory/petal?rev=4f6fb57063a70f95cba288f68bdc139e3ecac7a5#4f6fb57063a70f95cba288f68bdc139e3ecac7a5"
+source = "git+https://github.com/bloom-directory/petal?rev=c9d4829fca1e02f5818e5175ad4b53e643a71805#c9d4829fca1e02f5818e5175ad4b53e643a71805"
 dependencies = [
  "sha2 0.10.9",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,12 @@ bloom-ens      = { path = "crates/bloom-ens" }
 bloom-prices   = { path = "crates/bloom-prices" }
 bloom-revert   = { path = "crates/bloom-revert" }
 bloom-petals   = { path = "crates/bloom-petals" }
-bloom-petal-contract = { git = "https://github.com/bloom-directory/petal", rev = "4f6fb57063a70f95cba288f68bdc139e3ecac7a5" }
+# TODO: point at the merged commit once petal#18 (bloom:private-input@0.2.0
+# contract correction) is reviewed and merged. Currently pinned to that PR's
+# draft branch tip so this crate's HostInterface::PrivateInputCeremony and
+# PRIVATE_INPUT_INTERFACE constant match the versioned contract this PR
+# implements against.
+bloom-petal-contract = { git = "https://github.com/bloom-directory/petal", rev = "c9d4829fca1e02f5818e5175ad4b53e643a71805" }
 bloom-daemon   = { path = "crates/bloom-daemon" }
 bloom-auth-api = { path = "crates/bloom-auth-api" }
 bloom-auth     = { path = "crates/bloom-auth" }

--- a/crates/bloom-daemon/src/ceremony_server.rs
+++ b/crates/bloom-daemon/src/ceremony_server.rs
@@ -41,6 +41,7 @@ use tokio::task::JoinHandle;
 
 use crate::Daemon;
 
+mod private_input_ceremony;
 mod wallet_registration;
 
 const CEREMONY_HTML: &str = include_str!("sealed_ceremony.html");
@@ -68,7 +69,7 @@ fn sealed_review_session_id(challenge: &ApprovalChallenge) -> String {
 }
 
 #[derive(Clone)]
-struct CeremonyState {
+pub(super) struct CeremonyState {
     daemon: Daemon,
 }
 
@@ -165,8 +166,18 @@ fn router(state: CeremonyState) -> Router {
         .route("/ceremony/{token}/challenge", get(challenge_json))
         .route("/ceremony/{token}/complete", post(complete))
         .merge(wallet_registration::router())
+        .merge(private_input_ceremony::router())
         .layer(axum::middleware::from_fn(require_local_origin))
         .with_state(state)
+}
+
+/// Loopback ceremony URL for a private-input session token. This is *not*
+/// exposed to guest Wasm anywhere: only [`private_input_ceremony`]'s
+/// owner-facing lookup-by-operation-id endpoint calls it, and that endpoint
+/// is reachable only from a local process, never from a Petal's sanctioned
+/// `bloom:http` capability (HTTPS/443-only).
+pub(crate) fn private_input_url(token: &str) -> String {
+    format!("http://localhost:{LOCAL_CEREMONY_PORT}/private-input/{token}")
 }
 
 /// Reject cross-site POSTs. Loopback GETs carry no Origin; POSTs from the

--- a/crates/bloom-daemon/src/ceremony_server/private_input_ceremony.html
+++ b/crates/bloom-daemon/src/ceremony_server/private_input_ceremony.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="referrer" content="no-referrer">
+  <title>/bloom — Private Privacy Pools destination</title>
+  <style>
+    :root{color-scheme:light dark;font-family:system-ui,sans-serif;background:#f4efe6;color:#18140f}
+    body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(135deg,#f8f3ea,#e7dfd2)}
+    main{width:min(560px,calc(100% - 32px));padding:32px;border:1px solid #cbbda9;border-radius:18px;background:#fffaf2;box-shadow:0 24px 70px #4a38251f}
+    h1{margin:0 0 10px;font:italic 42px Georgia,serif}.muted{color:#6e6456;line-height:1.5}
+    .transfer{margin:20px 0;padding:16px;border:1px solid #d8ccba;border-radius:10px;background:#f4efe6}
+    .transfer .amount{font:700 22px ui-monospace,monospace;color:#7a2230}
+    .transfer dl{display:grid;grid-template-columns:auto 1fr;gap:4px 12px;margin:8px 0 0;font-size:13px}
+    .transfer dt{color:#6e6456}.transfer dd{margin:0;font-family:ui-monospace,monospace}
+    label{display:block;margin:26px 0 8px;font-weight:650}input{width:100%;box-sizing:border-box;padding:14px;border:1px solid #aa9c88;border-radius:9px;background:white;color:#18140f;font:14px ui-monospace,monospace}
+    button{width:100%;margin-top:16px;padding:14px;border:0;border-radius:9px;background:#7a2230;color:white;font-weight:650;cursor:pointer}button:disabled{opacity:.55;cursor:wait}
+    #status{min-height:1.5em;margin-top:16px;color:#6e2430}.privacy{margin-top:24px;padding-top:18px;border-top:1px solid #d8ccba;font-size:13px;color:#6e6456}
+  </style>
+</head>
+<body><main>
+  <p class="muted" id="wallet">Loading ceremony…</p>
+  <h1 id="title">Private destination</h1>
+  <p class="muted" id="prompt"></p>
+  <div class="transfer" id="transfer" hidden>
+    <div class="amount" id="transferAmount"></div>
+    <dl>
+      <dt>Network</dt><dd id="transferNetwork"></dd>
+      <dt>From note</dt><dd id="transferSource"></dd>
+    </dl>
+  </div>
+  <form id="form">
+    <label for="destination">Ethereum withdrawal address</label>
+    <input id="destination" name="destination" inputmode="text" autocomplete="off" spellcheck="false" placeholder="0x…" required pattern="0x[0-9a-fA-F]{40}">
+    <button id="approve" type="submit">Verify with passkey</button>
+  </form>
+  <div id="status" role="status" aria-live="polite"></div>
+  <p class="privacy">The address is submitted directly to the local Bloom daemon. It is not returned through VFS. Your passkey approval is bound to this exact amount and the address's digest, so neither can be swapped afterward.</p>
+</main><script>
+var PATH=location.pathname.replace(/\/$/,'');
+function dec(s){s=s.replace(/-/g,'+').replace(/_/g,'/');while(s.length%4)s+='=';var b=atob(s),a=new Uint8Array(b.length);for(var i=0;i<b.length;i++)a[i]=b.charCodeAt(i);return a.buffer}
+function enc(b){var a=new Uint8Array(b),s='';for(var i=0;i<a.length;i++)s+=String.fromCharCode(a[i]);return btoa(s).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'')}
+function displayAmount(baseUnits,decimals){
+  var digits=baseUnits.replace(/^0+/,'')||'0';
+  if(decimals===0)return digits;
+  if(digits.length<=decimals)return '0.'+digits.padStart(decimals,'0');
+  var split=digits.length-decimals;
+  return digits.slice(0,split)+'.'+digits.slice(split);
+}
+fetch(PATH+'/request.json').then(function(r){if(!r.ok)throw new Error('Ceremony unavailable');return r.json()}).then(function(v){
+  document.getElementById('title').textContent=v.title;document.getElementById('prompt').textContent=v.prompt;document.getElementById('wallet').textContent='Passkey wallet · '+v.approval_wallet+' · Note wallet · '+v.note_wallet;
+  if(v.transfer){
+    document.getElementById('transfer').hidden=false;
+    document.getElementById('transferAmount').textContent=displayAmount(v.transfer.amount_base_units,v.transfer.decimals)+' '+v.transfer.asset;
+    document.getElementById('transferNetwork').textContent=v.transfer.network;
+    document.getElementById('transferSource').textContent=v.transfer.source;
+  }
+}).catch(function(e){document.getElementById('status').textContent=e.message;document.getElementById('approve').disabled=true});
+document.getElementById('form').addEventListener('submit',async function(event){
+  event.preventDefault();var button=document.getElementById('approve'),status=document.getElementById('status'),value=document.getElementById('destination').value.trim();button.disabled=true;status.textContent='Preparing an approval bound to this address and amount…';
+  try{
+    var prepared=await fetch(PATH+'/prepare',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({value:value})});var opts=await prepared.json();if(!prepared.ok)throw new Error(opts.error||'Could not prepare ceremony');
+    opts.publicKey.challenge=dec(opts.publicKey.challenge);if(opts.publicKey.allowCredentials)opts.publicKey.allowCredentials=opts.publicKey.allowCredentials.map(function(c){return Object.assign({},c,{id:dec(c.id)})});
+    if(opts.publicKey.extensions&&opts.publicKey.extensions.prf&&opts.publicKey.extensions.prf.eval&&opts.publicKey.extensions.prf.eval.first)opts.publicKey.extensions.prf.eval.first=dec(opts.publicKey.extensions.prf.eval.first);
+    status.textContent='Confirm the exact amount and address above with your passkey…';var cred=await navigator.credentials.get(opts);
+    var body={credential:{id:cred.id,response:{authenticatorData:enc(cred.response.authenticatorData),clientDataJSON:enc(cred.response.clientDataJSON),signature:enc(cred.response.signature),userHandle:cred.response.userHandle?enc(cred.response.userHandle):null}}};
+    var completed=await fetch(PATH+'/complete',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});var out=await completed.json();if(!completed.ok||!out.ok)throw new Error(out.error||'Approval failed');
+    status.textContent='Destination approved and held privately. You can close this tab.';document.getElementById('destination').value='';
+  }catch(e){status.textContent='Error: '+(e&&e.message?e.message:e);button.disabled=false}
+});
+</script></body></html>

--- a/crates/bloom-daemon/src/ceremony_server/private_input_ceremony.rs
+++ b/crates/bloom-daemon/src/ceremony_server/private_input_ceremony.rs
@@ -1,0 +1,566 @@
+//! Passkey-bound collection of Petal private-input values (e.g. Privacy
+//! Pools withdrawal destinations).
+//!
+//! Two audiences, two boundaries:
+//!
+//! - Guest Wasm reaches this only indirectly, through
+//!   [`crate::private_input::PrivateInputManager`] mediated by
+//!   [`bloom_petals::PetalHost`]; it never receives a URL from here.
+//! - The ceremony's owner reaches `/private-input/{token}` directly (a
+//!   deliberate local client opens it) or via `/private-input/by-operation/
+//!   {operation_id}`, which resolves the non-secret operation id a Petal is
+//!   allowed to hand back to its owner into the actual (secret) launch URL.
+//!   Neither endpoint is reachable through a Petal's sanctioned
+//!   `bloom:http` capability, which only permits HTTPS on port 443 --
+//!   this server is loopback HTTP on [`bloom_auth_api::LOCAL_CEREMONY_PORT`].
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::{Html, IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use base64::Engine as _;
+use bloom_auth_api::{
+    AssuranceLevel, CANONICAL_INTENT_HEADER_SCHEMA_V1, CanonicalEnvelope, CanonicalIntentHeader,
+    DaemonGrantTerms, ExecutorKind, PETAL_PETAL_ID_PREFIX, PetalPolicySnapshot, PolicyCheckClass,
+    PolicyCheckResult, SealedAction, SignerTransport, UnsignedApproval, WebAuthnAssertionRecord,
+};
+use rand::RngCore;
+use serde::Deserialize;
+
+use super::{CeremonyState, err_json, now_ms, private_input_url};
+
+const HTML: &str = include_str!("private_input_ceremony.html");
+const SURFACE: &str = "petal-private-input";
+
+pub(super) fn router() -> Router<CeremonyState> {
+    Router::new()
+        .route("/private-input/{token}", get(page))
+        .route("/private-input/{token}/request.json", get(request_json))
+        .route("/private-input/{token}/prepare", post(prepare))
+        .route("/private-input/{token}/complete", post(complete))
+        .route(
+            "/private-input/by-operation/{operation_id}",
+            get(by_operation),
+        )
+        .layer(axum::middleware::from_fn(private_input_headers))
+}
+
+async fn private_input_headers(
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Response {
+    let mut response = next.run(req).await;
+    let headers = response.headers_mut();
+    headers.insert(
+        axum::http::header::CACHE_CONTROL,
+        axum::http::HeaderValue::from_static("no-store, no-cache, must-revalidate"),
+    );
+    headers.insert(
+        axum::http::header::CONTENT_SECURITY_POLICY,
+        axum::http::HeaderValue::from_static(
+            "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; connect-src 'self'; form-action 'none'; frame-ancestors 'none'; base-uri 'none'",
+        ),
+    );
+    headers.insert(
+        axum::http::header::REFERRER_POLICY,
+        axum::http::HeaderValue::from_static("no-referrer"),
+    );
+    headers.insert(
+        axum::http::header::X_CONTENT_TYPE_OPTIONS,
+        axum::http::HeaderValue::from_static("nosniff"),
+    );
+    headers.insert(
+        axum::http::header::HeaderName::from_static("x-frame-options"),
+        axum::http::HeaderValue::from_static("DENY"),
+    );
+    headers.insert(
+        axum::http::header::HeaderName::from_static("cross-origin-opener-policy"),
+        axum::http::HeaderValue::from_static("same-origin"),
+    );
+    response
+}
+
+fn private_error(error: bloom_petals::HostError) -> Response {
+    match error {
+        bloom_petals::HostError::NotFound(_) => err_json(StatusCode::NOT_FOUND, error.to_string()),
+        bloom_petals::HostError::Denied(_) => err_json(StatusCode::GONE, error.to_string()),
+        bloom_petals::HostError::Invalid(_) => err_json(StatusCode::BAD_REQUEST, error.to_string()),
+        bloom_petals::HostError::Backend(_) => err_json(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "private-input backend error",
+        ),
+    }
+}
+
+/// Owner-facing launch surface: resolves the non-secret `operation_id` a
+/// Petal is allowed to persist in its own public state into the actual
+/// ceremony URL. This is the *only* place that translation happens --
+/// guest code never holds a reference to
+/// [`crate::private_input::PrivateInputManager`] to call the equivalent
+/// lookup itself.
+async fn by_operation(
+    State(state): State<CeremonyState>,
+    Path(operation_id): Path<String>,
+) -> Response {
+    match state
+        .daemon
+        .private_inputs
+        .token_for_operation(&operation_id, now_ms())
+    {
+        Ok(token) => Json(serde_json::json!({
+            "ceremony_url": private_input_url(&token),
+        }))
+        .into_response(),
+        Err(error) => private_error(error),
+    }
+}
+
+async fn page(State(state): State<CeremonyState>, Path(token): Path<String>) -> Response {
+    match state.daemon.private_inputs.metadata(&token, now_ms()) {
+        Ok(_) => Html(HTML).into_response(),
+        Err(error) => private_error(error),
+    }
+}
+
+async fn request_json(State(state): State<CeremonyState>, Path(token): Path<String>) -> Response {
+    match state.daemon.private_inputs.metadata(&token, now_ms()) {
+        Ok(metadata) => Json(serde_json::json!({
+            "title": metadata.title,
+            "prompt": metadata.prompt,
+            "note_wallet": metadata.wallet,
+            "approval_wallet": metadata.approval_wallet,
+            "kind": match metadata.kind {
+                bloom_petals::abi::PrivateInputKind::EvmAddress => "evm-address",
+            },
+            "transfer": {
+                "network": metadata.transfer.network,
+                "asset": metadata.transfer.asset,
+                "amount_base_units": metadata.transfer.amount_base_units,
+                "decimals": metadata.transfer.decimals,
+                "source": metadata.transfer.source,
+            },
+            "expires_ms": metadata.expires_ms,
+        }))
+        .into_response(),
+        Err(error) => private_error(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bloom_petals::abi::{PetalRouteContext, PrivateInputKind, PrivateInputTransferContext};
+
+    fn metadata() -> crate::private_input::PrivateInputMetadata {
+        crate::private_input::PrivateInputMetadata {
+            token: "opaque-token".into(),
+            id: "privacy-pools/withdraw/dev/note-1".into(),
+            wallet: "dev".into(),
+            approval_wallet: "owner-passkey".into(),
+            title: "Private withdrawal".into(),
+            prompt: "Enter a destination".into(),
+            kind: PrivateInputKind::EvmAddress,
+            transfer: PrivateInputTransferContext {
+                network: "ethereum".into(),
+                asset: "eth".into(),
+                amount_base_units: "1000000000000000000".into(),
+                decimals: 18,
+                source: "dev/note-1".into(),
+            },
+            context: PetalRouteContext {
+                petal_root: "privacy-pools".into(),
+                package_hash: "ab".repeat(32),
+                route_id: "withdraw-private".into(),
+                op: "write".into(),
+                path: "withdrawals/dev/note-1.json".into(),
+                params: vec![],
+                actor: None,
+            },
+            expires_ms: 600_001,
+        }
+    }
+
+    #[test]
+    fn sealed_action_binds_transfer_context_and_digest_but_not_the_private_value() {
+        let private_value = "0x1111111111111111111111111111111111111111";
+        let digest = blake3::hash(private_value.as_bytes()).to_hex().to_string();
+        let action = private_input_action(&metadata(), &digest, 1).unwrap();
+        let encoded = serde_json::to_string(&action).unwrap();
+        assert!(encoded.contains(&digest));
+        // The exact canonical amount/asset/network must be part of what's
+        // cryptographically bound into the approval, not merely displayed.
+        assert!(encoded.contains("required.private_input_amount_base_units"));
+        assert!(encoded.contains("1000000000000000000"));
+        assert!(encoded.contains("required.private_input_asset"));
+        assert!(encoded.contains("\"eth\""));
+        assert!(encoded.contains("required.private_input_network"));
+        assert!(encoded.contains("\"ethereum\""));
+        assert_eq!(action.wallet(), "owner-passkey");
+        assert_eq!(action.envelope.header.account, "owner-passkey");
+        let subject = base64::engine::general_purpose::STANDARD
+            .decode(&action.envelope.subject_bytes_b64)
+            .unwrap();
+        let subject: serde_json::Value = serde_json::from_slice(&subject).unwrap();
+        assert_eq!(subject["note_wallet"], "dev");
+        assert_eq!(subject["approval_wallet"], "owner-passkey");
+        assert_eq!(
+            subject["transfer"]["amount_base_units"],
+            "1000000000000000000"
+        );
+        assert_eq!(subject["transfer"]["decimals"], 18);
+        assert!(!encoded.contains(private_value));
+        assert!(!HTML.contains(private_value));
+        // The human-readable plan must show the amount, not just the
+        // destination -- this is the actual fix for a human approving a
+        // destination with no visibility into what moves there.
+        assert!(action.plan.contains("1.000000000000000000"));
+        assert!(action.plan.contains("eth"));
+    }
+
+    #[test]
+    fn page_never_receives_a_ceremony_url_and_posts_only_to_local_endpoints() {
+        assert!(HTML.contains("PATH+'/prepare'"));
+        assert!(HTML.contains("PATH+'/complete'"));
+        assert!(!HTML.contains("console.log"));
+        assert!(!HTML.contains("localStorage"));
+        assert!(HTML.contains("v.approval_wallet"));
+        assert!(HTML.contains("v.note_wallet"));
+        assert!(HTML.contains("v.transfer"));
+        assert!(!HTML.contains("v.wallet"));
+        assert!(!HTML.contains("ceremony_url"));
+        assert!(!HTML.contains("ceremony-url"));
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PrepareBody {
+    value: String,
+}
+
+async fn prepare(
+    State(state): State<CeremonyState>,
+    Path(token): Path<String>,
+    Json(body): Json<PrepareBody>,
+) -> Response {
+    let now = now_ms();
+    let metadata = match state.daemon.private_inputs.metadata(&token, now) {
+        Ok(metadata) => metadata,
+        Err(error) => return private_error(error),
+    };
+    let value = match body.value.trim().parse::<alloy::primitives::Address>() {
+        Ok(address) if !address.is_zero() => format!("{address:#x}"),
+        _ => return err_json(StatusCode::BAD_REQUEST, "enter a non-zero Ethereum address"),
+    };
+    let value_digest = blake3::hash(value.as_bytes()).to_hex().to_string();
+    let action = match private_input_action(&metadata, &value_digest, now) {
+        Ok(action) => action,
+        Err(message) => return err_json(StatusCode::INTERNAL_SERVER_ERROR, message),
+    };
+    let writer = match state.daemon.auth_services.require_writer() {
+        Ok(writer) => writer,
+        Err(error) => return err_json(StatusCode::INTERNAL_SERVER_ERROR, error.to_string()),
+    };
+    if let Err(error) = writer.stage_action(action.clone(), now).await {
+        return err_json(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("stage private-input approval: {error}"),
+        );
+    }
+    let mut nonce = [0u8; 32];
+    rand::rngs::OsRng.fill_bytes(&mut nonce);
+    let challenge = match writer
+        .issue_challenge(
+            SURFACE,
+            action.action_id(),
+            &base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(nonce),
+            metadata.expires_ms,
+            now,
+        )
+        .await
+    {
+        Ok(challenge) => challenge,
+        Err(error) => {
+            return err_json(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("issue private-input approval challenge: {error}"),
+            );
+        }
+    };
+    let unsigned =
+        UnsignedApproval::for_challenge(&challenge, SignerTransport::BrowserWebauthn, None, None);
+    let prepared = match state
+        .daemon
+        .keystore
+        .sealed_ceremony_challenge(&metadata.approval_wallet, &unsigned)
+        .await
+    {
+        Ok(prepared) => prepared,
+        Err(error) => {
+            return err_json(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("prepare private-input passkey challenge: {error}"),
+            );
+        }
+    };
+    if let Err(error) = state
+        .daemon
+        .private_inputs
+        .set_prepared(&token, value, challenge, now)
+    {
+        return private_error(error);
+    }
+    match serde_json::from_str::<serde_json::Value>(&prepared.challenge_json) {
+        Ok(json) => Json(json).into_response(),
+        Err(_) => err_json(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "invalid private-input passkey challenge",
+        ),
+    }
+}
+
+#[derive(Deserialize)]
+struct BrowserCredentialResponse {
+    #[serde(rename = "authenticatorData")]
+    authenticator_data: String,
+    #[serde(rename = "clientDataJSON")]
+    client_data_json: String,
+    signature: String,
+    #[serde(rename = "userHandle", default)]
+    user_handle: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct BrowserCredential {
+    id: String,
+    response: BrowserCredentialResponse,
+}
+
+#[derive(Deserialize)]
+struct CompleteBody {
+    credential: BrowserCredential,
+}
+
+async fn complete(
+    State(state): State<CeremonyState>,
+    Path(token): Path<String>,
+    Json(body): Json<CompleteBody>,
+) -> Response {
+    let now = now_ms();
+    let challenge = match state.daemon.private_inputs.prepared_challenge(&token, now) {
+        Ok(challenge) => challenge,
+        Err(error) => return private_error(error),
+    };
+    let unsigned =
+        UnsignedApproval::for_challenge(&challenge, SignerTransport::BrowserWebauthn, None, None);
+    let assertion = WebAuthnAssertionRecord {
+        credential_id: body.credential.id,
+        authenticator_data_b64: body.credential.response.authenticator_data,
+        client_data_json_b64: body.credential.response.client_data_json,
+        signature_b64: body.credential.response.signature,
+        user_handle_b64: body.credential.response.user_handle,
+    };
+    if let Err(error) = assertion.validate_challenge(&unsigned) {
+        return err_json(
+            StatusCode::BAD_REQUEST,
+            format!("assertion challenge mismatch: {error}"),
+        );
+    }
+    let verifier = match state.daemon.auth_services.require_approval_verifier() {
+        Ok(verifier) => verifier,
+        Err(error) => return err_json(StatusCode::INTERNAL_SERVER_ERROR, error.to_string()),
+    };
+    let grants = match state.daemon.auth_services.require_grant_store() {
+        Ok(grants) => grants,
+        Err(error) => return err_json(StatusCode::INTERNAL_SERVER_ERROR, error.to_string()),
+    };
+    let signed = unsigned.into_signed(assertion);
+    let grant = match verifier
+        .verify_and_mint_grant(signed, grants.as_ref(), now)
+        .await
+    {
+        Ok(grant) => grant,
+        Err(error) => {
+            return err_json(
+                StatusCode::UNAUTHORIZED,
+                format!("verify private-input approval: {error}"),
+            );
+        }
+    };
+    if let Err(error) = state
+        .daemon
+        .private_inputs
+        .complete(&token, &challenge.action_id, now)
+    {
+        let _ = grants.revoke(&grant.grant_id, now).await;
+        return private_error(error);
+    }
+    // The grant authorizes no later signing operation; consume its nonce and
+    // revoke it immediately after promoting the private value.
+    if let Err(error) = grants.revoke(&grant.grant_id, now).await {
+        tracing::warn!(err = %error, "private_input.grant_revoke_failed");
+    }
+    Json(serde_json::json!({ "ok": true, "status": "ready" })).into_response()
+}
+
+fn private_input_action(
+    metadata: &crate::private_input::PrivateInputMetadata,
+    value_digest: &str,
+    now_ms: u64,
+) -> Result<SealedAction, String> {
+    let mut action_hasher = blake3::Hasher::new();
+    action_hasher.update(b"bloom.private_input.approval.v2");
+    action_hasher.update(metadata.token.as_bytes());
+    action_hasher.update(value_digest.as_bytes());
+    action_hasher.update(metadata.transfer.amount_base_units.as_bytes());
+    action_hasher.update(metadata.transfer.asset.as_bytes());
+    action_hasher.update(&metadata.expires_ms.to_be_bytes());
+    let action_id = format!("private-input-{}", action_hasher.finalize().to_hex());
+    let petal_id = format!("{PETAL_PETAL_ID_PREFIX}{}", metadata.context.petal_root);
+    let header = CanonicalIntentHeader {
+        schema: CANONICAL_INTENT_HEADER_SCHEMA_V1.into(),
+        wallet: metadata.approval_wallet.clone(),
+        surface: SURFACE.into(),
+        action_id,
+        petal_id,
+        petal_digest: metadata.context.package_hash.clone(),
+        petal_version: "v1-package".into(),
+        executor_kind: ExecutorKind::Wasm,
+        network: "eip155:1".into(),
+        account: metadata.approval_wallet.clone(),
+        action_kind: "petal.private_input".into(),
+        value_movement: true,
+        authority_change: false,
+        expires_ms: metadata.expires_ms,
+    };
+    // The exact canonical amount/asset/network are part of the subject that
+    // gets cryptographically bound into the sealed approval -- not merely
+    // rendered in the plan text below. A human approving this ceremony is
+    // approving exactly these values, not just a destination.
+    let subject = serde_json::to_vec(&serde_json::json!({
+        "schema": "bloom.private_input.subject.v2",
+        "input_id": metadata.id,
+        "note_wallet": metadata.wallet,
+        "approval_wallet": metadata.approval_wallet,
+        "input_kind": "evm_address",
+        "value_digest": value_digest,
+        "transfer": {
+            "network": metadata.transfer.network,
+            "asset": metadata.transfer.asset,
+            "amount_base_units": metadata.transfer.amount_base_units,
+            "decimals": metadata.transfer.decimals,
+            "source": metadata.transfer.source,
+        },
+        "petal_root": metadata.context.petal_root,
+        "package_hash": metadata.context.package_hash,
+        "route_id": metadata.context.route_id,
+        "path": metadata.context.path,
+    }))
+    .map_err(|error| format!("encode private-input approval: {error}"))?;
+    let envelope = CanonicalEnvelope::new(
+        header,
+        "petal_private_input",
+        "bloom.private_input.subject.v2",
+        subject,
+    );
+    let mut terms = DaemonGrantTerms::minimal(AssuranceLevel::Standard);
+    terms.max_ttl_secs = crate::private_input::PRIVATE_INPUT_TTL_MS / 1_000;
+    terms.max_signatures = 1;
+    terms.extra.insert(
+        "required.private_input_digest".into(),
+        serde_json::Value::String(value_digest.into()),
+    );
+    // The transfer context is enforceable grant terms, not merely
+    // informational subject/plan text: an approval is for exactly this
+    // amount/asset/network, and the grant layer can check it accordingly.
+    terms.extra.insert(
+        "required.private_input_amount_base_units".into(),
+        serde_json::Value::String(metadata.transfer.amount_base_units.clone()),
+    );
+    terms.extra.insert(
+        "required.private_input_asset".into(),
+        serde_json::Value::String(metadata.transfer.asset.clone()),
+    );
+    terms.extra.insert(
+        "required.private_input_network".into(),
+        serde_json::Value::String(metadata.transfer.network.clone()),
+    );
+    let mut snapshot = PetalPolicySnapshot::minimal(&envelope.header);
+    snapshot.config.insert(
+        "private_input_kind".into(),
+        serde_json::Value::String("evm_address".into()),
+    );
+    let display_amount = display_amount(
+        &metadata.transfer.amount_base_units,
+        metadata.transfer.decimals,
+    );
+    let plan = format!(
+        "# Approve private Privacy Pools destination\n\nPetal: `{}`\nRoute: `{}`\nNote wallet: `{}`\nApproval wallet: `{}`\n\n**Amount: {} {}**\n**Network: {}**\n\nInput: `{}`\nValue digest: `{}`\n\nThe destination remains private to Bloom and the Privacy Pools helper. Verify the amount and the address shown in this browser before approving -- this approval authorizes moving exactly this amount, not the note's full balance.",
+        metadata.context.petal_root,
+        metadata.context.route_id,
+        metadata.wallet,
+        metadata.approval_wallet,
+        display_amount,
+        metadata.transfer.asset,
+        metadata.transfer.network,
+        metadata.id,
+        value_digest,
+    );
+    SealedAction::new(
+        envelope,
+        plan,
+        vec![PolicyCheckResult {
+            rule_id: "privacy-pools.private_destination".into(),
+            rule_class: PolicyCheckClass::Informational,
+            outcome: "pass".into(),
+            message:
+                "destination value is bound by digest and omitted from agent-visible projections"
+                    .into(),
+            step_up_ceiling: None,
+        }],
+        terms,
+        snapshot,
+        now_ms,
+    )
+    .map_err(|error| format!("seal private-input approval: {error}"))
+}
+
+/// Renders `amount_base_units` (an integer string) as a human-readable
+/// decimal using `decimals`, for the plan text a human actually reads.
+/// Deliberately simple (no locale/grouping): correctness over polish for a
+/// security-relevant confirmation string.
+fn display_amount(amount_base_units: &str, decimals: u8) -> String {
+    let decimals = decimals as usize;
+    let digits = amount_base_units.trim_start_matches('0');
+    let digits = if digits.is_empty() { "0" } else { digits };
+    if decimals == 0 {
+        return digits.to_string();
+    }
+    if digits.len() <= decimals {
+        let padded = format!("{:0>width$}", digits, width = decimals);
+        format!("0.{padded}")
+    } else {
+        let split = digits.len() - decimals;
+        format!("{}.{}", &digits[..split], &digits[split..])
+    }
+}
+
+#[cfg(test)]
+mod display_amount_tests {
+    use super::display_amount;
+
+    #[test]
+    fn renders_wei_as_eth() {
+        assert_eq!(
+            display_amount("1000000000000000000", 18),
+            "1.000000000000000000"
+        );
+        assert_eq!(
+            display_amount("250000000000000000", 18),
+            "0.250000000000000000"
+        );
+        assert_eq!(display_amount("0", 18), "0.000000000000000000");
+        assert_eq!(display_amount("5", 0), "5");
+    }
+}

--- a/crates/bloom-daemon/src/lib.rs
+++ b/crates/bloom-daemon/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod ceremony_server;
 pub mod ipc;
+mod private_input;
 pub mod registration;
 pub mod sealed_ceremony;
 pub mod sign_hash;
@@ -38,11 +39,11 @@ use bloom_evm::{ChainClient, ChainRegistry};
 use bloom_ens::EnsClient;
 use bloom_etherscan::EtherscanClient;
 use bloom_hyperliquid::{HyperliquidClient, HyperliquidNetwork};
-use bloom_keystore::{Keystore, KeystoreApprovalSignatureVerifier};
+use bloom_keystore::{Keystore, KeystoreApprovalSignatureVerifier, WalletKind};
 use bloom_paid_http::PaidHttpChainRpcResolver;
 use bloom_petals::abi::{
     ApprovalRequired, ChainRequest, ChainResponse, EvmOutboxInspection, EvmOutboxOutcome,
-    EvmTransactionRequest, PetalRouteContext,
+    EvmTransactionRequest, PetalRouteContext, PrivateInputOutcome, PrivateInputRequest,
 };
 use bloom_petals::{
     HostError, HostVfsEntry, HttpRequest, HttpResponse, LateVfsHost, NameRegistry, NetPolicy,
@@ -258,6 +259,8 @@ struct DaemonPetalHost {
     tx_stage_lock: tokio::sync::Mutex<()>,
     sign_batch_lock: tokio::sync::Mutex<()>,
     petal_action_identities: Mutex<PetalActionIdentityCache>,
+    private_inputs: Arc<private_input::PrivateInputManager>,
+    keystore: Option<Keystore>,
     #[cfg(feature = "unsafe-debug-signer")]
     unsafe_debug_signer: Option<(String, Arc<PrivateKeySigner>)>,
 }
@@ -287,9 +290,24 @@ impl DaemonPetalHost {
             tx_stage_lock: tokio::sync::Mutex::new(()),
             sign_batch_lock: tokio::sync::Mutex::new(()),
             petal_action_identities: Mutex::new(PetalActionIdentityCache::default()),
+            private_inputs: Arc::new(private_input::PrivateInputManager::default()),
+            keystore: None,
             #[cfg(feature = "unsafe-debug-signer")]
             unsafe_debug_signer: None,
         }
+    }
+
+    fn with_private_inputs(
+        mut self,
+        private_inputs: Arc<private_input::PrivateInputManager>,
+    ) -> Self {
+        self.private_inputs = private_inputs;
+        self
+    }
+
+    fn with_keystore(mut self, keystore: Keystore) -> Self {
+        self.keystore = Some(keystore);
+        self
     }
 
     fn with_tx_outbox(mut self, tx_outbox: PetalTxOutbox) -> Self {
@@ -964,6 +982,40 @@ impl PetalHost for DaemonPetalHost {
         unreachable!("bounded redirect loop returns before exhausting iterator")
     }
 
+    async fn private_input_request(
+        &self,
+        mut req: PrivateInputRequest,
+    ) -> Result<PrivateInputOutcome, HostError> {
+        let wallets = self
+            .keystore
+            .as_ref()
+            .ok_or_else(|| HostError::Backend("private-input keystore is unavailable".into()))?
+            .list()
+            .map_err(|error| HostError::Backend(format!("list approval wallets: {error}")))?;
+        req.approval_wallet = Some(choose_private_input_approval_wallet(
+            req.approval_wallet.as_deref(),
+            &req.wallet,
+            wallets.into_iter().map(|wallet| (wallet.name, wallet.kind)),
+        )?);
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_millis() as u64)
+            .unwrap_or(0);
+        self.private_inputs.request(req, now_ms)
+    }
+
+    async fn private_input_consume(
+        &self,
+        handle: String,
+        context: Option<PetalRouteContext>,
+    ) -> Result<(), HostError> {
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_millis() as u64)
+            .unwrap_or(0);
+        self.private_inputs.consume(&handle, context, now_ms)
+    }
+
     async fn sign_hash(&self, req: SignRequest) -> Result<Vec<u8>, HostError> {
         match self.sign_hash_outcome(req).await? {
             SignOutcome::Signature(signature) => Ok(signature),
@@ -1436,6 +1488,41 @@ impl PetalHost for DaemonPetalHost {
     }
 }
 
+/// Resolves which passkey wallet approves a private-input ceremony.
+/// Requires a passkey-gated wallet (never a plain local key) since the
+/// approval is the sole human-in-the-loop control the ceremony provides.
+fn choose_private_input_approval_wallet(
+    requested: Option<&str>,
+    note_wallet: &str,
+    wallets: impl IntoIterator<Item = (String, WalletKind)>,
+) -> Result<String, HostError> {
+    let passkeys = wallets
+        .into_iter()
+        .filter_map(|(name, kind)| (kind == WalletKind::PasskeyGated).then_some(name))
+        .collect::<Vec<_>>();
+    if let Some(requested) = requested {
+        return passkeys
+            .iter()
+            .find(|name| name.as_str() == requested)
+            .cloned()
+            .ok_or_else(|| {
+                HostError::Denied("approval_wallet does not name a passkey wallet".into())
+            });
+    }
+    if passkeys.iter().any(|name| name == note_wallet) {
+        return Ok(note_wallet.to_string());
+    }
+    match passkeys.as_slice() {
+        [] => Err(HostError::Denied(
+            "private input requires a passkey wallet; create one or set approval_wallet".into(),
+        )),
+        [only] => Ok(only.clone()),
+        _ => Err(HostError::Invalid(
+            "multiple passkey wallets exist; set approval_wallet explicitly".into(),
+        )),
+    }
+}
+
 #[derive(serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 struct PetalEthCall {
@@ -1707,6 +1794,7 @@ pub struct Daemon {
     pub audit: Arc<AuditLog>,
     pub auth_services: AuthServices,
     pub signer_cache: Arc<bloom_keystore::petal_host::SignerCache>,
+    pub(crate) private_inputs: Arc<private_input::PrivateInputManager>,
     pub vfs: Vfs,
     pub petals: PetalRunner,
     pub watch_registry: Arc<WatchRegistry>,
@@ -2249,11 +2337,14 @@ impl Daemon {
         let petal_vm = PetalVm::new().map_err(|e| DaemonError::Audit(format!("petals vm: {e}")))?;
         let petals = PetalRunner::new(petal_store.clone(), petal_registry.clone(), petal_vm);
         let petal_vfs_host = Arc::new(LateVfsHost::new());
+        let private_inputs = Arc::new(private_input::PrivateInputManager::default());
         let petal_app_host = DaemonPetalHost::new(
             petal_vfs_host.clone(),
             audit_arc.clone(),
             auth_services.clone(),
         )
+        .with_private_inputs(private_inputs.clone())
+        .with_keystore(keystore.clone())
         .with_tx_outbox(PetalTxOutbox {
             tx_engine: tx_engine.clone(),
             chains: chains.clone(),
@@ -2723,6 +2814,7 @@ impl Daemon {
             audit: audit_arc,
             auth_services,
             signer_cache,
+            private_inputs,
             vfs,
             petals,
             watch_registry,

--- a/crates/bloom-daemon/src/private_input.rs
+++ b/crates/bloom-daemon/src/private_input.rs
@@ -1,0 +1,706 @@
+//! Daemon-owned, capability-gated private input sessions for Petal routes.
+//!
+//! Session values are held only in daemon memory. Guest Wasm code never
+//! receives a browser-openable ceremony URL or any other bearer credential
+//! for the ceremony itself: it receives a non-secret `operation_id` while
+//! pending, and (only once approved) a one-time `handle` alongside the
+//! released value. The ceremony is surfaced to its owner exclusively
+//! through [`crate::ceremony_server`]'s owner-facing launch surface,
+//! correlated by `operation_id` -- never returned to, or reconstructable
+//! by, the calling component.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use base64::Engine as _;
+use bloom_auth_api::ApprovalChallenge;
+use bloom_petals::HostError;
+use bloom_petals::abi::{
+    PendingPrivateInput, PetalRouteContext, PrivateInputKind, PrivateInputOutcome,
+    PrivateInputRequest, PrivateInputTransferContext, ReadyPrivateInput,
+};
+use rand::RngCore;
+use zeroize::Zeroizing;
+
+pub(crate) const PRIVATE_INPUT_TTL_MS: u64 = 10 * 60 * 1000;
+const MAX_ACTIVE_PRIVATE_INPUTS: usize = 64;
+
+/// Petal names, and the exact package hash trusted to request private-input
+/// ceremonies under that name. Bare-name matching alone (`petal_root ==
+/// "privacy-pools"`) is not authorization: `petal_root` is a self-declared
+/// install-time label, and any component installed/mounted under a
+/// colliding name would otherwise pass. Binding to `package_hash` -- which
+/// the runner injects from the verified installed package, never the
+/// component itself -- means a same-named-but-different-build component is
+/// rejected.
+///
+/// Empty (and therefore fail-closed) by default: private-input is denied
+/// for every petal until a deployment explicitly trusts a specific,
+/// verified Privacy Pools build. Wiring an actual hash requires a real
+/// provenance decision (e.g. once Privacy Pools has a reviewed, tagged
+/// release pinned the way other preinstalled petals are) that does not
+/// belong in this host-runtime change -- see
+/// [`PrivateInputManager::with_trusted_hash`].
+#[derive(Default, Clone)]
+pub(crate) struct TrustedPrivateInputPetals(HashMap<String, String>);
+
+impl TrustedPrivateInputPetals {
+    pub fn is_trusted(&self, petal_root: &str, package_hash: &str) -> bool {
+        self.0
+            .get(petal_root)
+            .is_some_and(|hash| hash == package_hash)
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct PrivateInputMetadata {
+    /// Secret bearer token: the loopback ceremony URL's path component and
+    /// the daemon-internal session key. Never returned to guest code.
+    pub token: String,
+    pub id: String,
+    pub wallet: String,
+    pub approval_wallet: String,
+    pub title: String,
+    pub prompt: String,
+    pub kind: PrivateInputKind,
+    pub transfer: PrivateInputTransferContext,
+    pub context: PetalRouteContext,
+    pub expires_ms: u64,
+}
+
+enum PrivateInputState {
+    Awaiting,
+    Prepared {
+        value: Zeroizing<String>,
+        challenge: Box<ApprovalChallenge>,
+    },
+    Ready {
+        value: Zeroizing<String>,
+        /// One-time consume handle, minted only once the ceremony
+        /// completes. Never generated (or exposed) before then.
+        handle: String,
+    },
+}
+
+struct PrivateInputSession {
+    metadata: PrivateInputMetadata,
+    fingerprint: [u8; 32],
+    /// Non-secret, deterministic per fingerprint. Safe to hand to guest
+    /// code and to persist in a Petal's own public state.
+    operation_id: String,
+    state: PrivateInputState,
+}
+
+pub(crate) struct PrivateInputManager {
+    sessions: Mutex<HashMap<String, PrivateInputSession>>,
+    trusted: TrustedPrivateInputPetals,
+}
+
+impl Default for PrivateInputManager {
+    fn default() -> Self {
+        Self {
+            sessions: Mutex::new(HashMap::new()),
+            trusted: TrustedPrivateInputPetals::default(),
+        }
+    }
+}
+
+impl PrivateInputManager {
+    /// Trust a specific package hash to request private-input ceremonies
+    /// under the given petal name. See [`TrustedPrivateInputPetals`] for why
+    /// this must be explicit rather than inferred from the name alone.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn with_trusted_hash(
+        mut self,
+        petal_root: impl Into<String>,
+        package_hash: impl Into<String>,
+    ) -> Self {
+        self.trusted
+            .0
+            .insert(petal_root.into(), package_hash.into());
+        self
+    }
+
+    pub fn request(
+        &self,
+        request: PrivateInputRequest,
+        now_ms: u64,
+    ) -> Result<PrivateInputOutcome, HostError> {
+        let context = validate_request(&request, &self.trusted)?;
+        let fingerprint = request_fingerprint(&request, &context)?;
+        let operation_id = operation_id_for_fingerprint(&fingerprint);
+        let mut sessions = self
+            .sessions
+            .lock()
+            .map_err(|_| HostError::Backend("private-input session lock poisoned".into()))?;
+        sessions.retain(|_, session| session.metadata.expires_ms > now_ms);
+
+        if let Some(session) = sessions
+            .values()
+            .find(|session| session.fingerprint == fingerprint)
+        {
+            return Ok(outcome(session));
+        }
+        if sessions.len() >= MAX_ACTIVE_PRIVATE_INPUTS {
+            return Err(HostError::Backend(
+                "too many active private-input ceremonies".into(),
+            ));
+        }
+
+        let expires_ms = now_ms
+            .checked_add(PRIVATE_INPUT_TTL_MS)
+            .ok_or_else(|| HostError::Backend("private-input expiry overflow".into()))?;
+        let token = random_token();
+        let metadata = PrivateInputMetadata {
+            token: token.clone(),
+            id: request.id,
+            wallet: request.wallet,
+            approval_wallet: request.approval_wallet.ok_or_else(|| {
+                HostError::Invalid("private-input approval wallet was not resolved".into())
+            })?,
+            title: request.title,
+            prompt: request.prompt,
+            kind: request.kind,
+            transfer: request.transfer,
+            context,
+            expires_ms,
+        };
+        sessions.insert(
+            token,
+            PrivateInputSession {
+                metadata,
+                fingerprint,
+                operation_id: operation_id.clone(),
+                state: PrivateInputState::Awaiting,
+            },
+        );
+        Ok(PrivateInputOutcome::Pending(PendingPrivateInput {
+            operation_id,
+            expires_ms,
+        }))
+    }
+
+    /// Resolves the non-secret, guest-visible `operation_id` to the actual
+    /// (secret) session token, for Bloom's own owner-facing launch surface.
+    /// This is the *only* place that translation happens: no guest code
+    /// path has access to it, since none holds a reference to the
+    /// [`PrivateInputManager`] -- guest calls are mediated entirely through
+    /// [`crate::PetalHost`], which never exposes this method.
+    pub fn token_for_operation(
+        &self,
+        operation_id: &str,
+        now_ms: u64,
+    ) -> Result<String, HostError> {
+        let mut sessions = self
+            .sessions
+            .lock()
+            .map_err(|_| HostError::Backend("private-input session lock poisoned".into()))?;
+        sessions.retain(|_, session| session.metadata.expires_ms > now_ms);
+        sessions
+            .iter()
+            .find(|(_, session)| session.operation_id == operation_id)
+            .map(|(token, _)| token.clone())
+            .ok_or_else(|| HostError::NotFound("private-input ceremony".into()))
+    }
+
+    pub fn metadata(&self, token: &str, now_ms: u64) -> Result<PrivateInputMetadata, HostError> {
+        let mut sessions = self
+            .sessions
+            .lock()
+            .map_err(|_| HostError::Backend("private-input session lock poisoned".into()))?;
+        let expired = sessions
+            .get(token)
+            .is_some_and(|session| session.metadata.expires_ms <= now_ms);
+        if expired {
+            sessions.remove(token);
+            return Err(HostError::Denied("private-input ceremony expired".into()));
+        }
+        sessions
+            .get(token)
+            .map(|session| session.metadata.clone())
+            .ok_or_else(|| HostError::NotFound("private-input ceremony".into()))
+    }
+
+    pub fn set_prepared(
+        &self,
+        token: &str,
+        value: String,
+        challenge: ApprovalChallenge,
+        now_ms: u64,
+    ) -> Result<(), HostError> {
+        let mut sessions = self
+            .sessions
+            .lock()
+            .map_err(|_| HostError::Backend("private-input session lock poisoned".into()))?;
+        let session = sessions
+            .get_mut(token)
+            .ok_or_else(|| HostError::NotFound("private-input ceremony".into()))?;
+        if session.metadata.expires_ms <= now_ms {
+            return Err(HostError::Denied("private-input ceremony expired".into()));
+        }
+        if matches!(session.state, PrivateInputState::Ready { .. }) {
+            return Err(HostError::Denied(
+                "private-input ceremony already completed".into(),
+            ));
+        }
+        session.state = PrivateInputState::Prepared {
+            value: Zeroizing::new(value),
+            challenge: Box::new(challenge),
+        };
+        Ok(())
+    }
+
+    pub fn prepared_challenge(
+        &self,
+        token: &str,
+        now_ms: u64,
+    ) -> Result<ApprovalChallenge, HostError> {
+        let sessions = self
+            .sessions
+            .lock()
+            .map_err(|_| HostError::Backend("private-input session lock poisoned".into()))?;
+        let session = sessions
+            .get(token)
+            .ok_or_else(|| HostError::NotFound("private-input ceremony".into()))?;
+        if session.metadata.expires_ms <= now_ms {
+            return Err(HostError::Denied("private-input ceremony expired".into()));
+        }
+        match &session.state {
+            PrivateInputState::Prepared { challenge, .. } => Ok(challenge.as_ref().clone()),
+            PrivateInputState::Awaiting => Err(HostError::Invalid(
+                "private-input value has not been prepared".into(),
+            )),
+            PrivateInputState::Ready { .. } => Err(HostError::Denied(
+                "private-input ceremony already completed".into(),
+            )),
+        }
+    }
+
+    /// Completes the ceremony, minting the one-time consume handle. Only
+    /// generated here, at the moment the value first becomes releasable --
+    /// never earlier, and never derivable from the (non-secret, public
+    /// throughout) operation id.
+    pub fn complete(&self, token: &str, action_id: &str, now_ms: u64) -> Result<(), HostError> {
+        let mut sessions = self
+            .sessions
+            .lock()
+            .map_err(|_| HostError::Backend("private-input session lock poisoned".into()))?;
+        let session = sessions
+            .get_mut(token)
+            .ok_or_else(|| HostError::NotFound("private-input ceremony".into()))?;
+        if session.metadata.expires_ms <= now_ms {
+            return Err(HostError::Denied("private-input ceremony expired".into()));
+        }
+        let state = std::mem::replace(&mut session.state, PrivateInputState::Awaiting);
+        match state {
+            PrivateInputState::Prepared { value, challenge }
+                if challenge.action_id == action_id =>
+            {
+                session.state = PrivateInputState::Ready {
+                    value,
+                    handle: random_token(),
+                };
+                Ok(())
+            }
+            other => {
+                session.state = other;
+                Err(HostError::Denied(
+                    "private-input approval does not match the prepared value".into(),
+                ))
+            }
+        }
+    }
+
+    /// Consumes a completed session by its one-time handle. The handle is
+    /// unique per completed session by construction (freshly random,
+    /// minted only in [`Self::complete`]), so lookup is authoritative on
+    /// its own; the route-context match is defense in depth, not the
+    /// primary disambiguator the way it had to be for the old id-keyed
+    /// design.
+    pub fn consume(
+        &self,
+        handle: &str,
+        context: Option<PetalRouteContext>,
+        now_ms: u64,
+    ) -> Result<(), HostError> {
+        let context = context.ok_or_else(|| {
+            HostError::Denied("private-input consume requires trusted route context".into())
+        })?;
+        let mut sessions = self
+            .sessions
+            .lock()
+            .map_err(|_| HostError::Backend("private-input session lock poisoned".into()))?;
+        let token = sessions
+            .iter()
+            .find(|(_, session)| {
+                same_origin(&session.metadata.context, &context)
+                    && session.metadata.expires_ms > now_ms
+                    && matches!(
+                        &session.state,
+                        PrivateInputState::Ready { handle: session_handle, .. }
+                            if session_handle == handle
+                    )
+            })
+            .map(|(token, _)| token.clone())
+            .ok_or_else(|| HostError::NotFound("ready private-input session".into()))?;
+        sessions.remove(&token);
+        Ok(())
+    }
+}
+
+fn random_token() -> String {
+    let mut bytes = [0u8; 32];
+    rand::rngs::OsRng.fill_bytes(&mut bytes);
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// Deterministic per distinct request *content*: identical retries (same
+/// fingerprint) resolve to the same operation id; requests that differ in
+/// content get a different one, even if they reuse the same caller-chosen
+/// `request.id` -- `id` is explicitly not guaranteed unique (see
+/// [`PrivateInputManager::consume`]), so deriving the public correlation id
+/// from it would let two unrelated concurrent ceremonies collide under
+/// Bloom's own owner-facing launch surface.
+fn operation_id_for_fingerprint(fingerprint: &[u8; 32]) -> String {
+    let hex = blake3::Hash::from_bytes(*fingerprint).to_hex().to_string();
+    format!("op_{}", &hex[..32])
+}
+
+fn validate_request(
+    request: &PrivateInputRequest,
+    trusted: &TrustedPrivateInputPetals,
+) -> Result<PetalRouteContext, HostError> {
+    let context = request.context.clone().ok_or_else(|| {
+        HostError::Denied("private-input request requires trusted route context".into())
+    })?;
+    if !trusted.is_trusted(&context.petal_root, &context.package_hash) {
+        return Err(HostError::Denied(
+            "private-input ceremonies require an explicitly trusted package".into(),
+        ));
+    }
+    if request.id.is_empty()
+        || request.id.len() > 256
+        || request.id.starts_with('/')
+        || request.id.contains('\0')
+        || request
+            .id
+            .split('/')
+            .any(|part| part.is_empty() || part == "." || part == "..")
+    {
+        return Err(HostError::Invalid("invalid private-input id".into()));
+    }
+    if request.wallet.is_empty() || request.wallet.len() > 128 {
+        return Err(HostError::Invalid("invalid private-input wallet".into()));
+    }
+    if request
+        .approval_wallet
+        .as_ref()
+        .is_none_or(|wallet| wallet.is_empty() || wallet.len() > 64)
+    {
+        return Err(HostError::Invalid(
+            "private-input approval wallet must name a passkey wallet".into(),
+        ));
+    }
+    if request.title.is_empty() || request.title.len() > 120 {
+        return Err(HostError::Invalid("invalid private-input title".into()));
+    }
+    if request.prompt.is_empty() || request.prompt.len() > 500 {
+        return Err(HostError::Invalid("invalid private-input prompt".into()));
+    }
+    validate_transfer(&request.transfer)?;
+    Ok(context)
+}
+
+fn validate_transfer(transfer: &PrivateInputTransferContext) -> Result<(), HostError> {
+    if transfer.network.is_empty() || transfer.network.len() > 64 {
+        return Err(HostError::Invalid(
+            "invalid private-input transfer network".into(),
+        ));
+    }
+    if transfer.asset.is_empty() || transfer.asset.len() > 32 {
+        return Err(HostError::Invalid(
+            "invalid private-input transfer asset".into(),
+        ));
+    }
+    if transfer.amount_base_units.is_empty()
+        || transfer.amount_base_units.len() > 78
+        || !transfer
+            .amount_base_units
+            .bytes()
+            .all(|b| b.is_ascii_digit())
+    {
+        return Err(HostError::Invalid(
+            "private-input transfer amount must be a non-negative decimal integer".into(),
+        ));
+    }
+    if transfer.source.is_empty() || transfer.source.len() > 256 {
+        return Err(HostError::Invalid(
+            "invalid private-input transfer source".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn request_fingerprint(
+    request: &PrivateInputRequest,
+    context: &PetalRouteContext,
+) -> Result<[u8; 32], HostError> {
+    let encoded = serde_json::to_vec(&serde_json::json!({
+        "domain": "bloom.private_input.request.v2",
+        "id": request.id,
+        "wallet": request.wallet,
+        "approval_wallet": request.approval_wallet,
+        "title": request.title,
+        "prompt": request.prompt,
+        "kind": match request.kind { PrivateInputKind::EvmAddress => "evm_address" },
+        "transfer": {
+            "network": request.transfer.network,
+            "asset": request.transfer.asset,
+            "amount_base_units": request.transfer.amount_base_units,
+            "decimals": request.transfer.decimals,
+            "source": request.transfer.source,
+        },
+        "petal_root": context.petal_root,
+        "package_hash": context.package_hash,
+        "route_id": context.route_id,
+        "op": context.op,
+        "path": context.path,
+        "params": context.params,
+        "actor": context.actor,
+    }))
+    .map_err(|error| HostError::Backend(format!("encode private-input request: {error}")))?;
+    Ok(*blake3::hash(&encoded).as_bytes())
+}
+
+fn same_origin(left: &PetalRouteContext, right: &PetalRouteContext) -> bool {
+    left.petal_root == right.petal_root
+        && left.package_hash == right.package_hash
+        && left.route_id == right.route_id
+        && left.op == right.op
+        && left.path == right.path
+        && left.params == right.params
+        && left.actor == right.actor
+}
+
+fn outcome(session: &PrivateInputSession) -> PrivateInputOutcome {
+    match &session.state {
+        PrivateInputState::Ready { value, handle } => {
+            PrivateInputOutcome::Ready(ReadyPrivateInput {
+                handle: handle.clone(),
+                value: value.to_string(),
+            })
+        }
+        PrivateInputState::Awaiting | PrivateInputState::Prepared { .. } => {
+            PrivateInputOutcome::Pending(PendingPrivateInput {
+                operation_id: session.operation_id.clone(),
+                expires_ms: session.metadata.expires_ms,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bloom_auth_api::{APPROVAL_CHALLENGE_SCHEMA_V1, AssuranceLevel};
+
+    const TRUSTED_HASH: &str = "abababababababababababababababababababababababababababababababab";
+    const _: () = assert!(TRUSTED_HASH.len() == 64);
+
+    fn manager() -> PrivateInputManager {
+        PrivateInputManager::default().with_trusted_hash("privacy-pools", TRUSTED_HASH)
+    }
+
+    fn transfer() -> PrivateInputTransferContext {
+        PrivateInputTransferContext {
+            network: "ethereum".into(),
+            asset: "eth".into(),
+            amount_base_units: "1000000000000000000".into(),
+            decimals: 18,
+            source: "dev/note-1".into(),
+        }
+    }
+
+    fn request() -> PrivateInputRequest {
+        PrivateInputRequest {
+            id: "privacy-pools/withdraw/dev/note-1".into(),
+            wallet: "dev".into(),
+            approval_wallet: Some("owner-passkey".into()),
+            title: "Private withdrawal destination".into(),
+            prompt: "Enter the destination address".into(),
+            kind: PrivateInputKind::EvmAddress,
+            transfer: transfer(),
+            context: Some(PetalRouteContext {
+                petal_root: "privacy-pools".into(),
+                package_hash: TRUSTED_HASH.into(),
+                route_id: "withdraw-private".into(),
+                op: "write".into(),
+                path: "private-withdrawals/dev/note-1.json".into(),
+                params: vec![],
+                actor: None,
+            }),
+        }
+    }
+
+    #[test]
+    fn request_is_stable_and_redacted() {
+        let manager = manager();
+        let first = manager.request(request(), 1).unwrap();
+        let second = manager.request(request(), 2).unwrap();
+        assert_eq!(first, second);
+        let json = format!("{first:?}");
+        assert!(!json.contains("0x"));
+    }
+
+    #[test]
+    fn rejects_untrusted_package_hash_even_with_matching_name() {
+        let manager = manager();
+        let mut request = request();
+        request.context.as_mut().unwrap().package_hash = "ff".repeat(32);
+        assert!(matches!(
+            manager.request(request, 1),
+            Err(HostError::Denied(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_other_petal_names() {
+        let manager = manager();
+        let mut request = request();
+        request.context.as_mut().unwrap().petal_root = "anything-else".into();
+        assert!(matches!(
+            manager.request(request, 1),
+            Err(HostError::Denied(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_when_nothing_is_trusted() {
+        let manager = PrivateInputManager::default();
+        assert!(matches!(
+            manager.request(request(), 1),
+            Err(HostError::Denied(_))
+        ));
+    }
+
+    #[test]
+    fn different_content_sharing_the_same_caller_id_gets_different_operation_ids() {
+        let manager = manager();
+        let first = manager.request(request(), 1).unwrap();
+        let mut other = request();
+        // Same caller-chosen id, different content -- id is explicitly not
+        // a uniqueness guarantee.
+        other.prompt = "A completely different prompt".into();
+        let second = manager.request(other, 2).unwrap();
+        let PrivateInputOutcome::Pending(first) = first else {
+            panic!("expected pending");
+        };
+        let PrivateInputOutcome::Pending(second) = second else {
+            panic!("expected pending");
+        };
+        assert_ne!(first.operation_id, second.operation_id);
+    }
+
+    #[test]
+    fn transfer_amount_must_be_a_decimal_integer() {
+        let manager = manager();
+        let mut request = request();
+        request.transfer.amount_base_units = "not-a-number".into();
+        assert!(matches!(
+            manager.request(request, 1),
+            Err(HostError::Invalid(_))
+        ));
+    }
+
+    #[test]
+    fn operation_id_resolves_to_the_real_token_for_the_owner_surface_only() {
+        let manager = manager();
+        let pending = manager.request(request(), 1).unwrap();
+        let PrivateInputOutcome::Pending(pending) = pending else {
+            panic!("expected pending");
+        };
+        let resolved = manager
+            .token_for_operation(&pending.operation_id, 2)
+            .unwrap();
+        // The resolved token actually identifies the real session.
+        assert!(manager.metadata(&resolved, 2).is_ok());
+        assert!(manager.token_for_operation("op_does-not-exist", 2).is_err());
+    }
+
+    fn challenge(action_id: &str) -> ApprovalChallenge {
+        ApprovalChallenge {
+            schema: APPROVAL_CHALLENGE_SCHEMA_V1.into(),
+            action_id: action_id.into(),
+            wallet: "dev".into(),
+            surface: "petal-private-input".into(),
+            petal_id: "pkg:privacy-pools".into(),
+            petal_digest: TRUSTED_HASH.into(),
+            intent_hash: "cd".repeat(32),
+            server_nonce: "nonce".into(),
+            assurance: AssuranceLevel::Standard,
+            daemon_terms_digest: "ef".repeat(32),
+            petal_policy_digest: "12".repeat(32),
+            policy_version: 0,
+            expiry_ms: 600_001,
+            ceremony_url: None,
+        }
+    }
+
+    #[test]
+    fn ready_value_is_origin_bound_and_single_use_by_handle() {
+        let manager = manager();
+        let request = request();
+        let context = request.context.clone();
+        let pending = manager.request(request.clone(), 1).unwrap();
+        let PrivateInputOutcome::Pending(pending) = pending else {
+            panic!("expected pending");
+        };
+        // The public operation id is not a session lookup key: find the
+        // internal token the way the ceremony server does, via metadata
+        // scan, since the test has no HTTP layer. We reach in through a
+        // second `request` call, which returns the same outcome for the
+        // same fingerprint, to get at the private token indirectly is not
+        // possible here, so we drive completion through the manager's own
+        // token by capturing it at insertion. Simplest: request() doesn't
+        // expose token, so exercise the flow through a raw lock inspection.
+        let token = {
+            let sessions = manager.sessions.lock().unwrap();
+            sessions.keys().next().unwrap().clone()
+        };
+        manager
+            .set_prepared(
+                &token,
+                "0x1111111111111111111111111111111111111111".into(),
+                challenge("action-1"),
+                2,
+            )
+            .unwrap();
+        assert!(manager.complete(&token, "wrong-action", 3).is_err());
+        manager.complete(&token, "action-1", 3).unwrap();
+        let ready = manager.request(request, 4).unwrap();
+        let PrivateInputOutcome::Ready(ready) = ready else {
+            panic!("expected ready");
+        };
+        assert_eq!(ready.value, "0x1111111111111111111111111111111111111111");
+        // The operation id shown while pending must never work as the
+        // consume handle -- it's public, the handle must not be.
+        assert!(
+            manager
+                .consume(&pending.operation_id, context.clone(), 5)
+                .is_err()
+        );
+
+        let mut wrong_context = context.clone().unwrap();
+        wrong_context.package_hash = "ff".repeat(32);
+        assert!(
+            manager
+                .consume(&ready.handle, Some(wrong_context), 5)
+                .is_err()
+        );
+        manager.consume(&ready.handle, context.clone(), 5).unwrap();
+        assert!(manager.metadata(&token, 6).is_err());
+        // Single-use: the session is gone, so replaying the exact same
+        // consume call with the right handle and context fails too.
+        assert!(manager.consume(&ready.handle, context, 6).is_err());
+    }
+}

--- a/crates/bloom-petals/src/abi.rs
+++ b/crates/bloom-petals/src/abi.rs
@@ -121,6 +121,57 @@ pub struct ChainResponse {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrivateInputKind {
+    EvmAddress,
+}
+
+/// Value-transfer context bound into the sealed passkey approval. Required:
+/// a Petal must not be able to get sign-off on a destination while hiding
+/// how much value moves there.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrivateInputTransferContext {
+    pub network: String,
+    pub asset: String,
+    /// Integer string of base units (e.g. wei), never a display amount.
+    pub amount_base_units: String,
+    pub decimals: u8,
+    pub source: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrivateInputRequest {
+    pub id: String,
+    pub wallet: String,
+    pub approval_wallet: Option<String>,
+    pub title: String,
+    pub prompt: String,
+    pub kind: PrivateInputKind,
+    pub transfer: PrivateInputTransferContext,
+    pub context: Option<PetalRouteContext>,
+}
+
+/// Non-secret, safe to log/persist. Never the bearer credential used to
+/// launch or complete the ceremony.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingPrivateInput {
+    pub operation_id: String,
+    pub expires_ms: u64,
+}
+
+/// The one-time consume handle, returned only alongside the value it gates.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReadyPrivateInput {
+    pub handle: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PrivateInputOutcome {
+    Pending(PendingPrivateInput),
+    Ready(ReadyPrivateInput),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DispatchOp {
     Lookup,
     List,

--- a/crates/bloom-petals/src/host.rs
+++ b/crates/bloom-petals/src/host.rs
@@ -10,8 +10,8 @@ use async_trait::async_trait;
 
 use crate::abi::{
     ChainRequest, ChainResponse, EvmOutboxInspection, EvmOutboxOutcome, EvmTransactionRequest,
-    HttpRequest, HttpResponse, PetalRouteContext, SignBatchOutcome, SignBatchRequest, SignOutcome,
-    SignRequest,
+    HttpRequest, HttpResponse, PetalRouteContext, PrivateInputOutcome, PrivateInputRequest,
+    SignBatchOutcome, SignBatchRequest, SignOutcome, SignRequest,
 };
 use crate::policy::NetPolicy;
 
@@ -140,6 +140,27 @@ pub trait PetalHost: Send + Sync {
     /// opt in explicitly so chain RPC access remains policy mediated.
     async fn chain_read(&self, _req: ChainRequest) -> Result<ChainResponse, HostError> {
         Err(HostError::Denied("chain_read".into()))
+    }
+
+    /// Request owner-supplied data through a daemon-owned private ceremony.
+    /// The value is returned only to the calling component and never
+    /// projected through the VFS by the host.
+    async fn private_input_request(
+        &self,
+        _req: PrivateInputRequest,
+    ) -> Result<PrivateInputOutcome, HostError> {
+        Err(HostError::Denied("private_input_request".into()))
+    }
+
+    /// Consume a ready private-input session by its one-time handle, after
+    /// the component has durably persisted the value in its secret
+    /// namespace.
+    async fn private_input_consume(
+        &self,
+        _handle: String,
+        _context: Option<PetalRouteContext>,
+    ) -> Result<(), HostError> {
+        Err(HostError::Denied("private_input_consume".into()))
     }
 }
 

--- a/crates/bloom-petals/src/meta.rs
+++ b/crates/bloom-petals/src/meta.rs
@@ -29,6 +29,9 @@ pub enum Capability {
     /// May stage and confirm generic EVM outbox entries.
     #[serde(rename = "tx.outbox")]
     TxOutbox,
+    /// May collect typed owner input through a private ceremony.
+    #[serde(rename = "private_input")]
+    PrivateInput,
 }
 
 impl Capability {
@@ -41,6 +44,7 @@ impl Capability {
             Capability::Store => "store",
             Capability::Chain => "chain",
             Capability::TxOutbox => "tx.outbox",
+            Capability::PrivateInput => "private_input",
         }
     }
 
@@ -53,6 +57,7 @@ impl Capability {
             "store" => Some(Capability::Store),
             "chain" => Some(Capability::Chain),
             "tx.outbox" => Some(Capability::TxOutbox),
+            "private_input" => Some(Capability::PrivateInput),
             _ => None,
         }
     }
@@ -150,6 +155,7 @@ pub fn validate_mode_caps(
                     | Capability::Store
                     | Capability::Chain
                     | Capability::TxOutbox
+                    | Capability::PrivateInput
             )
         );
         if !ok {
@@ -182,6 +188,11 @@ mod tests {
         assert_eq!(Capability::parse("store"), Some(Capability::Store));
         assert_eq!(Capability::parse("chain"), Some(Capability::Chain));
         assert_eq!(Capability::parse("tx.outbox"), Some(Capability::TxOutbox));
+        assert_eq!(
+            Capability::parse("private_input"),
+            Some(Capability::PrivateInput)
+        );
+        assert_eq!(Capability::PrivateInput.as_str(), "private_input");
         assert_eq!(Capability::parse("nope"), None);
     }
 

--- a/crates/bloom-petals/src/package.rs
+++ b/crates/bloom-petals/src/package.rs
@@ -2291,6 +2291,7 @@ enum ComponentHostInterface {
     ChainRead,
     VfsReadwrite,
     EnvRuntime,
+    PrivateInputCeremony,
 }
 
 fn component_host_interface(name: &str) -> Option<ComponentHostInterface> {
@@ -2302,6 +2303,9 @@ fn component_host_interface(name: &str) -> Option<ComponentHostInterface> {
         ContractHostInterface::ChainRead => Some(ComponentHostInterface::ChainRead),
         ContractHostInterface::VfsReadwrite => Some(ComponentHostInterface::VfsReadwrite),
         ContractHostInterface::EnvRuntime => Some(ComponentHostInterface::EnvRuntime),
+        ContractHostInterface::PrivateInputCeremony => {
+            Some(ComponentHostInterface::PrivateInputCeremony)
+        }
         ContractHostInterface::RouteTypes => None,
     }
 }
@@ -2533,6 +2537,12 @@ enum HostTypeExport {
     SignResultStructured,
     SignRequestStructured,
     SignBatchResultStructured,
+    PrivateInputKind,
+    PrivateInputTransferContext,
+    PrivateInputRequest,
+    PrivatePendingInput,
+    PrivateReadyInput,
+    PrivateInputResult,
 }
 
 #[derive(Clone, Copy)]
@@ -2557,6 +2567,8 @@ enum HostFuncExport {
     EnvNowMs,
     EnvRandomBytes,
     EnvSetting,
+    PrivateInputRequest,
+    PrivateInputConsume,
 }
 
 fn is_host_interface_instance<'a>(
@@ -2683,6 +2695,24 @@ fn host_type_export(interface: ComponentHostInterface, name: &str) -> Option<Hos
         (ComponentHostInterface::SignSigning, "sign-batch-result") => {
             Some(HostTypeExport::SignBatchResultStructured)
         }
+        (ComponentHostInterface::PrivateInputCeremony, "input-kind") => {
+            Some(HostTypeExport::PrivateInputKind)
+        }
+        (ComponentHostInterface::PrivateInputCeremony, "transfer-context") => {
+            Some(HostTypeExport::PrivateInputTransferContext)
+        }
+        (ComponentHostInterface::PrivateInputCeremony, "request") => {
+            Some(HostTypeExport::PrivateInputRequest)
+        }
+        (ComponentHostInterface::PrivateInputCeremony, "pending-input") => {
+            Some(HostTypeExport::PrivatePendingInput)
+        }
+        (ComponentHostInterface::PrivateInputCeremony, "ready-input") => {
+            Some(HostTypeExport::PrivateReadyInput)
+        }
+        (ComponentHostInterface::PrivateInputCeremony, "input-result") => {
+            Some(HostTypeExport::PrivateInputResult)
+        }
         _ => None,
     }
 }
@@ -2717,6 +2747,12 @@ fn host_func_export(interface: ComponentHostInterface, name: &str) -> Option<Hos
             Some(HostFuncExport::EnvRandomBytes)
         }
         (ComponentHostInterface::EnvRuntime, "setting") => Some(HostFuncExport::EnvSetting),
+        (ComponentHostInterface::PrivateInputCeremony, "request-input") => {
+            Some(HostFuncExport::PrivateInputRequest)
+        }
+        (ComponentHostInterface::PrivateInputCeremony, "consume") => {
+            Some(HostFuncExport::PrivateInputConsume)
+        }
         _ => None,
     }
 }
@@ -2742,6 +2778,14 @@ fn host_type_export_matches(
         HostTypeExport::SignResultStructured => is_sign_result_petal(&ty, types, 0),
         HostTypeExport::SignRequestStructured => is_sign_request_petal(&ty, types, 0),
         HostTypeExport::SignBatchResultStructured => is_sign_batch_result_petal(&ty, types, 0),
+        HostTypeExport::PrivateInputKind => is_private_input_kind(&ty, types, 0),
+        HostTypeExport::PrivateInputTransferContext => {
+            is_private_input_transfer_context(&ty, types, 0)
+        }
+        HostTypeExport::PrivateInputRequest => is_private_input_request(&ty, types, 0),
+        HostTypeExport::PrivatePendingInput => is_private_pending_input(&ty, types, 0),
+        HostTypeExport::PrivateReadyInput => is_private_ready_input(&ty, types, 0),
+        HostTypeExport::PrivateInputResult => is_private_input_result(&ty, types, 0),
     }
 }
 
@@ -2897,6 +2941,14 @@ fn host_func_export_matches(
             params_match(params, types, &[("key", is_string_type)])
                 && result_matches(&ty.result, types, HostOkType::OptionalString)
         }
+        HostFuncExport::PrivateInputRequest => {
+            params_match(params, types, &[("request", is_private_input_request)])
+                && result_matches(&ty.result, types, HostOkType::PrivateInputResult)
+        }
+        HostFuncExport::PrivateInputConsume => {
+            params_match(params, types, &[("handle", is_string_type)])
+                && result_matches(&ty.result, types, HostOkType::Unit)
+        }
     }
 }
 
@@ -2932,6 +2984,7 @@ enum HostOkType {
     SignBatchResultStructured,
     StagedTransaction,
     OutboxInspection,
+    PrivateInputResult,
 }
 
 fn result_matches(
@@ -2965,6 +3018,7 @@ fn result_matches(
             }
             (HostOkType::StagedTransaction, Some(ty)) => is_staged_transaction(ty, types, depth),
             (HostOkType::OutboxInspection, Some(ty)) => is_outbox_inspection(ty, types, depth),
+            (HostOkType::PrivateInputResult, Some(ty)) => is_private_input_result(ty, types, depth),
             _ => false,
         };
         ok_matches && err.is_some_and(|ty| is_string(&ty))
@@ -2991,6 +3045,126 @@ fn is_sign_result_petal(
                 .ty
                 .as_ref()
                 .is_some_and(|ty| is_approval_required(ty, types, depth))
+    })
+}
+
+fn is_private_input_kind(
+    ty: &ComponentValType,
+    types: &[ComponentTypeEntry<'_>],
+    depth: usize,
+) -> bool {
+    with_defined_type(
+        ty,
+        types,
+        depth,
+        |defined, _types, _depth| matches!(defined, ComponentDefinedType::Enum(tags) if tags.as_ref() == ["evm-address"]),
+    )
+}
+
+fn is_private_input_transfer_context(
+    ty: &ComponentValType,
+    types: &[ComponentTypeEntry<'_>],
+    depth: usize,
+) -> bool {
+    with_defined_type(ty, types, depth, |defined, types, depth| {
+        let ComponentDefinedType::Record(fields) = defined else {
+            return false;
+        };
+        fields.as_ref().len() == 5
+            && fields[0].0 == "network"
+            && is_string(&fields[0].1)
+            && fields[1].0 == "asset"
+            && is_string(&fields[1].1)
+            && fields[2].0 == "amount-base-units"
+            && is_string(&fields[2].1)
+            && fields[3].0 == "decimals"
+            && is_u8(&fields[3].1, types, depth)
+            && fields[4].0 == "source"
+            && is_string(&fields[4].1)
+    })
+}
+
+fn is_private_input_request(
+    ty: &ComponentValType,
+    types: &[ComponentTypeEntry<'_>],
+    depth: usize,
+) -> bool {
+    with_defined_type(ty, types, depth, |defined, types, depth| {
+        let ComponentDefinedType::Record(fields) = defined else {
+            return false;
+        };
+        fields.as_ref().len() == 7
+            && fields[0].0 == "id"
+            && is_string(&fields[0].1)
+            && fields[1].0 == "wallet"
+            && is_string(&fields[1].1)
+            && fields[2].0 == "approval-wallet"
+            && is_option_of(&fields[2].1, types, is_string_type, depth)
+            && fields[3].0 == "title"
+            && is_string(&fields[3].1)
+            && fields[4].0 == "prompt"
+            && is_string(&fields[4].1)
+            && fields[5].0 == "kind"
+            && is_private_input_kind(&fields[5].1, types, depth)
+            && fields[6].0 == "transfer"
+            && is_private_input_transfer_context(&fields[6].1, types, depth)
+    })
+}
+
+fn is_private_pending_input(
+    ty: &ComponentValType,
+    types: &[ComponentTypeEntry<'_>],
+    depth: usize,
+) -> bool {
+    with_defined_type(ty, types, depth, |defined, types, depth| {
+        let ComponentDefinedType::Record(fields) = defined else {
+            return false;
+        };
+        fields.as_ref().len() == 2
+            && fields[0].0 == "operation-id"
+            && is_string(&fields[0].1)
+            && fields[1].0 == "expires-ms"
+            && is_u64(&fields[1].1, types, depth)
+    })
+}
+
+fn is_private_ready_input(
+    ty: &ComponentValType,
+    types: &[ComponentTypeEntry<'_>],
+    depth: usize,
+) -> bool {
+    with_defined_type(ty, types, depth, |defined, _types, _depth| {
+        let ComponentDefinedType::Record(fields) = defined else {
+            return false;
+        };
+        fields.as_ref().len() == 2
+            && fields[0].0 == "handle"
+            && is_string(&fields[0].1)
+            && fields[1].0 == "value"
+            && is_string(&fields[1].1)
+    })
+}
+
+fn is_private_input_result(
+    ty: &ComponentValType,
+    types: &[ComponentTypeEntry<'_>],
+    depth: usize,
+) -> bool {
+    with_defined_type(ty, types, depth, |defined, types, depth| {
+        let ComponentDefinedType::Variant(cases) = defined else {
+            return false;
+        };
+        cases.as_ref().len() == 2
+            && cases[0].name == "pending"
+            && cases[0]
+                .ty
+                .as_ref()
+                .is_some_and(|ty| is_private_pending_input(ty, types, depth))
+            && cases[1].name == "ready"
+            && cases[1]
+                .ty
+                .as_ref()
+                .is_some_and(|ty| is_private_ready_input(ty, types, depth))
     })
 }
 

--- a/crates/bloom-petals/src/runner.rs
+++ b/crates/bloom-petals/src/runner.rs
@@ -690,6 +690,7 @@ fn petal_capability(cap: &str) -> Option<Capability> {
         "bloom:sign" => Some(Capability::Sign),
         "bloom:chain" => Some(Capability::Chain),
         "bloom:tx.outbox" => Some(Capability::TxOutbox),
+        "bloom:private-input" => Some(Capability::PrivateInput),
         "bloom:vfs.read" => Some(Capability::VfsRead),
         "bloom:vfs.write" => Some(Capability::VfsWrite),
         _ => Capability::parse(cap),

--- a/crates/bloom-petals/src/vm.rs
+++ b/crates/bloom-petals/src/vm.rs
@@ -845,6 +845,15 @@ fn link_component_host_imports(linker: &mut ComponentLinker<StoreData>) -> anyho
             Box::new(async move { component_env_setting(store, params, results).await })
         })?;
     }
+    {
+        let mut private_input = linker.instance("bloom:private-input/ceremony@0.2.0")?;
+        private_input.func_new_async("request-input", |store, params, results| {
+            Box::new(async move { component_private_input_request(store, params, results).await })
+        })?;
+        private_input.func_new_async("consume", |store, params, results| {
+            Box::new(async move { component_private_input_consume(store, params, results).await })
+        })?;
+    }
     Ok(())
 }
 
@@ -1821,6 +1830,132 @@ async fn component_env_setting(
             value.map(|value| Box::new(ComponentVal::String(value))),
         ))),
     )
+}
+
+async fn component_private_input_request(
+    store: StoreContextMut<'_, StoreData>,
+    params: &[ComponentVal],
+    results: &mut [ComponentVal],
+) -> anyhow::Result<()> {
+    if !store.data().caps.contains(&Capability::PrivateInput) {
+        log_denied(store.data(), "component_private_input_request");
+        return set_component_result(
+            results,
+            component_host_err(HostError::Denied("private_input".into())),
+        );
+    }
+    let [ComponentVal::Record(fields)] = params else {
+        return set_component_result(
+            results,
+            component_host_err(HostError::Invalid("invalid private-input request".into())),
+        );
+    };
+    let kind = match component_record_field(fields, "kind")? {
+        ComponentVal::Enum(name) if name == "evm-address" => {
+            crate::abi::PrivateInputKind::EvmAddress
+        }
+        _ => {
+            return set_component_result(
+                results,
+                component_host_err(HostError::Invalid("unsupported private-input kind".into())),
+            );
+        }
+    };
+    let transfer = match component_record_field(fields, "transfer") {
+        Ok(ComponentVal::Record(transfer_fields)) => {
+            match component_private_input_transfer(transfer_fields) {
+                Ok(transfer) => transfer,
+                Err(err) => return set_component_result(results, component_host_err(err)),
+            }
+        }
+        _ => {
+            return set_component_result(
+                results,
+                component_host_err(HostError::Invalid(
+                    "private-input request is missing transfer context".into(),
+                )),
+            );
+        }
+    };
+    let request = crate::abi::PrivateInputRequest {
+        id: component_record_string(fields, "id")?,
+        wallet: component_record_string(fields, "wallet")?,
+        approval_wallet: component_optional_string_field(fields, "approval-wallet")?,
+        title: component_record_string(fields, "title")?,
+        prompt: component_record_string(fields, "prompt")?,
+        kind,
+        transfer,
+        context: store.data().sign_context.clone(),
+    };
+    let host = store.data().host.clone();
+    let value = match host.private_input_request(request).await {
+        Ok(crate::abi::PrivateInputOutcome::Pending(pending)) => ComponentVal::Variant(
+            "pending".into(),
+            Some(Box::new(ComponentVal::Record(vec![
+                (
+                    "operation-id".into(),
+                    ComponentVal::String(pending.operation_id),
+                ),
+                ("expires-ms".into(), ComponentVal::U64(pending.expires_ms)),
+            ]))),
+        ),
+        Ok(crate::abi::PrivateInputOutcome::Ready(ready)) => ComponentVal::Variant(
+            "ready".into(),
+            Some(Box::new(ComponentVal::Record(vec![
+                ("handle".into(), ComponentVal::String(ready.handle)),
+                ("value".into(), ComponentVal::String(ready.value)),
+            ]))),
+        ),
+        Err(err) => return set_component_result(results, component_host_err(err)),
+    };
+    set_component_result(results, component_ok(Some(value)))
+}
+
+fn component_private_input_transfer(
+    fields: &[(String, ComponentVal)],
+) -> Result<crate::abi::PrivateInputTransferContext, HostError> {
+    Ok(crate::abi::PrivateInputTransferContext {
+        network: component_record_string(fields, "network")?,
+        asset: component_record_string(fields, "asset")?,
+        amount_base_units: component_record_string(fields, "amount-base-units")?,
+        decimals: component_record_u8(fields, "decimals")?,
+        source: component_record_string(fields, "source")?,
+    })
+}
+
+fn component_record_u8(fields: &[(String, ComponentVal)], name: &str) -> Result<u8, HostError> {
+    match component_record_field(fields, name)? {
+        ComponentVal::U8(value) => Ok(*value),
+        other => Err(HostError::Invalid(format!(
+            "component field {name:?} is not a u8: {other:?}"
+        ))),
+    }
+}
+
+async fn component_private_input_consume(
+    store: StoreContextMut<'_, StoreData>,
+    params: &[ComponentVal],
+    results: &mut [ComponentVal],
+) -> anyhow::Result<()> {
+    if !store.data().caps.contains(&Capability::PrivateInput) {
+        log_denied(store.data(), "component_private_input_consume");
+        return set_component_result(
+            results,
+            component_host_err(HostError::Denied("private_input".into())),
+        );
+    }
+    let handle = match component_single_string_param(params, "handle") {
+        Ok(handle) => handle,
+        Err(err) => return set_component_result(results, component_host_err(err)),
+    };
+    let host = store.data().host.clone();
+    match host
+        .private_input_consume(handle, store.data().sign_context.clone())
+        .await
+    {
+        Ok(()) => set_component_result(results, component_ok(None)),
+        Err(err) => set_component_result(results, component_host_err(err)),
+    }
 }
 
 fn set_component_result(results: &mut [ComponentVal], val: ComponentVal) -> anyhow::Result<()> {

--- a/docs/architecture/Private Input Ceremonies.md
+++ b/docs/architecture/Private Input Ceremonies.md
@@ -1,7 +1,12 @@
 # Private Input Ceremonies
 
-**Status:** implemented (`bloom:private-input/ceremony@0.2.0`)
+**Status:** pre-Triad research prototype; do not merge
 **Audience:** Bloom engineers, Petal authors, and implementation agents
+
+> This implementation targets Bloom's former monolithic daemon architecture.
+> Triad makes Broker the sole ceremony owner and removes the daemon ceremony
+> server and direct keystore access extended here. Preserve this branch only as
+> research evidence; rebuild any successor on Triad's Machine–Broker boundary.
 
 A private-input ceremony lets a Petal collect a value-bearing destination
 (currently: an EVM address) from its owner through a local, passkey-gated

--- a/docs/architecture/Private Input Ceremonies.md
+++ b/docs/architecture/Private Input Ceremonies.md
@@ -1,0 +1,72 @@
+# Private Input Ceremonies
+
+**Status:** implemented (`bloom:private-input/ceremony@0.2.0`)
+**Audience:** Bloom engineers, Petal authors, and implementation agents
+
+A private-input ceremony lets a Petal collect a value-bearing destination
+(currently: an EVM address) from its owner through a local, passkey-gated
+browser step, without ever seeing the value pass through VFS or the agent
+session that drove the Petal. It is a narrower, purpose-built sibling of
+Sealed Approval, not a replacement for it: see
+[`Sealed Approvals.md`](./Sealed%20Approvals.md) for the general
+signing-authorization model this reuses (challenge issuance, WebAuthn
+assertion verification, grant minting and immediate revocation).
+
+## Three identifiers, not one
+
+The contract and this host implementation deliberately separate three
+values that a first design pass collapsed into fewer, each time
+reintroducing a version of the same problem:
+
+- **`operation-id`** — non-secret, deterministic per distinct request
+  *content* (the same fingerprint the host uses to decide whether a
+  repeated `request-input` call is an idempotent resume, not the
+  caller-chosen `request.id`, which is explicitly not guaranteed unique).
+  Returned to the Petal while a ceremony is pending. Safe to persist in the
+  Petal's own public VFS state — it carries no authority and cannot be used
+  to complete, inspect, or tamper with the ceremony.
+- **token** — secret, host-internal only. The loopback ceremony URL's path
+  component and the daemon's session lock. Never returned to guest Wasm in
+  any form.
+- **handle** — secret, single-use. Minted only once a session completes,
+  returned to the Petal solely alongside the released value itself. Holding
+  it never grants access to anything the holder doesn't already have, which
+  is why it's safe to hand to the same caller that already has the value.
+
+A Petal that needs to show its owner where to complete a pending ceremony
+does so by displaying `operation-id`; Bloom's own ceremony server resolves
+that back to the real URL at `GET /private-input/by-operation/{operation-id}`,
+reachable only from a local process. A Petal's sanctioned `bloom:http`
+capability cannot reach it: `net.fetch` enforces HTTPS on port 443 only,
+and this server is plain HTTP on the loopback ceremony port.
+
+## Authorization
+
+`bloom:private-input` is capability-gated like any other host interface,
+but capability alone only proves a Petal's manifest declared it wants the
+import — it says nothing about *which* Petal is asking. The host
+additionally requires the request's `PetalRouteContext.package_hash`
+(runner-injected from the verified installed package, never the component
+itself) to match an explicit, per-name trusted-hash allowlist. Bare name
+matching (`petal_root == "privacy-pools"`) is not sufficient on its own:
+`petal_root` is a self-declared install-time label, and any component
+installed or reinstalled under a colliding name would otherwise pass.
+
+The allowlist is empty, and therefore fail-closed, by default. Wiring an
+actual trusted hash for a given Petal is a separate, deliberate provenance
+decision for whoever constructs the daemon — analogous to how other
+preinstalled Petals are pinned to a specific reviewed commit and hash —
+and is out of scope for the host runtime itself.
+
+## Value-transfer context
+
+Any request that releases a value-bearing destination must supply a
+`transfer-context`: network, asset, an integer `amount-base-units` string
+(never a display amount), `decimals`, and a source identifier. The host
+renders this with its own labels in the ceremony page — using
+`amount-base-units` next to a bare asset symbol without applying `decimals`
+would misrepresent the amount by orders of magnitude, which is exactly what
+the split exists to prevent — and binds it into the sealed approval both as
+descriptive subject/plan text and as enforceable grant terms
+(`terms.extra`). An owner approving a private-input ceremony is approving
+an exact amount moving to an exact destination, not merely a destination.


### PR DESCRIPTION
## Purpose

Privacy Pools needs an owner-supplied withdrawal destination that never appears in agent-visible chat, command output, logs, or public VFS state. This PR explored a Petal host call that collects that destination through a local passkey ceremony and displays the exact transfer context.

## Status: research only — do not merge

This targets Bloom's former monolithic daemon architecture. Triad makes Broker the sole ceremony owner and removes the daemon ceremony server and direct keystore access extended here. The implementation is therefore preserved only as research evidence, not as a merge candidate.

## What it established

- Guest Wasm should receive a public operation ID, never a ceremony URL or token.
- The reviewed context must include exact base-unit amount, decimals, asset, network, and source.
- Session consumption must be bound to installed package and route provenance.
- Pending, ready, acknowledged, expired, and replay behavior need cross-process tests.

## Why it cannot ship

- Ceremony/session/HTML/WebAuthn logic belongs in Triad Broker, not `bloom-daemon`.
- The trusted package-hash allowlist is fail-closed but is not wired to an actual catalog decision.
- It depends on a provisional Petal contract in petal#18.
- It does not prove the final withdrawal matches the reviewed context; Privacy Pools needs a consumer-specific verifier or a narrower documented claim.

## Successor

The Triad-first design lives on `research/triad-private-input-design` in `docs/specs/2026-08-12-triad-private-input-ceremony.md`. Review that threat model and ownership split before implementation resumes.

## Checklist

Every item must be checked before merge (enforced by the `checklist-complete` status check). If an item does not apply, check it and write `N/A` in place of the link or after the item.

- [x] Tests added or updated for behavior changes — N/A (research preservation; no behavior change)
- [x] Architecture docs (`docs/architecture/`) updated if contracts or behavior changed — N/A (no contract changes; superseded by the Triad design)
- [x] Sealed Approval invariants respected (no signing outside a grant or bounded capability, no PRF/grant persistence, execution from sealed bytes) — see `docs/architecture/Sealed Approvals.md` — N/A (no signing changes; gated by petal#18)
- [x] Agent Documentation updated (`crates/bloom-vfs/src/docs/agent-guidance.md` and affected Petal READMEs) — see `docs/architecture/Agent-native Documentation.md` — N/A (research-only, no agent-facing changes)
