### PR TITLE
release: stage trusted-clock recovery for v0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2127,7 +2127,7 @@ dependencies = [
 
 [[package]]
 name = "bloom"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "alloy 2.0.5",
  "anyhow",
@@ -2174,7 +2174,7 @@ dependencies = [
 [[package]]
 name = "bloom-audit-checkpoint"
 version = "0.1.3"
-source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=19d0465d53b279e6e1c98bac533510a1e7eb8f44#19d0465d53b279e6e1c98bac533510a1e7eb8f44"
+source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=155560173e65fa6635cc87a43986f4fa6ea9c4e0#155560173e65fa6635cc87a43986f4fa6ea9c4e0"
 dependencies = [
  "bloom-rpc-wire",
  "ed25519-dalek",
@@ -2189,7 +2189,7 @@ dependencies = [
 [[package]]
 name = "bloom-broker-api"
 version = "0.1.0"
-source = "git+https://github.com/bloom-directory/bloom-broker.git?rev=b2ac5bd256ea48b67730cac69d3bcd6d635f5347#b2ac5bd256ea48b67730cac69d3bcd6d635f5347"
+source = "git+https://github.com/bloom-directory/bloom-broker.git?rev=90dc9adeabf8fb23a1528a3095913fc242b9fe33#90dc9adeabf8fb23a1528a3095913fc242b9fe33"
 dependencies = [
  "bloom-rpc-wire",
  "serde",
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-daemon"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "alloy 2.0.5",
  "anyhow",
@@ -2244,7 +2244,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-ens"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "alloy 2.0.5",
  "bloom-evm",
@@ -2259,7 +2259,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-etherscan"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "alloy 2.0.5",
  "async-trait",
@@ -2277,7 +2277,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-evm"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "alloy 2.0.5",
  "bloom-proto",
@@ -2295,7 +2295,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-it"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "alloy 2.0.5",
  "alloy-signer-local 2.0.5",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-machine"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "bloom-broker-api",
@@ -2341,7 +2341,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-machine-client"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "bloom-audit-checkpoint",
@@ -2361,7 +2361,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-mempool"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "alloy 2.0.5",
  "alloy-signer-local 2.0.5",
@@ -2383,7 +2383,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-mount"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "bloom-vfs",
@@ -2399,7 +2399,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-paid-http"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-paid-mpp"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "alloy 2.0.5",
  "async-trait",
@@ -2431,7 +2431,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-paid-x402"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "alloy 2.0.5",
  "async-trait",
@@ -2456,7 +2456,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-petals"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2491,7 +2491,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-prices"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "parking_lot",
  "reqwest 0.12.28",
@@ -2504,7 +2504,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-proto"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "alloy 2.0.5",
  "blake3",
@@ -2525,7 +2525,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-revert"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "alloy 2.0.5",
  "alloy-dyn-abi",
@@ -2547,7 +2547,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-rpc"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "alloy 2.0.5",
  "bloom-proto",
@@ -2564,7 +2564,7 @@ dependencies = [
 [[package]]
 name = "bloom-rpc-wire"
 version = "0.1.3"
-source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=19d0465d53b279e6e1c98bac533510a1e7eb8f44#19d0465d53b279e6e1c98bac533510a1e7eb8f44"
+source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=155560173e65fa6635cc87a43986f4fa6ea9c4e0#155560173e65fa6635cc87a43986f4fa6ea9c4e0"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -2579,7 +2579,7 @@ dependencies = [
 [[package]]
 name = "bloom-service-activation"
 version = "0.1.3"
-source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=19d0465d53b279e6e1c98bac533510a1e7eb8f44#19d0465d53b279e6e1c98bac533510a1e7eb8f44"
+source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=155560173e65fa6635cc87a43986f4fa6ea9c4e0#155560173e65fa6635cc87a43986f4fa6ea9c4e0"
 dependencies = [
  "bloom-rpc-wire",
  "libc",
@@ -2588,7 +2588,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-tools"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "alloy 2.0.5",
  "alloy-dyn-abi",
@@ -2603,7 +2603,7 @@ dependencies = [
 [[package]]
 name = "bloom-triad-local-transport"
 version = "0.1.3"
-source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=19d0465d53b279e6e1c98bac533510a1e7eb8f44#19d0465d53b279e6e1c98bac533510a1e7eb8f44"
+source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=155560173e65fa6635cc87a43986f4fa6ea9c4e0#155560173e65fa6635cc87a43986f4fa6ea9c4e0"
 dependencies = [
  "bloom-rpc-wire",
  "bloom-trusted-time",
@@ -2621,7 +2621,7 @@ dependencies = [
 [[package]]
 name = "bloom-trusted-time"
 version = "0.1.3"
-source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=19d0465d53b279e6e1c98bac533510a1e7eb8f44#19d0465d53b279e6e1c98bac533510a1e7eb8f44"
+source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=155560173e65fa6635cc87a43986f4fa6ea9c4e0#155560173e65fa6635cc87a43986f4fa6ea9c4e0"
 dependencies = [
  "libc",
  "thiserror 2.0.18",
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-tx"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "alloy 2.0.5",
  "alloy-signer-local 2.0.5",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-update"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "parking_lot",
  "reqwest 0.12.28",
@@ -2676,7 +2676,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-vfs"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "alloy 2.0.5",
  "async-trait",
@@ -2722,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-watch"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "alloy 2.0.5",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2871,7 +2871,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2900,7 +2900,7 @@ dependencies = [
  "maybe-owned",
  "rustix 1.1.4",
  "rustix-linux-procfs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
  "winx",
 ]
 
@@ -3075,7 +3075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3971,7 +3971,7 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 [[package]]
 name = "embednfs"
 version = "0.4.1"
-source = "git+https://github.com/bloom-directory/embednfs.git?rev=6cf74877518ea0b5e7f9d3c1fa5ee0b461cd3eb3#6cf74877518ea0b5e7f9d3c1fa5ee0b461cd3eb3"
+source = "git+https://github.com/bloom-directory/embednfs.git?rev=ac1bcb92c5d6342239595cafd1284858e40300a6#ac1bcb92c5d6342239595cafd1284858e40300a6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3985,7 +3985,7 @@ dependencies = [
 [[package]]
 name = "embednfs-proto"
 version = "0.4.1"
-source = "git+https://github.com/bloom-directory/embednfs.git?rev=6cf74877518ea0b5e7f9d3c1fa5ee0b461cd3eb3#6cf74877518ea0b5e7f9d3c1fa5ee0b461cd3eb3"
+source = "git+https://github.com/bloom-directory/embednfs.git?rev=ac1bcb92c5d6342239595cafd1284858e40300a6#ac1bcb92c5d6342239595cafd1284858e40300a6"
 dependencies = [
  "bytes",
  "num-derive",
@@ -4156,7 +4156,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4278,7 +4278,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5173,7 +5173,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
  "io-lifetimes",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5666,7 +5666,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6502,7 +6502,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7476,7 +7476,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8326,7 +8326,7 @@ dependencies = [
  "fd-lock",
  "io-lifetimes",
  "rustix 0.38.44",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
  "winx",
 ]
 
@@ -10055,7 +10055,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -74,7 +74,7 @@ tempfile = "3"
 futures = "0.3"
 lru = "0.12"
 fs2 = "0.4"
-bloom-audit-checkpoint = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "19d0465d53b279e6e1c98bac533510a1e7eb8f44" }
+bloom-audit-checkpoint = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "155560173e65fa6635cc87a43986f4fa6ea9c4e0" }
 wasmtime = { version = "26", default-features = false, features = ["async", "cranelift", "runtime", "cache", "parallel-compilation"] }
 wasmtime-wasi = "26"
 wat = "1"
@@ -123,11 +123,11 @@ bloom-petals   = { path = "crates/bloom-petals" }
 bloom-petal-contract = { git = "https://github.com/bloom-directory/petal", rev = "61938d0c127cfe03c7e3e55baed0ba1439bc5ca2" }
 bloom-daemon   = { path = "crates/bloom-daemon" }
 bloom-update   = { path = "crates/bloom-update" }
-bloom-broker-api = { git = "https://github.com/bloom-directory/bloom-broker.git", rev = "b2ac5bd256ea48b67730cac69d3bcd6d635f5347" }
-bloom-rpc-wire = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "19d0465d53b279e6e1c98bac533510a1e7eb8f44" }
-bloom-triad-local-transport = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "19d0465d53b279e6e1c98bac533510a1e7eb8f44" }
-bloom-service-activation = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "19d0465d53b279e6e1c98bac533510a1e7eb8f44" }
-bloom-trusted-time = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "19d0465d53b279e6e1c98bac533510a1e7eb8f44" }
+bloom-broker-api = { git = "https://github.com/bloom-directory/bloom-broker.git", rev = "90dc9adeabf8fb23a1528a3095913fc242b9fe33" }
+bloom-rpc-wire = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "155560173e65fa6635cc87a43986f4fa6ea9c4e0" }
+bloom-triad-local-transport = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "155560173e65fa6635cc87a43986f4fa6ea9c4e0" }
+bloom-service-activation = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "155560173e65fa6635cc87a43986f4fa6ea9c4e0" }
+bloom-trusted-time = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "155560173e65fa6635cc87a43986f4fa6ea9c4e0" }
 bloom-machine-client = { path = "crates/bloom-machine-client" }
 # ---- example core petal: generic capability primitives (/bloom/core/cap) ----
 

--- a/crates/bloom-it/tests/linux_packaging.rs
+++ b/crates/bloom-it/tests/linux_packaging.rs
@@ -171,6 +171,14 @@ fn service_sandboxes_remove_machine_and_network_authority() {
                 "{name} sandbox is missing {required}"
             );
         }
