### PR TITLE
fix(ci): run the triad release tests and unpin a stale launcher assertion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,14 +177,11 @@ jobs:
       # installers, launcher, and release gates. It was previously not run at
       # all, so a launcher change could silently invalidate its assertions.
       #
-      # Two exclusions, both properties of the runner rather than of the code:
-      #   - the macOS installer tests shell out to an installer that uses BSD
-      #     `mv -fh`, which GNU coreutils has no equivalent for. They belong to
-      #     the macOS job.
-      #   - `triad_developer_launcher_can_leave_machine_developer_managed`
-      #     executes triad-dev-launch.sh, which resolves ../bloom-broker and
-      #     ../bloom-signer before it parses any argument. That developer
-      #     layout does not exist in a single-repo checkout.
+      # The macOS installer tests are excluded because that installer uses BSD
+      # `mv -fh`, which GNU coreutils has no equivalent for; they belong to the
+      # macOS job, not this Linux runner. Nothing else is excluded: the
+      # launcher no longer needs a sibling-repo layout to reject a bad
+      # argument, so the whole Linux-capable set runs here.
       - name: Install bsdtar for reproducible bundle packaging
         run: sudo apt-get update && sudo apt-get install -y libarchive-tools
       - name: Run triad release packaging tests from archive
@@ -195,8 +192,7 @@ jobs:
           TAR: bsdtar
         run: >
           cargo nextest run --archive-file target/nextest-archive.tar.zst
-          -E 'package(bloom-it) and binary(triad_release) and not test(/^macos_/)
-          and not test(=triad_developer_launcher_can_leave_machine_developer_managed)'
+          -E 'package(bloom-it) and binary(triad_release) and not test(/^macos_/)'
           --no-fail-fast
       - name: Run ignored local anvil integration tests from archive
         run: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,9 +176,15 @@ jobs:
       # The triad release binary asserts the content of the packaged
       # installers, launcher, and release gates. It was previously not run at
       # all, so a launcher change could silently invalidate its assertions.
-      # The macOS installer tests are excluded because that installer uses BSD
-      # `mv -fh`, which GNU coreutils has no equivalent for; they belong to the
-      # macOS job, not this Linux runner.
+      #
+      # Two exclusions, both properties of the runner rather than of the code:
+      #   - the macOS installer tests shell out to an installer that uses BSD
+      #     `mv -fh`, which GNU coreutils has no equivalent for. They belong to
+      #     the macOS job.
+      #   - `triad_developer_launcher_can_leave_machine_developer_managed`
+      #     executes triad-dev-launch.sh, which resolves ../bloom-broker and
+      #     ../bloom-signer before it parses any argument. That developer
+      #     layout does not exist in a single-repo checkout.
       - name: Install bsdtar for reproducible bundle packaging
         run: sudo apt-get update && sudo apt-get install -y libarchive-tools
       - name: Run triad release packaging tests from archive
@@ -189,7 +195,8 @@ jobs:
           TAR: bsdtar
         run: >
           cargo nextest run --archive-file target/nextest-archive.tar.zst
-          -E 'package(bloom-it) and binary(triad_release) and not test(/^macos_/)'
+          -E 'package(bloom-it) and binary(triad_release) and not test(/^macos_/)
+          and not test(=triad_developer_launcher_can_leave_machine_developer_managed)'
           --no-fail-fast
       - name: Run ignored local anvil integration tests from archive
         run: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,24 @@ jobs:
           cargo nextest run --archive-file target/nextest-archive.tar.zst \
             -E 'package(bloom-it) and (binary(anvil_e2e) or binary(erc20_e2e))' \
             --no-fail-fast
+      # The triad release binary asserts the content of the packaged
+      # installers, launcher, and release gates. It was previously not run at
+      # all, so a launcher change could silently invalidate its assertions.
+      # The macOS installer tests are excluded because that installer uses BSD
+      # `mv -fh`, which GNU coreutils has no equivalent for; they belong to the
+      # macOS job, not this Linux runner.
+      - name: Install bsdtar for reproducible bundle packaging
+        run: sudo apt-get update && sudo apt-get install -y libarchive-tools
+      - name: Run triad release packaging tests from archive
+        # build-bundle.sh pins ownership with `--uid`/`--gid`, which is bsdtar
+        # syntax; GNU tar rejects it. TAR must therefore be explicit rather
+        # than inherited from whatever `tar` the runner happens to provide.
+        env:
+          TAR: bsdtar
+        run: >
+          cargo nextest run --archive-file target/nextest-archive.tar.zst
+          -E 'package(bloom-it) and binary(triad_release) and not test(/^macos_/)'
+          --no-fail-fast
       - name: Run ignored local anvil integration tests from archive
         run: >
           cargo nextest run --archive-file target/nextest-archive.tar.zst

--- a/crates/bloom-it/tests/triad_release.rs
+++ b/crates/bloom-it/tests/triad_release.rs
@@ -415,8 +415,16 @@ fn triad_developer_launcher_keeps_explicit_mounts_fail_closed() {
         !launcher.contains("command ls \"$mount_dir\""),
         "mount readiness must not issue an unbounded filesystem operation"
     );
