### PR TITLE
Clarify triad launcher PATH usage

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -89,11 +89,13 @@ transport, Broker-owned ceremony HTTP, genuine WebAuthn, and Signer-held keys.
 The developer feature is rejected by production release packaging.
 
 The launcher writes public authenticated connection settings to
-`/tmp/bloom-triad-logs/triad.env`. Source it only in a second developer shell:
+`/tmp/bloom-triad-logs/triad.env`. Source it only in a second developer shell.
+This prepends the selected debug binary directory to `PATH` in that terminal,
+so use `bloom` directly for commands against the running Machine:
 
 ```sh
 source /tmp/bloom-triad-logs/triad.env
-target/debug/bloom wallet new test-wallet
+bloom wallet new test-wallet
 ```
 
 Wallet registration, import, credential changes, policy updates, delegated-key

--- a/crates/bloom-it/tests/triad_release.rs
+++ b/crates/bloom-it/tests/triad_release.rs
@@ -367,8 +367,11 @@ fn triad_developer_launcher_supports_vfs_only_mode() {
     );
     assert!(
         launcher.contains("Bloom is ready without a kernel mount")
-            && launcher.contains("\"$BLOOM_BIN\" vfs ls /")
-            && launcher.contains("\"$BLOOM_BIN\" vfs cat /next.md"),
+            && launcher
+                .contains("Source triad.env to put the selected debug bloom binary first on PATH;")
+            && launcher.contains("then use bloom directly in that terminal:")
+            && launcher.contains("bloom vfs ls /")
+            && launcher.contains("bloom vfs cat /next.md"),
         "VFS-only startup must tell the developer how to use the running Machine"
     );
     assert!(
@@ -427,6 +430,10 @@ fn triad_developer_launcher_can_leave_machine_developer_managed() {
     assert!(launcher.contains("--services-only) services_only=1; shift ;;"));
     assert!(launcher.contains("if [ \"$services_only\" -eq 1 ]; then"));
     assert!(launcher.contains("Bloom triad services are ready; Machine is developer-managed."));
+    assert!(
+        launcher.contains("Source triad.env to put the selected debug bloom binary first on PATH;")
+    );
+    assert!(launcher.contains("then use bloom directly in that terminal:"));
     assert!(launcher.contains("supervise_services"));
 
     let directory = tempfile::tempdir().unwrap();

--- a/docs/local-mainnet-integration.md
+++ b/docs/local-mainnet-integration.md
@@ -95,11 +95,13 @@ scripts/triad-dev-launch.sh \
 ```
 
 The launcher writes the exact authenticated connection environment to
-`/tmp/bloom-triad-logs/triad.env`. In a second terminal:
+`/tmp/bloom-triad-logs/triad.env`. In a second terminal, source that file to
+prepend the selected debug binary directory to `PATH`, then use `bloom`
+directly:
 
 ```bash
 source /tmp/bloom-triad-logs/triad.env
-bloom wallet import WALLET_NAME   # or: wallet new WALLET_NAME
+bloom wallet import WALLET_NAME   # or: bloom wallet new WALLET_NAME
 ```
 
 If macOS cannot mount Bloom's NFS 4.1 VFS, omit `--mount` and use the VFS CLI
@@ -119,13 +121,14 @@ Then, from another terminal:
 
 ```bash
 source /tmp/bloom-triad-logs/triad.env
-"$BLOOM_BIN" vfs ls /
-"$BLOOM_BIN" vfs cat /next.md
+bloom vfs ls /
+bloom vfs cat /next.md
 ```
 
-`triad.env` selects both the exact developer binary and its authenticated
-Machine IPC endpoint. Supplying `--mount` remains fail-closed: the launcher
-will not silently switch modes when a requested mount fails. The
+`triad.env` selects both the exact developer binary, by putting its directory
+first on `PATH` in the current terminal, and its authenticated Machine IPC
+endpoint. Supplying `--mount` remains fail-closed: the launcher will not
+silently switch modes when a requested mount fails. The
 `local-mainnet-integration.sh` and projection-fidelity runners below still
 require a supported kernel mount because they intentionally test mounted path
 behavior.
@@ -169,7 +172,7 @@ to the manual `bloom serve` command if the host supports it.
 Open the printed Broker ceremony URL. Registration creates a fresh address;
 import requires entering the key only in the Broker-hosted browser ceremony.
 Stop the launcher after the wallet appears under the mount, or under
-`"$BLOOM_BIN" vfs ls /wallets` in VFS-only mode. Subsequent runner invocations
+`bloom vfs ls /wallets` in VFS-only mode. Subsequent runner invocations
 reuse that Signer state and select it with `--wallet WALLET_NAME`.
 
 ## 1. Run preflight

--- a/scripts/triad-dev-launch.sh
+++ b/scripts/triad-dev-launch.sh
@@ -401,6 +401,8 @@ if [ "$services_only" -eq 1 ]; then
   printf 'ready\n' > "$ready_file"
   printf '%s\n' \
     'Bloom triad services are ready; Machine is developer-managed.' \
+    'Source triad.env to put the selected debug bloom binary first on PATH;' \
+    'then use bloom directly in that terminal:' \
     "  source ${env_file}" \
     "  cd ${repo_root}" \
     '  cargo build -p bloom --no-default-features --features mount,triad-dev-harness' \
@@ -486,9 +488,11 @@ printf 'ready\n' > "$ready_file"
 if [ -z "$mount_dir" ]; then
   printf '%s\n' \
     'Bloom is ready without a kernel mount.' \
+    'Source triad.env to put the selected debug bloom binary first on PATH;' \
+    'then use bloom directly in that terminal:' \
     "  source ${env_file}" \
-    '  "$BLOOM_BIN" vfs ls /' \
-    '  "$BLOOM_BIN" vfs cat /next.md'
+    '  bloom vfs ls /' \
+    '  bloom vfs cat /next.md'
 else
   while kill -0 "$machine_pid" 2>/dev/null; do
     if ! mount_is_live; then


### PR DESCRIPTION
## Summary

- explain that sourcing the generated `triad.env` prepends the selected debug binary directory to `PATH`
- recommend invoking `bloom` directly in launcher output and developer docs
- update launcher contract tests to cover the clarified guidance in VFS-only and services-only modes

## Why

The launcher already updated `PATH`, but some output and documentation continued to recommend `"$BLOOM_BIN"`. That made the intended terminal workflow look more cumbersome and obscured that plain `bloom` resolves to the selected debug build after sourcing the environment file.

## Developer impact

After sourcing `triad.env`, developers can consistently copy and run `bloom ...` commands in that terminal session.

## Validation

- `bash -n scripts/triad-dev-launch.sh`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p bloom-it triad_developer_launcher -- --nocapture` *(blocked by an unrelated existing compile error: `crates/bloom-it/src/lib.rs:227` initializes `ProvenanceRecord` without the required `petal_lineage` field)*