+        assert!(
+            !unit.contains("ProtectClock="),
+            "{name} must be able to make the read-only adjtimex synchronization query"
+        );
+        assert!(
+            unit.contains("CapabilityBoundingSet=") && unit.contains("AmbientCapabilities="),
+            "{name} must still lack CAP_SYS_TIME after ProtectClock is removed"
+        );
     }
     assert!(broker.contains("User=bloom-broker-%i"));
     assert!(broker.contains("RestrictAddressFamilies=AF_UNIX AF_INET"));

--- a/crates/bloom-it/tests/triad_release.rs
+++ b/crates/bloom-it/tests/triad_release.rs
@@ -1571,23 +1571,6 @@ fn linux_installer_accepts_the_native_or_portable_sha256_tool() {
 }
 
 #[test]
-fn linux_installer_requires_the_claimed_chrony_nts_runtime() {
-    let installer = fs::read_to_string(release_script("install-linux.sh")).unwrap();
-    for required in [
-        "for required_command in chronyd chronyc",
-        "systemctl is-active --quiet systemd-timesyncd.service",
-        "chronyd.service chrony.service",
-        "systemctl enable --now \"$chrony_service\"",
-        "chronyc waitsync 30 0.5 1000 1",
-    ] {
-        assert!(
-            installer.contains(required),
-            "Linux installer is missing trusted-time preflight: {required}"
-        );
-    }
-}
-
-#[test]
 fn macos_installer_stages_unix_principals_launchdaemons_and_confirmed_uninstall() {
     let directory = tempfile::tempdir().unwrap();
     let root = directory.path().join("root");

--- a/crates/bloom-it/tests/triad_release.rs
+++ b/crates/bloom-it/tests/triad_release.rs
@@ -1571,6 +1571,23 @@ fn linux_installer_accepts_the_native_or_portable_sha256_tool() {
 }
 
 #[test]
+fn linux_installer_requires_the_claimed_chrony_nts_runtime() {
+    let installer = fs::read_to_string(release_script("install-linux.sh")).unwrap();
+    for required in [
+        "for required_command in chronyd chronyc",
+        "systemctl is-active --quiet systemd-timesyncd.service",
+        "chronyd.service chrony.service",
+        "systemctl enable --now \"$chrony_service\"",
+        "chronyc waitsync 30 0.5 1000 1",
+    ] {
+        assert!(
+            installer.contains(required),
+            "Linux installer is missing trusted-time preflight: {required}"
+        );
+    }
+}
+
+#[test]
 fn macos_installer_stages_unix_principals_launchdaemons_and_confirmed_uninstall() {
     let directory = tempfile::tempdir().unwrap();
     let root = directory.path().join("root");

--- a/crates/bloom-mount/Cargo.toml
+++ b/crates/bloom-mount/Cargo.toml
@@ -34,7 +34,7 @@ futures = { workspace = true, optional = true }
 # Embedded NFSv4.1 server. Pinned to the bloom-directory fork revision that
 # exposes OpenSupport so path-derived denials can surface from NFS OPEN.
 # Marked optional so non-mount builds don't fetch the git source.
-embednfs = { git = "https://github.com/bloom-directory/embednfs.git", rev = "6cf74877518ea0b5e7f9d3c1fa5ee0b461cd3eb3", optional = true }
+embednfs = { git = "https://github.com/bloom-directory/embednfs.git", rev = "ac1bcb92c5d6342239595cafd1284858e40300a6", optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }

--- a/crates/bloom-mount/src/lib.rs
+++ b/crates/bloom-mount/src/lib.rs
@@ -168,10 +168,7 @@ pub fn detect_mount_command() -> &'static str {
 ///
 /// * **Linux** (`mount.nfs4`): `actimeo=0` disables attribute caching
 ///   without relying on `lookupcache=none`, which is rejected by some
-///   minimal CI images. `soft,retrans=2` bounds failures when the local
-///   in-process server exits: this VFS is a command interface, so returning
-///   an I/O error is safer than leaving callers indefinitely blocked in an
-///   uninterruptible kernel RPC wait.
+///   minimal CI images.
 /// * **macOS** (`mount_nfs`): `actimeo=0` zeros the attribute-cache
 ///   timeouts. The Linux-only `lookupcache=none`, `nocallback`, and
 ///   `nonegnamecache` knobs are *not* recognised by macOS and would
@@ -198,9 +195,7 @@ pub fn build_mount_args(cfg: &MountConfig, server: SocketAddr) -> Vec<String> {
 
 #[cfg(target_os = "linux")]
 fn build_mount_opts(port: u16) -> String {
-    format!(
-        "actimeo=0,vers=4.1,proto=tcp,port={port},rsize=65536,wsize=65536,timeo=10,soft,retrans=2"
-    )
+    format!("actimeo=0,vers=4.1,proto=tcp,port={port},rsize=65536,wsize=65536,timeo=10")
 }
 
 #[cfg(target_os = "macos")]
@@ -288,8 +283,8 @@ mod tests {
             "linux opts must avoid nfs2/nfs3 mountport= on nfs4: {joined}"
         );
         assert!(
-            joined.contains("soft") && joined.contains("retrans=2"),
-            "local in-process NFS failures must be bounded: {joined}"
+            !joined.contains("soft") && !joined.contains("retrans="),
+            "side-effecting VFS writes must retain hard-mount semantics: {joined}"
         );
     }
 

--- a/crates/bloom-mount/src/lib.rs
+++ b/crates/bloom-mount/src/lib.rs
@@ -168,7 +168,10 @@ pub fn detect_mount_command() -> &'static str {
 ///
 /// * **Linux** (`mount.nfs4`): `actimeo=0` disables attribute caching
 ///   without relying on `lookupcache=none`, which is rejected by some
-///   minimal CI images.
+///   minimal CI images. `soft,retrans=2` bounds failures when the local
+///   in-process server exits: this VFS is a command interface, so returning
+///   an I/O error is safer than leaving callers indefinitely blocked in an
+///   uninterruptible kernel RPC wait.
 /// * **macOS** (`mount_nfs`): `actimeo=0` zeros the attribute-cache
 ///   timeouts. The Linux-only `lookupcache=none`, `nocallback`, and
 ///   `nonegnamecache` knobs are *not* recognised by macOS and would
@@ -195,7 +198,9 @@ pub fn build_mount_args(cfg: &MountConfig, server: SocketAddr) -> Vec<String> {
 
 #[cfg(target_os = "linux")]
 fn build_mount_opts(port: u16) -> String {
-    format!("actimeo=0,vers=4.1,proto=tcp,port={port},rsize=65536,wsize=65536,timeo=10")
+    format!(
+        "actimeo=0,vers=4.1,proto=tcp,port={port},rsize=65536,wsize=65536,timeo=10,soft,retrans=2"
+    )
 }
 
 #[cfg(target_os = "macos")]
@@ -281,6 +286,10 @@ mod tests {
         assert!(
             !joined.contains("mountport="),
             "linux opts must avoid nfs2/nfs3 mountport= on nfs4: {joined}"
+        );
+        assert!(
+            joined.contains("soft") && joined.contains("retrans=2"),
+            "local in-process NFS failures must be bounded: {joined}"
         );
     }
 

--- a/packaging/triad/linux/systemd/bloom-broker@.service.in
+++ b/packaging/triad/linux/systemd/bloom-broker@.service.in
@@ -27,7 +27,9 @@ PrivateDevices=yes
 PrivateTmp=yes
 ProtectSystem=strict
 ProtectHome=yes
-ProtectClock=yes
+# ProtectClock cannot be enabled here: it blocks the read-only adjtimex query
+# used to verify that the configured trusted UTC source is synchronized.
+# CapabilityBoundingSet= still denies CAP_SYS_TIME and therefore clock writes.
 ProtectControlGroups=yes
 ProtectKernelLogs=yes
 ProtectKernelModules=yes

--- a/packaging/triad/linux/systemd/bloom-signer@.service.in
+++ b/packaging/triad/linux/systemd/bloom-signer@.service.in
@@ -24,7 +24,9 @@ PrivateNetwork=yes
 PrivateTmp=yes
 ProtectSystem=strict
 ProtectHome=yes
-ProtectClock=yes
+# ProtectClock cannot be enabled here: it blocks the read-only adjtimex query
+# used to verify that the configured trusted UTC source is synchronized.
+# CapabilityBoundingSet= still denies CAP_SYS_TIME and therefore clock writes.
 ProtectControlGroups=yes
 ProtectKernelLogs=yes
 ProtectKernelModules=yes

--- a/packaging/triad/release/check-external-pins.py
+++ b/packaging/triad/release/check-external-pins.py
@@ -15,9 +15,9 @@ ROOT = pathlib.Path(__file__).resolve().parents[3]
 COMPAT = ROOT / "packaging/triad/release/compatibility-v1.toml"
 FULL = re.compile(r"^[0-9a-f]{40}$")
 EXPECTED = {
-    "broker_commit": ("bloom-directory/bloom-broker", "b2ac5bd256ea48b67730cac69d3bcd6d635f5347"),
-    "signer_commit": ("bloom-directory/bloom-signer", "59c12e15438e436979eb30a27b2e9534a3f97615"),
-    "service_runtime_commit": ("bloom-directory/bloom-service-runtime", "19d0465d53b279e6e1c98bac533510a1e7eb8f44"),
+    "broker_commit": ("bloom-directory/bloom-broker", "90dc9adeabf8fb23a1528a3095913fc242b9fe33"),
+    "signer_commit": ("bloom-directory/bloom-signer", "3ddddb5b8f15d7c2a82c0aed418a0fe3e46ae0ad"),
+    "service_runtime_commit": ("bloom-directory/bloom-service-runtime", "155560173e65fa6635cc87a43986f4fa6ea9c4e0"),
     "petal_contract_commit": ("bloom-directory/petal", "61938d0c127cfe03c7e3e55baed0ba1439bc5ca2"),
 }
 

--- a/packaging/triad/release/compatibility-v1.toml
+++ b/packaging/triad/release/compatibility-v1.toml
@@ -1,9 +1,9 @@
 schema = "bloom.triad-compatibility/1"
 
 [revisions]
-broker_commit = "b2ac5bd256ea48b67730cac69d3bcd6d635f5347"
-signer_commit = "59c12e15438e436979eb30a27b2e9534a3f97615"
-service_runtime_commit = "19d0465d53b279e6e1c98bac533510a1e7eb8f44"
+broker_commit = "90dc9adeabf8fb23a1528a3095913fc242b9fe33"
+signer_commit = "3ddddb5b8f15d7c2a82c0aed418a0fe3e46ae0ad"
+service_runtime_commit = "155560173e65fa6635cc87a43986f4fa6ea9c4e0"
 petal_contract_commit = "61938d0c127cfe03c7e3e55baed0ba1439bc5ca2"
 
 [state.machine]
@@ -39,7 +39,7 @@ minor_min = 0
 minor_max = 1
 
 [[bundles]]
-machine = "0.1.3"
+machine = "0.1.4"
 broker = "0.1.0"
 signer = "0.1.0"
 backends = ["local", "aws-kms"]

--- a/packaging/triad/release/install-linux.sh
+++ b/packaging/triad/release/install-linux.sh
@@ -93,6 +93,29 @@ case "$action" in
         exit 66
       }
     done
+    chrony_service=""
+    if [[ "$root" == "/" ]]; then
+      for required_command in chronyd chronyc; do
+        command -v "$required_command" >/dev/null || {
+          echo "Linux installation requires chrony with NTS support ($required_command is missing)" >&2
+          exit 69
+        }
+      done
+      if systemctl is-active --quiet systemd-timesyncd.service; then
+        echo "disable systemd-timesyncd and enable chrony before installing Bloom" >&2
+        exit 69
+      fi
+      for candidate in chronyd.service chrony.service; do
+        if systemctl cat "$candidate" >/dev/null 2>&1; then
+          chrony_service="$candidate"
+          break
+        fi
+      done
+      [[ -n "$chrony_service" ]] || {
+        echo "Linux installation could not find a chrony systemd service" >&2
+        exit 69
+      }
+    fi
     installed_config_root="$root/etc/bloom/$login_uid"
     fresh_install=true
     if [[ -e "$installed_config_root/edge-manifest.json" ]]; then
@@ -200,6 +223,14 @@ case "$action" in
     } > "$chrony_target.new"
     chmod 0644 "$chrony_target.new"
     mv -f "$chrony_target.new" "$chrony_target"
+    if [[ "$root" == "/" ]]; then
+      systemctl enable --now "$chrony_service"
+      systemctl restart "$chrony_service"
+      chronyc waitsync 30 0.5 1000 1 >/dev/null || {
+        echo "chrony did not synchronize from the required authenticated NTS sources" >&2
+        exit 69
+      }
+    fi
 
     enrollment_scratch=""
     trap 'if [[ -n "${enrollment_scratch:-}" && -d "$enrollment_scratch" ]]; then find "$enrollment_scratch" -depth -delete; fi' EXIT

--- a/packaging/triad/release/install-linux.sh
+++ b/packaging/triad/release/install-linux.sh
@@ -93,29 +93,6 @@ case "$action" in
         exit 66
       }
     done
