### PR TITLE
feat(docker): add canonical Linux Triad Compose setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,66 @@
+# Bloom triad container stack -- example environment.
+#
+#     cp .env.example .env
+#
+# Every value here is NON-SECRET by design. Signing seeds, service identities
+# and the edge manifest are files, not variables: they are bind-mounted
+# read-only from ${BLOOM_CONFIG_DIR} so they never land in `docker inspect`,
+# never end up in a named volume, and never survive in shell history.
+#
+# Do not add a private key, seed or mnemonic to this file or to .env.
+
+# ---------------------------------------------------------------------------
+# Host mount projection (Linux only)
+# ---------------------------------------------------------------------------
+# Where the wallet tree appears on your host. The compose default is
+# ${HOME}/bloom; set this to override. The directory is created if missing.
+#
+# This bind uses rshared propagation, which requires the host mount that
+# contains this path to be a shared mount. Check with:
+#     findmnt -no PROPAGATION -T "${HOME}/bloom"
+# If that prints "private", make it shared before starting the stack --
+# see README.md, "Mount propagation".
+BLOOM_HOST_DIR=
+
+# ---------------------------------------------------------------------------
+# Secret material (bind-mounted read-only; NOT stored in this file)
+# ---------------------------------------------------------------------------
+# Root of the per-service config trees. The compose file expects:
+#
+#   ${BLOOM_CONFIG_DIR}/signer/   -> signer.json, signer-identity.json,
+#                                    edge-manifest.json, authority-edge-history.json
+#   ${BLOOM_CONFIG_DIR}/broker/   -> broker.json, broker-identity.json,
+#                                    edge-manifest.json, authority-edge-history.json,
+#                                    plus the provenance catalog named by broker.json
+#   ${BLOOM_CONFIG_DIR}/machine/  -> machine-identity.json, edge-manifest.json
+#
+# Keep this directory outside the repo, or gitignored. signer.json and
+# broker.json carry signing seeds in cleartext and must be mode 0600.
+# scripts/triad-dev-launch.sh is the reference for what these files contain.
+BLOOM_CONFIG_DIR=./deploy/bloom-config
+
+# ---------------------------------------------------------------------------
+# Service identity
+# ---------------------------------------------------------------------------
+# The Broker and Signer authenticate their peer by effective uid against the
+# edge manifest. These MUST equal `broker.effective_uid` and
+# `signer.effective_uid` in the edge manifest you mount, and they must match
+# each other -- the Signer's socket directory is mode 0700, and the Broker can
+# only traverse it because it runs as the same uid.
+BLOOM_SERVICE_UID=10001
+BLOOM_SERVICE_GID=10001
+
+# ---------------------------------------------------------------------------
+# Images
+# ---------------------------------------------------------------------------
+BLOOM_IMAGE_TAG=local
+
+# ---------------------------------------------------------------------------
+# Logging (RUST_LOG syntax, per service)
+# ---------------------------------------------------------------------------
+# Raise to debug/trace when diagnosing. Be aware that trace-level logs from the
+# Broker and Signer can include request shapes and key identifiers; they should
+# not include seed material, but treat them as sensitive anyway.
+BLOOM_SIGNER_LOG=info
+BLOOM_BROKER_LOG=info
+BLOOM_MACHINE_LOG=info

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,11 +66,15 @@ RUN set -eux; \
 
 # ----------------------------------------------------------------------------
 FROM debian:${DEBIAN_RELEASE}-slim AS runtime
+# nfs-common supplies /sbin/mount.nfs4, which bloom-mount execs to mount the
+# embedded NFSv4.1 export at the --mount path. Without it `bloom serve --mount`
+# fails at the mount step.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
         ca-certificates \
         libssl3 \
         netcat-openbsd \
+        nfs-common \
  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /out/bin/bloom      /usr/local/bin/bloom

--- a/README.md
+++ b/README.md
@@ -216,6 +216,205 @@ and example crates used by the broader Bloom runtime and examples.
   chains, private broadcast returns an error instead of silently falling
   back to public RPC.
 
