### PR TITLE
Remove legacy policy.toml VFS surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,8 +211,7 @@ and example crates used by the broader Bloom runtime and examples.
   when a non-empty confirm file is written.
 - **Policy custody before signing.** The writable `policy.json` surface uses
   Broker `policy.validate_update`, a Signer-completed `policy_update` custody
-  ceremony, and receipt-only `policy.commit_update`. The legacy `policy.toml`
-  view is read-only.
+  ceremony, and receipt-only `policy.commit_update`.
 - **Private orderflow is opt-in and fail-closed.** On unsupported
   chains, private broadcast returns an error instead of silently falling
   back to public RPC.

--- a/crates/bloom-daemon/src/ipc.rs
+++ b/crates/bloom-daemon/src/ipc.rs
@@ -2902,7 +2902,7 @@ summary = "Demo app used by IPC tests."
         for path in [
             // Policy updates and Sealed Approval lifecycle operations reach the
             // VFS handler and are delegated to Broker.
-            "/wallets/minnow/policy.toml",
+            "/wallets/minnow/policy.json",
             "/wallets/minnow/sealed-approvals/new.json",
             "/wallets/minnow/sealed-approvals/approval-1/revoke",
             "/wallets/minnow/chains/polygon/outbox/new.tx",

--- a/crates/bloom-daemon/src/lib.rs
+++ b/crates/bloom-daemon/src/lib.rs
@@ -3113,7 +3113,7 @@ impl Daemon {
         //
         // The canonical Broker policy has no Machine-local bump tuning.
         // Resolve wallet existence from the public projection and use the
-        // scanner's explicit defaults; never reopen legacy policy.toml.
+        // scanner's explicit defaults; never reopen Machine-local policy state.
         let mut bump_shutdown: Vec<tokio::sync::oneshot::Sender<()>> = Vec::new();
         if !mempool_indexes.is_empty() && tokio::runtime::Handle::try_current().is_ok() {
             let shared_indexes: bloom_tx::bump_scanner::MempoolIndexes =

--- a/crates/bloom-it/src/lib.rs
+++ b/crates/bloom-it/src/lib.rs
@@ -230,6 +230,7 @@ pub fn exact_signing_catalog(operation_classes: &[&str]) -> ProvenanceCatalog {
                     operation_class: Token::new(*operation_class).unwrap(),
                 },
                 publisher: Token::new("bloom-installer").unwrap(),
+                petal_lineage: None,
                 operation_classes: vec![ProvenanceOperationClass {
                     operation_class: Token::new(*operation_class).unwrap(),
                     fee_asset: Some(ProvenanceFeeAsset {

--- a/crates/bloom-mount/src/adapter.rs
+++ b/crates/bloom-mount/src/adapter.rs
@@ -916,7 +916,7 @@ impl BloomFs {
     ///
     /// Mode bits are *not* a useful gate here. Many writable files
     /// (mode 0o644) are also legitimately readable — addressbook
-    /// aliases resolve to an address, `policy.toml` reads back the
+    /// aliases resolve to an address, `policy.json` reads back the
     /// committed config, etc. A pure write-only sink (e.g.
     /// `outbox/pending/<id>/confirm`) returns a NotAFile-style error
     /// from `read`; that flows through `render_with_dedup` and falls
@@ -1077,7 +1077,7 @@ impl FileSystem for BloomFs {
         // views, wallet metadata, watch outputs). Those entries report
         // mode 0o444 from the VFS; only a small handful of injection
         // points (wallets/new, sign/*, outbox writes, watch/new, defi
-        // intents new+confirm, policy.toml) report 0o644. Reflect that
+        // intents new+confirm, policy.json) report 0o644. Reflect that
         // here so clients see a faithful permission view in `stat` /
         // `access(2)` rather than discovering write rejection only at
         // write-time.
@@ -1909,7 +1909,7 @@ mod tests {
         // Handler-owned Sealed Approval actions must reach the VFS handler, not
         // be denied at the mount signer lane. Broker remains authoritative.
         for path in [
-            "/wallets/minnow/policy.toml",
+            "/wallets/minnow/policy.json",
             "/wallets/minnow/sealed-approvals/new.json",
             "/wallets/minnow/sealed-approvals/approval-id/renew",
             "/wallets/minnow/sealed-approvals/approval-id/revoke",
@@ -2981,7 +2981,7 @@ mod tests {
     }
 
     /// Bug #1 acceptance: a writable file (mode 0o644) whose `read`
-    /// returns content — addressbook aliases, `policy.toml`, etc — is
+    /// returns content — addressbook aliases, `policy.json`, etc — is
     /// rendered at GETATTR so `cat` sees a non-zero size. The old
     /// "skip if writable" gate broke these read-write files; the only
     /// real reason to skip is `is_read_side_effecting`, not the mode

--- a/crates/bloom-proto/src/defi_policy.rs
+++ b/crates/bloom-proto/src/defi_policy.rs
@@ -91,10 +91,9 @@ pub struct DefiPolicy {
     ///
     /// Boundaries:
     /// - This is a **policy-file setting only**. It must **never** be exposed
-    ///   as a CLI flag (`--trust-route` / `--no-verify` etc.) — flipping it is
-    ///   an operator act in the wallet's `policy.toml`, signature-gated for
-    ///   passkey wallets (`bloom wallet sign-policy`), so an agent cannot flip
-    ///   it mid-run.
+    ///   as a CLI flag (`--trust-route` / `--no-verify` etc.) — changing it is
+    ///   an authenticated wallet-policy update, so an agent cannot flip it
+    ///   mid-run.
     /// - **Do not set `false` for wallets driven by autonomous/unattended
     ///   agents.** It is intended for operator-initiated routes where a human
     ///   reviews the rendered plan before confirming.

--- a/crates/bloom-proto/src/policy.rs
+++ b/crates/bloom-proto/src/policy.rs
@@ -1,7 +1,6 @@
 //! Per-wallet policy: caps, allow/deny lists, automation knobs.
 //!
-//! See spec §6.3. The on-disk representation is `policy.toml`. The
-//! `Policy` type is the *parsed* form used by the tx engine.
+//! The `Policy` type is the parsed form used by the tx engine.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -12,9 +11,7 @@ use serde::{Deserialize, Serialize};
 pub struct Policy {
     #[serde(default)]
     pub caps: PolicyCaps,
-    /// Legacy per-section allow/deny — kept for backward compatibility
-    /// with existing policy.toml files that use `[contracts]`/`[tokens]`
-    /// blocks.
+    /// Per-section allow/deny compatibility fields.
     #[serde(default)]
     pub contracts: PolicyAllowDeny,
     #[serde(default)]
@@ -47,8 +44,7 @@ pub struct Policy {
     #[serde(default)]
     pub approval: ApprovalPolicy,
     /// Cross-surface spending limits used by the agent-autonomy evaluator.
-    /// These are parsed from signed `policy.toml` and apply to CLI, VFS, IPC,
-    /// and daemon surfaces alike.
+    /// These apply to CLI, VFS, IPC, and daemon surfaces alike.
     #[serde(default)]
     pub limits: LimitsPolicy,
     /// Polymarket order policy (`[polymarket]`). Trading is enabled by default;

--- a/crates/bloom-tx/src/policy_engine.rs
+++ b/crates/bloom-tx/src/policy_engine.rs
@@ -1,4 +1,4 @@
-//! Translate per-wallet policy.toml into a list of `PolicyCheck` entries
+//! Translate per-wallet policy into a list of `PolicyCheck` entries
 //! attached to a staged tx.
 //!
 //! Rules covered:

--- a/crates/bloom-tx/src/tx_engine.rs
+++ b/crates/bloom-tx/src/tx_engine.rs
@@ -4758,6 +4758,7 @@ mod tests {
                     operation_class: Token::new("transaction.confirm").unwrap(),
                 },
                 publisher: Token::new("bloom-installer").unwrap(),
+                petal_lineage: None,
                 operation_classes: vec![ProvenanceOperationClass {
                     operation_class: Token::new("transaction.confirm").unwrap(),
                     fee_asset: Some(ProvenanceFeeAsset {
@@ -6849,7 +6850,7 @@ mod tests {
         assert!(matches!(err, TxEngineError::Token(_)), "got {err:?}");
     }
 
-    /// Fix #11: the override sentinel comes from policy.toml, not a hard
+    /// Fix #11: the override sentinel comes from wallet policy, not a hard
     /// "override" string. A custom token must be honoured.
     #[tokio::test]
     async fn policy_hard_deny_blocks_confirm_and_marks_failed() {

--- a/crates/bloom-vfs/src/docs/README.md
+++ b/crates/bloom-vfs/src/docs/README.md
@@ -241,8 +241,7 @@ cat /bloom/wallets/alice/policy-updates/latest/status.json
 
 The mounted status and challenge files are public projections of operation,
 review, receipt, ceremony, and commit state. Receipt authority remains between
-Broker and Signer. The legacy `policy.toml` projection is read-only; Machine
-never writes it or creates a policy signature.
+Broker and Signer. Machine has no direct policy writer.
 
 ## Writing (stage-confirm)
 

--- a/crates/bloom-vfs/src/docs/agent-guidance.md
+++ b/crates/bloom-vfs/src/docs/agent-guidance.md
@@ -122,8 +122,7 @@ action id; do not treat them as separate approval queues.
 ## Updating wallet policy
 
 `wallets/<wallet>/policy.json` is the only writable policy surface. It accepts
-the complete canonical JSON document. `policy.toml` is a legacy read-only
-projection and must never be used as an update target.
+the complete canonical JSON document.
 
 ```sh
 # 1. Read the current canonical policy and prepare exact replacement bytes.

--- a/crates/bloom-vfs/src/exact_signing.rs
+++ b/crates/bloom-vfs/src/exact_signing.rs
@@ -920,6 +920,7 @@ mod tests {
                         operation_class: token("transaction.confirm"),
                     },
                     publisher: token("bloom-installer"),
+                    petal_lineage: None,
                     operation_classes: vec![ProvenanceOperationClass {
                         operation_class: token("transaction.confirm"),
                         fee_asset: None,
@@ -996,6 +997,7 @@ mod tests {
                 records: vec![ProvenanceRecord {
                     subject: subject.clone(),
                     publisher: token("bloom-installer"),
+                    petal_lineage: None,
                     operation_classes: vec![ProvenanceOperationClass {
                         operation_class: token("order.place"),
                         fee_asset: None,

--- a/crates/bloom-vfs/src/handler.rs
+++ b/crates/bloom-vfs/src/handler.rs
@@ -48,7 +48,7 @@ impl Entry {
     /// views, status, tools output, prices, docs, audit views, wallet
     /// metadata files, watch outputs. Per the v1 spec only a small set
     /// of injection points (wallets/new, sign/*, outbox writes,
-    /// watch/new, defi intents new+confirm, policy.toml) are writable;
+    /// watch/new, defi intents new+confirm, policy.json) are writable;
     /// those should use [`Entry::writable_file`].
     pub fn file(name: &str) -> Self {
         Self::read_only_file(name)
@@ -326,8 +326,8 @@ mod tests {
 
     #[test]
     fn writable_file_defaults() {
-        let e = Entry::writable_file("policy.toml");
-        assert_eq!(e.name, "policy.toml");
+        let e = Entry::writable_file("policy.json");
+        assert_eq!(e.name, "policy.json");
         assert_eq!(e.kind, EntryKind::File);
         assert_eq!(e.size, 0);
         assert_eq!(e.mode, 0o644);

--- a/crates/bloom-vfs/src/handlers/docs.rs
+++ b/crates/bloom-vfs/src/handlers/docs.rs
@@ -215,13 +215,7 @@ mod tests {
             help.contains("same proposed bytes") && help.contains("**exact"),
             "{help}"
         );
-        for stale in [
-            "> /bloom/wallets/alice/policy.toml",
-            "policy.toml.sig",
-            "host signer",
-            "the grant",
-            "a grant",
-        ] {
+        for stale in ["policy.toml", "host signer", "the grant", "a grant"] {
             assert!(
                 !help.contains(stale),
                 "mounted help retains stale Machine-authority vocabulary {stale:?}"

--- a/crates/bloom-vfs/src/handlers/wallets.rs
+++ b/crates/bloom-vfs/src/handlers/wallets.rs
@@ -16,7 +16,6 @@
 //! - `wallets/<wallet>/addresses.json`                              — owner/signer + role addresses
 //! - `wallets/<wallet>/public_key`                                  — secp256k1 pubkey hex
 //! - `wallets/<wallet>/kind`                                        — local/watch
-//! - `wallets/<wallet>/policy.toml`                                 — legacy read-only policy
 //! - `wallets/<wallet>/policy.json`                                 — canonical triad policy
 //! - `wallets/<wallet>/sealed-approvals/*`                          — Broker approval lifecycle
 //! - `wallets/<wallet>/chains/<chain>/{balance,balance.raw,balance.json}` — native balance
@@ -1611,7 +1610,6 @@ impl WalletsHandler {
             Entry::file("public_key"),
             Entry::file("kind"),
             Entry::file("projection.json"),
-            Entry::file("policy.toml"),
             Entry::writable_file("policy.json"),
             Entry::dir("chains"),
             Entry::dir("sealed-approvals"),
@@ -2036,7 +2034,6 @@ impl WalletsHandler {
         match segs[1].as_str() {
             "address" | "address.qr.png" | "address.qr.svg" | "addresses.json" | "public_key"
             | "kind" | "projection.json" => Ok(Entry::file(&segs[1])),
-            "policy.toml" => Ok(Entry::file("policy.toml")),
             "policy.json" => Ok(Entry::writable_file("policy.json")),
             "chains" => match segs.len() {
                 2 => Ok(Entry::dir("chains")),
@@ -2215,14 +2212,6 @@ impl WalletsHandler {
                 out.push(b'\n');
                 Ok(out)
             }
-            "policy.toml" => {
-                let projection = self.wallet_projection(wallet).await?;
-                let policy: bloom_broker_api::CanonicalWalletPolicy =
-                    serde_json::from_slice(&projection.policy.canonical_policy.decode())
-                        .map_err(err_be)?;
-                let body = toml::to_string_pretty(&policy).map_err(err_be)?;
-                Ok(body.into_bytes())
-            }
             "policy.json" => self.read_triad_wallet_policy(wallet).await,
             "chains" if segs.len() >= 4 => self.read_chain(wallet, &segs[2], &segs[3..]).await,
             "sealed-approvals" if segs.len() == 3 && segs[2] == "new.json" => {
@@ -2330,13 +2319,6 @@ impl WalletsHandler {
         let wallet = &segs[0];
         if segs.len() >= 4 && segs[1] == "chains" && segs[3] == "outbox" {
             return self.write_outbox(wallet, &segs[2], &segs[4..], data).await;
-        }
-        if segs.len() == 2 && segs[1] == "policy.toml" {
-            return Err(HandlerError::Unsupported(
-                "legacy policy.toml is read-only; write the complete canonical policy document \
-                 to policy.json so Broker can prepare a policy_update custody ceremony"
-                    .into(),
-            ));
         }
         if segs.len() == 2 && segs[1] == "policy.json" {
             self.write_permit()?;
@@ -3039,6 +3021,13 @@ mod tests {
     use bloom_tx::tx_engine::TxEngine;
     use sha2::Digest as _;
     use std::sync::Mutex;
+
+    #[test]
+    fn wallet_directory_excludes_retired_policy_toml_surface() {
+        let entries = WalletsHandler::wallet_dir_entries();
+        assert!(entries.iter().any(|entry| entry.name == "policy.json"));
+        assert!(!entries.iter().any(|entry| entry.name == "policy.toml"));
+    }
 
     struct Fixture {
         _tmp: tempfile::TempDir,

--- a/crates/bloom-vfs/src/router.rs
+++ b/crates/bloom-vfs/src/router.rs
@@ -696,13 +696,7 @@ mod tests {
                 && text.contains("exact same proposed bytes"),
             "guidance must document the canonical mounted triad policy-update flow"
         );
-        for stale in [
-            "> wallets/<wallet>/policy.toml",
-            "policy.toml.sig",
-            "host signer",
-            "the grant",
-            "a grant",
-        ] {
+        for stale in ["policy.toml", "host signer", "the grant", "a grant"] {
             assert!(
                 !text.contains(stale),
                 "guidance retains stale Machine-authority vocabulary {stale:?}"

--- a/crates/bloom-vfs/tests/support/m2_exact_production_routes.rs
+++ b/crates/bloom-vfs/tests/support/m2_exact_production_routes.rs
@@ -189,6 +189,7 @@ fn exact_signer(wallet: WalletPublic) -> (BrokerExactPayloadSigner, Arc<ExactBro
                 operation_class: token(class),
             },
             publisher: token("bloom-installer"),
+            petal_lineage: None,
             operation_classes: vec![ProvenanceOperationClass {
                 operation_class: token(class),
                 fee_asset: None,

--- a/crates/bloom-vfs/tests/triad_policy_update.rs
+++ b/crates/bloom-vfs/tests/triad_policy_update.rs
@@ -302,6 +302,27 @@ async fn signer_wallet_is_visible_in_vfs_without_a_legacy_keystore_record() {
             .unwrap(),
         b"passkey\n"
     );
+    let wallet_entries = handler
+        .list(&VfsPath::parse("/alice").unwrap())
+        .await
+        .unwrap();
+    assert!(
+        wallet_entries
+            .iter()
+            .any(|entry| entry.name == "policy.json")
+    );
+    assert!(
+        !wallet_entries
+            .iter()
+            .any(|entry| entry.name == "policy.toml"),
+        "removed compatibility policy surface must not be discoverable"
+    );
+    assert!(matches!(
+        handler
+            .lookup(&VfsPath::parse("/alice/policy.toml").unwrap())
+            .await,
+        Err(HandlerError::NotFound(_))
+    ));
 
     fixture.available.store(false, Ordering::SeqCst);
     let stale_projections = Arc::new(
@@ -340,38 +361,6 @@ async fn signer_wallet_is_visible_in_vfs_without_a_legacy_keystore_record() {
         expected_policy,
         "canonical policy must remain readable from the authenticated stale projection"
     );
-}
-
-#[tokio::test]
-async fn vfs_policy_write_without_broker_never_mutates_legacy_policy_bytes() {
-    let temp = tempfile::tempdir().unwrap();
-    let legacy_policy = temp.path().join("keystore/alice/policy.toml");
-    std::fs::create_dir_all(legacy_policy.parent().unwrap()).unwrap();
-    let before = b"legacy policy bytes remain opaque\n";
-    std::fs::write(&legacy_policy, before).unwrap();
-    let proposed_legacy_toml = "# direct-write probe\n";
-    let home = HomeDir::at(temp.path().join("home"));
-    let permit = Arc::new(HomeWritePermit::acquire(&home).unwrap());
-    let handler = WalletsHandler::new(
-        bloom_evm::ChainRegistry::default(),
-        TxEngine::new(Outbox::new(temp.path().join("outbox")).unwrap(), 60_000),
-        AddressBook::default(),
-        projection_reader(temp.path().join("cache/no-broker-wallets.json"), None),
-        temp.path().join("machine-policy-projections"),
-    )
-    .with_home_write_permit(permit);
-
-    let error = handler
-        .write(
-            &VfsPath::parse("alice/policy.toml").unwrap(),
-            proposed_legacy_toml.as_bytes(),
-        )
-        .await
-        .unwrap_err();
-    assert!(
-        matches!(error, HandlerError::Unsupported(ref message) if message.contains("read-only"))
-    );
-    assert_eq!(std::fs::read(legacy_policy).unwrap(), before);
 }
 
 #[tokio::test]

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -80,7 +80,7 @@ data or rely on their own internal caches, e.g. the etherscan client).
 | Tx lookups | `chains/<chain>/tx/<hash>/{receipt.json,status,block_number,gas_used,logs.json,full.json}` | shipped | `chains.rs` (eth_getTransactionByHash + receipt) |
 | Etherscan history (txs, internal, ERC-20, ERC-721, source, abi) | `chains/<chain>/addresses/<a>/{txs,internal_txs,erc20_txs,erc721_txs}` and `chains/<chain>/contracts/<a>/{source,abi}` | shipped | `chains_history.rs` + `crates/bloom-etherscan/src/lib.rs` (TTL cache in `cache.rs`) |
 | Wallets: VFS-driven creation (local / import / watch) | `wallets/new` (writable) | shipped | `wallets.rs::write_new_wallet` + `parse_new_wallet_spec` |
-| Wallets: metadata, balance, nonce, policy round-trip | `wallets/<w>/{address,public_key,kind,policy.toml,chains/<c>/{balance,balance.raw,balance.json,nonce}}` | shipped | `wallets.rs`; covered by outbox tests + `acceptance.sh` |
+| Wallets: metadata, balance, nonce, policy round-trip | `wallets/<w>/{address,public_key,kind,policy.json,chains/<c>/{balance,balance.raw,balance.json,nonce}}` | shipped | `wallets.rs`; covered by outbox tests + `acceptance.sh` |
 | Wallets: outbox stage / confirm | `wallets/<w>/chains/<c>/outbox/{new.tx,pending/<id>/{plan.md,policy_check.json,confirm},sent/<id>/*,failed/<id>/*}` | shipped | `wallets.rs::write_outbox` → `crates/bloom-tx/src/tx_engine.rs`. Intents: `send` (native + ERC-20), `approve`, `call`, `raw`, plus NFT writes — `nft_transfer` (auto-detects ERC-721 vs ERC-1155, optional `safe`/`amount`/`data`), `nft_approve` (per-token, ERC-721 only), `nft_approve_all` (`setApprovalForAll`, policy-warned). |
 | Wallets: sign — EIP-191 + raw hash + EIP-712 | `wallets/<w>/sign/{message,hash,typed_data}` (+ `.sig`) | shipped | `wallets.rs::write_sign` |
 | DeFi (Enso intents, route quoting, stage-confirm) | `petals/enso/intents/<wallet>/{new,<sess>/{intent.txt,route.json,plan.md,tx.json,simulation.json,confirm}}` | extracted to Petal | [`bloom-petal-enso`](https://github.com/bloom-directory/bloom-petal-enso); installed applications mount through `crates/bloom-petals` |
@@ -147,7 +147,7 @@ Verified end-to-end via `tests/docker/run.sh --mempool`.
 | Direct contract `call` intents | shipped | `RawIntent::call` (method + args); covered by tx-engine tests and mount-driven transaction flows. |
 | EIP-1559 + legacy fallback per chain spec | shipped | `crates/bloom-proto/src/chain.rs::ChainSpec.legacy_tx`; `tx_engine.rs` branches accordingly. |
 | Replacement / cancel | shipped | `tx_engine.rs::replace_with_intent` substitutes (to/value/data) from the posted body and bumps fees ≥10%; cancel is a same-nonce self-send. |
-| Per-wallet `policy.toml` enforcement | shipped | `crates/bloom-tx/src/policy_engine.rs` — per-tx + rolling 24h USD caps backed by `Outbox::sum_usd_since`, allow/deny lists, contract-call gating; results land at `pending/<id>/policy_check.json`. |
+| Per-wallet policy enforcement | shipped | `crates/bloom-tx/src/policy_engine.rs` — per-tx + rolling 24h USD caps backed by `Outbox::sum_usd_since`, allow/deny lists, contract-call gating; results land at `pending/<id>/policy_check.json`. |
 | USD-priced policy caps via DefiLlama | shipped | `bloom-tx/src/oracle.rs` (`PriceOracle` trait) wired to `bloom-daemon/src/price_oracle.rs::PricesOracle` over `bloom-prices`. |
 | Reverse ENS at `chains/<chain>/addresses/<addr>/ens` | shipped | `bloom-vfs/src/handlers/chains.rs` (`with_ens` builder); cross-checked by `EnsClient::reverse`. |
 

--- a/docs/architecture/Open-Internet Sealed Approval Ceremony.md
+++ b/docs/architecture/Open-Internet Sealed Approval Ceremony.md
@@ -20,7 +20,7 @@ mounted-VFS implementation supports Bloom Machine-owned loopback ceremony URLs o
 `http://localhost:18734`: `approval_challenge.json` carries a local
 `ceremony_url`, the token is derived from `server_nonce`, and the Bloom Machine owns
 grant minting for the mounted flows (the EVM outbox, paid-HTTP `/requests`, and
-wallet `policy.toml` updates). This document is the target design for
+wallet policy updates). This document is the target design for
 making that same ceremony reachable from another device over the open internet.
 The `ceremony_url` contract itself — the field in `approval_challenge.json`,
 single-use token, `expiry_ms` bound — is defined in
@@ -148,8 +148,8 @@ ways:
   `http://localhost:18734` with RP ID `localhost`; it does not expose that
   endpoint over the open internet.
 - Today `approval_challenge.json` carries a local loopback `ceremony_url` for
-  the mounted flows (EVM outbox, paid-HTTP `/requests`, and wallet
-  `policy.toml` updates). In the target relay design, the same projection
+  the mounted flows (EVM outbox, paid-HTTP `/requests`, and wallet policy
+  updates). In the target relay design, the same projection
   points at a per-install HTTPS hostname.
 - Today there is no relay, per-install hostname, internet exposure setting, or
   Bloom Machine-held public certificate for a relay hostname.

--- a/docs/architecture/Wallet.md
+++ b/docs/architecture/Wallet.md
@@ -64,8 +64,8 @@ The mounted policy surface uses Broker's policy custody protocol:
 5. Broker calls Signer `policy.compare_and_swap` with the proposed bytes,
    ceremony receipt, and Broker validation receipt.
 
-A direct commit, local policy writer, `policy.toml.sig`, `approval.json`, or
-`policy-session` path is not part of the architecture.
+A direct commit, local policy writer, `approval.json`, or `policy-session` path
+is not part of the architecture.
 
 ## Degraded operation
 

--- a/docs/examples-domain/03-wallets-simulate-watch.md
+++ b/docs/examples-domain/03-wallets-simulate-watch.md
@@ -57,8 +57,7 @@ cp proposed-policy.json /bloom/wallets/alice/policy.json
 ```
 
 Broker carries the completed custody and validation receipts to Signer's
-compare-and-swap. Machine never signs or installs policy. The legacy
-`policy.toml` view, when present for compatibility, is read-only.
+compare-and-swap. Machine never signs or installs policy.
 
 ERC-20 reads are not under `wallets/` — they live under the
 chain-rooted reader at

--- a/docs/examples-domain/06-status-docs-endpoints.md
+++ b/docs/examples-domain/06-status-docs-endpoints.md
@@ -2,7 +2,7 @@
 
 The `status/` tree is the daemon's introspection layer: uptime and version, per-chain RPC reachability, the audit-log digest, cache and outbox counts, the active backend mapping, and a per-endpoint health snapshot for every configured RPC URL. The `docs/` tree is the daemon's vendored help (the same markdown checked into `crates/bloom-vfs/src/docs/`). The per-endpoint leaves under `status/chains/<chain>/endpoints/<idx>/` are the RPC-robustness fleet view added in WP-3 (commit `9f5eab6`): one directory per configured endpoint, populated by a 15 s active probe loop with EWMA latency, success-rate sampling, and a cooldown state machine. All examples below assume the VFS is mounted at `/bloom/`.
 
-A point of caution on naming: leaves are exactly what the source advertises. There is no `status/chains/<chain>.json`, no `status/chains/summary.json`, no `outbox/list.json`, no `wallets/list.json`, no `cache/count`, and no `audit/tail.jsonl`. Canonical per-wallet policy lives at `/bloom/wallets/<wallet>/policy.json` (handled by the wallets handler, not status); the legacy `policy.toml` projection is read-only. Use the listings below as the authoritative shape.
+A point of caution on naming: leaves are exactly what the source advertises. There is no `status/chains/<chain>.json`, no `status/chains/summary.json`, no `outbox/list.json`, no `wallets/list.json`, no `cache/count`, and no `audit/tail.jsonl`. Canonical per-wallet policy lives at `/bloom/wallets/<wallet>/policy.json` (handled by the wallets handler, not status). Use the listings below as the authoritative shape.
 
 ## Daemon
 
@@ -105,7 +105,7 @@ ls /bloom/status/outbox/                               # pending_count
 cat /bloom/status/outbox/pending_count                 # total pending tx ids across all wallets and chains
 ```
 
-Per-wallet policy is **not** under `status/`; canonical updates use `/bloom/wallets/<wallet>/policy.json` and Broker's validate/ceremony/exact-retry commit flow. The legacy `policy.toml` projection is read-only.
+Per-wallet policy is **not** under `status/`; canonical updates use `/bloom/wallets/<wallet>/policy.json` and Broker's validate/ceremony/exact-retry commit flow.
 
 ## Backends
 

--- a/docs/specs/2026-07-24-triad-implementability-review.md
+++ b/docs/specs/2026-07-24-triad-implementability-review.md
@@ -170,7 +170,7 @@ The current handler's complete public categories route as follows:
 |---|---|
 | `/wallets/new` and registration `status.json`, `ceremony_url`, `cancel` | daemon projection over keystore `wallet.registration_*`; local/raw secret fields are removed from VFS |
 | wallet `address`, QR, `addresses.json`, `public_key`, `kind` | daemon read projection from `wallet.get_public`; no key material |
-| `policy.toml` and `policy-updates/{pending,confirmed,failed}` | daemon workflow projection → signing validate/review → keystore policy CAS |
+| `policy.json` and `policy-updates/{pending,confirmed,failed}` | daemon workflow projection → signing validate/review → keystore policy CAS |
 | `unlock-passkey` | daemon returns keystore trusted UI from `wallet.unlock_prepare`; PRF never returns through VFS |
 | `sign/{message,hash,typed_data}` | remains rejected; it is not restored as an opaque signing bypass |
 | `policy-session/new`, `active.json`, `<id>/use`, `<id>/revoke` | standing `prepare/list/status/budget_state/revoke`; `use` becomes an ordinary semantic sign operation under the authority |

--- a/docs/specs/triad-implementation-log.md
+++ b/docs/specs/triad-implementation-log.md
@@ -221,6 +221,5 @@ wire detail. It does not amend that specification.
   canonical bytes but does not assign a VFS filename or a TOML translation.
   Production VFS therefore exposes Broker's authenticated canonical projection
   as `wallets/<wallet>/policy.json` and accepts complete policy replacement
-  there. The legacy `policy.toml` projection is read-only in production:
-  translating its narrower schema would omit authority fields and could not
-  preserve the exact proposed bytes bound by the policy-update ceremony.
+  there. No secondary policy projection or translation is exposed: policy
+  review and commit remain bound to the exact canonical bytes.


### PR DESCRIPTION
## Summary

- remove the legacy `wallets/<wallet>/policy.toml` VFS entry from directory listings, lookup, reads, and writes
- keep `policy.json` as the sole mounted policy projection and update surface
- update live architecture, embedded VFS help, mount/IPC routing tests, and operator-facing docs so they advertise only the canonical JSON flow
- replace the legacy write-protection test with negative discovery/lookup regressions
- complete stale `ProvenanceRecord::petal_lineage` test fixtures required by the current pinned Broker API so all-target builds can compile

The only remaining `policy.toml` strings outside archived dated design/issue documents are negative regression assertions proving that the retired path is absent.

## Related Issue

N/A — follow-up to the triad architecture work in #135.

## Type of Change

- [x] Bug fix (removes a retired compatibility surface)
- [x] New feature — N/A
- [x] Breaking change (removes the legacy mounted path)
- [x] Documentation update

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p bloom-vfs -p bloom-mount -p bloom-daemon`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p bloom-vfs --lib` — 349 passed
- [x] `cargo test -p bloom-vfs --test triad_policy_update` — 7 passed
- [x] mount classifier and daemon IPC routing tests
- [x] `cargo test --workspace --doc --no-fail-fast`

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules — N/A, no downstream module changes