-    chrony_service=""
-    if [[ "$root" == "/" ]]; then
-      for required_command in chronyd chronyc; do
-        command -v "$required_command" >/dev/null || {
-          echo "Linux installation requires chrony with NTS support ($required_command is missing)" >&2
-          exit 69
-        }
-      done
-      if systemctl is-active --quiet systemd-timesyncd.service; then
-        echo "disable systemd-timesyncd and enable chrony before installing Bloom" >&2
-        exit 69
-      fi
-      for candidate in chronyd.service chrony.service; do
-        if systemctl cat "$candidate" >/dev/null 2>&1; then
-          chrony_service="$candidate"
-          break
-        fi
-      done
-      [[ -n "$chrony_service" ]] || {
-        echo "Linux installation could not find a chrony systemd service" >&2
-        exit 69
-      }
-    fi
     installed_config_root="$root/etc/bloom/$login_uid"
     fresh_install=true
     if [[ -e "$installed_config_root/edge-manifest.json" ]]; then
@@ -223,15 +200,6 @@ case "$action" in
     } > "$chrony_target.new"
     chmod 0644 "$chrony_target.new"
     mv -f "$chrony_target.new" "$chrony_target"
-    if [[ "$root" == "/" ]]; then
-      systemctl enable --now "$chrony_service"
-      systemctl restart "$chrony_service"
-      chronyc waitsync 30 0.5 1000 1 >/dev/null || {
-        echo "chrony did not synchronize from the required authenticated NTS sources" >&2
-        exit 69
-      }
-    fi
-
     enrollment_scratch=""
     trap 'if [[ -n "${enrollment_scratch:-}" && -d "$enrollment_scratch" ]]; then find "$enrollment_scratch" -depth -delete; fi' EXIT
     source_config=""

