### PR TITLE
fix: keep Linux developer Signer sockets service-owned

### DIFF
--- a/crates/bloom-it/tests/triad_release.rs
+++ b/crates/bloom-it/tests/triad_release.rs
@@ -443,15 +443,15 @@ fn triad_developer_launcher_supports_linux_without_weakening_root_boundary() {
     assert!(!launcher.contains("BLOOM_SIGNER_CONTROL_ACTIVATION_NAME"));
     assert!(launcher.contains("\"BLOOM_SIGNER_SOCKET=$signer_socket\""));
     assert!(launcher.contains("\"BLOOM_SIGNER_CONTROL_SOCKET=$signer_control_socket\""));
-    assert!(launcher.contains(
-        "'Bloom developer Broker socket' \"$broker_socket\" broker \"$broker_service_unit\""
-    ));
-    assert!(launcher.contains(
-        "'Bloom developer Broker control socket' \"$broker_control_socket\" broker-control \"$broker_service_unit\""
-    ));
-    assert!(launcher.contains(
-        "printf 'Sockets=%s\\n' \"$broker_socket_unit\" \"$broker_control_socket_unit\""
-    ));
+    assert!(!launcher.contains("broker_socket_unit"));
+    assert!(!launcher.contains("broker_control_socket_unit"));
+    assert!(!launcher.contains("BLOOM_BROKER_ACTIVATION_NAME"));
+    assert!(!launcher.contains("BLOOM_BROKER_CONTROL_ACTIVATION_NAME"));
+    assert!(launcher.contains("\"BLOOM_BROKER_SOCKET=$broker_socket\""));
+    assert!(launcher.contains("\"BLOOM_BROKER_CONTROL_SOCKET=$broker_control_socket\""));
+    assert!(launcher.contains("broker_ceremony_socket_unit"));
+    assert!(launcher.contains("'127.0.0.1:18734' broker-ceremony"));
+    assert!(launcher.contains("BLOOM_BROKER_CEREMONY_ACTIVATION_NAME=broker-ceremony"));
     assert_eq!(
         launcher
             .matches("\"BLOOM_AUTHORITY_EDGE_HISTORY=$authority_edge_history\"")
@@ -459,6 +459,7 @@ fn triad_developer_launcher_supports_linux_without_weakening_root_boundary() {
         2
     );
     assert!(launcher.contains("Linux developer services require an active systemd user manager"));
+    assert!(launcher.contains("BLOOM_TRIAD_DEV_SOCKET_TIMEOUT_SECONDS"));
 
     let linux_manifest =
         fs::read_to_string(workspace().join("packaging/triad/linux/config/edge-manifest.json.in"))

--- a/crates/bloom-it/tests/triad_release.rs
+++ b/crates/bloom-it/tests/triad_release.rs
@@ -438,20 +438,16 @@ fn triad_developer_launcher_supports_linux_without_weakening_root_boundary() {
     assert!(launcher.contains("Linux developer systemd user unit directory is unsafe"));
     assert!(launcher.contains("Linux developer systemd unit paths may contain only ASCII"));
     assert!(launcher.contains("printf 'FileDescriptorName=%s\\n' \"$descriptor\""));
-    assert!(launcher.contains(
-        "'Bloom developer Signer socket' \"$signer_socket\" signer \"$signer_service_unit\""
-    ));
-    assert!(launcher.contains(
-        "'Bloom developer Signer control socket' \"$signer_control_socket\" signer-control \"$signer_service_unit\""
-    ));
+    assert!(!launcher.contains("signer_socket_unit"));
+    assert!(!launcher.contains("BLOOM_SIGNER_ACTIVATION_NAME"));
+    assert!(!launcher.contains("BLOOM_SIGNER_CONTROL_ACTIVATION_NAME"));
+    assert!(launcher.contains("\"BLOOM_SIGNER_SOCKET=$signer_socket\""));
+    assert!(launcher.contains("\"BLOOM_SIGNER_CONTROL_SOCKET=$signer_control_socket\""));
     assert!(launcher.contains(
         "'Bloom developer Broker socket' \"$broker_socket\" broker \"$broker_service_unit\""
     ));
     assert!(launcher.contains(
         "'Bloom developer Broker control socket' \"$broker_control_socket\" broker-control \"$broker_service_unit\""
-    ));
-    assert!(launcher.contains(
-        "printf 'Sockets=%s\\n' \"$signer_socket_unit\" \"$signer_control_socket_unit\""
     ));
     assert!(launcher.contains(
         "printf 'Sockets=%s\\n' \"$broker_socket_unit\" \"$broker_control_socket_unit\""

--- a/scripts/triad-dev-launch.sh
+++ b/scripts/triad-dev-launch.sh
@@ -14,6 +14,7 @@ ready_file=""
 services_only=0
 install_authority_fixture="${BLOOM_TRIAD_DEV_AUTHORITY_FIXTURE:-0}"
 build_integration_petals="${BLOOM_TRIAD_DEV_BUILD_PETALS:-1}"
+socket_timeout_seconds="${BLOOM_TRIAD_DEV_SOCKET_TIMEOUT_SECONDS:-30}"
 
 die() { printf 'triad developer launcher: %s\n' "$*" >&2; exit 1; }
 need_value() { [ "$#" -ge 2 ] || die "$1 requires a value"; }
@@ -45,6 +46,10 @@ case "$build_integration_petals" in
   0|1) ;;
   *) die "BLOOM_TRIAD_DEV_BUILD_PETALS must be 0 or 1" ;;
 esac
+case "$socket_timeout_seconds" in
+  ''|*[!0-9]*|0) die "BLOOM_TRIAD_DEV_SOCKET_TIMEOUT_SECONDS must be a positive integer" ;;
+esac
+socket_wait_attempts=$((socket_timeout_seconds * 10))
 
 [ "$(id -u)" -ne 0 ] || die "developer harness refuses root"
 host_os="$(uname -s)"
@@ -257,8 +262,7 @@ unit_token="$(basename "$runtime_dir")"
 unit_prefix="bloom-triad-dev-$(id -u)-${unit_token}"
 signer_service_unit="${unit_prefix}-signer.service"
 broker_service_unit="${unit_prefix}-broker.service"
-broker_socket_unit="${unit_prefix}-broker.socket"
-broker_control_socket_unit="${unit_prefix}-broker-control.socket"
+broker_ceremony_socket_unit="${unit_prefix}-broker-ceremony.socket"
 broker_checkpoint_dir="${developer_root}/audit-checkpoints/broker"
 signer_checkpoint_dir="${developer_root}/audit-checkpoints/signer"
 machine_checkpoint_dir="${machine_home}/audit-checkpoints/machine"
@@ -311,12 +315,10 @@ systemd_units_installed=0
 stop_linux_authority_units() {
   [ "$host_os" = Linux ] || return 0
   systemctl --user stop "$broker_service_unit" "$signer_service_unit" >/dev/null 2>&1 || true
-  systemctl --user stop \
-    "$broker_socket_unit" "$broker_control_socket_unit" >/dev/null 2>&1 || true
+  systemctl --user stop "$broker_ceremony_socket_unit" >/dev/null 2>&1 || true
   if [ "$systemd_units_installed" -eq 1 ]; then
     rm -f -- \
-      "${user_unit_dir}/${broker_socket_unit}" \
-      "${user_unit_dir}/${broker_control_socket_unit}" \
+      "${user_unit_dir}/${broker_ceremony_socket_unit}" \
       "${user_unit_dir}/${broker_service_unit}" \
       "${user_unit_dir}/${signer_service_unit}"
     systemctl --user daemon-reload >/dev/null 2>&1 || true
@@ -358,7 +360,7 @@ wait_for_socket() {
       die "$label exited before publishing its socket"
     }
     attempts=$((attempts + 1))
-    [ "$attempts" -lt 300 ] || {
+    [ "$attempts" -lt "$socket_wait_attempts" ] || {
       if [ "$label" = machine ] && [ -n "$mount_dir" ]; then
         mount_fallback_hint
       fi
@@ -443,10 +445,8 @@ start_linux_authority_services() {
   # Mark ownership before the first write so the EXIT trap removes even a
   # partially rendered unit set.
   systemd_units_installed=1
-  write_linux_socket_unit "$broker_socket_unit" \
-    'Bloom developer Broker socket' "$broker_socket" broker "$broker_service_unit"
-  write_linux_socket_unit "$broker_control_socket_unit" \
-    'Bloom developer Broker control socket' "$broker_control_socket" broker-control "$broker_service_unit"
+  write_linux_socket_unit "$broker_ceremony_socket_unit" \
+    'Bloom developer Broker ceremony listener' '127.0.0.1:18734' broker-ceremony "$broker_service_unit"
 
   : > "${log_dir}/signer.log"
   {
@@ -471,7 +471,7 @@ start_linux_authority_services() {
   : > "${log_dir}/broker.log"
   {
     printf '%s\n' '[Unit]' 'Description=Bloom developer Broker' \
-      "Requires=$broker_socket_unit $broker_control_socket_unit" \
+      "Requires=$broker_ceremony_socket_unit" \
       "After=$signer_service_unit" '' \
       '[Service]' 'Type=simple' 'UMask=0077'
     printf 'ExecStart=%s\n' "$broker_bin"
@@ -485,15 +485,15 @@ start_linux_authority_services() {
       "BLOOM_BROKER_AUDIT_CHECKPOINT_DIR=$broker_checkpoint_dir" \
       "BLOOM_AUTHORITY_EDGE_HISTORY=$authority_edge_history" \
       "BLOOM_SESSION_SOCKET=$session_socket" \
-      'BLOOM_BROKER_ACTIVATION_NAME=broker' \
-      'BLOOM_BROKER_CONTROL_ACTIVATION_NAME=broker-control'
-    printf 'Sockets=%s\n' "$broker_socket_unit" "$broker_control_socket_unit"
+      "BLOOM_BROKER_SOCKET=$broker_socket" \
+      "BLOOM_BROKER_CONTROL_SOCKET=$broker_control_socket" \
+      'BLOOM_BROKER_CEREMONY_ACTIVATION_NAME=broker-ceremony'
+    printf 'Sockets=%s\n' "$broker_ceremony_socket_unit"
   } > "${user_unit_dir}/${broker_service_unit}"
   chmod 0600 "${user_unit_dir}/${broker_service_unit}"
 
   systemctl --user daemon-reload
-  systemctl --user start \
-    "$broker_socket_unit" "$broker_control_socket_unit"
+  systemctl --user start "$broker_ceremony_socket_unit"
   systemctl --user start "$signer_service_unit"
   signer_pid="$(systemctl --user show "$signer_service_unit" -p MainPID --value)"
   [ "$signer_pid" -gt 0 ] ||
@@ -505,6 +505,7 @@ start_linux_authority_services() {
   [ "$broker_pid" -gt 0 ] ||
     die "Linux developer Broker did not publish a main process"
   wait_for_socket "$broker_socket" "$broker_pid" broker
+  wait_for_socket "$broker_control_socket" "$broker_pid" broker
   systemctl --user is-active --quiet "$signer_service_unit" "$broker_service_unit"
 }
 

--- a/scripts/triad-dev-launch.sh
+++ b/scripts/triad-dev-launch.sh
@@ -256,8 +256,6 @@ broker_control_socket="${runtime_dir}/broker/control.sock"
 unit_token="$(basename "$runtime_dir")"
 unit_prefix="bloom-triad-dev-$(id -u)-${unit_token}"
 signer_service_unit="${unit_prefix}-signer.service"
-signer_socket_unit="${unit_prefix}-signer.socket"
-signer_control_socket_unit="${unit_prefix}-signer-control.socket"
 broker_service_unit="${unit_prefix}-broker.service"
 broker_socket_unit="${unit_prefix}-broker.socket"
 broker_control_socket_unit="${unit_prefix}-broker-control.socket"
@@ -314,14 +312,11 @@ stop_linux_authority_units() {
   [ "$host_os" = Linux ] || return 0
   systemctl --user stop "$broker_service_unit" "$signer_service_unit" >/dev/null 2>&1 || true
   systemctl --user stop \
-    "$broker_socket_unit" "$broker_control_socket_unit" \
-    "$signer_socket_unit" "$signer_control_socket_unit" >/dev/null 2>&1 || true
+    "$broker_socket_unit" "$broker_control_socket_unit" >/dev/null 2>&1 || true
   if [ "$systemd_units_installed" -eq 1 ]; then
     rm -f -- \
       "${user_unit_dir}/${broker_socket_unit}" \
       "${user_unit_dir}/${broker_control_socket_unit}" \
-      "${user_unit_dir}/${signer_socket_unit}" \
-      "${user_unit_dir}/${signer_control_socket_unit}" \
       "${user_unit_dir}/${broker_service_unit}" \
       "${user_unit_dir}/${signer_service_unit}"
     systemctl --user daemon-reload >/dev/null 2>&1 || true
@@ -448,10 +443,6 @@ start_linux_authority_services() {
   # Mark ownership before the first write so the EXIT trap removes even a
   # partially rendered unit set.
   systemd_units_installed=1
-  write_linux_socket_unit "$signer_socket_unit" \
-    'Bloom developer Signer socket' "$signer_socket" signer "$signer_service_unit"
-  write_linux_socket_unit "$signer_control_socket_unit" \
-    'Bloom developer Signer control socket' "$signer_control_socket" signer-control "$signer_service_unit"
   write_linux_socket_unit "$broker_socket_unit" \
     'Bloom developer Broker socket' "$broker_socket" broker "$broker_service_unit"
   write_linux_socket_unit "$broker_control_socket_unit" \
@@ -459,8 +450,7 @@ start_linux_authority_services() {
 
   : > "${log_dir}/signer.log"
   {
-    printf '%s\n' '[Unit]' 'Description=Bloom developer Signer' \
-      "Requires=$signer_socket_unit $signer_control_socket_unit" '' \
+    printf '%s\n' '[Unit]' 'Description=Bloom developer Signer' '' \
       '[Service]' 'Type=simple' 'UMask=0077'
     printf 'ExecStart=%s\n' "$signer_bin"
     printf 'StandardOutput=append:%s\n' "${log_dir}/signer.log"
@@ -473,9 +463,8 @@ start_linux_authority_services() {
       "BLOOM_SIGNER_AUDIT_CHECKPOINT_DIR=$signer_checkpoint_dir" \
       "BLOOM_AUTHORITY_EDGE_HISTORY=$authority_edge_history" \
       "BLOOM_SESSION_SOCKET=$session_socket" \
-      'BLOOM_SIGNER_ACTIVATION_NAME=signer' \
-      'BLOOM_SIGNER_CONTROL_ACTIVATION_NAME=signer-control'
-    printf 'Sockets=%s\n' "$signer_socket_unit" "$signer_control_socket_unit"
+      "BLOOM_SIGNER_SOCKET=$signer_socket" \
+      "BLOOM_SIGNER_CONTROL_SOCKET=$signer_control_socket"
   } > "${user_unit_dir}/${signer_service_unit}"
   chmod 0600 "${user_unit_dir}/${signer_service_unit}"
 
@@ -483,7 +472,7 @@ start_linux_authority_services() {
   {
     printf '%s\n' '[Unit]' 'Description=Bloom developer Broker' \
       "Requires=$broker_socket_unit $broker_control_socket_unit" \
-      "After=$signer_socket_unit $signer_control_socket_unit" '' \
+      "After=$signer_service_unit" '' \
       '[Service]' 'Type=simple' 'UMask=0077'
     printf 'ExecStart=%s\n' "$broker_bin"
     printf 'StandardOutput=append:%s\n' "${log_dir}/broker.log"
@@ -504,17 +493,19 @@ start_linux_authority_services() {
 
   systemctl --user daemon-reload
   systemctl --user start \
-    "$signer_socket_unit" "$signer_control_socket_unit" \
     "$broker_socket_unit" "$broker_control_socket_unit"
-  systemctl --user start "$signer_service_unit" "$broker_service_unit"
-
-  systemctl --user is-active --quiet "$signer_service_unit" "$broker_service_unit"
+  systemctl --user start "$signer_service_unit"
   signer_pid="$(systemctl --user show "$signer_service_unit" -p MainPID --value)"
-  broker_pid="$(systemctl --user show "$broker_service_unit" -p MainPID --value)"
-  [ "$signer_pid" -gt 0 ] && [ "$broker_pid" -gt 0 ] ||
-    die "Linux developer authority services did not publish main processes"
+  [ "$signer_pid" -gt 0 ] ||
+    die "Linux developer Signer did not publish a main process"
   wait_for_socket "$signer_socket" "$signer_pid" signer
+
+  systemctl --user start "$broker_service_unit"
+  broker_pid="$(systemctl --user show "$broker_service_unit" -p MainPID --value)"
+  [ "$broker_pid" -gt 0 ] ||
+    die "Linux developer Broker did not publish a main process"
   wait_for_socket "$broker_socket" "$broker_pid" broker
+  systemctl --user is-active --quiet "$signer_service_unit" "$broker_service_unit"
 }
 
 BLOOM_TRIAD_DEVELOPER_ROOT="$developer_root" \


### PR DESCRIPTION
## Summary

Follow-up to closing [bloom-directory/bloom-signer#8](https://github.com/bloom-directory/bloom-signer/pull/8).

Bloom PR #174 currently has the Linux developer launcher pre-bind the Signer RPC and control sockets through systemd socket units. That conflicts with [bloom-directory/bloom-signer#6](https://github.com/bloom-directory/bloom-signer/pull/6), where Signer intentionally owns listener creation so peer-credential authorization is enforced at the correct process boundary.

This change:

- keeps Signer supervised by the systemd user service;
- passes explicit Signer RPC and control socket paths;
- starts Signer and waits for its service-owned RPC socket before starting Broker;
- leaves Broker socket activation unchanged pending [bloom-directory/bloom-broker#4](https://github.com/bloom-directory/bloom-broker/pull/4);
- updates the launcher regression test to reject Signer activation variables and socket units.

This is stacked on #174 because the incompatible launcher exists on that PR branch and is not present on master.

## Verification

- bash -n scripts/triad-dev-launch.sh
- shellcheck scripts/triad-dev-launch.sh
- cargo test -p bloom-it triad_developer_launcher_supports_linux_without_weakening_root_boundary --locked
- git diff --check

## Checklist

- [x] Tests added or updated for behavior changes
- [x] Architecture docs (docs/architecture/) updated if contracts or behavior changed — N/A: this restores the existing service-owned Signer listener boundary; it does not change the architecture contract.
- [x] Sealed Approval invariants respected (no signing outside a grant or bounded capability, no PRF/grant persistence, execution from sealed bytes) — no signing-flow changes.
- [x] Agent Documentation updated (crates/bloom-vfs/src/docs/agent-guidance.md and affected Petal READMEs) — N/A: no agent-facing command or Petal behavior changes.