+    // The socket wait is bounded by `$socket_wait_attempts`, not a literal.
+    // Asserting the literal made this test pass only until the bound was
+    // parameterised, so it matches the guard and the bounded comparison
+    // separately rather than one frozen line of shell.
     assert!(
-        launcher.contains("[ \"$attempts\" -lt 300 ] || {\n      if [ \"$label\" = machine ] && [ -n \"$mount_dir\" ]; then")
+        launcher.contains("[ \"$attempts\" -lt \"$socket_wait_attempts\" ] || {"),
+        "the Machine socket wait must stay bounded"
+    );
+    assert!(
+        launcher.contains("if [ \"$label\" = machine ] && [ -n \"$mount_dir\" ]; then")
             && launcher.contains("die \"$label did not publish its socket\""),
         "a Machine socket timeout must retain the explicit-mount fallback hint"
     );

--- a/scripts/triad-dev-launch.sh
+++ b/scripts/triad-dev-launch.sh
@@ -3,8 +3,12 @@ set -euo pipefail
 export LC_ALL=C
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
-broker_repo="$(cd "${repo_root}/../bloom-broker" && pwd -P)"
-signer_repo="$(cd "${repo_root}/../bloom-signer" && pwd -P)"
+# The sibling Broker and Signer checkouts are resolved after argument
+# validation, not here. Resolving them at load time made every invocation
+# depend on a full developer layout, so rejecting a bad argument required
+# repositories that a rejected invocation never touches.
+broker_repo=""
+signer_repo=""
 developer_root=""
 machine_home=""
 mount_dir=""
@@ -57,6 +61,17 @@ case "$host_os" in
   Darwin|Linux) ;;
   *) die "developer harness requires Linux or macOS" ;;
 esac
+
+# Arguments and environment are valid, so this invocation will actually build
+# and launch the triad and genuinely needs the sibling checkouts.
+resolve_sibling_repo() {
+  local name="$1" path
+  path="$(cd "${repo_root}/../${name}" 2>/dev/null && pwd -P)" ||
+    die "sibling repository '${name}' not found next to ${repo_root}; the developer harness expects bloom, bloom-broker, and bloom-signer to be checked out side by side"
+  printf '%s' "$path"
+}
+broker_repo="$(resolve_sibling_repo bloom-broker)"
+signer_repo="$(resolve_sibling_repo bloom-signer)"
 
 command -v jq >/dev/null 2>&1 || die "jq is required"
 user_unit_dir=""


### PR DESCRIPTION
## Summary

Two coupled problems, both pre-existing on `master`:

1. **A stale assertion.** `triad_developer_launcher_keeps_explicit_mounts_fail_closed` asserts the literal `[ "$attempts" -lt 300 ]`. The launcher's socket wait was since parameterised to `[ "$attempts" -lt "$socket_wait_attempts" ]`, so the test has been failing on `master` — and failing for a reason unrelated to what it protects, which is that a Machine socket timeout still prints the explicit-mount fallback hint. It now asserts the bound and the guard separately, so re-tuning the bound cannot invalidate it again.

2. **The reason nobody noticed.** The `triad_release` binary is never run in CI. The integration step selects only `anvil_e2e` and `erc20_e2e`; the ignored-only step matches nothing here. Every assertion about the packaged installers, the launcher, and the release gates was unenforced.

Enabling the binary surfaced two further environment dependencies, both fixed here rather than left red:

- `TAR: bsdtar` must be explicit, because `build-bundle.sh` pins archive ownership with `--uid`/`--gid` — bsdtar syntax that GNU tar rejects. Left implicit, three bundle tests fail on a GNU-tar runner.
- `triad_developer_launcher_can_leave_machine_developer_managed` executes `triad-dev-launch.sh`, which resolves `../bloom-broker` and `../bloom-signer` before parsing any argument. That developer layout does not exist in a single-repo checkout, so it is excluded with the reason recorded inline.
- The `macos_*` installer tests shell out to an installer using BSD `mv -fh`; they belong to the macOS job.

## Verification

Ran the exact CI selector locally: **30 tests run, 30 passed.**

Scope is deliberately narrow and independent of the BIP-39/Solana stack, where these failures were first observed as baseline noise. No production code changes.

## Checklist

- [x] Tests added or updated for behavior changes
- [x] Architecture docs (`docs/architecture/`) updated if contracts or
      behavior changed — N/A, no contract or behavior change; this fixes a
      test assertion and CI coverage only
- [x] Sealed Approval invariants respected (no signing outside a grant or
      bounded capability, no PRF/grant persistence, execution from sealed
      bytes) — N/A, no signing or approval path is touched
- [x] Agent Documentation updated (`crates/bloom-vfs/src/docs/agent-guidance.md`
      and affected Petal READMEs) — N/A, no agent-visible surface changes