+## Container stack (Docker Compose)
+
+`docker-compose.yml` builds and wires the full triad — Machine (this repo),
+Broker (`../bloom-broker`), Signer (`../bloom-signer`) — from the sibling
+checkout layout that `scripts/triad-dev-launch.sh` already assumes:
+
+```
+bloom-directory/
+  bloom/          <- this repo, build context "."
+  bloom-broker/   <- build context "../bloom-broker"
+  bloom-signer/   <- build context "../bloom-signer"
+```
+
+```bash
+cp .env.example .env          # then set BLOOM_CONFIG_DIR and BLOOM_HOST_DIR
+docker compose run --rm machine-init   # `bloom init` populates BLOOM_HOME
+docker compose up --build
+```
+
+**Read [Mount propagation](#mount-propagation-linux-only) before starting the
+`machine` service.** The mount path is Linux-only and needs host-side setup.
+
+### Trust topology
+
+Reachability is enforced by which containers share which Unix-socket volume,
+not by network rules:
+
+```
+machine  --(broker.sock)-->  broker  --(signer.sock)-->  signer
+```
+
+The Machine has no path to the Signer, because the `signer-rpc` volume is
+mounted only into `signer` and `broker`. Adding that volume to the `machine`
+service would collapse the custody boundary — don't.
+
+Each RPC edge gets its own named volume, shared by exactly the two services on
+that edge. Both **control** sockets (the Broker's and the Signer's) are
+deliberately routed into each service's *private* state volume instead, because
+they are operator surfaces rather than peer surfaces; that way mounting an RPC
+volume into another container can never expose them.
+
+Ownership is worth understanding, because it is easy to break. A fresh named
+volume is initialised from whatever the image has at that mount point,
+*including uid/gid and mode*. The Signer image pre-creates its runtime directory
+as `10001:10001` mode `0700`, so the first container to mount `signer-rpc`
+stamps that onto the volume. The `depends_on: condition: service_healthy`
+chain guarantees the Signer wins that race. The Broker can then traverse a `0700`
+directory only because it runs as the same uid — which is why
+`BLOOM_SERVICE_UID` must match on both, and must equal `broker.effective_uid` /
+`signer.effective_uid` in your edge manifest.
+
+### Service commands
+
+The Broker and Signer services intentionally declare **no `command:`**. Both
+binaries are entirely env- and config-driven and accept no flags beyond a bare
+`--version`; every knob is an environment variable or a field in
+`broker.json` / `signer.json`. The image `ENTRYPOINT` is the whole invocation.
+
+The Machine's command is real and verified against `bloom serve --help`:
+
+```yaml
+command: ["serve", "--mount", "/bloom"]
+```
+
+`--mount` takes an optional path and defaults to `/bloom` on Linux; the path is
+passed explicitly so the file does not depend on the platform default.
+
+### State and secrets
+
+Durable, **non-secret** state lives in named volumes: the Signer and Broker
+SQLite stores, their audit-checkpoint chains, the Broker journal/authority/
+ceremony files, and the Machine's `BLOOM_HOME`.
+
+Secret material is **not** in named volumes. Service identities, the edge
+manifest, `authority-edge-history.json`, and the seed-bearing `signer.json` /
+`broker.json` are bind-mounted read-only from `${BLOOM_CONFIG_DIR}`, so
+`docker compose down -v` cannot destroy them and `docker volume inspect` never
+surfaces them. Keep that directory outside the repo; `signer.json` and
+`broker.json` must be mode `0600`. `scripts/triad-dev-launch.sh` is the
+reference for what those files contain.
+
+If the workspace's `bloom-directory` git dependencies are private, the Broker
+Dockerfile accepts an optional `git_credentials` build secret. It is left
+unwired in compose because a missing file would break the default public build:
+
+```bash
+docker build --secret id=git_credentials,src="$HOME/.git-credentials" ../bloom-broker
+```
+
+### Networking
+
+The Broker and Signer sit on an `internal: true` network. Neither ever uses it —
+they speak only `AF_UNIX` — but Docker installs no gateway for an internal
+network, so it denies egress even if some future code path tried. For the
+tightest possible setting, replace their `networks:` key with
+`network_mode: "none"`; Compose forbids combining the two, which is the only
+reason it is not the default here.
+
+Only the Machine gets egress, on `bloom-egress`. It needs it for JSON-RPC, price
+feeds, ENS, and the GitHub update check.
+
+**The NFS port is not published, on purpose.** The embedded server defaults to
+`nfs_listen_addr = "127.0.0.1:12049"`, and the only client is the mount call in
+the same container, so the traffic never leaves loopback. Publishing it would
+expose an unauthenticated NFS export of the wallet tree to anything that can
+reach the port — there is no NFS-level auth in front of it. If you must inspect
+the export while debugging, bind it to loopback only
+(`127.0.0.1:12049:12049/tcp`) and remove it afterwards.
+
+### Mount propagation (Linux only)
+
+`bloom serve --mount /bloom` starts an embedded NFSv4.1 server bound to loopback
+*inside* the container, then shells out to `mount.nfs4` to mount it at `/bloom`.
+That mount is created in the container's mount namespace. To make the host see
+it, the compose file binds the host directory with `rshared` propagation:
+
+```yaml
+- type: bind
+  source: ${BLOOM_HOST_DIR:-${HOME}/bloom}
+  target: /bloom
+  bind:
+    propagation: rshared
+    create_host_path: true
+```
+
+Three host-side preconditions, none of which are optional:
+
+1. **Linux host.** Mount propagation does not exist on Docker Desktop for macOS
+   or Windows — the daemon runs inside its own VM, so `rshared` would at best
+   project into that VM and never onto your desktop. On those platforms use
+   `bloom vfs` instead of a mount.
+2. **The host bind source must be on a shared mount.** Otherwise the daemon
+   refuses the bind with `path is mounted on / but it is not a shared mount`.
+   Check and fix:
+   ```bash
+   findmnt -no PROPAGATION -T "${HOME}/bloom"   # want: shared
+   sudo mount --make-shared /                   # blunt, affects the whole host
+   ```
+   To scope it instead of making `/` shared, bind the directory onto itself and
+   share only that subtree:
+   ```bash
+   sudo mount --bind "${HOME}/bloom" "${HOME}/bloom"
+   sudo mount --make-shared "${HOME}/bloom"
+   ```
+   Neither survives a reboot unless you add it to `/etc/fstab` or a systemd unit.
+3. **NFS client support in the host kernel** (`sudo modprobe nfs`). The
+   container shares the host kernel and cannot supply this itself.
+
+The mount helper itself is not a host concern: the runtime stage of this repo's
+`Dockerfile` installs `nfs-common`, so `mount.nfs4` is present in the image.
+
+#### Required privileges
+
+The Machine is the only service granted any privilege:
+
+```yaml
+cap_add:
+  - SYS_ADMIN
+security_opt:
+  - apparmor:unconfined
+```
+
+- **`CAP_SYS_ADMIN`** is required for `mount(2)`. Be clear-eyed about it: with
+  the `rshared` bind it is close to root-equivalent on the host, since it is
+  enough to affect host mount state. This is the actual price of projecting the
+  mount outward, and it is precisely why the Broker and Signer are separate
+  services running `cap_drop: [ALL]` — a compromise of the Machine must not
+  reach key material.
+- **`apparmor:unconfined`** is required on AppArmor hosts (Ubuntu, and Debian
+  with AppArmor enabled): the `docker-default` profile denies `mount`
+  unconditionally, so `CAP_SYS_ADMIN` alone is not enough there. Docker's default
+  **seccomp** profile already permits `mount`/`umount2` once `CAP_SYS_ADMIN` is
+  present, so no seccomp override is needed. On an SELinux-enforcing host, drop
+  the AppArmor line and expect to need an SELinux policy adjustment instead.
+- **`privileged: true`** is left commented out as a blunt fallback. It grants
+  strictly more than this needs — all capabilities, unmasked `/proc` and `/sys`,
+  all devices. Use it only to confirm a diagnosis, then narrow it again.
+
+`stop_grace_period: 30s` gives the daemon room to unmount before `SIGKILL`;
+without it the host can be left with a stale NFS mount at `/bloom`.
+
+### Healthchecks
+
+What each probe actually proves, since two of the three are weaker than
+"healthy" suggests:
+
+| Service | Probe | Proves |
+| --- | --- | --- |
+| `signer` | `test -S /run/bloom/signer.sock` | The RPC listener is bound. **Not** that it answers RPC. |
+| `broker` | `test -S` on both sockets | Both listeners are bound, ruling out the half-initialised window. **Not** that either answers RPC. |
+| `machine` | `bloom status -q` | Genuinely round-trips the daemon IPC socket. **Not** that `/bloom` is mounted. |
+
+The Broker and Signer runtime images install no packages at all — not even
+`ca-certificates` — so no shell in them can speak the framed, uid-authenticated
+protocol. Socket existence is the strongest honest signal available. For the
+Machine, the runtime image has no `mountpoint` binary, so a healthy Machine with
+a failed mount is possible; check `docker compose logs machine` for the mount
+result.
+
 ## Limitations
 
 - **Per-login Machine surface.** Production Broker and Signer run as isolated

--- a/deploy/triad/Dockerfile.bootstrap
+++ b/deploy/triad/Dockerfile.bootstrap
@@ -1,0 +1,94 @@
+# syntax=docker/dockerfile:1.7
+#
+# Bloom triad bootstrap image -- DEVELOPMENT / SANDBOX ONLY.
+#
+# This image never runs as part of the stack. It runs once, under the
+# `bootstrap` Compose profile, to mint developer enrollment material into the
+# triad's config volumes and then exits.
+#
+# The three release binaries are RECEIVED, not rebuilt. They arrive through
+# BuildKit named contexts that point straight at the already-built service
+# images:
+#
+#     additional_contexts:
+#       bloom-machine-image: docker-image://bloom:<tag>
+#       bloom-broker-image:  docker-image://bloom-broker:<tag>
+#       bloom-signer-image:  docker-image://bloom-signer:<tag>
+#
+# That is the whole point of the design. The release digest that ends up in
+# broker.json and signer.json is computed over these exact bytes, so it cannot
+# describe a build different from the one the services execute. Rebuilding the
+# binaries here from source instead would reintroduce precisely that gap.
+#
+# Build context is the repository root (the packaging templates live there).
+
+ARG DEBIAN_RELEASE=bookworm
+
+# ---------------------------------------------------------------------------
+# Ceremony activation shim
+#
+# Statically linked so it is immune to any libc skew between this image and the
+# Broker runtime image it gets mounted into. See ceremony-activate.c for why a
+# shim is needed at all.
+# ---------------------------------------------------------------------------
+FROM debian:${DEBIAN_RELEASE}-slim AS shim
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends gcc libc6-dev \
+ && rm -rf /var/lib/apt/lists/*
+COPY deploy/triad/ceremony-activate.c /src/ceremony-activate.c
+RUN mkdir -p /out \
+ && gcc -static -O2 -std=c11 -D_DEFAULT_SOURCE -Wall -Wextra -Werror \
+        -o /out/bloom-ceremony-activate /src/ceremony-activate.c \
+ && /out/bloom-ceremony-activate 2>&1 | grep -q '^bloom-ceremony-activate: usage:'
+
+# ---------------------------------------------------------------------------
+# Bootstrap runtime
+# ---------------------------------------------------------------------------
+FROM debian:${DEBIAN_RELEASE}-slim AS bootstrap
+
+LABEL org.opencontainers.image.title="bloom-triad-bootstrap" \
+      org.opencontainers.image.description="Development-only triad enrollment bootstrap for the Bloom Compose stack" \
+      dev.bloom.profile="development-sandbox"
+
+# jq       -- the config rewrites, exactly as scripts/triad-dev-launch.sh uses it
+# libssl3  -- `bloom` links libssl/libcrypto (see the runtime stage of ../../Dockerfile)
+# setpriv  -- from util-linux; drops to the service uid, because
+#             `init triad-render-developer-enrollment` refuses to run as root
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends jq libssl3 util-linux \
+ && rm -rf /var/lib/apt/lists/*
+
+# The exact binaries the services will run. Ordering here mirrors the digest
+# ordering in bootstrap.sh: machine, Broker, Signer.
+COPY --from=bloom-machine-image /usr/local/bin/bloom        /opt/bloom-triad/bin/bloom
+COPY --from=bloom-broker-image  /usr/local/bin/bloom-broker /opt/bloom-triad/bin/bloom-broker
+COPY --from=bloom-signer-image  /usr/local/bin/bloom-signer /opt/bloom-triad/bin/bloom-signer
+
+# Config templates, selected the same way the dev launcher selects them on
+# Linux: the Linux edge manifest, and the platform-neutral Broker/Signer/
+# provenance templates that only exist under packaging/triad/macos/config.
+COPY packaging/triad/linux/config/edge-manifest.json.in \
+     /opt/bloom-triad/templates/edge-manifest.json.in
+COPY packaging/triad/macos/config/broker.json.in \
+     packaging/triad/macos/config/signer.json.in \
+     packaging/triad/macos/config/provenance-catalog.unsigned.json \
+     /opt/bloom-triad/templates/
+
+COPY --from=shim /out/bloom-ceremony-activate /opt/bloom-triad/tools/bloom-ceremony-activate
+COPY deploy/triad/bootstrap.sh /usr/local/bin/bloom-triad-bootstrap
+
+RUN chmod 0755 /usr/local/bin/bloom-triad-bootstrap \
+                /opt/bloom-triad/bin/bloom \
+                /opt/bloom-triad/bin/bloom-broker \
+                /opt/bloom-triad/bin/bloom-signer \
+                /opt/bloom-triad/tools/bloom-ceremony-activate \
+ && chmod 0644 /opt/bloom-triad/templates/* \
+ && /opt/bloom-triad/bin/bloom --version \
+ && /opt/bloom-triad/bin/bloom-broker --version \
+ && /opt/bloom-triad/bin/bloom-signer --version
+
+# Runs as root on purpose: it installs root-owned trust anchors, and drops to
+# the service uid for the one step that must not be root.
+USER root:root
+ENTRYPOINT ["/usr/local/bin/bloom-triad-bootstrap"]
+CMD ["bootstrap"]

--- a/deploy/triad/bootstrap.sh
+++ b/deploy/triad/bootstrap.sh
@@ -1,0 +1,625 @@
+#!/usr/bin/env bash
+#
+# bloom-triad-bootstrap -- DEVELOPMENT / SANDBOX ONLY triad enrollment for the
+# Docker Compose stack.
+#
+# ============================================================================
+# THIS IS NOT A PRODUCTION INSTALLER. It mints a fresh developer signing
+# identity inside Docker named volumes. The keys it generates are for a
+# throwaway sandbox. Do not point it at, and do not copy its output into, an
+# installation that holds value.
+# ============================================================================
+#
+# What it does, and why each step exists
+# --------------------------------------
+#  1. Computes the release digest over the exact bloom / bloom-broker /
+#     bloom-signer binaries that the Compose services will execute. The
+#     formula is byte-for-byte the one in scripts/triad-dev-launch.sh:
+#         sha256(each binary) -> take hex column -> sha256 of that stream
+#     in the fixed order machine, Broker, Signer. The binaries arrive in this
+#     image through BuildKit named contexts pointing at the three service
+#     images, so "the digest" and "what runs" cannot drift apart.
+#  2. Renders enrollment material with `bloom init
+#     triad-render-developer-enrollment`, from the same templates the dev
+#     launcher uses (Linux edge manifest, macOS Broker/Signer/catalog
+#     templates -- see TEMPLATE NOTE below). That command refuses to run as
+#     root, so it is executed under the service UID via setpriv.
+#  3. Applies only the config rewrites the canonical dev launcher already
+#     proves, retargeted at this stack's socket and database paths.
+#  4. Distributes each file to a per-service config volume with the ownership
+#     and mode that the *production* trust path in bloom-broker /
+#     bloom-signer / bloom requires: root-owned trust anchors, service-owned
+#     mode-0600 identity and seed-bearing config.
+#  5. Stamps the socket directories 0710 service-owned, which is what
+#     bloom_service_activation::bind_owned_unix_listener demands, and
+#     pre-creates the one nested mount point Docker cannot create itself --
+#     `session/` inside the read-only session-config volume.
+#
+# Secrets discipline: seeds exist only inside the tmpfs enrollment area and
+# inside files this script writes with umask 077. Nothing here ever cats,
+# echoes, or logs a config file's contents, and the installer signing seed is
+# deliberately destroyed with the tmpfs rather than handed to any service.
+#
+# Subcommands:
+#   bootstrap   provision (or re-conform) every volume            [default]
+#   status      report what is provisioned, without changing it
+#   reset       destroy developer custody, guarded by a confirmation token
+
+set -euo pipefail
+export LC_ALL=C
+umask 077
+
+# ---------------------------------------------------------------------------
+# Image-baked inputs
+# ---------------------------------------------------------------------------
+bin_dir=/opt/bloom-triad/bin
+template_dir=/opt/bloom-triad/templates
+tool_source=/opt/bloom-triad/tools/bloom-ceremony-activate
+
+# ---------------------------------------------------------------------------
+# Mount points inside THIS container (see docker-compose.yml `bootstrap`)
+# ---------------------------------------------------------------------------
+config_root=/state/config
+run_root=/state/run
+db_root=/state/db
+machine_home=/state/machine-home
+tools_root=/state/tools
+enrollment_root=/state/enrollment
+
+stamp_name=.bloom-triad-stamp.json
+stamp_schema=bloom.triad-compose-bootstrap.1
+
+# Volumes that carry a provisioning stamp. Socket and database volumes carry
+# ownership only -- they are re-stampable at any time and hold no identity.
+stamped_roles=(signer broker machine session machine-home tools)
+
+# ---------------------------------------------------------------------------
+# Paths as the SERVICE containers see them. These must match docker-compose.yml
+# exactly; scripts/test-triad-compose-stack.sh asserts that they do.
+# ---------------------------------------------------------------------------
+service_signer_socket=/run/bloom-signer-rpc/signer.sock
+service_signer_control=/run/bloom-signer-control/signer-control.sock
+service_broker_socket=/run/bloom-broker-rpc/broker.sock
+service_broker_control=/run/bloom-broker-control/broker-control.sock
+service_signer_db=/var/db/bloom/signer/signer.db
+service_broker_journal=/var/db/bloom/broker/journal.db
+service_broker_authority=/var/db/bloom/broker/authority.db
+service_broker_ceremony=/var/db/bloom/broker/ceremonies.db
+service_broker_catalog=/etc/bloom/provenance-catalog.json
+
+# The dev launcher raises this ceiling because an interactive developer session
+# trips the production 1200/minute quota during ordinary exploration.
+developer_request_ceiling=10000
+
+service_uid="${BLOOM_SERVICE_UID:-10001}"
+service_gid="${BLOOM_SERVICE_GID:-10001}"
+
+die() { printf 'bloom-triad-bootstrap: %s\n' "$*" >&2; exit 1; }
+note() { printf 'bloom-triad-bootstrap: %s\n' "$*"; }
+
+# ---------------------------------------------------------------------------
+# Preconditions
+# ---------------------------------------------------------------------------
+require_environment() {
+  [ "$(uname -s)" = Linux ] ||
+    die "this stack is Linux-only"
+  [ "$(id -u)" -eq 0 ] ||
+    die "the bootstrap container must run as root so it can install root-owned trust files"
+  case "$service_uid" in ''|*[!0-9]*|0)
+    die "BLOOM_SERVICE_UID must be a positive integer" ;;
+  esac
+  case "$service_gid" in ''|*[!0-9]*|0)
+    die "BLOOM_SERVICE_GID must be a positive integer" ;;
+  esac
+  command -v jq >/dev/null 2>&1 || die "jq is missing from the bootstrap image"
+  command -v setpriv >/dev/null 2>&1 || die "setpriv is missing from the bootstrap image"
+  for binary in bloom bloom-broker bloom-signer; do
+    [ -x "${bin_dir}/${binary}" ] ||
+      die "release binary was not staged into the bootstrap image: ${binary}"
+  done
+  [ -x "$tool_source" ] || die "ceremony activation shim was not built into the image"
+  for mount_point in \
+    "${config_root}/signer" "${config_root}/broker" "${config_root}/machine" \
+    "${config_root}/session" "${run_root}/signer-rpc" "${run_root}/signer-control" \
+    "${run_root}/broker-rpc" "${run_root}/broker-control" "${run_root}/session-rpc" \
+    "${db_root}/signer" "${db_root}/broker" "$machine_home" "$tools_root"
+  do
+    [ -d "$mount_point" ] ||
+      die "expected volume is not mounted: ${mount_point} (run this through docker compose)"
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Release digest -- identical construction to scripts/triad-dev-launch.sh
+# ---------------------------------------------------------------------------
+compute_release_digest() {
+  sha256sum "${bin_dir}/bloom" "${bin_dir}/bloom-broker" "${bin_dir}/bloom-signer" |
+    awk '{print $1}' | sha256sum | awk '{print $1}'
+}
+
+# ---------------------------------------------------------------------------
+# State inspection
+#
+# Fail-closed rule: every stamped volume must be either uniformly absent
+# (fresh) or uniformly present and mutually agreeing (provisioned). Anything
+# else is a half-built stack -- most often one volume removed by hand, or a
+# `down -v` that only caught some of them -- and is refused rather than
+# repaired, because "repairing" it means minting a new identity over the top of
+# durable state signed by the old one.
+# ---------------------------------------------------------------------------
+stamp_path_for() {
+  case "$1" in
+    signer|broker|machine|session) printf '%s/%s/%s' "$config_root" "$1" "$stamp_name" ;;
+    machine-home) printf '%s/%s' "$machine_home" "$stamp_name" ;;
+    tools) printf '%s/%s' "$tools_root" "$stamp_name" ;;
+    *) die "unknown stamp role: $1" ;;
+  esac
+}
+
+# Sets: state_kind (fresh|provisioned), state_enrollment_id, state_digest
+inspect_state() {
+  local present=() absent=() role path ids
+  for role in "${stamped_roles[@]}"; do
+    path="$(stamp_path_for "$role")"
+    if [ -e "$path" ]; then present+=("$role"); else absent+=("$role"); fi
+  done
+
+  if [ "${#present[@]}" -eq 0 ]; then
+    # No stamps at all. Insist the config volumes are genuinely empty, so a
+    # hand-populated or externally managed config tree is never overwritten.
+    for role in signer broker machine session; do
+      if find "${config_root}/${role}" -mindepth 1 -print -quit | grep -q .; then
+        die "config volume for ${role} has content but no bootstrap stamp; refusing to overwrite unknown material (use 'reset' if it is disposable)"
+      fi
+    done
+    state_kind=fresh
+    state_enrollment_id=""
+    state_digest=""
+    return
+  fi
+
+  if [ "${#absent[@]}" -ne 0 ]; then
+    die "inconsistent state: provisioned [${present[*]}] but missing [${absent[*]}]; run 'reset' and bootstrap again (this destroys the developer identity)"
+  fi
+
+  for role in "${stamped_roles[@]}"; do
+    path="$(stamp_path_for "$role")"
+    jq -e --arg schema "$stamp_schema" --arg role "$role" \
+      '.schema == $schema and .role == $role' "$path" >/dev/null 2>&1 ||
+      die "bootstrap stamp for ${role} is unreadable or has the wrong schema; run 'reset'"
+  done
+
+  ids="$(
+    for role in "${stamped_roles[@]}"; do
+      jq -r '.enrollment_id' "$(stamp_path_for "$role")"
+    done | sort -u | tr '\n' ' '
+  )"
+  case "$ids" in
+    *' '*' '*) die "volumes carry different enrollment ids (${ids}); they were provisioned by separate bootstraps. Run 'reset' and bootstrap again (this destroys the developer identity)" ;;
+  esac
+
+  state_kind=provisioned
+  state_enrollment_id="$(jq -r '.enrollment_id' "$(stamp_path_for signer)")"
+  state_digest="$(jq -r '.release_digest' "$(stamp_path_for signer)")"
+  local stamped_uid
+  stamped_uid="$(jq -r '.service_uid' "$(stamp_path_for signer)")"
+  [ "$stamped_uid" = "$service_uid" ] ||
+    die "this enrollment pins service uid ${stamped_uid}, but BLOOM_SERVICE_UID is ${service_uid}. The uid is baked into the edge manifest and cannot be changed without a reset."
+}
+
+# ---------------------------------------------------------------------------
+# File placement helpers
+# ---------------------------------------------------------------------------
+# Trust anchors the services verify as root-owned and not group/other writable.
+install_root_owned() {
+  install -o 0 -g 0 -m 0644 "$1" "$2"
+}
+# Identity and seed-bearing config: readable only by the service uid.
+install_service_owned() {
+  install -o "$service_uid" -g "$service_gid" -m 0600 "$1" "$2"
+}
+
+write_stamp() {
+  local role="$1" enrollment_id="$2" digest="$3" path
+  path="$(stamp_path_for "$role")"
+  jq -n --arg schema "$stamp_schema" --arg role "$role" \
+        --arg enrollment_id "$enrollment_id" --arg digest "$digest" \
+        --argjson uid "$service_uid" --argjson gid "$service_gid" \
+        --arg at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '{schema:$schema, role:$role, enrollment_id:$enrollment_id,
+      service_uid:$uid, service_gid:$gid, release_digest:$digest,
+      bootstrapped_at:$at, profile:"development-sandbox"}' > "${path}.new"
+  chmod 0644 "${path}.new"
+  chown 0:0 "${path}.new"
+  mv -f "${path}.new" "$path"
+}
+
+# ---------------------------------------------------------------------------
+# Fresh enrollment
+# ---------------------------------------------------------------------------
+render_enrollment() {
+  local developer_root="${enrollment_root}/root"
+  local staging="${developer_root}/templates"
+  local rendered="${developer_root}/config"
+
+  [ ! -e "$developer_root" ] ||
+    die "enrollment work area already exists; it must be a fresh tmpfs"
+  # The tmpfs arrives root-owned 0700. The renderer runs as the service uid and
+  # has to traverse into it; 0711 grants exactly that and no listing.
+  chmod 0711 "$enrollment_root"
+  mkdir -p "$staging" "$rendered"
+  # `bloom init triad-render-developer-enrollment` requires every template and
+  # the (empty) output directory to be owned by the *calling* uid.
+  chown "${service_uid}:${service_gid}" "$developer_root" "$staging" "$rendered"
+  chmod 0700 "$developer_root" "$staging" "$rendered"
+
+  # TEMPLATE NOTE: the Linux edge manifest is the Linux one; the Broker,
+  # Signer and provenance-catalog templates live only under
+  # packaging/triad/macos/config and are platform-neutral in content (every
+  # platform-specific value is an @PLACEHOLDER@). This is exactly the same
+  # selection scripts/triad-dev-launch.sh makes on Linux.
+  local name
+  for name in edge-manifest.json.in broker.json.in signer.json.in \
+              provenance-catalog.unsigned.json
+  do
+    install -o "$service_uid" -g "$service_gid" -m 0600 \
+      "${template_dir}/${name}" "${staging}/${name}"
+  done
+
+  setpriv --reuid="$service_uid" --regid="$service_gid" --clear-groups \
+    env HOME="$developer_root" \
+    "${bin_dir}/bloom" init triad-render-developer-enrollment \
+      "$staging" "$rendered" "$release_digest"
+
+  rm -rf -- "$staging"
+
+  # Everything the renderer is contracted to produce. A missing file here means
+  # the enrollment command changed shape; fail rather than ship a partial tree.
+  for name in edge-manifest.json broker.json signer.json provenance-catalog.json \
+              machine-identity.json broker-identity.json signer-identity.json \
+              session-identity.json
+  do
+    [ -f "${rendered}/${name}" ] && [ ! -L "${rendered}/${name}" ] ||
+      die "developer enrollment did not produce ${name}"
+  done
+
+  # The authority-edge application-key history starts empty. The dev launcher
+  # writes the identical stub; the services verify it is owned by uid 0 (their
+  # production trust path), which is why it is installed root-owned below.
+  printf '%s\n' \
+    '{' \
+    '  "schema": "bloom.authority-edge-application-history.1",' \
+    '  "historical_keys": [],' \
+    '  "handovers": []' \
+    '}' > "${rendered}/authority-edge-history.json"
+}
+
+# ---------------------------------------------------------------------------
+# Config rewrites
+#
+# Exactly the rewrites the canonical dev launcher performs
+# (rewrite_broker_config / rewrite_signer_config), plus the durable-path fields
+# that render_developer_runtime_paths pointed at a host developer root and that
+# must instead name this stack's container paths. No other field is touched.
+# ---------------------------------------------------------------------------
+rewrite_broker_config() {
+  local source="$1" temporary="$1.new"
+  jq --arg signer_socket "$service_signer_socket" \
+     --arg digest "$release_digest" \
+     --arg journal "$service_broker_journal" \
+     --arg authority "$service_broker_authority" \
+     --arg ceremony "$service_broker_ceremony" \
+     --arg catalog "$service_broker_catalog" \
+     --argjson ceiling "$developer_request_ceiling" \
+    '.signer_socket_path = $signer_socket
+     | .build_digest = $digest
+     | .journal_path = $journal
+     | .authority_path = $authority
+     | .ceremony_path = $ceremony
+     | .provenance_catalog_path = $catalog
+     | .network_containment = null
+     | .maximum_requests_per_window = $ceiling' \
+    "$source" > "$temporary"
+  chmod 0600 "$temporary"
+  mv -f "$temporary" "$source"
+}
+
+rewrite_signer_config() {
+  local source="$1" temporary="$1.new"
+  jq --arg digest "$release_digest" \
+     --arg database "$service_signer_db" \
+     --argjson ceiling "$developer_request_ceiling" \
+    '.build_digest = $digest
+     | .database_path = $database
+     | .network_containment = null
+     | .maximum_requests_per_window = $ceiling' \
+    "$source" > "$temporary"
+  chmod 0600 "$temporary"
+  mv -f "$temporary" "$source"
+}
+
+assert_no_placeholders() {
+  # A surviving @PLACEHOLDER@ means a template gained a field the renderer does
+  # not substitute. Catch it here rather than as an opaque parse failure at
+  # service startup.
+  local path="$1"
+  if grep -q '@[A-Z_]\{2,\}@' "$path"; then
+    die "$(basename "$path") still contains an unresolved packaging placeholder"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Distribution to the per-service config volumes
+# ---------------------------------------------------------------------------
+distribute() {
+  local rendered="${enrollment_root}/root/config"
+
+  # --- Signer -------------------------------------------------------------
+  # /etc/bloom itself stays root-owned: the Signer only needs to read.
+  chown 0:0 "${config_root}/signer"; chmod 0755 "${config_root}/signer"
+  install_root_owned    "${rendered}/edge-manifest.json"          "${config_root}/signer/edge-manifest.json"
+  install_root_owned    "${rendered}/authority-edge-history.json" "${config_root}/signer/authority-edge-history.json"
+  install_service_owned "${rendered}/signer-identity.json"        "${config_root}/signer/signer-identity.json"
+  install_service_owned "${rendered}/signer.json"                 "${config_root}/signer/signer.json"
+
+  # --- Broker -------------------------------------------------------------
+  chown 0:0 "${config_root}/broker"; chmod 0755 "${config_root}/broker"
+  install_root_owned    "${rendered}/edge-manifest.json"          "${config_root}/broker/edge-manifest.json"
+  install_root_owned    "${rendered}/authority-edge-history.json" "${config_root}/broker/authority-edge-history.json"
+  install_root_owned    "${rendered}/provenance-catalog.json"     "${config_root}/broker/provenance-catalog.json"
+  install_service_owned "${rendered}/broker-identity.json"        "${config_root}/broker/broker-identity.json"
+  install_service_owned "${rendered}/broker.json"                 "${config_root}/broker/broker.json"
+
+  # --- Machine ------------------------------------------------------------
+  # No broker.json/signer.json equivalent: the Machine holds no signing seed.
+  chown 0:0 "${config_root}/machine"; chmod 0755 "${config_root}/machine"
+  install_root_owned    "${rendered}/edge-manifest.json"          "${config_root}/machine/edge-manifest.json"
+  install_root_owned    "${rendered}/authority-edge-history.json" "${config_root}/machine/authority-edge-history.json"
+  install_root_owned    "${rendered}/provenance-catalog.json"     "${config_root}/machine/provenance-catalog.json"
+  install_service_owned "${rendered}/machine-identity.json"       "${config_root}/machine/machine-identity.json"
+
+  # --- Session sentinel ---------------------------------------------------
+  # The odd one out, and deliberately so. bloom-broker and bloom-signer both
+  # block at startup on an authenticated connection to the session sentinel, so
+  # the stack cannot omit it. But `bloom serve session-sentinel` has only two
+  # modes: a macOS-enrollment lookup (which would mean fabricating a
+  # `bloom.macos-enrollment.1` record on Linux) or the dev-harness mode keyed
+  # off BLOOM_TRIAD_DEVELOPER_ROOT. The dev-harness mode is the honest choice
+  # for a dev-only stack, and it demands the mirror image of the production
+  # contract: one service-UID-owned mode-0700 root holding service-UID-owned
+  # mode-0600 files. Hence a second, byte-identical copy of the edge manifest
+  # with different ownership. It carries public keys only.
+  chown "${service_uid}:${service_gid}" "${config_root}/session"
+  chmod 0700 "${config_root}/session"
+  install -d -o "$service_uid" -g "$service_gid" -m 0700 "${config_root}/session/config"
+  install_service_owned "${rendered}/edge-manifest.json"    "${config_root}/session/config/edge-manifest.json"
+  install_service_owned "${rendered}/session-identity.json" "${config_root}/session/config/session-identity.json"
+}
+
+# ---------------------------------------------------------------------------
+# Session socket mount point
+#
+# The sentinel mounts session-config READ-ONLY at /var/lib/bloom-session and
+# session-rpc *nested* inside it at /var/lib/bloom-session/session. Docker
+# creates a missing mount point in the parent before the container starts, and
+# on a read-only parent that mkdirat fails -- the container never starts:
+#
+#     mkdirat .../var/lib/bloom-session/session: read-only file system
+#
+# So the directory has to already exist in the session-config volume. It is
+# only ever a mount point: session-rpc is mounted over it and its own 0710
+# service-owned stamp (see stamp_runtime_directories) is what
+# require_session_directory actually inspects. It is stamped identically here
+# so the shadowed directory never contradicts the one that shadows it.
+#
+# This does not widen config secrecy: the parent ${config_root}/session stays
+# 0700 service-owned, so nothing outside the service uid can traverse into it.
+# ---------------------------------------------------------------------------
+provision_session_socket_mount_point() {
+  install -d -o "$service_uid" -g "$service_gid" -m 0710 \
+    "${config_root}/session/session"
+}
+
+# ---------------------------------------------------------------------------
+# Runtime directory ownership
+#
+# bloom_service_activation::bind_owned_unix_listener refuses any parent that is
+# not owned by the effective uid with mode *exactly* 0710. The service images
+# create these directories 0700 or 0755, and a fresh named volume inherits the
+# image's ownership and mode, so every one of them has to be re-stamped here.
+# 0710 is what makes the socket group-reachable while keeping the directory
+# unlistable to others; the sockets themselves are created 0660 group-owned.
+#
+# The `.keep` file is load-bearing, not tidiness. Docker only copies an image
+# directory's contents *and its uid/gid/mode* into a named volume while that
+# volume is still empty. A socket directory is empty by nature, so without a
+# marker file the very next container to mount one would silently restamp it
+# with the image's 0700/0755 and the Broker or Signer would then refuse to bind.
+# ---------------------------------------------------------------------------
+stamp_runtime_directories() {
+  local directory
+  for directory in signer-rpc signer-control broker-rpc broker-control session-rpc; do
+    install -o 0 -g 0 -m 0644 /dev/null "${run_root}/${directory}/.keep"
+    chown "${service_uid}:${service_gid}" "${run_root}/${directory}"
+    chmod 0710 "${run_root}/${directory}"
+  done
+  # Durable service state: private to the service uid.
+  for directory in signer broker; do
+    chown -R "${service_uid}:${service_gid}" "${db_root}/${directory}"
+    chmod 0700 "${db_root}/${directory}"
+  done
+  install -d -o "$service_uid" -g "$service_gid" -m 0700 \
+    "${db_root}/signer/audit-checkpoints" "${db_root}/broker/audit-checkpoints"
+}
+
+# ---------------------------------------------------------------------------
+# Machine home
+#
+# `bloom init` cannot be used here: it opens the authenticated Machine->Broker
+# edge, so it only works once the triad is already up. The sandbox config must
+# contain a real chain (Config validates against an empty map) but must opt out
+# of network-fetched release Petals. This is the canonical ChainSpec::anvil_default
+# shape, rendered in TOML with serde-defaulted fields omitted.
+# ---------------------------------------------------------------------------
+provision_machine_home() {
+  chown "${service_uid}:${service_gid}" "$machine_home"
+  chmod 0700 "$machine_home"
+  install -d -o "$service_uid" -g "$service_gid" -m 0700 \
+    "${machine_home}/audit-checkpoints" "${machine_home}/audit-checkpoints/machine"
+
+  if [ ! -e "${machine_home}/config.toml" ]; then
+    cat > "${machine_home}/config.toml" <<'TOML'
+# Bloom Machine configuration -- DEVELOPMENT SANDBOX.
+# Anvil is deliberately local-only. Start an Anvil-compatible endpoint at
+# 127.0.0.1:8545 inside the Machine network namespace before using chain I/O.
+default_chain = "anvil"
+
+[petals]
+preinstalled = []
+
+[chains.anvil]
+name = "anvil"
+chain_id = 31337
+rpc_urls = ["http://127.0.0.1:8545"]
+TOML
+    chown "${service_uid}:${service_gid}" "${machine_home}/config.toml"
+    chmod 0600 "${machine_home}/config.toml"
+  else
+    chown "${service_uid}:${service_gid}" "${machine_home}/config.toml"
+    chmod 0600 "${machine_home}/config.toml"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Operational tools volume (non-secret)
+# ---------------------------------------------------------------------------
+provision_tools() {
+  chown 0:0 "$tools_root"; chmod 0755 "$tools_root"
+  install -o 0 -g 0 -m 0755 "$tool_source" "${tools_root}/bloom-ceremony-activate"
+}
+
+# ---------------------------------------------------------------------------
+# Subcommands
+# ---------------------------------------------------------------------------
+cmd_bootstrap() {
+  require_environment
+  release_digest="$(compute_release_digest)"
+  case "$release_digest" in
+    *[!0-9a-f]*) die "computed release digest is not lowercase hex" ;;
+  esac
+  [ "${#release_digest}" -eq 64 ] || die "computed release digest is malformed"
+
+  inspect_state
+
+  if [ "$state_kind" = provisioned ]; then
+    # Re-conform. Identity is NEVER regenerated here: the durable Broker and
+    # Signer stores are signed by the existing keys, and silently rotating them
+    # would strand that state. Only the fields the dev launcher itself rewrites
+    # on every launch are refreshed, which is what lets you rebuild the images
+    # and restart without a reset.
+    if [ "$state_digest" != "$release_digest" ]; then
+      note "release digest changed (${state_digest:0:12}... -> ${release_digest:0:12}...); re-pinning configs, keeping the existing developer identity"
+    else
+      note "already provisioned (enrollment ${state_enrollment_id:0:12}...); re-conforming ownership and paths"
+    fi
+    rewrite_broker_config "${config_root}/broker/broker.json"
+    rewrite_signer_config "${config_root}/signer/signer.json"
+    chown "${service_uid}:${service_gid}" \
+      "${config_root}/broker/broker.json" "${config_root}/signer/signer.json"
+    chmod 0600 \
+      "${config_root}/broker/broker.json" "${config_root}/signer/signer.json"
+    provision_session_socket_mount_point
+    stamp_runtime_directories
+    provision_machine_home
+    provision_tools
+    local role
+    for role in "${stamped_roles[@]}"; do
+      write_stamp "$role" "$state_enrollment_id" "$release_digest"
+    done
+    note "re-conformed. Developer identity ${state_enrollment_id:0:12}... is unchanged."
+    return
+  fi
+
+  note "no existing enrollment; minting a fresh DEVELOPMENT-ONLY triad identity"
+  local enrollment_id
+  enrollment_id="$(od -vAn -N16 -tx1 /dev/urandom | tr -d ' \n')"
+
+  render_enrollment
+  local rendered="${enrollment_root}/root/config"
+  rewrite_broker_config "${rendered}/broker.json"
+  rewrite_signer_config "${rendered}/signer.json"
+  assert_no_placeholders "${rendered}/broker.json"
+  assert_no_placeholders "${rendered}/signer.json"
+  assert_no_placeholders "${rendered}/edge-manifest.json"
+
+  distribute
+  provision_session_socket_mount_point
+  stamp_runtime_directories
+  provision_machine_home
+  provision_tools
+  local role
+  for role in "${stamped_roles[@]}"; do
+    write_stamp "$role" "$enrollment_id" "$release_digest"
+  done
+
+  # The tmpfs mount is discarded with the container, but do not rely on that:
+  # the installer signing seed and the revoke identity live here and are
+  # intentionally never distributed to any service.
+  rm -rf -- "${enrollment_root}/root"
+
+  note "bootstrap complete."
+  note "  enrollment id : ${enrollment_id}"
+  note "  release digest: ${release_digest}"
+  note "  service uid   : ${service_uid}:${service_gid}"
+  note "This identity lives only in Docker named volumes. 'docker compose down -v' destroys it."
+}
+
+cmd_status() {
+  require_environment
+  release_digest="$(compute_release_digest)"
+  inspect_state
+  printf 'profile         : development-sandbox (Linux, Docker Compose)\n'
+  printf 'state           : %s\n' "$state_kind"
+  printf 'image digest    : %s\n' "$release_digest"
+  if [ "$state_kind" = provisioned ]; then
+    printf 'enrollment id   : %s\n' "$state_enrollment_id"
+    printf 'pinned digest   : %s\n' "$state_digest"
+    if [ "$state_digest" != "$release_digest" ]; then
+      printf 'drift           : YES -- rerun bootstrap to re-pin the configs\n'
+    else
+      printf 'drift           : no\n'
+    fi
+    printf 'service uid/gid : %s:%s\n' "$service_uid" "$service_gid"
+  else
+    printf 'next step       : docker compose --profile bootstrap run --rm bootstrap\n'
+  fi
+}
+
+cmd_reset() {
+  require_environment
+  local token="${BLOOM_TRIAD_RESET_CONFIRM:-}"
+  local expected="destroy-developer-custody"
+  [ "$token" = "$expected" ] ||
+    die "reset destroys the developer signing identity and all triad state in these volumes. Re-run with -e BLOOM_TRIAD_RESET_CONFIRM=${expected}"
+
+  local role directory
+  for role in signer broker machine session; do
+    find "${config_root}/${role}" -mindepth 1 -delete
+  done
+  for directory in signer-rpc signer-control broker-rpc broker-control session-rpc; do
+    find "${run_root}/${directory}" -mindepth 1 -delete
+  done
+  for directory in signer broker; do
+    find "${db_root}/${directory}" -mindepth 1 -delete
+  done
+  find "$machine_home" -mindepth 1 -delete
+  find "$tools_root" -mindepth 1 -delete
+  note "reset complete; every triad volume is empty. Run bootstrap to mint a new identity."
+}
+
+case "${1:-bootstrap}" in
+  bootstrap) cmd_bootstrap ;;
+  status) cmd_status ;;
+  reset) cmd_reset ;;
+  *) die "unknown subcommand: ${1} (expected bootstrap, status, or reset)" ;;
+esac

--- a/deploy/triad/ceremony-activate.c
+++ b/deploy/triad/ceremony-activate.c
@@ -1,0 +1,159 @@
+/*
+ * bloom-ceremony-activate -- minimal systemd-style socket activation shim.
+ *
+ * DEVELOPMENT / SANDBOX ONLY. Not part of any release bundle.
+ *
+ * Why this exists
+ * ---------------
+ * bloom-broker acquires its ceremony origin listener through
+ * `bloom_service_activation::take_tcp_listener("broker-ceremony")`, and that
+ * adapter has, by design, no path-binding fallback:
+ *
+ *     "There is deliberately no path-binding fallback. A process outside its
+ *      launch manager fails closed instead of creating a weaker endpoint."
+ *
+ * On Linux the adapter reads the systemd socket-activation protocol --
+ * LISTEN_PID / LISTEN_FDS / LISTEN_FDNAMES with the listeners starting at fd 3.
+ * scripts/triad-dev-launch.sh satisfies that with a real
+ * `bloom-triad-dev-*-broker-ceremony.socket` systemd user unit. A container has
+ * no systemd, so this shim performs exactly the same handoff and nothing else:
+ * bind one TCP listener, place it on fd 3, publish the three variables, exec
+ * the real Broker.
+ *
+ * It is deliberately not a supervisor: `exec` replaces this process, so the
+ * Broker keeps PID 1 semantics, receives signals directly, and LISTEN_PID
+ * stays correct across the handoff.
+ *
+ * Usage:
+ *     bloom-ceremony-activate <ip:port> <fd-name> <program> [args...]
+ *
+ * It handles no secrets and reads no configuration.
+ */
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#define LISTEN_FD 3
+
+static void fail(const char *message)
+{
+	fprintf(stderr, "bloom-ceremony-activate: %s: %s\n", message,
+		strerror(errno));
+	exit(1);
+}
+
+static void reject(const char *message)
+{
+	fprintf(stderr, "bloom-ceremony-activate: %s\n", message);
+	exit(1);
+}
+
+/* Parses a strict "dotted.quad:port" listen address. Host names are rejected
+ * on purpose: this endpoint must stay pinned to a literal loopback address,
+ * and a resolver would make that depend on container DNS. */
+static void parse_listen_address(const char *value, struct sockaddr_in *out)
+{
+	char host[64];
+	const char *colon = strrchr(value, ':');
+	size_t host_length;
+	char *end = NULL;
+	long port;
+
+	if (colon == NULL) {
+		reject("listen address must be <ip>:<port>");
+	}
+	host_length = (size_t)(colon - value);
+	if (host_length == 0 || host_length >= sizeof(host)) {
+		reject("listen address host is empty or too long");
+	}
+	memcpy(host, value, host_length);
+	host[host_length] = '\0';
+
+	errno = 0;
+	port = strtol(colon + 1, &end, 10);
+	if (errno != 0 || end == colon + 1 || *end != '\0' || port <= 0 ||
+	    port > 65535) {
+		reject("listen address port is not in 1..65535");
+	}
+
+	memset(out, 0, sizeof(*out));
+	out->sin_family = AF_INET;
+	out->sin_port = htons((unsigned short)port);
+	if (inet_pton(AF_INET, host, &out->sin_addr) != 1) {
+		reject("listen address host is not a literal IPv4 address");
+	}
+}
+
+int main(int argc, char **argv)
+{
+	struct sockaddr_in address;
+	char pid_value[32];
+	int fd;
+
+	if (argc < 4) {
+		reject("usage: bloom-ceremony-activate <ip:port> <fd-name> "
+		       "<program> [args...]");
+	}
+	if (argv[2][0] == '\0' || strchr(argv[2], ':') != NULL) {
+		reject("fd name must be non-empty and contain no ':'");
+	}
+
+	parse_listen_address(argv[1], &address);
+
+	fd = socket(AF_INET, SOCK_STREAM, 0);
+	if (fd < 0) {
+		fail("socket");
+	}
+	/* The Broker owns this origin exclusively; SO_REUSEADDR only avoids the
+	 * TIME_WAIT rebind stall after a restart, and SO_REUSEPORT is
+	 * deliberately NOT set so a second Broker in the same network namespace
+	 * still loses the AC-31 origin race loudly. */
+	{
+		int one = 1;
+
+		if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one,
+			       sizeof(one)) < 0) {
+			fail("setsockopt(SO_REUSEADDR)");
+		}
+	}
+	if (bind(fd, (struct sockaddr *)&address, sizeof(address)) < 0) {
+		fail("bind");
+	}
+	if (listen(fd, SOMAXCONN) < 0) {
+		fail("listen");
+	}
+
+	if (fd != LISTEN_FD) {
+		if (dup2(fd, LISTEN_FD) < 0) {
+			fail("dup2");
+		}
+		if (close(fd) < 0) {
+			fail("close");
+		}
+	}
+	/* systemd hands activated descriptors over without FD_CLOEXEC; the
+	 * adapter in the Broker expects to inherit fd 3 across the exec. */
+	if (fcntl(LISTEN_FD, F_SETFD, 0) < 0) {
+		fail("fcntl(F_SETFD)");
+	}
+
+	if (snprintf(pid_value, sizeof(pid_value), "%ld", (long)getpid()) < 0) {
+		reject("could not format LISTEN_PID");
+	}
+	if (setenv("LISTEN_PID", pid_value, 1) != 0 ||
+	    setenv("LISTEN_FDS", "1", 1) != 0 ||
+	    setenv("LISTEN_FDNAMES", argv[2], 1) != 0) {
+		fail("setenv");
+	}
+
+	execv(argv[3], &argv[3]);
+	fail("execv");
+	return 1;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,609 @@
+# =============================================================================
+# Bloom triad container stack -- DEVELOPMENT / SANDBOX ONLY. LINUX ONLY.
+# =============================================================================
+#
+# This stack mints its own throwaway signing identity into Docker named volumes
+# and runs the full triad against it. It is a development sandbox, not a
+# deployment: the keys live in `docker volume` storage, `docker compose down -v`
+# destroys them irreversibly, and nothing here is a substitute for the reviewed
+# packaging under packaging/triad/. Do not put value behind it.
+#
+# Trust direction is one-way and enforced by Unix-socket reachability plus
+# peer-uid authentication, not by network ACLs:
+#
+#     machine --(broker.sock)--> broker --(signer.sock)--> signer
+#                                   \                        /
+#                                    `--(session.sock)--> session sentinel
+#
+# The Machine can never reach the Signer, because the Signer's RPC socket volume
+# is mounted only into the Signer and the Broker. Adding that volume to the
+# `machine` service would collapse the whole custody boundary; do not.
+#
+# Sibling checkout layout, the same one scripts/triad-dev-launch.sh assumes:
+#
+#     bloom-directory/
+#       bloom/          <- this repo (Machine + session sentinel), context "."
+#       bloom-broker/   <- context "../bloom-broker"
+#       bloom-signer/   <- context "../bloom-signer"
+#
+# Quick start (details and prerequisites: README.md, "Container stack"):
+#
+#     cp .env.example .env
+#     docker compose build signer broker machine
+#     docker compose --profile bootstrap run --rm bootstrap
+#     docker compose up -d
+#     ls ~/bloom
+#
+# READ THE MOUNT SECTION IN README.md BEFORE STARTING `machine`. The mount path
+# needs CAP_SYS_ADMIN, an unconfined AppArmor profile, host NFS client support,
+# and a *shared* host mount at the `/bloom` bind source.
+
+name: bloom-triad
+
+# ---------------------------------------------------------------------------
+# Networks
+# ---------------------------------------------------------------------------
+networks:
+  # Session sentinel, Broker and Signer speak only over Unix domain sockets, and
+  # the Broker's ceremony origin listener is bound to literal loopback. They are
+  # attached to this network purely so Compose has somewhere to put them;
+  # `internal: true` means Docker installs no NAT/gateway rule, so none of them
+  # can reach the internet or the host even if a future code path tried to.
+  #
+  # `network_mode: none` would be marginally tighter (no interface at all), but
+  # Compose forbids combining `network_mode` with any other service networking
+  # key, and it makes attaching a debugger harder.
+  bloom-isolated:
+    internal: true
+
+  # Only the Machine gets egress. It needs it: JSON-RPC to chain endpoints,
+  # price feeds, ENS, and the GitHub update check all originate here.
+  bloom-egress: {}
+
+# ---------------------------------------------------------------------------
+# Volumes
+#
+# Four kinds, and the distinction matters:
+#
+#   *-config  Per-service enrollment material, written once by `bootstrap` and
+#             mounted READ-ONLY into exactly the one service that needs it.
+#             Each service gets only the files it is entitled to: the Machine
+#             never sees a signing seed, the Signer never sees the Broker's.
+#   *-rpc /
+#   *-control Unix socket directories. Shared between exactly the two services
+#             on either end of one edge. These are the trust boundary.
+#   *-db      Durable service state (SQLite stores, journals, audit checkpoint
+#             chains) signed by the enrolled identity.
+#   triad-tools
+#             One non-secret helper binary; see the `broker` entrypoint.
+#
+# CUSTODY WARNING. Unlike a production install, the signing seeds ARE in named
+# volumes here -- that is what makes the stack self-contained, and it is exactly
+# why it is dev-only. `docker compose down -v` deletes every one of them and the
+# developer identity is gone for good; the Broker and Signer databases signed by
+# it become unreadable. Use plain `docker compose down` to stop the stack.
+#
+# Ownership note (easy to get wrong): a named volume inherits the image's
+# uid/gid/mode at the mount point *while it is still empty*. `bootstrap` runs
+# first and leaves every volume non-empty with the ownership the services
+# require, which is what makes that copy-up a no-op afterwards.
+# ---------------------------------------------------------------------------
+volumes:
+  # --- per-service enrollment material (read-only at every service) ---
+  signer-config: {}
+  broker-config: {}
+  machine-config: {}
+  session-config: {}
+
+  # --- RPC socket volumes (the trust boundary) ---
+  signer-rpc: {} # signer.sock   -- mounted by: signer, broker
+  broker-rpc: {} # broker.sock   -- mounted by: broker, machine
+  session-rpc: {} # session.sock -- mounted by: session, signer, broker
+
+  # --- control socket volumes (operator surfaces, deliberately not shared) ---
+  signer-control: {}
+  broker-control: {}
+
+  # --- durable state ---
+  signer-db: {} # /var/db/bloom/signer  + audit-checkpoints
+  broker-db: {} # /var/db/bloom/broker  + journal/authority/ceremony/checkpoints
+  machine-home: {} # BLOOM_HOME
+
+  # --- non-secret operational helper ---
+  triad-tools: {}
+
+# ---------------------------------------------------------------------------
+# Anchors
+# ---------------------------------------------------------------------------
+x-service-user: &service-user "${BLOOM_SERVICE_UID:-10001}:${BLOOM_SERVICE_GID:-10001}"
+
+# Every authority service: no capabilities, no privilege escalation, no egress.
+x-authority-hardening: &authority-hardening
+  cap_drop: [ALL]
+  security_opt:
+    - no-new-privileges:true
+  networks: [bloom-isolated]
+  restart: unless-stopped
+
+services:
+  # =========================================================================
+  # bootstrap -- one-shot, profile-gated. Mints the developer enrollment.
+  #
+  #     docker compose --profile bootstrap run --rm bootstrap
+  #     docker compose --profile bootstrap run --rm bootstrap status
+  #
+  # Rerunning it is safe and is the supported way to re-pin the configs after
+  # rebuilding the images: it re-conforms paths, ownership and the release
+  # digest but NEVER rotates the developer identity, because the Broker and
+  # Signer databases are signed by it. Destroying the identity is a separate,
+  # explicitly confirmed operation:
+  #
+  #     docker compose --profile bootstrap run --rm \
+  #       -e BLOOM_TRIAD_RESET_CONFIRM=destroy-developer-custody bootstrap reset
+  # =========================================================================
+  bootstrap:
+    profiles: [bootstrap]
+    build:
+      # Repo root: the packaging templates the bootstrap reuses live there.
+      context: .
+      dockerfile: deploy/triad/Dockerfile.bootstrap
+      # BuildKit named contexts. The bootstrap does not rebuild the triad; it
+      # copies the exact binaries out of the three service images and hashes
+      # those bytes, so the release digest it pins into broker.json/signer.json
+      # is provably the digest of what actually runs. Build those three images
+      # first -- `docker compose build signer broker machine`.
+      additional_contexts:
+        bloom-machine-image: docker-image://bloom:${BLOOM_IMAGE_TAG:-local}
+        bloom-broker-image: docker-image://bloom-broker:${BLOOM_IMAGE_TAG:-local}
+        bloom-signer-image: docker-image://bloom-signer:${BLOOM_IMAGE_TAG:-local}
+    image: bloom-triad-bootstrap:${BLOOM_IMAGE_TAG:-local}
+
+    # Root on purpose. The Broker and Signer verify their edge manifest,
+    # authority-edge history and provenance catalog are owned by uid 0 -- that
+    # is their production trust path and this stack does not weaken it -- so
+    # something has to be able to install root-owned files. The one step that
+    # must not be root (`init triad-render-developer-enrollment` refuses it)
+    # is dropped to the service uid with setpriv inside the script.
+    user: "0:0"
+
+    environment:
+      BLOOM_SERVICE_UID: ${BLOOM_SERVICE_UID:-10001}
+      BLOOM_SERVICE_GID: ${BLOOM_SERVICE_GID:-10001}
+
+    # Seed material is generated into this tmpfs and never touches a disk-backed
+    # layer. The installer signing seed and the revoke identity are discarded
+    # with it: no service in this stack is entitled to them.
+    tmpfs:
+      - /state/enrollment:mode=0700,uid=0,gid=0
+
+    volumes:
+      - type: volume
+        source: signer-config
+        target: /state/config/signer
+      - type: volume
+        source: broker-config
+        target: /state/config/broker
+      - type: volume
+        source: machine-config
+        target: /state/config/machine
+      - type: volume
+        source: session-config
+        target: /state/config/session
+      - type: volume
+        source: signer-rpc
+        target: /state/run/signer-rpc
+      - type: volume
+        source: signer-control
+        target: /state/run/signer-control
+      - type: volume
+        source: broker-rpc
+        target: /state/run/broker-rpc
+      - type: volume
+        source: broker-control
+        target: /state/run/broker-control
+      - type: volume
+        source: session-rpc
+        target: /state/run/session-rpc
+      - type: volume
+        source: signer-db
+        target: /state/db/signer
+      - type: volume
+        source: broker-db
+        target: /state/db/broker
+      - type: volume
+        source: machine-home
+        target: /state/machine-home
+      - type: volume
+        source: triad-tools
+        target: /state/tools
+
+    # No network at all: it generates keys and writes files.
+    network_mode: "none"
+    restart: "no"
+
+  # =========================================================================
+  # session -- the login-session sentinel.
+  #
+  # Not optional and not decorative: bloom-broker and bloom-signer each block
+  # at startup on `connect_authenticated_session(...)` and exit if it fails, so
+  # the triad does not come up without this. It holds no custody -- it proves
+  # liveness of an authenticated login session and nothing else.
+  #
+  # It is also the one service that uses the developer trust path rather than
+  # the production one, because `bloom serve session-sentinel` otherwise looks
+  # for a macOS enrollment record. See the long comment in
+  # deploy/triad/bootstrap.sh; the practical consequence is that its copy of
+  # the edge manifest is service-owned instead of root-owned. That file holds
+  # public keys only.
+  # =========================================================================
+  session:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: bloom:${BLOOM_IMAGE_TAG:-local}
+    command: ["serve", "session-sentinel"]
+    user: *service-user
+
+    environment:
+      # The sentinel derives everything from these two. config_root is
+      # <root>/config and the socket directory is <runtime>/session, and it
+      # requires the runtime to be inside the root -- hence both point at the
+      # same directory.
+      BLOOM_TRIAD_DEVELOPER_ROOT: /var/lib/bloom-session
+      BLOOM_TRIAD_DEVELOPER_RUNTIME: /var/lib/bloom-session
+      RUST_LOG: ${BLOOM_SESSION_LOG:-info}
+
+    volumes:
+      - type: volume
+        source: session-config
+        target: /var/lib/bloom-session
+        read_only: true
+      # Nested inside the read-only volume above, and writable: this is where
+      # the sentinel binds session.sock. Compose mounts by increasing path
+      # depth, so the parent lands first.
+      - type: volume
+        source: session-rpc
+        target: /var/lib/bloom-session/session
+
+    <<: *authority-hardening
+
+    # Honest scope: proves the listener is bound. It does not prove the sentinel
+    # will complete an authenticated handshake -- doing that would require
+    # speaking the framed protocol as a pinned peer, which no shell can do.
+    healthcheck:
+      test: ["CMD-SHELL", "test -S /var/lib/bloom-session/session/session.sock"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+      start_period: 5s
+
+  # =========================================================================
+  # Signer -- innermost. Holds key material. Reachable only by the Broker.
+  # =========================================================================
+  signer:
+    build:
+      context: ../bloom-signer
+      dockerfile: Dockerfile
+      # SIGNER_UID/GID must equal `signer.effective_uid` in the edge manifest,
+      # because the Signer authenticates its peer by effective uid. The
+      # bootstrap renders that manifest from its own uid, so all three services
+      # and the bootstrap share one id -- see BLOOM_SERVICE_UID in .env.example.
+      args:
+        SIGNER_UID: ${BLOOM_SERVICE_UID:-10001}
+        SIGNER_GID: ${BLOOM_SERVICE_GID:-10001}
+    image: bloom-signer:${BLOOM_IMAGE_TAG:-local}
+    user: *service-user
+
+    # No `command:`. The image's ENTRYPOINT is the whole invocation: bloom-signer
+    # takes no subcommands and no flags other than a bare `--version`. Every knob
+    # is an env var or a field in signer.json. Do not invent flags here.
+
+    depends_on:
+      session:
+        condition: service_healthy
+
+    environment:
+      # Socket paths have no compiled-in default and are required at startup.
+      BLOOM_SIGNER_SOCKET: /run/bloom-signer-rpc/signer.sock
+      # Control socket -> its own volume, mounted nowhere else. It carries
+      # revocation control RPCs, which are an operator surface, not a Broker
+      # surface, so it must not ride along in the volume the Broker sees.
+      BLOOM_SIGNER_CONTROL_SOCKET: /run/bloom-signer-control/signer-control.sock
+      BLOOM_SESSION_SOCKET: /run/bloom-session/session.sock
+
+      BLOOM_SIGNER_IDENTITY: /etc/bloom/signer-identity.json
+      BLOOM_EDGE_MANIFEST: /etc/bloom/edge-manifest.json
+      BLOOM_SIGNER_CONFIG: /etc/bloom/signer.json
+      BLOOM_AUTHORITY_EDGE_HISTORY: /etc/bloom/authority-edge-history.json
+      BLOOM_SIGNER_AUDIT_CHECKPOINT_DIR: /var/db/bloom/signer/audit-checkpoints
+      # Raising this past info can surface request shapes and key identifiers.
+      # It does not print seeds, but treat the output as sensitive anyway.
+      RUST_LOG: ${BLOOM_SIGNER_LOG:-info}
+
+    volumes:
+      # Read-only, and holding only what the Signer is entitled to:
+      # signer.json (its seeds), signer-identity.json, plus the root-owned
+      # edge manifest and authority-edge history it verifies as trust anchors.
+      - type: volume
+        source: signer-config
+        target: /etc/bloom
+        read_only: true
+      - type: volume
+        source: signer-rpc
+        target: /run/bloom-signer-rpc
+      - type: volume
+        source: signer-control
+        target: /run/bloom-signer-control
+      - type: volume
+        source: session-rpc
+        target: /run/bloom-session
+      - type: volume
+        source: signer-db
+        target: /var/db/bloom/signer
+
+    <<: *authority-hardening
+
+    # As with the sentinel: this proves both listeners are bound, which rules
+    # out the half-initialised window. It does NOT prove the Signer answers RPC.
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "test -S /run/bloom-signer-rpc/signer.sock && test -S /run/bloom-signer-control/signer-control.sock",
+        ]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+      start_period: 5s
+
+  # =========================================================================
+  # Broker -- mediates. Talks to the Signer, is talked to by the Machine.
+  # =========================================================================
+  broker:
+    build:
+      context: ../bloom-broker
+      dockerfile: Dockerfile
+      args:
+        BLOOM_UID: ${BLOOM_SERVICE_UID:-10001}
+        BLOOM_GID: ${BLOOM_SERVICE_GID:-10001}
+      # If the workspace's bloom-directory git dependencies are private, the
+      # Dockerfile accepts an optional `git_credentials` build secret. Left
+      # unwired because a missing file would break the default public build;
+      # see README.md.
+    image: bloom-broker:${BLOOM_IMAGE_TAG:-local}
+    user: *service-user
+
+    # The Broker acquires its ceremony origin listener through systemd socket
+    # activation and has, by design, no path-binding fallback -- a Broker
+    # outside its launch manager fails closed rather than creating a weaker
+    # endpoint. scripts/triad-dev-launch.sh satisfies that with a real systemd
+    # user socket unit. There is no systemd here, so this shim performs the
+    # identical handoff (bind, place on fd 3, publish LISTEN_PID/LISTEN_FDS/
+    # LISTEN_FDNAMES) and then execs the real binary, which keeps PID 1 and
+    # receives signals directly. It is a plain static C binary delivered in a
+    # read-only volume; it handles no secrets. See
+    # deploy/triad/ceremony-activate.c.
+    entrypoint:
+      - /opt/bloom-tools/bloom-ceremony-activate
+      - 127.0.0.1:18734
+      - broker-ceremony
+      - /usr/local/bin/bloom-broker
+
+    depends_on:
+      session:
+        condition: service_healthy
+      signer:
+        condition: service_healthy
+
+    environment:
+      BLOOM_BROKER_SOCKET: /run/bloom-broker-rpc/broker.sock
+      # Operator surface; kept out of the volume the Machine sees, for the same
+      # reason as the Signer's.
+      BLOOM_BROKER_CONTROL_SOCKET: /run/bloom-broker-control/broker-control.sock
+      BLOOM_SESSION_SOCKET: /run/bloom-session/session.sock
+      BLOOM_BROKER_CEREMONY_ACTIVATION_NAME: broker-ceremony
+
+      BLOOM_BROKER_IDENTITY: /etc/bloom/broker-identity.json
+      BLOOM_EDGE_MANIFEST: /etc/bloom/edge-manifest.json
+      BLOOM_BROKER_CONFIG: /etc/bloom/broker.json
+      BLOOM_AUTHORITY_EDGE_HISTORY: /etc/bloom/authority-edge-history.json
+      BLOOM_BROKER_AUDIT_CHECKPOINT_DIR: /var/db/bloom/broker/audit-checkpoints
+      RUST_LOG: ${BLOOM_BROKER_LOG:-info}
+
+      # NOTE: the Broker finds the Signer through `signer_socket_path` in
+      # broker.json, NOT through an env var. The bootstrap sets that field to
+      # /run/bloom-signer-rpc/signer.sock, which is why the Signer's socket
+      # volume is mounted at the *same* path in both containers.
+
+    volumes:
+      - type: volume
+        source: broker-config
+        target: /etc/bloom
+        read_only: true
+      - type: volume
+        source: broker-rpc
+        target: /run/bloom-broker-rpc
+      - type: volume
+        source: broker-control
+        target: /run/bloom-broker-control
+      # The Signer's socket directory. This mount, and only this mount, is what
+      # gives the Broker a path to the Signer.
+      - type: volume
+        source: signer-rpc
+        target: /run/bloom-signer-rpc
+      - type: volume
+        source: session-rpc
+        target: /run/bloom-session
+      - type: volume
+        source: broker-db
+        target: /var/db/bloom/broker
+      - type: volume
+        source: triad-tools
+        target: /opt/bloom-tools
+        read_only: true
+
+    <<: *authority-hardening
+
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "test -S /run/bloom-broker-rpc/broker.sock && test -S /run/bloom-broker-control/broker-control.sock",
+        ]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+      start_period: 5s
+
+  # =========================================================================
+  # Machine -- outermost. The only service with egress, and the only one that
+  # needs elevated privileges. Everything unusual about this service is a
+  # consequence of one line: `bloom serve --mount /bloom`.
+  # =========================================================================
+  machine:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: bloom:${BLOOM_IMAGE_TAG:-local}
+
+    # Same uid as the authority services, and not negotiable: the Broker
+    # authenticates this peer against `machine.effective_uid` in the edge
+    # manifest, which the bootstrap rendered from its own uid.
+    user: *service-user
+
+    # Verified against `bloom serve --help`:
+    #   --mount [<PATH>]  Mount the VFS for the lifetime of the daemon.
+    #                     With no PATH, defaults to /bloom on Linux.
+    # PATH is passed explicitly so this file does not depend on that default.
+    command: ["serve", "--mount", "/bloom"]
+
+    depends_on:
+      broker:
+        condition: service_healthy
+
+    environment:
+      BLOOM_HOME: /var/lib/bloom
+      BLOOM_BROKER_SOCKET: /run/bloom-broker-rpc/broker.sock
+      BLOOM_MACHINE_IDENTITY: /etc/bloom/machine-identity.json
+      BLOOM_EDGE_MANIFEST: /etc/bloom/edge-manifest.json
+      BLOOM_PROVENANCE_CATALOG: /etc/bloom/provenance-catalog.json
+      BLOOM_AUTHORITY_EDGE_HISTORY: /etc/bloom/authority-edge-history.json
+      BLOOM_MACHINE_AUDIT_CHECKPOINT_DIR: /var/lib/bloom/audit-checkpoints/machine
+      RUST_LOG: ${BLOOM_MACHINE_LOG:-info}
+
+    volumes:
+      # Note what is absent: no signer.json, no broker.json, no signing seed of
+      # any kind. The Machine gets an identity and three trust anchors.
+      - type: volume
+        source: machine-config
+        target: /etc/bloom
+        read_only: true
+      - type: volume
+        source: machine-home
+        target: /var/lib/bloom
+      - type: volume
+        source: broker-rpc
+        target: /run/bloom-broker-rpc
+
+      # ---------------------------------------------------------------------
+      # THE MOUNT PROJECTION. LINUX ONLY. READ README.md.
+      #
+      # `bloom serve --mount /bloom` starts an embedded NFSv4.1 server bound to
+      # loopback inside this container, then execs `mount.nfs4` to mount it at
+      # /bloom. That mount is created inside the container's mount namespace.
+      # `rshared` propagation is what pushes it back out to the host directory
+      # below, so the host actually sees the wallet tree.
+      #
+      # Preconditions, all of which fail loudly rather than silently if unmet:
+      #
+      #   1. Linux host. Mount propagation does not exist on Docker Desktop for
+      #      macOS or Windows -- the daemon runs in its own VM, and `rshared`
+      #      would at best project into that VM, never to your desktop. On those
+      #      platforms use `bloom vfs` instead of a mount.
+      #   2. The host source directory must itself be on a *shared* mount, or
+      #      the daemon rejects the rshared bind with
+      #      "path is mounted on / but it is not a shared mount".
+      #      Check:  findmnt -no PROPAGATION -T "${HOME}/bloom"
+      #      Fix:    sudo mount --make-shared /     (see README.md to scope it)
+      #   3. The host kernel needs NFS client support (`sudo modprobe nfs`); the
+      #      container shares the host kernel and cannot supply it.
+      #
+      # The mount helper itself is in the image: the runtime stage installs
+      # nfs-common, which provides the setuid-root mount.nfs4. That setuid bit
+      # is how an unprivileged uid 10001 gets to call mount(2) here, and it is
+      # why `no-new-privileges` is NOT set on this service (it is set on all
+      # three authority services).
+      # ---------------------------------------------------------------------
+      - type: bind
+        source: ${BLOOM_HOST_DIR:-${HOME}/bloom}
+        target: /bloom
+        bind:
+          propagation: rshared
+          create_host_path: true
+
+    networks: [bloom-egress]
+
+    # -----------------------------------------------------------------------
+    # PRIVILEGE. This service is deliberately the only one that gets any.
+    #
+    # CAP_SYS_ADMIN is required for mount(2). It is also, bluntly, close to
+    # root-equivalent on the host: combined with the rshared bind it is enough
+    # to affect host mount state. This is the price of projecting the mount out
+    # of the container, and it is why the Broker, Signer and sentinel are
+    # separate services with cap_drop: [ALL] -- a compromise of the Machine must
+    # not reach key material.
+    #
+    # apparmor:unconfined is required on AppArmor hosts (Ubuntu, Debian with
+    # apparmor enabled): the docker-default profile denies mount unconditionally,
+    # so CAP_SYS_ADMIN alone is not sufficient there. Docker's default seccomp
+    # profile already permits mount/umount2 once CAP_SYS_ADMIN is present, so no
+    # seccomp override is needed.
+    #
+    # If your host is SELinux-enforcing rather than AppArmor, drop the apparmor
+    # line (it is a no-op or an error there) and expect to need an SELinux
+    # policy adjustment instead.
+    #
+    # `privileged: true` is the blunt fallback if the pair below is not enough
+    # on your host. It grants strictly more than this needs -- all capabilities,
+    # unmasked /proc and /sys, all devices. Prefer the narrow form; reach for
+    # privileged only to confirm a diagnosis, then narrow it again.
+    # -----------------------------------------------------------------------
+    cap_add:
+      - SYS_ADMIN
+    security_opt:
+      - apparmor:unconfined
+    # privileged: true
+
+    # -----------------------------------------------------------------------
+    # NFS PORT: deliberately NOT published.
+    #
+    # The embedded server defaults to `nfs_listen_addr = "127.0.0.1:12049"` and
+    # the client that consumes it is the mount call in this same container, so
+    # the traffic never leaves the loopback interface. Publishing it would
+    # expose an unauthenticated NFS export of the wallet tree to anything that
+    # can reach the port -- there is no NFS-level auth in front of it.
+    #
+    # Only if you are debugging the export from the host, and only bound to
+    # loopback, uncomment:
+    #   ports:
+    #     - "127.0.0.1:12049:12049/tcp"
+    # -----------------------------------------------------------------------
+
+    # `bloom status` is a real subcommand that round-trips over the daemon's IPC
+    # socket, so unlike the socket-existence probes above this one genuinely
+    # exercises the service. It does not assert that /bloom is mounted -- the
+    # runtime image has no `mountpoint` binary -- so a healthy Machine with a
+    # failed mount is possible. Check `docker compose logs machine` for the
+    # mount result, or just `ls` the host directory.
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/bloom", "status", "-q"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 30s
+
+    # The mount is torn down on shutdown; give the daemon room to unmount before
+    # SIGKILL, otherwise the host can be left with a stale NFS mount at /bloom.
+    stop_grace_period: 30s
+
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- add a Linux-only Docker Compose Triad stack with slim service images
- add Docker-native development bootstrap with scoped config/state volumes
- document Linux mount propagation, lifecycle, and custody boundaries

## Verification
- `bash -n deploy/triad/bootstrap.sh`
- `docker compose config -q`
- bootstrap image build and clean-volume status smoke

## Linked changes
Depends on the sibling Broker and Signer Dockerfile draft PRs.

- [x] Draft: runtime host-projection smoke remains in progress; no production-custody claim.