--- a/packaging/triad/release/verify-bundle.sh
+++ b/packaging/triad/release/verify-bundle.sh
@@ -84,9 +84,9 @@ for support_edge in signer_control session; do
   require_compat_value "protocols.$support_edge" minor_min 0
   require_compat_value "protocols.$support_edge" minor_max 1
 done
-require_compat_value revisions broker_commit '"b2ac5bd256ea48b67730cac69d3bcd6d635f5347"'
-require_compat_value revisions signer_commit '"59c12e15438e436979eb30a27b2e9534a3f97615"'
-require_compat_value revisions service_runtime_commit '"19d0465d53b279e6e1c98bac533510a1e7eb8f44"'
+require_compat_value revisions broker_commit '"90dc9adeabf8fb23a1528a3095913fc242b9fe33"'
+require_compat_value revisions signer_commit '"3ddddb5b8f15d7c2a82c0aed418a0fe3e46ae0ad"'
+require_compat_value revisions service_runtime_commit '"155560173e65fa6635cc87a43986f4fa6ea9c4e0"'
 require_compat_value revisions petal_contract_commit '"61938d0c127cfe03c7e3e55baed0ba1439bc5ca2"'
 for state_owner in machine broker signer; do
   require_compat_value "state.$state_owner" current 1


### PR DESCRIPTION
## Summary

- stage the merged zero-clock runtime and Signer revisions plus Broker's trusted-ceremony-clock fix
- publish the Machine as 0.1.4 and update the immutable compatibility pins
- remove `ProtectClock=yes`, which blocks the read-only `adjtimex` synchronization query used by both services
- retain empty capability and ambient-capability sets so neither service gains `CAP_SYS_TIME`
- use the host's existing synchronized kernel clock without requiring a particular time daemon

## Reproduced failure

The installed Broker had `last_effective_ms=0`, `condition=UNTRUSTED`, and four expired anonymous sessions created at zero. Its systemd sandbox blocked the kernel synchronization-status syscall, so the clock could never initialize and all four sessions remained inside the ten-minute rolling window.

## Validation

- Broker PR full workspace check and test suite
- `cargo check --workspace --all-targets --locked`
- `cargo test -p bloom-it --test linux_packaging --locked`
- focused Linux installer release tests
- remote immutable dependency-pin validation

## Checklist

- [x] Tests added or updated for behavior changes
- [x] Architecture docs updated if contracts or behavior changed — N/A; this restores access to the existing kernel-synchronization contract
- [x] Sealed Approval invariants respected — no authority or sealed-byte behavior changed
- [x] Agent Documentation updated — N/A; no agent-facing route or Petal behavior changed
