### PR TITLE
Restore practical Triad observability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,8 +188,8 @@ jobs:
       github.ref_name == 'triad-architecture'
     uses: ./.github/workflows/macos-unix-w0.yml
     with:
-      broker_ref: bdf5d36b48f6a476539ff992084c483becd67629
-      signer_ref: a9dcbbfef8a4057b9e6f94b17e010f051f7ab32e
+      broker_ref: 50050a272b90d2b0473d25c1014886a0ea8ae7d7
+      signer_ref: 3e9473ce4354dfd17303c5ea68ed8218417c0b49
 
   linux_w0_isolation:
     name: Linux W0 principal and socket isolation

--- a/.github/workflows/macos-two-login-w0.yml
+++ b/.github/workflows/macos-two-login-w0.yml
@@ -7,12 +7,12 @@ on:
         description: Public bloom-broker ref
         required: false
         type: string
-        default: bdf5d36b48f6a476539ff992084c483becd67629
+        default: 50050a272b90d2b0473d25c1014886a0ea8ae7d7
       signer_ref:
         description: Public bloom-signer ref
         required: false
         type: string
-        default: a9dcbbfef8a4057b9e6f94b17e010f051f7ab32e
+        default: 3e9473ce4354dfd17303c5ea68ed8218417c0b49
       login_uid_a:
         description: First active GUI login UID
         required: true
@@ -34,11 +34,11 @@ on:
       broker_ref:
         description: Public bloom-broker ref
         required: true
-        default: bdf5d36b48f6a476539ff992084c483becd67629
+        default: 50050a272b90d2b0473d25c1014886a0ea8ae7d7
       signer_ref:
         description: Public bloom-signer ref
         required: true
-        default: a9dcbbfef8a4057b9e6f94b17e010f051f7ab32e
+        default: 3e9473ce4354dfd17303c5ea68ed8218417c0b49
       login_uid_a:
         description: First active GUI login UID
         required: true
@@ -75,8 +75,8 @@ jobs:
       - name: Reject mutable sibling refs
         shell: bash
         env:
-          BROKER_REF: ${{ inputs.broker_ref || 'bdf5d36b48f6a476539ff992084c483becd67629' }}
-          SIGNER_REF: ${{ inputs.signer_ref || 'a9dcbbfef8a4057b9e6f94b17e010f051f7ab32e' }}
+          BROKER_REF: ${{ inputs.broker_ref || '50050a272b90d2b0473d25c1014886a0ea8ae7d7' }}
+          SIGNER_REF: ${{ inputs.signer_ref || '3e9473ce4354dfd17303c5ea68ed8218417c0b49' }}
         run: |
           [[ "$BROKER_REF" =~ ^[0-9a-f]{40}$ ]]
           [[ "$SIGNER_REF" =~ ^[0-9a-f]{40}$ ]]
@@ -84,13 +84,13 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: bloom-directory/bloom-broker
-          ref: ${{ inputs.broker_ref || 'bdf5d36b48f6a476539ff992084c483becd67629' }}
+          ref: ${{ inputs.broker_ref || '50050a272b90d2b0473d25c1014886a0ea8ae7d7' }}
           path: bloom-broker
       - name: Check out Signer
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: bloom-directory/bloom-signer
-          ref: ${{ inputs.signer_ref || 'a9dcbbfef8a4057b9e6f94b17e010f051f7ab32e' }}
+          ref: ${{ inputs.signer_ref || '3e9473ce4354dfd17303c5ea68ed8218417c0b49' }}
           path: bloom-signer
       - name: Install Rust toolchain
         run: rustup toolchain install "$RUSTUP_TOOLCHAIN" --profile minimal

--- a/.github/workflows/macos-unix-w0.yml
+++ b/.github/workflows/macos-unix-w0.yml
@@ -7,22 +7,22 @@ on:
         description: Public bloom-broker ref
         required: false
         type: string
-        default: bdf5d36b48f6a476539ff992084c483becd67629
+        default: 50050a272b90d2b0473d25c1014886a0ea8ae7d7
       signer_ref:
         description: Public bloom-signer ref
         required: false
         type: string
-        default: a9dcbbfef8a4057b9e6f94b17e010f051f7ab32e
+        default: 3e9473ce4354dfd17303c5ea68ed8218417c0b49
   workflow_dispatch:
     inputs:
       broker_ref:
         description: Public bloom-broker ref
         required: true
-        default: bdf5d36b48f6a476539ff992084c483becd67629
+        default: 50050a272b90d2b0473d25c1014886a0ea8ae7d7
       signer_ref:
         description: Public bloom-signer ref
         required: true
-        default: a9dcbbfef8a4057b9e6f94b17e010f051f7ab32e
+        default: 3e9473ce4354dfd17303c5ea68ed8218417c0b49
 
 permissions:
   contents: read
@@ -42,8 +42,8 @@ jobs:
       - name: Reject mutable sibling refs
         shell: bash
         env:
-          BROKER_REF: ${{ inputs.broker_ref || 'bdf5d36b48f6a476539ff992084c483becd67629' }}
-          SIGNER_REF: ${{ inputs.signer_ref || 'a9dcbbfef8a4057b9e6f94b17e010f051f7ab32e' }}
+          BROKER_REF: ${{ inputs.broker_ref || '50050a272b90d2b0473d25c1014886a0ea8ae7d7' }}
+          SIGNER_REF: ${{ inputs.signer_ref || '3e9473ce4354dfd17303c5ea68ed8218417c0b49' }}
         run: |
           [[ "$BROKER_REF" =~ ^[0-9a-f]{40}$ ]]
           [[ "$SIGNER_REF" =~ ^[0-9a-f]{40}$ ]]
@@ -51,13 +51,13 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: bloom-directory/bloom-broker
-          ref: ${{ inputs.broker_ref || 'bdf5d36b48f6a476539ff992084c483becd67629' }}
+          ref: ${{ inputs.broker_ref || '50050a272b90d2b0473d25c1014886a0ea8ae7d7' }}
           path: bloom-broker
       - name: Check out Signer
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: bloom-directory/bloom-signer
-          ref: ${{ inputs.signer_ref || 'a9dcbbfef8a4057b9e6f94b17e010f051f7ab32e' }}
+          ref: ${{ inputs.signer_ref || '3e9473ce4354dfd17303c5ea68ed8218417c0b49' }}
           path: bloom-signer
       - name: Install Rust toolchain
         run: rustup toolchain install "$RUSTUP_TOOLCHAIN" --profile minimal
@@ -138,8 +138,8 @@ jobs:
       - name: Reject mutable sibling refs
         shell: bash
         env:
-          BROKER_REF: ${{ inputs.broker_ref || 'bdf5d36b48f6a476539ff992084c483becd67629' }}
-          SIGNER_REF: ${{ inputs.signer_ref || 'a9dcbbfef8a4057b9e6f94b17e010f051f7ab32e' }}
+          BROKER_REF: ${{ inputs.broker_ref || '50050a272b90d2b0473d25c1014886a0ea8ae7d7' }}
+          SIGNER_REF: ${{ inputs.signer_ref || '3e9473ce4354dfd17303c5ea68ed8218417c0b49' }}
         run: |
           [[ "$BROKER_REF" =~ ^[0-9a-f]{40}$ ]]
           [[ "$SIGNER_REF" =~ ^[0-9a-f]{40}$ ]]
@@ -147,13 +147,13 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: bloom-directory/bloom-broker
-          ref: ${{ inputs.broker_ref || 'bdf5d36b48f6a476539ff992084c483becd67629' }}
+          ref: ${{ inputs.broker_ref || '50050a272b90d2b0473d25c1014886a0ea8ae7d7' }}
           path: bloom-broker
       - name: Check out Signer
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: bloom-directory/bloom-signer
-          ref: ${{ inputs.signer_ref || 'a9dcbbfef8a4057b9e6f94b17e010f051f7ab32e' }}
+          ref: ${{ inputs.signer_ref || '3e9473ce4354dfd17303c5ea68ed8218417c0b49' }}
           path: bloom-signer
       - name: Install Rust toolchain
         run: rustup toolchain install "$RUSTUP_TOOLCHAIN" --profile minimal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2170,7 +2170,7 @@ dependencies = [
 [[package]]
 name = "bloom-audit-checkpoint"
 version = "0.1.3"
-source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=d2542a07a988261fe2f82b738462de2127b317d2#d2542a07a988261fe2f82b738462de2127b317d2"
+source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=bc88cc6760b00bbff0c6a6e5f56d42bb03004436#bc88cc6760b00bbff0c6a6e5f56d42bb03004436"
 dependencies = [
  "bloom-rpc-wire",
  "ed25519-dalek",
@@ -2565,7 +2565,7 @@ dependencies = [
 [[package]]
 name = "bloom-rpc-wire"
 version = "0.1.3"
-source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=d2542a07a988261fe2f82b738462de2127b317d2#d2542a07a988261fe2f82b738462de2127b317d2"
+source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=bc88cc6760b00bbff0c6a6e5f56d42bb03004436#bc88cc6760b00bbff0c6a6e5f56d42bb03004436"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -2580,7 +2580,7 @@ dependencies = [
 [[package]]
 name = "bloom-service-activation"
 version = "0.1.3"
-source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=d2542a07a988261fe2f82b738462de2127b317d2#d2542a07a988261fe2f82b738462de2127b317d2"
+source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=bc88cc6760b00bbff0c6a6e5f56d42bb03004436#bc88cc6760b00bbff0c6a6e5f56d42bb03004436"
 dependencies = [
  "bloom-rpc-wire",
  "libc",
@@ -2590,7 +2590,7 @@ dependencies = [
 [[package]]
 name = "bloom-service-observability"
 version = "0.1.3"
-source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=d2542a07a988261fe2f82b738462de2127b317d2#d2542a07a988261fe2f82b738462de2127b317d2"
+source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=bc88cc6760b00bbff0c6a6e5f56d42bb03004436#bc88cc6760b00bbff0c6a6e5f56d42bb03004436"
 dependencies = [
  "libc",
  "rustix 1.1.4",
@@ -2615,7 +2615,7 @@ dependencies = [
 [[package]]
 name = "bloom-triad-local-transport"
 version = "0.1.3"
-source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=d2542a07a988261fe2f82b738462de2127b317d2#d2542a07a988261fe2f82b738462de2127b317d2"
+source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=bc88cc6760b00bbff0c6a6e5f56d42bb03004436#bc88cc6760b00bbff0c6a6e5f56d42bb03004436"
 dependencies = [
  "bloom-rpc-wire",
  "bloom-trusted-time",
@@ -2634,7 +2634,7 @@ dependencies = [
 [[package]]
 name = "bloom-trusted-time"
 version = "0.1.3"
-source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=d2542a07a988261fe2f82b738462de2127b317d2#d2542a07a988261fe2f82b738462de2127b317d2"
+source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=bc88cc6760b00bbff0c6a6e5f56d42bb03004436#bc88cc6760b00bbff0c6a6e5f56d42bb03004436"
 dependencies = [
  "libc",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,7 +2186,7 @@ dependencies = [
 [[package]]
 name = "bloom-broker-api"
 version = "0.1.0"
-source = "git+https://github.com/bloom-directory/bloom-broker.git?rev=77c30ccedbd6904c0f2f2ad19e48c5587061b04e#77c30ccedbd6904c0f2f2ad19e48c5587061b04e"
+source = "git+https://github.com/bloom-directory/bloom-broker.git?rev=50050a272b90d2b0473d25c1014886a0ea8ae7d7#50050a272b90d2b0473d25c1014886a0ea8ae7d7"
 dependencies = [
  "bloom-rpc-wire",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1458,7 +1458,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1469,7 +1469,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2170,7 +2170,7 @@ dependencies = [
 [[package]]
 name = "bloom-audit-checkpoint"
 version = "0.1.3"
-source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=67727b20476a5e12beea4be9734afd83bf74dea4#67727b20476a5e12beea4be9734afd83bf74dea4"
+source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=d2542a07a988261fe2f82b738462de2127b317d2#d2542a07a988261fe2f82b738462de2127b317d2"
 dependencies = [
  "bloom-rpc-wire",
  "ed25519-dalek",
@@ -2186,7 +2186,7 @@ dependencies = [
 [[package]]
 name = "bloom-broker-api"
 version = "0.1.0"
-source = "git+https://github.com/bloom-directory/bloom-broker.git?rev=f001cb9242c60d3d80c348506d329fdcfb126eb0#f001cb9242c60d3d80c348506d329fdcfb126eb0"
+source = "git+https://github.com/bloom-directory/bloom-broker.git?rev=77c30ccedbd6904c0f2f2ad19e48c5587061b04e#77c30ccedbd6904c0f2f2ad19e48c5587061b04e"
 dependencies = [
  "bloom-rpc-wire",
  "serde",
@@ -2565,7 +2565,7 @@ dependencies = [
 [[package]]
 name = "bloom-rpc-wire"
 version = "0.1.3"
-source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=67727b20476a5e12beea4be9734afd83bf74dea4#67727b20476a5e12beea4be9734afd83bf74dea4"
+source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=d2542a07a988261fe2f82b738462de2127b317d2#d2542a07a988261fe2f82b738462de2127b317d2"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -2580,7 +2580,7 @@ dependencies = [
 [[package]]
 name = "bloom-service-activation"
 version = "0.1.3"
-source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=67727b20476a5e12beea4be9734afd83bf74dea4#67727b20476a5e12beea4be9734afd83bf74dea4"
+source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=d2542a07a988261fe2f82b738462de2127b317d2#d2542a07a988261fe2f82b738462de2127b317d2"
 dependencies = [
  "bloom-rpc-wire",
  "libc",
@@ -2590,7 +2590,7 @@ dependencies = [
 [[package]]
 name = "bloom-service-observability"
 version = "0.1.3"
-source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=67727b20476a5e12beea4be9734afd83bf74dea4#67727b20476a5e12beea4be9734afd83bf74dea4"
+source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=d2542a07a988261fe2f82b738462de2127b317d2#d2542a07a988261fe2f82b738462de2127b317d2"
 dependencies = [
  "libc",
  "rustix 1.1.4",
@@ -2615,7 +2615,7 @@ dependencies = [
 [[package]]
 name = "bloom-triad-local-transport"
 version = "0.1.3"
-source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=67727b20476a5e12beea4be9734afd83bf74dea4#67727b20476a5e12beea4be9734afd83bf74dea4"
+source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=d2542a07a988261fe2f82b738462de2127b317d2#d2542a07a988261fe2f82b738462de2127b317d2"
 dependencies = [
  "bloom-rpc-wire",
  "bloom-trusted-time",
@@ -2634,7 +2634,7 @@ dependencies = [
 [[package]]
 name = "bloom-trusted-time"
 version = "0.1.3"
-source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=67727b20476a5e12beea4be9734afd83bf74dea4#67727b20476a5e12beea4be9734afd83bf74dea4"
+source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=d2542a07a988261fe2f82b738462de2127b317d2#d2542a07a988261fe2f82b738462de2127b317d2"
 dependencies = [
  "libc",
  "thiserror 2.0.18",
@@ -4068,7 +4068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5685,7 +5685,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7511,7 +7511,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7579,7 +7579,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8161,7 +8161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8364,7 +8364,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9817,7 +9817,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,7 +973,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde 1.8.3",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -994,7 +994,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde 2.0.5",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -1265,7 +1265,7 @@ checksum = "e8597d36d546e1dab822345ad563243ec3920e199322cb554ce56c8ef1a1e2e7"
 dependencies = [
  "alloy-json-rpc 1.8.3",
  "alloy-transport 1.8.3",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "reqwest 0.13.4",
  "serde_json",
  "tower",
@@ -1281,7 +1281,7 @@ checksum = "b273587487921274f4f5d0ef2c7ef36944dcbb75a4e2318e69eae822bd263f91"
 dependencies = [
  "alloy-json-rpc 2.0.5",
  "alloy-transport 2.0.5",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "reqwest 0.13.4",
  "serde_json",
  "tower",
@@ -2137,6 +2137,7 @@ dependencies = [
  "bloom-petals",
  "bloom-proto",
  "bloom-service-activation",
+ "bloom-service-observability",
  "bloom-triad-local-transport",
  "bloom-tx",
  "bloom-update",
@@ -2148,6 +2149,7 @@ dependencies = [
  "hex",
  "humantime",
  "openssl-sys",
+ "oslog",
  "predicates",
  "qrcode",
  "rand 0.8.6",
@@ -2168,7 +2170,7 @@ dependencies = [
 [[package]]
 name = "bloom-audit-checkpoint"
 version = "0.1.3"
-source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=d8229e51d80971505af69c387818334a3c44aef0#d8229e51d80971505af69c387818334a3c44aef0"
+source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=67727b20476a5e12beea4be9734afd83bf74dea4#67727b20476a5e12beea4be9734afd83bf74dea4"
 dependencies = [
  "bloom-rpc-wire",
  "ed25519-dalek",
@@ -2184,7 +2186,7 @@ dependencies = [
 [[package]]
 name = "bloom-broker-api"
 version = "0.1.0"
-source = "git+https://github.com/bloom-directory/bloom-broker.git?rev=bdf5d36b48f6a476539ff992084c483becd67629#bdf5d36b48f6a476539ff992084c483becd67629"
+source = "git+https://github.com/bloom-directory/bloom-broker.git?rev=f001cb9242c60d3d80c348506d329fdcfb126eb0#f001cb9242c60d3d80c348506d329fdcfb126eb0"
 dependencies = [
  "bloom-rpc-wire",
  "serde",
@@ -2341,6 +2343,8 @@ dependencies = [
  "async-trait",
  "bloom-audit-checkpoint",
  "bloom-broker-api",
+ "bloom-rpc-wire",
+ "bloom-service-observability",
  "bloom-triad-local-transport",
  "ed25519-dalek",
  "fs2",
@@ -2352,6 +2356,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -2560,7 +2565,7 @@ dependencies = [
 [[package]]
 name = "bloom-rpc-wire"
 version = "0.1.3"
-source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=d8229e51d80971505af69c387818334a3c44aef0#d8229e51d80971505af69c387818334a3c44aef0"
+source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=67727b20476a5e12beea4be9734afd83bf74dea4#67727b20476a5e12beea4be9734afd83bf74dea4"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -2575,11 +2580,22 @@ dependencies = [
 [[package]]
 name = "bloom-service-activation"
 version = "0.1.3"
-source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=d8229e51d80971505af69c387818334a3c44aef0#d8229e51d80971505af69c387818334a3c44aef0"
+source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=67727b20476a5e12beea4be9734afd83bf74dea4#67727b20476a5e12beea4be9734afd83bf74dea4"
 dependencies = [
  "bloom-rpc-wire",
  "libc",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "bloom-service-observability"
+version = "0.1.3"
+source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=67727b20476a5e12beea4be9734afd83bf74dea4#67727b20476a5e12beea4be9734afd83bf74dea4"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+ "tracing",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -2599,7 +2615,7 @@ dependencies = [
 [[package]]
 name = "bloom-triad-local-transport"
 version = "0.1.3"
-source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=d8229e51d80971505af69c387818334a3c44aef0#d8229e51d80971505af69c387818334a3c44aef0"
+source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=67727b20476a5e12beea4be9734afd83bf74dea4#67727b20476a5e12beea4be9734afd83bf74dea4"
 dependencies = [
  "bloom-rpc-wire",
  "bloom-trusted-time",
@@ -2612,12 +2628,13 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "bloom-trusted-time"
 version = "0.1.3"
-source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=d8229e51d80971505af69c387818334a3c44aef0#d8229e51d80971505af69c387818334a3c44aef0"
+source = "git+https://github.com/bloom-directory/bloom-service-runtime.git?rev=67727b20476a5e12beea4be9734afd83bf74dea4#67727b20476a5e12beea4be9734afd83bf74dea4"
 dependencies = [
  "libc",
  "thiserror 2.0.18",
@@ -2870,7 +2887,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2899,7 +2916,7 @@ dependencies = [
  "maybe-owned",
  "rustix 1.1.4",
  "rustix-linux-procfs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "winx",
 ]
 
@@ -3074,7 +3091,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4051,7 +4068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4167,7 +4184,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4289,7 +4306,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5184,7 +5201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
  "io-lifetimes",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6015,6 +6032,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "oslog"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d2043d1f61d77cb2f4b1f7b7b2295f40507f5f8e9d1c8bf10a1ca5f97a3969"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6497,7 +6523,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7472,7 +7498,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7485,7 +7511,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7553,7 +7579,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8301,7 +8327,7 @@ dependencies = [
  "fd-lock",
  "io-lifetimes",
  "rustix 0.38.44",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "winx",
 ]
 
@@ -8338,7 +8364,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9791,7 +9817,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10155,7 +10181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ tempfile = "3"
 futures = "0.3"
 lru = "0.12"
 fs2 = "0.4"
-bloom-audit-checkpoint = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "67727b20476a5e12beea4be9734afd83bf74dea4" }
+bloom-audit-checkpoint = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "d2542a07a988261fe2f82b738462de2127b317d2" }
 wasmtime = { version = "36.0.13", default-features = false, features = ["async", "cranelift", "runtime", "cache", "parallel-compilation"] }
 wasmtime-wasi = "36.0.13"
 wat = "1"
@@ -123,12 +123,12 @@ bloom-petals   = { path = "crates/bloom-petals" }
 bloom-petal-contract = { git = "https://github.com/bloom-directory/petal", rev = "61938d0c127cfe03c7e3e55baed0ba1439bc5ca2" }
 bloom-daemon   = { path = "crates/bloom-daemon" }
 bloom-update   = { path = "crates/bloom-update" }
-bloom-broker-api = { git = "https://github.com/bloom-directory/bloom-broker.git", rev = "f001cb9242c60d3d80c348506d329fdcfb126eb0" }
-bloom-rpc-wire = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "67727b20476a5e12beea4be9734afd83bf74dea4" }
-bloom-triad-local-transport = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "67727b20476a5e12beea4be9734afd83bf74dea4" }
-bloom-service-activation = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "67727b20476a5e12beea4be9734afd83bf74dea4" }
-bloom-service-observability = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "67727b20476a5e12beea4be9734afd83bf74dea4" }
-bloom-trusted-time = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "67727b20476a5e12beea4be9734afd83bf74dea4" }
+bloom-broker-api = { git = "https://github.com/bloom-directory/bloom-broker.git", rev = "77c30ccedbd6904c0f2f2ad19e48c5587061b04e" }
+bloom-rpc-wire = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "d2542a07a988261fe2f82b738462de2127b317d2" }
+bloom-triad-local-transport = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "d2542a07a988261fe2f82b738462de2127b317d2" }
+bloom-service-activation = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "d2542a07a988261fe2f82b738462de2127b317d2" }
+bloom-service-observability = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "d2542a07a988261fe2f82b738462de2127b317d2" }
+bloom-trusted-time = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "d2542a07a988261fe2f82b738462de2127b317d2" }
 bloom-machine-client = { path = "crates/bloom-machine-client" }
 # ---- example core petal: generic capability primitives (/bloom/core/cap) ----
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ tempfile = "3"
 futures = "0.3"
 lru = "0.12"
 fs2 = "0.4"
-bloom-audit-checkpoint = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "d2542a07a988261fe2f82b738462de2127b317d2" }
+bloom-audit-checkpoint = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "bc88cc6760b00bbff0c6a6e5f56d42bb03004436" }
 wasmtime = { version = "36.0.13", default-features = false, features = ["async", "cranelift", "runtime", "cache", "parallel-compilation"] }
 wasmtime-wasi = "36.0.13"
 wat = "1"
@@ -124,11 +124,11 @@ bloom-petal-contract = { git = "https://github.com/bloom-directory/petal", rev =
 bloom-daemon   = { path = "crates/bloom-daemon" }
 bloom-update   = { path = "crates/bloom-update" }
 bloom-broker-api = { git = "https://github.com/bloom-directory/bloom-broker.git", rev = "77c30ccedbd6904c0f2f2ad19e48c5587061b04e" }
-bloom-rpc-wire = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "d2542a07a988261fe2f82b738462de2127b317d2" }
-bloom-triad-local-transport = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "d2542a07a988261fe2f82b738462de2127b317d2" }
-bloom-service-activation = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "d2542a07a988261fe2f82b738462de2127b317d2" }
-bloom-service-observability = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "d2542a07a988261fe2f82b738462de2127b317d2" }
-bloom-trusted-time = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "d2542a07a988261fe2f82b738462de2127b317d2" }
+bloom-rpc-wire = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "bc88cc6760b00bbff0c6a6e5f56d42bb03004436" }
+bloom-triad-local-transport = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "bc88cc6760b00bbff0c6a6e5f56d42bb03004436" }
+bloom-service-activation = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "bc88cc6760b00bbff0c6a6e5f56d42bb03004436" }
+bloom-service-observability = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "bc88cc6760b00bbff0c6a6e5f56d42bb03004436" }
+bloom-trusted-time = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "bc88cc6760b00bbff0c6a6e5f56d42bb03004436" }
 bloom-machine-client = { path = "crates/bloom-machine-client" }
 # ---- example core petal: generic capability primitives (/bloom/core/cap) ----
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ bloom-petals   = { path = "crates/bloom-petals" }
 bloom-petal-contract = { git = "https://github.com/bloom-directory/petal", rev = "61938d0c127cfe03c7e3e55baed0ba1439bc5ca2" }
 bloom-daemon   = { path = "crates/bloom-daemon" }
 bloom-update   = { path = "crates/bloom-update" }
-bloom-broker-api = { git = "https://github.com/bloom-directory/bloom-broker.git", rev = "77c30ccedbd6904c0f2f2ad19e48c5587061b04e" }
+bloom-broker-api = { git = "https://github.com/bloom-directory/bloom-broker.git", rev = "50050a272b90d2b0473d25c1014886a0ea8ae7d7" }
 bloom-rpc-wire = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "bc88cc6760b00bbff0c6a6e5f56d42bb03004436" }
 bloom-triad-local-transport = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "bc88cc6760b00bbff0c6a6e5f56d42bb03004436" }
 bloom-service-activation = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "bc88cc6760b00bbff0c6a6e5f56d42bb03004436" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ tempfile = "3"
 futures = "0.3"
 lru = "0.12"
 fs2 = "0.4"
-bloom-audit-checkpoint = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "d8229e51d80971505af69c387818334a3c44aef0" }
+bloom-audit-checkpoint = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "67727b20476a5e12beea4be9734afd83bf74dea4" }
 wasmtime = { version = "36.0.13", default-features = false, features = ["async", "cranelift", "runtime", "cache", "parallel-compilation"] }
 wasmtime-wasi = "36.0.13"
 wat = "1"
@@ -123,11 +123,12 @@ bloom-petals   = { path = "crates/bloom-petals" }
 bloom-petal-contract = { git = "https://github.com/bloom-directory/petal", rev = "61938d0c127cfe03c7e3e55baed0ba1439bc5ca2" }
 bloom-daemon   = { path = "crates/bloom-daemon" }
 bloom-update   = { path = "crates/bloom-update" }
-bloom-broker-api = { git = "https://github.com/bloom-directory/bloom-broker.git", rev = "bdf5d36b48f6a476539ff992084c483becd67629" }
-bloom-rpc-wire = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "d8229e51d80971505af69c387818334a3c44aef0" }
-bloom-triad-local-transport = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "d8229e51d80971505af69c387818334a3c44aef0" }
-bloom-service-activation = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "d8229e51d80971505af69c387818334a3c44aef0" }
-bloom-trusted-time = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "d8229e51d80971505af69c387818334a3c44aef0" }
+bloom-broker-api = { git = "https://github.com/bloom-directory/bloom-broker.git", rev = "f001cb9242c60d3d80c348506d329fdcfb126eb0" }
+bloom-rpc-wire = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "67727b20476a5e12beea4be9734afd83bf74dea4" }
+bloom-triad-local-transport = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "67727b20476a5e12beea4be9734afd83bf74dea4" }
+bloom-service-activation = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "67727b20476a5e12beea4be9734afd83bf74dea4" }
+bloom-service-observability = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "67727b20476a5e12beea4be9734afd83bf74dea4" }
+bloom-trusted-time = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "67727b20476a5e12beea4be9734afd83bf74dea4" }
 bloom-machine-client = { path = "crates/bloom-machine-client" }
 # ---- example core petal: generic capability primitives (/bloom/core/cap) ----
 

--- a/crates/bloom-daemon/src/ipc.rs
+++ b/crates/bloom-daemon/src/ipc.rs
@@ -56,7 +56,7 @@ use tokio::io::{
 };
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::Notify;
-use tracing::{debug, info, trace, warn};
+use tracing::{Instrument as _, debug, info, trace, warn};
 
 /// Maximum physical newline-delimited frame and reassembled logical message.
 /// Logical messages above one frame are transported as ordered base64 chunks.
@@ -665,6 +665,7 @@ pub struct IpcServer {
     petal_mutation: Arc<tokio::sync::Mutex<()>>,
     batch_confirmation: Option<Arc<dyn BatchConfirmationService>>,
     machine_commands: Option<Arc<dyn MachineCommandService>>,
+    ready: Option<Arc<dyn Fn() + Send + Sync>>,
     shutdown: Arc<Notify>,
 }
 
@@ -680,6 +681,7 @@ impl IpcServer {
             petal_mutation: Arc::new(tokio::sync::Mutex::new(())),
             batch_confirmation: None,
             machine_commands: None,
+            ready: None,
             shutdown: Arc::new(Notify::new()),
         }
     }
@@ -714,6 +716,12 @@ impl IpcServer {
 
     pub fn with_machine_commands(mut self, service: Arc<dyn MachineCommandService>) -> Self {
         self.machine_commands = Some(service);
+        self
+    }
+
+    /// Run a small notification after the secured socket is published.
+    pub fn with_ready_callback(mut self, ready: Arc<dyn Fn() + Send + Sync>) -> Self {
+        self.ready = Some(ready);
         self
     }
 
@@ -757,6 +765,9 @@ impl IpcServer {
         listener.set_nonblocking(true)?;
         let listener = UnixListener::from_std(listener)?;
         info!(socket = %socket_path.display(), "ipc.listening");
+        if let Some(ready) = &self.ready {
+            ready();
+        }
 
         loop {
             tokio::select! {
@@ -770,7 +781,8 @@ impl IpcServer {
                             let observed_uid = match stream.peer_cred() {
                                 Ok(credential) => credential.uid(),
                                 Err(error) => {
-                                    warn!(%error, "ipc.peer_credentials_failed");
+                                    let _ = error;
+                                    warn!(error_kind = "peer_credentials", "ipc.peer_credentials_failed");
                                     continue;
                                 }
                             };
@@ -783,15 +795,20 @@ impl IpcServer {
                             }
                             trace!("ipc.conn_accepted");
                             let me = self.clone();
+                            let connection_span = tracing::Span::current();
                             tokio::spawn(async move {
                                 match me.handle_conn(stream).await {
                                     Ok(()) => trace!("ipc.conn_closed"),
-                                    Err(e) => warn!(error = %e, "ipc.conn_err"),
+                                    Err(error) => {
+                                        let _ = error;
+                                        warn!(error_kind = "connection_io", "ipc.conn_err")
+                                    },
                                 }
-                            });
+                            }.instrument(connection_span));
                         }
-                        Err(e) => {
-                            warn!(error = %e, "ipc.accept_err");
+                        Err(error) => {
+                            let _ = error;
+                            warn!(error_kind = "listener_accept", "ipc.accept_err");
                         }
                     }
                 }
@@ -885,12 +902,15 @@ impl IpcServer {
                     }
                 }
                 Err(e) => {
-                    debug!(error = %e, "ipc.parse_error");
+                    debug!(error_kind = "request_parse", "ipc.parse_error");
                     Response::err(Value::Null, -32700, format!("parse error: {e}"))
                 }
             };
-            let out = serde_json::to_vec(&resp).unwrap_or_else(|e| {
-                debug!(error = %e, "ipc.response_serialise_failed");
+            let out = serde_json::to_vec(&resp).unwrap_or_else(|_error| {
+                debug!(
+                    error_kind = "response_serialise",
+                    "ipc.response_serialise_failed"
+                );
                 // We cannot echo the request id here (serialisation of the
                 // proper Response already failed, so we may not have a
                 // well-formed id either). `null` is the safe default per
@@ -2026,7 +2046,7 @@ impl IpcClient {
                     daemon: daemon_protocol,
                 })?;
         if let Some(error) = v.get("error") {
-            debug!(%method, error = %error, "ipc.client.rpc_error");
+            debug!(%method, error_kind = "remote_rpc", "ipc.client.rpc_error");
             let error: RpcError = serde_json::from_value(error.clone())
                 .map_err(|error| IpcClientError::Protocol(error.to_string()))?;
             let machine = error

--- a/crates/bloom-daemon/src/lib.rs
+++ b/crates/bloom-daemon/src/lib.rs
@@ -71,7 +71,7 @@ use sha2::Digest as _;
 use thiserror::Error;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
-use tracing::{debug, info, warn};
+use tracing::{Instrument as _, debug, info, warn};
 
 const WALLET_PROJECTION_LIVE_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -1702,7 +1702,7 @@ impl PetalHost for DaemonPetalHost {
             warn!(
                 package_hash = %context.package_hash,
                 route = %context.route_id,
-                reason = %error,
+                protocol_error_code = error.code.as_str(),
                 "petal.sign_payload_denied"
             );
             HostError::Denied(format!("{}: {}", error.code.as_str(), error.message))
@@ -2799,7 +2799,11 @@ fn invalidate_stale_ceremony_projections(cache_dir: &Path) -> Result<usize, Daem
             Ok(Some(state)) => state,
             Ok(None) => continue,
             Err(error) => {
-                warn!(path = %path.display(), error = %error, "petal.key_projection_unreadable");
+                let _ = error;
+                warn!(
+                    error_kind = "key_projection",
+                    "petal.key_projection_unreadable"
+                );
                 continue;
             }
         };
@@ -2831,14 +2835,22 @@ fn invalidate_stale_ceremony_projections(cache_dir: &Path) -> Result<usize, Daem
         let bytes = match std::fs::read(&path) {
             Ok(bytes) => bytes,
             Err(error) => {
-                warn!(path = %path.display(), error = %error, "petal.signing_projection_unreadable");
+                let _ = error;
+                warn!(
+                    error_kind = "signing_projection",
+                    "petal.signing_projection_unreadable"
+                );
                 continue;
             }
         };
         let projection: PetalSigningRequestProjection = match serde_json::from_slice(&bytes) {
             Ok(projection) => projection,
             Err(error) => {
-                warn!(path = %path.display(), error = %error, "petal.signing_projection_unreadable");
+                let _ = error;
+                warn!(
+                    error_kind = "signing_projection",
+                    "petal.signing_projection_unreadable"
+                );
                 continue;
             }
         };
@@ -2975,7 +2987,10 @@ impl Daemon {
         for spec in config.chains.values() {
             match ChainClient::new(spec.clone()) {
                 Ok(c) => clients.push(c),
-                Err(e) => warn!(chain = %spec.name, error = %e, "daemon.chain_skipped"),
+                Err(error) => {
+                    let _ = error;
+                    warn!(chain = %spec.name, error_kind = "chain_configuration", "daemon.chain_skipped")
+                }
             }
         }
         let chains = ChainRegistry::default();
@@ -3144,7 +3159,11 @@ impl Daemon {
                 b
             }
             Err(e) => {
-                debug!(path = %address_book_path.display(), error = %e, "addressbook.load_failed_using_empty");
+                let _ = e;
+                debug!(
+                    error_kind = "address_book_load",
+                    "addressbook.load_failed_using_empty"
+                );
                 AddressBook::default()
             }
         };
@@ -3248,7 +3267,11 @@ impl Daemon {
                     EtherscanClient::with_base_url(c.api_key.clone(), url)
                 }
                 Err(e) => {
-                    warn!(api_url = %c.api_url, error = %e, "daemon.etherscan_url_invalid_using_default");
+                    let _ = e;
+                    warn!(
+                        error_kind = "etherscan_configuration",
+                        "daemon.etherscan_url_invalid_using_default"
+                    );
                     EtherscanClient::new(c.api_key.clone())
                 }
             });
@@ -3290,14 +3313,16 @@ impl Daemon {
                     Ok(p) => {
                         let arc_p: Arc<dyn bloom_mempool::PrivateRpcProvider> = Arc::new(p);
                         if let Err(e) = tx_engine.register_private_rpc(chain_id, arc_p.clone()) {
-                            warn!(chain = %chain_name, error = %e, "daemon.private_rpc_register_failed");
+                            let _ = e;
+                            warn!(chain = %chain_name, error_kind = "private_rpc_registration", "daemon.private_rpc_register_failed");
                         } else {
                             debug!(chain = %chain_name, provider = "mev_blocker", "daemon.private_rpc_registered");
                             private_rpc_probes.push((chain_name.clone(), arc_p));
                         }
                     }
                     Err(e) => {
-                        warn!(chain = %chain_name, error = %e, "daemon.mev_blocker_init_failed")
+                        let _ = e;
+                        warn!(chain = %chain_name, error_kind = "private_rpc_configuration", "daemon.mev_blocker_init_failed")
                     }
                 }
             }
@@ -3306,14 +3331,16 @@ impl Daemon {
                     Ok(p) => {
                         let arc_p: Arc<dyn bloom_mempool::PrivateRpcProvider> = Arc::new(p);
                         if let Err(e) = tx_engine.register_private_rpc(chain_id, arc_p.clone()) {
-                            warn!(chain = %chain_name, error = %e, "daemon.private_rpc_register_failed");
+                            let _ = e;
+                            warn!(chain = %chain_name, error_kind = "private_rpc_registration", "daemon.private_rpc_register_failed");
                         } else {
                             debug!(chain = %chain_name, provider = "flashbots", "daemon.private_rpc_registered");
                             private_rpc_probes.push((chain_name.clone(), arc_p));
                         }
                     }
                     Err(e) => {
-                        warn!(chain = %chain_name, error = %e, "daemon.flashbots_init_failed")
+                        let _ = e;
+                        warn!(chain = %chain_name, error_kind = "private_rpc_configuration", "daemon.flashbots_init_failed")
                     }
                 }
             }
@@ -3591,7 +3618,8 @@ impl Daemon {
         // mount serve loop) always have one.
         if tokio::runtime::Handle::try_current().is_ok() {
             if let Err(e) = watch_executor.start() {
-                warn!(error = %e, "watch.executor.start_failed");
+                let _ = e;
+                warn!(error_kind = "watch_executor", "watch.executor.start_failed");
             }
         } else {
             warn!("watch.executor.skipped: no tokio runtime; call Daemon::start_workers later");
@@ -3790,7 +3818,8 @@ impl Daemon {
     /// outside one.
     pub fn start_workers(&self) {
         if let Err(e) = self.watch_executor.start() {
-            warn!(error = %e, "watch.executor.start_failed");
+            let _ = e;
+            warn!(error_kind = "watch_executor", "watch.executor.start_failed");
         }
     }
 
@@ -3863,6 +3892,7 @@ impl Daemon {
         let audit = self.audit.clone();
         let (tx, mut rx) = watch::channel(false);
         let interval = Duration::from_secs(60);
+        let background_span = tracing::Span::current();
         let handle = tokio::spawn(async move {
             // Tick at `interval`, but exit promptly when the cancel
             // channel flips. We use `tokio::select!` so a long sleep
@@ -3879,7 +3909,10 @@ impl Daemon {
                         match run_expiry_sweep_once(&outbox, &audit, now_ms) {
                             Ok(0) => tracing::trace!("outbox.sweep_expired.empty"),
                             Ok(n) => info!(swept = n, "outbox.sweep_expired"),
-                            Err(e) => warn!(error = %e, "outbox.sweep_expired_failed"),
+                            Err(error) => {
+                                let _ = error;
+                                warn!(error_kind = "expiry_sweep", "outbox.sweep_expired_failed")
+                            },
                         }
                     }
                     _ = rx.changed() => {
@@ -3889,7 +3922,7 @@ impl Daemon {
                     }
                 }
             }
-        });
+        }.instrument(background_span));
         BackgroundTasks {
             cancel: tx,
             handle: Some(handle),
@@ -4043,11 +4076,20 @@ fn spawn_wallet_projection_refresh(
     projections: Arc<dyn WalletProjectionReader>,
     audit: Arc<AuditLog>,
 ) -> JoinHandle<()> {
-    tokio::spawn(async move {
-        if let Err(error) = refresh_wallet_projections_once(projections.as_ref(), &audit).await {
-            warn!(%error, "Machine wallet projection refresh failed");
+    let background_span = tracing::Span::current();
+    tokio::spawn(
+        async move {
+            if let Err(error) = refresh_wallet_projections_once(projections.as_ref(), &audit).await
+            {
+                let _ = error;
+                warn!(
+                    error_kind = "wallet_projection_refresh",
+                    "Machine wallet projection refresh failed"
+                );
+            }
         }
-    })
+        .instrument(background_span),
+    )
 }
 
 struct WalletProjectionRefreshAudit<'a> {
@@ -4094,7 +4136,11 @@ impl Drop for WalletProjectionRefreshAudit<'_> {
             "error": "wallet projection refresh was cancelled before completion",
         });
         if let Err(error) = self.append_result(result) {
-            warn!(%error, "Machine wallet projection cancellation audit failed");
+            let _ = error;
+            warn!(
+                error_kind = "projection_cancellation_audit",
+                "Machine wallet projection cancellation audit failed"
+            );
         }
     }
 }
@@ -4269,7 +4315,11 @@ fn render_installed_petals_doc(petals: &PetalRunner) -> Vec<u8> {
     match petals.installed_petal_discovery() {
         Ok(installed) => render_petal_discovery_markdown(&installed),
         Err(error) => {
-            warn!(error = %error, "daemon.petals_docs_render_failed");
+            let _ = error;
+            warn!(
+                error_kind = "petal_docs_render",
+                "daemon.petals_docs_render_failed"
+            );
             format!(
                 "# Installed Petals\n\n\
                  Bloom could not read the installed Petal manifests: `{error}`\n"

--- a/crates/bloom-it/tests/triad_release.rs
+++ b/crates/bloom-it/tests/triad_release.rs
@@ -2609,6 +2609,15 @@ fn macos_staged_lifecycle_upgrades_repairs_retains_restores_and_rejects_downgrad
         "same-digest repair must be idempotent"
     );
 
+    // A retained pre-observability enrollment must not acquire a sentinel
+    // log GID that prevents restore from performing the real migration.
+    let enrollment_501 = root.join("Library/Application Support/BloomTriad/enrollments/501.json");
+    let mut legacy: serde_json::Value =
+        serde_json::from_slice(&fs::read(&enrollment_501).unwrap()).unwrap();
+    legacy.as_object_mut().unwrap().remove("log_group");
+    legacy.as_object_mut().unwrap().remove("log_gid");
+    fs::write(&enrollment_501, serde_json::to_vec(&legacy).unwrap()).unwrap();
+
     let retained = Command::new(&installer)
         .args(["uninstall", "--retain-custody"])
         .arg(&root)
@@ -2628,6 +2637,11 @@ fn macos_staged_lifecycle_upgrades_repairs_retains_restores_and_rejects_downgrad
     assert!(
         root.join("Library/Application Support/BloomTriad/retained/501.json")
             .is_file()
+    );
+    assert!(
+        !fs::read_to_string(root.join("Library/Application Support/BloomTriad/retained/501.json"))
+            .unwrap()
+            .contains("log_gid")
     );
     assert_eq!(fs::read(&identity).unwrap(), identity_before);
 

--- a/crates/bloom-it/tests/triad_release.rs
+++ b/crates/bloom-it/tests/triad_release.rs
@@ -719,9 +719,7 @@ fn serve_starts_audited_projection_refresh_after_fallible_setup() {
         .find("let endpoint = resolve_server_endpoint")
         .unwrap();
     let server = serve.find("let server = IpcServer::new").unwrap();
-    let background = serve
-        .find("let sweeper = d.spawn_background_tasks()")
-        .unwrap();
+    let background = serve.find("d.spawn_background_tasks()").unwrap();
 
     assert!(
         mount < background && endpoint < background && server < background,
@@ -1040,6 +1038,7 @@ fn stage_macos_install_digest(
         .env("BLOOM_MACOS_MACHINE_BROKER_GID", "260501")
         .env("BLOOM_MACOS_BROKER_SIGNER_GID", "260502")
         .env("BLOOM_MACOS_REVOKE_GID", "260503")
+        .env("BLOOM_MACOS_LOG_GID", "260504")
         .env("BLOOM_RELEASE_DIGEST", digest)
         .output()
         .unwrap()
@@ -1525,6 +1524,7 @@ fn linux_installer_upgrade_rotation_and_confirmed_uninstall_are_staged_safely() 
     let root = directory.path().join("root");
     fs::create_dir(&root).unwrap();
     let payload = make_installer_payload(directory.path());
+    let release_digest = hex::encode(Sha256::digest(b"test payload\n"));
     let installer = release_script("install-linux.sh");
     let install = Command::new(&installer)
         .args(["install"])
@@ -1558,7 +1558,10 @@ fn linux_installer_upgrade_rotation_and_confirmed_uninstall_are_staged_safely() 
     ));
     assert_eq!(
         fs::read_to_string(root.join("etc/bloom/1000/machine.env")).unwrap(),
-        "BLOOM_NFS_LISTEN=127.0.0.1:20000\n"
+        format!(
+            "BLOOM_NFS_LISTEN=127.0.0.1:20000\nBLOOM_RELEASE_DIGEST={}\n",
+            release_digest
+        )
     );
     assert!(root.join("home/alice/bloom").is_dir());
     assert_eq!(
@@ -1979,6 +1982,7 @@ fn linux_installer_allocates_distinct_ports_and_rejects_mixed_release_sets() {
     let root = directory.path().join("root");
     fs::create_dir(&root).unwrap();
     let payload = make_installer_payload(&directory.path().join("release-a"));
+    let release_digest = hex::encode(Sha256::digest(b"test payload\n"));
     let installer = release_script("install-linux.sh");
     for (uid, user) in [("1000", "alice"), ("2000", "bob")] {
         let installed = Command::new(&installer)
@@ -1997,11 +2001,17 @@ fn linux_installer_allocates_distinct_ports_and_rejects_mixed_release_sets() {
     }
     assert_eq!(
         fs::read_to_string(root.join("etc/bloom/1000/machine.env")).unwrap(),
-        "BLOOM_NFS_LISTEN=127.0.0.1:20000\n"
+        format!(
+            "BLOOM_NFS_LISTEN=127.0.0.1:20000\nBLOOM_RELEASE_DIGEST={}\n",
+            release_digest
+        )
     );
     assert_eq!(
         fs::read_to_string(root.join("etc/bloom/2000/machine.env")).unwrap(),
-        "BLOOM_NFS_LISTEN=127.0.0.1:20001\n"
+        format!(
+            "BLOOM_NFS_LISTEN=127.0.0.1:20001\nBLOOM_RELEASE_DIGEST={}\n",
+            release_digest
+        )
     );
     let fstab = fs::read_to_string(root.join("etc/fstab")).unwrap();
     assert!(fstab.contains("port=20000") && fstab.contains("port=20001"));
@@ -2105,6 +2115,32 @@ fn linux_installer_demand_starts_only_the_active_login_ceremony_socket() {
     assert!(!installer.contains(
         "systemctl enable --now \\\n        \"bloom-broker-ceremony@$login_uid.socket\""
     ));
+}
+
+#[test]
+fn linux_services_send_structured_stderr_to_stable_journal_identifiers() {
+    let root = workspace().join("packaging/triad/linux");
+    for (relative, identifier) in [
+        ("systemd-user/bloom-machine.service", "bloom-machine"),
+        ("systemd-user/bloom-session.service", "bloom-session"),
+        ("systemd/bloom-broker@.service.in", "bloom-broker-%i"),
+        ("systemd/bloom-signer@.service.in", "bloom-signer-%i"),
+    ] {
+        let source = fs::read_to_string(root.join(relative)).unwrap();
+        assert!(source.contains("StandardOutput=journal"));
+        assert!(source.contains("StandardError=journal"));
+        assert!(source.contains(&format!("SyslogIdentifier={identifier}")));
+    }
+    for relative in [
+        "systemd-user/bloom-machine.service",
+        "systemd-user/bloom-session.service",
+    ] {
+        assert!(
+            fs::read_to_string(root.join(relative))
+                .unwrap()
+                .contains("Environment=BLOOM_LOG_OUTPUT=json-stderr")
+        );
+    }
 }
 
 #[test]
@@ -2309,6 +2345,16 @@ fn macos_installer_stages_unix_principals_launchdaemons_and_confirmed_uninstall(
             service.to_ascii_uppercase()
         )));
         assert!(source.contains("BLOOM_AUTHORITY_EDGE_HISTORY"));
+        assert!(source.contains(&format!("BLOOM_{}_LOG_PATH", service.to_ascii_uppercase())));
+        assert!(source.contains(&format!(
+            "BLOOM_{}_LOG_OWNER_UID",
+            service.to_ascii_uppercase()
+        )));
+        assert!(source.contains(&format!(
+            "BLOOM_{}_LOG_READER_GID",
+            service.to_ascii_uppercase()
+        )));
+        assert!(source.contains("<string>/dev/null</string>"));
         assert!(source.contains("<key>UserName</key>"));
         assert_eq!(
             fs::metadata(plist).unwrap().permissions().mode() & 0o777,
@@ -2354,6 +2400,21 @@ fn macos_installer_stages_unix_principals_launchdaemons_and_confirmed_uninstall(
             & 0o777,
         0o700
     );
+    for service in ["broker", "signer"] {
+        for name in [
+            format!("{service}.jsonl"),
+            format!("{service}-bootstrap.log"),
+        ] {
+            let log = root.join("var/log/bloom/501").join(name);
+            assert_eq!(
+                fs::metadata(log).unwrap().permissions().mode() & 0o777,
+                0o640
+            );
+        }
+    }
+    let rotation = fs::read_to_string(root.join("etc/newsyslog.d/bloom-501.conf")).unwrap();
+    assert!(rotation.contains("broker.jsonl bloom-broker-501:bloom-log-501 640 5 1024 * BN"));
+    assert!(rotation.contains("signer.jsonl bloom-signer-501:bloom-log-501 640 5 1024 * BN"));
     let authority_history = fs::read_to_string(
         root.join("Library/Application Support/BloomTriad/config/501/authority-edge-history.json"),
     )
@@ -2490,6 +2551,28 @@ fn macos_staged_lifecycle_upgrades_repairs_retains_restores_and_rejects_downgrad
             .status
             .success()
     );
+    let second = Command::new(&installer)
+        .args(["install"])
+        .arg(&root)
+        .args(["502", "bob"])
+        .arg(&baseline)
+        .env("BLOOM_ALLOW_TEST_UNCLAIMED", "true")
+        .env("BLOOM_MACOS_BROKER_UID", "250511")
+        .env("BLOOM_MACOS_SIGNER_UID", "250512")
+        .env("BLOOM_MACOS_BROKER_GID", "260509")
+        .env("BLOOM_MACOS_SIGNER_GID", "260510")
+        .env("BLOOM_MACOS_MACHINE_BROKER_GID", "260511")
+        .env("BLOOM_MACOS_BROKER_SIGNER_GID", "260512")
+        .env("BLOOM_MACOS_REVOKE_GID", "260513")
+        .env("BLOOM_MACOS_LOG_GID", "260514")
+        .env("BLOOM_RELEASE_DIGEST", &old_digest)
+        .output()
+        .unwrap();
+    assert!(
+        second.status.success(),
+        "{}",
+        String::from_utf8_lossy(&second.stderr)
+    );
     let identity =
         root.join("Library/Application Support/BloomTriad/config/501/signer/identity.json");
     let identity_before = fs::read(&identity).unwrap();
@@ -2505,6 +2588,20 @@ fn macos_staged_lifecycle_upgrades_repairs_retains_restores_and_rejects_downgrad
         Path::new("releases").join(&new_digest)
     );
     assert_eq!(fs::read(&identity).unwrap(), identity_before);
+    for uid in ["501", "502"] {
+        let enrollment = fs::read_to_string(root.join(format!(
+            "Library/Application Support/BloomTriad/enrollments/{uid}.json"
+        )))
+        .unwrap();
+        assert!(enrollment.contains(&new_digest));
+        for service in ["broker", "signer"] {
+            let log = root.join(format!("var/log/bloom/{uid}/{service}.jsonl"));
+            assert_eq!(
+                fs::metadata(log).unwrap().permissions().mode() & 0o777,
+                0o640
+            );
+        }
+    }
     assert!(
         stage_macos_install_digest(&installer, &root, &candidate, &new_digest)
             .status
@@ -2547,6 +2644,7 @@ fn macos_staged_lifecycle_upgrades_repairs_retains_restores_and_rejects_downgrad
         .env("BLOOM_MACOS_MACHINE_BROKER_GID", "260501")
         .env("BLOOM_MACOS_BROKER_SIGNER_GID", "260502")
         .env("BLOOM_MACOS_REVOKE_GID", "260503")
+        .env("BLOOM_MACOS_LOG_GID", "260504")
         .env("BLOOM_RELEASE_DIGEST", &new_digest)
         .output()
         .unwrap();
@@ -2621,6 +2719,7 @@ fn macos_restore_cannot_downgrade_the_release_shared_by_an_active_login() {
         .env("BLOOM_MACOS_MACHINE_BROKER_GID", "260511")
         .env("BLOOM_MACOS_BROKER_SIGNER_GID", "260512")
         .env("BLOOM_MACOS_REVOKE_GID", "260513")
+        .env("BLOOM_MACOS_LOG_GID", "260514")
         .env("BLOOM_RELEASE_DIGEST", &new_digest)
         .output()
         .unwrap();
@@ -2643,6 +2742,7 @@ fn macos_restore_cannot_downgrade_the_release_shared_by_an_active_login() {
         .env("BLOOM_MACOS_MACHINE_BROKER_GID", "260501")
         .env("BLOOM_MACOS_BROKER_SIGNER_GID", "260502")
         .env("BLOOM_MACOS_REVOKE_GID", "260503")
+        .env("BLOOM_MACOS_LOG_GID", "260504")
         .env("BLOOM_RELEASE_DIGEST", &old_digest)
         .output()
         .unwrap();

--- a/crates/bloom-machine-client/Cargo.toml
+++ b/crates/bloom-machine-client/Cargo.toml
@@ -12,6 +12,7 @@ async-trait.workspace = true
 bloom-audit-checkpoint.workspace = true
 bloom-triad-local-transport.workspace = true
 bloom-broker-api.workspace = true
+bloom-rpc-wire.workspace = true
 fs2.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -23,6 +24,8 @@ tracing.workspace = true
 ed25519-dalek.workspace = true
 
 [dev-dependencies]
+bloom-service-observability.workspace = true
 ed25519-dalek.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
+tracing-subscriber.workspace = true

--- a/crates/bloom-machine-client/src/lib.rs
+++ b/crates/bloom-machine-client/src/lib.rs
@@ -39,7 +39,9 @@ where
 }
 
 pub use bloom_audit_checkpoint::AuthorityEdgeHistory;
-use bloom_audit_checkpoint::{CheckpointSink, CheckpointStore, PinnedAuditKey};
+use bloom_audit_checkpoint::{
+    CheckpointDecision, CheckpointDecisionOutcome, CheckpointStore, PinnedAuditKey,
+};
 use bloom_broker_api::{
     ActivationMode, ApprovalLifecycleState, ApprovalLimitState, ApprovalLimits,
     ApprovalPrepareRequest, ApprovalPublicStatus, ApprovalRenewRequest, ApprovalSelector,
@@ -181,6 +183,8 @@ impl UnixMachineBrokerService {
         request: MachineBrokerRequest,
     ) -> Result<MachineBrokerResponse, ProtocolError> {
         let method = request.method()?;
+        let operation_id = request.operation_id()?.map(|value| value.to_string());
+        let started = std::time::Instant::now();
         let (provider, checkpoints) = {
             let state = self
                 .journals
@@ -198,7 +202,12 @@ impl UnixMachineBrokerService {
                     sequence,
                     head_hash,
                 );
-                if let Err(error) = checkpoints.append_peer_head(&head) {
+                if let Err(error) = append_checkpoint_with_event(
+                    &checkpoints,
+                    &head,
+                    method.as_str(),
+                    operation_id.as_deref(),
+                ) {
                     provider.latch_mutations(format!(
                         "persist Machine authority-edge audit head: {error}"
                     ));
@@ -223,7 +232,9 @@ impl UnixMachineBrokerService {
         let mut stream = tokio::net::UnixStream::connect(&self.socket_path)
             .await
             .map_err(|error| service_unavailable(format!("connect Broker: {error}")))?;
-        bloom_triad_local_transport::call_with_journal_head(
+        let checkpoint_method = method.clone();
+        let checkpoint_operation_id = operation_id.clone();
+        let result = bloom_triad_local_transport::call_with_journal_head(
             &mut stream,
             &self.identity,
             &self.broker,
@@ -233,11 +244,16 @@ impl UnixMachineBrokerService {
             30_000,
             sender_head,
             move |peer_head| {
-                if let Err(error) = checkpoints.append_peer_head(peer_head) {
+                if let Err(error) = append_checkpoint_with_event(
+                    &checkpoints,
+                    peer_head,
+                    checkpoint_method.as_str(),
+                    checkpoint_operation_id.as_deref(),
+                ) {
                     provider.latch_mutations(format!(
                         "persist Broker authority-edge audit head: {error}"
                     ));
-                    if !is_read_only_method(&method) {
+                    if !is_read_only_method(&checkpoint_method) {
                         return Err(service_unavailable(format!(
                             "persist Broker audit checkpoint before publishing mutation result: {error}"
                         )));
@@ -246,7 +262,106 @@ impl UnixMachineBrokerService {
                 Ok(())
             },
         )
-        .await
+        .await;
+        let duration_ms = started.elapsed().as_millis() as u64;
+        match &result {
+            Ok(_) if is_read_only_method(&method) => tracing::debug!(
+                event = "rpc.request_completed",
+                peer_service_id = self.broker.service_id.as_str(),
+                method = method.as_str(),
+                operation_id = operation_id.as_deref().unwrap_or(""),
+                duration_ms,
+                outcome = "ok"
+            ),
+            Ok(_) => tracing::info!(
+                event = "rpc.request_completed",
+                peer_service_id = self.broker.service_id.as_str(),
+                method = method.as_str(),
+                operation_id = operation_id.as_deref().unwrap_or(""),
+                duration_ms,
+                outcome = "ok"
+            ),
+            Err(error) => tracing::warn!(
+                event = "rpc.request_completed",
+                peer_service_id = self.broker.service_id.as_str(),
+                method = method.as_str(),
+                operation_id = operation_id.as_deref().unwrap_or(""),
+                duration_ms,
+                outcome = "error",
+                protocol_error_code = error.code.as_str()
+            ),
+        }
+        result
+    }
+}
+
+fn checkpoint_outcome(outcome: CheckpointDecisionOutcome) -> &'static str {
+    match outcome {
+        CheckpointDecisionOutcome::Appended => "appended",
+        CheckpointDecisionOutcome::AlreadyPresent => "already_present",
+        CheckpointDecisionOutcome::SequenceRollback => "sequence_rollback",
+        CheckpointDecisionOutcome::SequenceConflict => "sequence_conflict",
+        CheckpointDecisionOutcome::InvalidSignature => "invalid_signature",
+        CheckpointDecisionOutcome::UnpinnedPeer => "unpinned_peer",
+        CheckpointDecisionOutcome::StorageOrConfigurationFailure => {
+            "storage_or_configuration_failure"
+        }
+    }
+}
+
+fn emit_checkpoint_decision(
+    decision: &CheckpointDecision,
+    method: &str,
+    operation_id: Option<&str>,
+    mutations_disabled_latched: bool,
+) {
+    let retained = decision.retained.as_ref();
+    let recipient = decision
+        .recipient_service_id
+        .as_ref()
+        .map(|token| token.as_str())
+        .unwrap_or("");
+    macro_rules! emit {
+        ($level:ident) => {
+            tracing::$level!(
+                event = "audit.checkpoint_decision",
+                recipient_service_id = recipient,
+                peer_service_id = decision.attempted.service_id.as_str(),
+                peer_key_id = decision.attempted.key_id.as_str(),
+                method,
+                operation_id = operation_id.unwrap_or(""),
+                attempted_sequence = decision.attempted.sequence,
+                attempted_head_digest = decision.attempted.head_digest.as_str(),
+                retained_present = retained.is_some(),
+                retained_sequence = retained.map(|head| head.sequence).unwrap_or(0),
+                retained_head_digest = retained.map(|head| head.head_digest.as_str()).unwrap_or(""),
+                outcome = checkpoint_outcome(decision.outcome),
+                mutations_disabled_latched
+            )
+        };
+    }
+    match decision.outcome {
+        CheckpointDecisionOutcome::AlreadyPresent => emit!(debug),
+        CheckpointDecisionOutcome::Appended => emit!(info),
+        _ => emit!(error),
+    }
+}
+
+fn append_checkpoint_with_event(
+    checkpoints: &CheckpointStore,
+    head: &bloom_rpc_wire::SignedJournalHead,
+    method: &str,
+    operation_id: Option<&str>,
+) -> Result<(), bloom_audit_checkpoint::CheckpointError> {
+    match checkpoints.append_diagnosed(head) {
+        Ok(decision) => {
+            emit_checkpoint_decision(&decision, method, operation_id, false);
+            Ok(())
+        }
+        Err(failure) => {
+            emit_checkpoint_decision(&failure.decision, method, operation_id, true);
+            Err(failure.source)
+        }
     }
 }
 
@@ -2335,6 +2450,95 @@ mod tests {
         NormalizedSignature, RequestNonce, ServiceFuture, SignatureEncoding,
     };
     use ed25519_dalek::SigningKey;
+    use tracing_subscriber::prelude::*;
+
+    #[test]
+    fn checkpoint_event_has_exact_safe_evidence_and_omits_marker_secret() {
+        let capture = bloom_service_observability::CapturedWriter::default();
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .json()
+                .with_writer(capture.clone()),
+        );
+        let marker = "BLOOM_MARKER_CHECKPOINT_SECRET_2b1a";
+        let directory = tempfile::tempdir().unwrap();
+        let checkpoint_root = directory.path().join(marker);
+        std::fs::create_dir(&checkpoint_root).unwrap();
+        std::fs::set_permissions(&checkpoint_root, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let uid = std::fs::metadata(&checkpoint_root).unwrap().uid();
+        let machine = local_identity("bloom-machine", "machine-key", 31);
+        let broker = local_identity("bloom-broker", "broker-key", 32);
+        let store = CheckpointStore::open_with_history(
+            &checkpoint_root,
+            uid,
+            machine.service_id.clone(),
+            [
+                PinnedAuditKey {
+                    service_id: machine.service_id.clone(),
+                    key_id: machine.application_key_id.clone(),
+                    verifying_key: machine.signing_key.verifying_key(),
+                },
+                PinnedAuditKey {
+                    service_id: broker.service_id.clone(),
+                    key_id: broker.application_key_id.clone(),
+                    verifying_key: broker.signing_key.verifying_key(),
+                },
+            ],
+            Vec::new(),
+            Vec::new(),
+        )
+        .unwrap();
+        std::fs::set_permissions(&checkpoint_root, std::fs::Permissions::from_mode(0o500)).unwrap();
+        let failing_head = bloom_triad_local_transport::sign_journal_head(
+            &broker,
+            10,
+            Digest32::from_bytes([10; 32]),
+        );
+        let decision = CheckpointDecision {
+            recipient_service_id: Some(bloom_rpc_wire::Token::new("bloom-machine").unwrap()),
+            attempted: bloom_audit_checkpoint::CheckpointHeadMetadata {
+                service_id: bloom_rpc_wire::Token::new("bloom-broker").unwrap(),
+                key_id: bloom_rpc_wire::Token::new("broker-public-key").unwrap(),
+                sequence: 7,
+                head_digest: "aa".repeat(32),
+            },
+            retained: Some(bloom_audit_checkpoint::CheckpointHeadMetadata {
+                service_id: bloom_rpc_wire::Token::new("bloom-broker").unwrap(),
+                key_id: bloom_rpc_wire::Token::new("broker-public-key").unwrap(),
+                sequence: 9,
+                head_digest: "bb".repeat(32),
+            }),
+            outcome: CheckpointDecisionOutcome::SequenceRollback,
+        };
+        tracing::subscriber::with_default(subscriber, || {
+            assert!(
+                append_checkpoint_with_event(
+                    &store,
+                    &failing_head,
+                    "policy.commit_update",
+                    Some(&"cc".repeat(32)),
+                )
+                .is_err()
+            );
+            emit_checkpoint_decision(
+                &decision,
+                "policy.commit_update",
+                Some(&"cc".repeat(32)),
+                true,
+            );
+        });
+        let output = capture.text();
+        assert!(!output.contains(marker));
+        let event = output
+            .lines()
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+            .find(|event| event["fields"]["outcome"] == "sequence_rollback")
+            .unwrap();
+        assert_eq!(event["fields"]["attempted_sequence"], 7);
+        assert_eq!(event["fields"]["retained_sequence"], 9);
+        assert_eq!(event["fields"]["outcome"], "sequence_rollback");
+        assert_eq!(event["fields"]["mutations_disabled_latched"], true);
+    }
 
     #[derive(Deserialize)]
     struct MachineSignOperationVector {

--- a/crates/bloom-machine-client/src/projection.rs
+++ b/crates/bloom-machine-client/src/projection.rs
@@ -390,7 +390,7 @@ impl WalletProjectionReader for CachedWalletProjectionReader {
             Ok(projections) => Ok(projections),
             Err(error) if error.code == ProtocolErrorCode::ServiceUnavailable => {
                 tracing::warn!(
-                    error = %error,
+                    protocol_error_code = error.code.as_str(),
                     "Machine authority edge unavailable; serving cached wallet projections"
                 );
                 self.cached()
@@ -413,7 +413,7 @@ impl WalletProjectionReader for CachedWalletProjectionReader {
             Err(error) => return Err(error),
         };
         tracing::warn!(
-            error = %broker_error,
+            protocol_error_code = broker_error.code.as_str(),
             wallet_id = %wallet_id.as_str(),
             "Machine authority edge unavailable; serving cached wallet projection"
         );

--- a/crates/bloom-proto/src/audit.rs
+++ b/crates/bloom-proto/src/audit.rs
@@ -71,10 +71,23 @@ struct AuditInner {
     journal_snapshot: Option<JournalSnapshot>,
     identity: Option<AuditIdentity>,
     degraded: Option<String>,
+    degradation_latched: bool,
     #[cfg(any(test, feature = "audit-test-seam"))]
     fail_next_write: bool,
     #[cfg(any(test, feature = "audit-test-seam"))]
     fail_after_writes: Option<usize>,
+}
+
+fn latch_degradation(inner: &mut AuditInner, reason: String, cause_code: &'static str) {
+    inner.degradation_latched = true;
+    if inner.degraded.is_none() {
+        inner.degraded = Some(reason);
+        tracing::error!(
+            event = "machine.mutations_disabled",
+            cause_code,
+            mutations_disabled_latched = true
+        );
+    }
 }
 
 /// Cheap identity and mutation evidence for the journal verified at startup.
@@ -515,22 +528,30 @@ impl AuditLog {
         };
         let verifier = identity.as_ref().map(AuditIdentity::verifier);
         let inspected = inspect(&path, verifier.as_ref());
-        let (last_digest, sequence, pending_effects, degraded) = if path.exists() {
+        let (last_digest, sequence, pending_effects, degraded, inspected_latched) = if path.exists()
+        {
             match inspected {
                 Ok((digest, tail)) => {
                     let degraded = pending_effect_degradation(&tail.pending_effects);
-                    (digest, tail.sequence, tail.pending_effects, degraded)
+                    (digest, tail.sequence, tail.pending_effects, degraded, false)
                 }
                 Err(error) if identity.is_some() => (
                     String::new(),
                     0,
                     std::collections::BTreeSet::new(),
                     Some(error.to_string()),
+                    true,
                 ),
                 Err(error) => return Err(error),
             }
         } else {
-            (String::new(), 0, std::collections::BTreeSet::new(), None)
+            (
+                String::new(),
+                0,
+                std::collections::BTreeSet::new(),
+                None,
+                false,
+            )
         };
         let journal_snapshot = journal_snapshot(&path)?;
         let history_error = identity
@@ -539,6 +560,10 @@ impl AuditLog {
                 verify_rotation_history(&path, &current.verifier(), trusted_history).err()
             })
             .map(|error| error.to_string());
+        let degradation_latched = inspected_latched
+            || legacy_error.is_some()
+            || rotation_recovery_error.is_some()
+            || history_error.is_some();
         let log = Self {
             inner: Arc::new(Mutex::new(AuditInner {
                 path,
@@ -551,12 +576,20 @@ impl AuditLog {
                     .or(degraded)
                     .or(rotation_recovery_error)
                     .or(history_error),
+                degradation_latched,
                 #[cfg(any(test, feature = "audit-test-seam"))]
                 fail_next_write: false,
                 #[cfg(any(test, feature = "audit-test-seam"))]
                 fail_after_writes: None,
             })),
         };
+        if log.mutation_degradation().is_some() {
+            tracing::error!(
+                event = "machine.mutations_disabled",
+                cause_code = "audit_startup_verification",
+                mutations_disabled_latched = true
+            );
+        }
         if let Some(binding) = legacy_binding {
             log.append(AuditRecord {
                 ts_ms: 0,
@@ -597,19 +630,19 @@ impl AuditLog {
             Ok(snapshot) => snapshot,
             Err(error) => {
                 let reason = error.to_string();
-                g.degraded = Some(reason.clone());
+                latch_degradation(g, reason.clone(), "audit_storage");
                 return Err(AuditError::Degraded(reason));
             }
         };
         if observed_snapshot != g.journal_snapshot {
             let reason = "journal changed since its last verified mutation".to_owned();
-            g.degraded = Some(reason.clone());
+            latch_degradation(g, reason.clone(), "audit_journal_changed");
             return Err(AuditError::Degraded(reason));
         }
         let mut next_pending_effects = g.pending_effects.clone();
         if !apply_effect_transition(&mut next_pending_effects, &record) {
             let reason = "audit effect transition is invalid".to_owned();
-            g.degraded = Some(reason.clone());
+            latch_degradation(g, reason.clone(), "audit_transition_invalid");
             return Err(AuditError::Degraded(reason));
         }
         record.prev = g.last_digest.clone();
@@ -646,7 +679,7 @@ impl AuditLog {
         if g.fail_next_write {
             g.fail_next_write = false;
             let reason = "injected audit write failure".to_owned();
-            g.degraded = Some(reason.clone());
+            latch_degradation(g, reason.clone(), "audit_storage");
             return Err(AuditError::Degraded(reason));
         }
         #[cfg(any(test, feature = "audit-test-seam"))]
@@ -654,7 +687,7 @@ impl AuditLog {
             if *remaining == 0 {
                 g.fail_after_writes = None;
                 let reason = "injected delayed audit write failure".to_owned();
-                g.degraded = Some(reason.clone());
+                latch_degradation(g, reason.clone(), "audit_storage");
                 return Err(AuditError::Degraded(reason));
             }
             *remaining -= 1;
@@ -699,13 +732,13 @@ impl AuditLog {
             Ok(snapshot) => snapshot,
             Err(error) => {
                 let reason = error.to_string();
-                g.degraded = Some(reason);
+                latch_degradation(g, reason, "audit_storage");
                 return Err(AuditError::Io(error));
             }
         };
         if !file_existed && let Err(error) = sync_parent(&g.path) {
             let reason = error.to_string();
-            g.degraded = Some(reason);
+            latch_degradation(g, reason, "audit_storage");
             return Err(error);
         }
         g.last_digest = digest;
@@ -727,14 +760,7 @@ impl AuditLog {
     pub fn latch_mutations(&self, reason: impl Into<String>) {
         let mut g = self.inner.lock();
         let reason = reason.into();
-        match &mut g.degraded {
-            Some(existing) if !existing.contains(&reason) => {
-                existing.push_str("; ");
-                existing.push_str(&reason);
-            }
-            Some(_) => {}
-            None => g.degraded = Some(reason),
-        }
+        latch_degradation(&mut g, reason, "authority_edge_checkpoint");
     }
 
     pub fn sequence(&self) -> u64 {
@@ -792,7 +818,7 @@ impl AuditLog {
             ));
         }
         let pending_degradation = pending_effect_degradation(&tail.pending_effects);
-        if g.degraded != pending_degradation {
+        if g.degradation_latched || g.degraded != pending_degradation {
             return Err(AuditError::Degraded(g.degraded.clone().unwrap_or_else(|| {
                 "audit reconciliation refused because the active degradation is not solely an unresolved effect"
                     .to_owned()
@@ -1820,6 +1846,18 @@ mod tests {
         }
     }
 
+    #[test]
+    fn mutation_degradation_preserves_the_first_cause() {
+        let directory = tempfile::tempdir().unwrap();
+        let log = AuditLog::open(directory.path().join("audit.jsonl")).unwrap();
+        log.latch_mutations("first safe cause");
+        log.latch_mutations("later safe cause");
+        assert_eq!(
+            log.mutation_degradation().as_deref(),
+            Some("first safe cause")
+        );
+    }
+
     fn write_rotation_marker_fixture(
         path: &Path,
         old: &AuditIdentity,
@@ -2283,11 +2321,7 @@ mod tests {
                 "RECONCILE MACHINE AUDIT independent:a AS ABORTED",
             )
             .unwrap_err();
-        assert!(
-            error
-                .to_string()
-                .contains("packaging trust evidence invalid")
-        );
+        assert!(error.to_string().contains("durable intents but no results"));
         assert_eq!(
             restarted.pending_effect_correlations().unwrap(),
             vec!["independent:a".to_owned()]
@@ -2296,7 +2330,7 @@ mod tests {
             restarted
                 .mutation_degradation()
                 .unwrap()
-                .contains("packaging trust evidence invalid")
+                .contains("durable intents but no results")
         );
     }
 

--- a/crates/bloom/Cargo.toml
+++ b/crates/bloom/Cargo.toml
@@ -31,6 +31,7 @@ bloom-daemon.workspace = true
 bloom-machine-client.workspace = true
 bloom-triad-local-transport.workspace = true
 bloom-service-activation.workspace = true
+bloom-service-observability.workspace = true
 bloom-broker-api.workspace = true
 blake3.workspace = true
 bloom-mount = { workspace = true, optional = true }
@@ -67,6 +68,9 @@ zeroize.workspace = true
 # glibc OpenSSL, so build it from source only for musl targets.
 [target.'cfg(target_env = "musl")'.dependencies]
 openssl-sys = { version = "0.9", features = ["vendored"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+oslog = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/crates/bloom/src/main.rs
+++ b/crates/bloom/src/main.rs
@@ -38,7 +38,7 @@ use bloom_proto::{AuditIdentity, AuditLog, HomeDir, HomeWritePermit};
 use bloom_service_observability::LogOutput;
 use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::{Shell, generate};
-use tracing::{Instrument as _, debug, info, trace};
+use tracing::{Instrument as _, debug, info, trace, warn};
 
 #[cfg(target_os = "linux")]
 const DEFAULT_MOUNT_PATH: &str = "/bloom";
@@ -874,8 +874,12 @@ impl MachineCommandService for DaemonMachineCommands {
             }
             let result = execute_machine_command(&self.home, &self.daemon, command).await;
             match class {
-                MachineCommandEventClass::DurableMutation if result.is_err() => {
-                    emit_machine_mutation(workflow, operation_id.as_deref(), "rejected");
+                MachineCommandEventClass::DurableMutation => {
+                    emit_machine_mutation_rejection_if_needed(
+                        workflow,
+                        operation_id.as_deref(),
+                        &result,
+                    );
                 }
                 MachineCommandEventClass::Prepared => info!(
                     event = "machine.workflow_transition",
@@ -893,10 +897,23 @@ impl MachineCommandService for DaemonMachineCommands {
                     operation_id = operation_id.as_deref().unwrap_or(""),
                     outcome = if result.is_ok() { "read" } else { "rejected" }
                 ),
-                MachineCommandEventClass::DurableMutation => {}
             }
             result.map_err(machine_error_from_anyhow)
         })
+    }
+}
+
+fn emit_machine_mutation_rejection_if_needed<T>(
+    workflow: &str,
+    operation_id: Option<&str>,
+    result: &Result<T>,
+) {
+    let Some(error) = result.as_ref().err() else {
+        return;
+    };
+    let remote_commit_recorded = workflow == "ceremony" && error.is::<CeremonyRemoteCommitted>();
+    if !remote_commit_recorded {
+        emit_machine_mutation(workflow, operation_id, "rejected");
     }
 }
 
@@ -1351,7 +1368,6 @@ async fn execute_machine_command(
             action,
             operation_id,
         } => {
-            let mutation = matches!(action, MachineCeremonyAction::Cancel);
             let command = match action {
                 MachineCeremonyAction::Status => CeremonyCmd::Status {
                     operation_id: operation_id.clone(),
@@ -1363,11 +1379,7 @@ async fn execute_machine_command(
                     operation_id: operation_id.clone(),
                 },
             };
-            let output = handle_ceremony(home, command).await?;
-            if mutation {
-                emit_machine_mutation("ceremony", Some(&operation_id), "committed");
-            }
-            output
+            handle_ceremony(home, command).await?
         }
         MachineCommand::Operation {
             action,
@@ -1817,11 +1829,12 @@ async fn handle_ceremony(home: &HomeDir, command: CeremonyCmd) -> Result<String>
     }
 
     let status = if action == "cancel" {
-        client
-            .cancel_ceremony(operation_id.clone())
-            .await
-            .map_err(anyhow::Error::new)
-            .context("cancel Broker ceremony")?
+        ceremony_cancel_remote_result(
+            operation_id.as_str(),
+            client.cancel_ceremony(operation_id.clone()).await,
+        )
+        .map_err(anyhow::Error::new)
+        .context("cancel Broker ceremony")?
     } else {
         client
             .ceremony_status(operation_id.clone())
@@ -1829,30 +1842,71 @@ async fn handle_ceremony(home: &HomeDir, command: CeremonyCmd) -> Result<String>
             .map_err(anyhow::Error::new)
             .context("read Broker ceremony status")?
     };
-    anyhow::ensure!(
-        status.operation_id == operation_id,
-        "Broker ceremony status operation identity mismatch"
-    );
-    let now_ms = current_unix_ms();
-    let mut projection = match load_ceremony_projection(home, &operation_id)? {
-        Some(mut projection) => {
-            projection
-                .reconcile_custody(&status, now_ms)
+    let local_result = (|| -> Result<String> {
+        anyhow::ensure!(
+            status.operation_id == operation_id,
+            "Broker ceremony status operation identity mismatch"
+        );
+        let now_ms = current_unix_ms();
+        let mut projection = match load_ceremony_projection(home, &operation_id)? {
+            Some(mut projection) => {
+                projection
+                    .reconcile_custody(&status, now_ms)
+                    .map_err(anyhow::Error::new)
+                    .context("reconcile durable Machine ceremony projection")?;
+                projection
+            }
+            None => bloom_machine_client::CeremonyProjection::from_custody_status(&status, now_ms)
                 .map_err(anyhow::Error::new)
-                .context("reconcile durable Machine ceremony projection")?;
-            projection
-        }
-        None => bloom_machine_client::CeremonyProjection::from_custody_status(&status, now_ms)
-            .map_err(anyhow::Error::new)
-            .context("rebuild Machine ceremony projection from Broker")?,
-    };
-    projection.expire_launch_secret(now_ms);
-    let path = persist_ceremony_projection(home, &projection)?;
-    Ok(format!(
-        "{}\nprojection: {}\n",
-        serde_json::to_string_pretty(&projection).context("encode ceremony projection")?,
-        path.display(),
-    ))
+                .context("rebuild Machine ceremony projection from Broker")?,
+        };
+        projection.expire_launch_secret(now_ms);
+        let path = persist_ceremony_projection(home, &projection)?;
+        Ok(format!(
+            "{}\nprojection: {}\n",
+            serde_json::to_string_pretty(&projection).context("encode ceremony projection")?,
+            path.display(),
+        ))
+    })();
+    if action == "cancel" {
+        return finish_ceremony_cancel_projection(operation_id.as_str(), local_result);
+    }
+    local_result
+}
+
+#[derive(Debug)]
+struct CeremonyRemoteCommitted;
+
+impl std::fmt::Display for CeremonyRemoteCommitted {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("Broker ceremony cancellation committed before local projection update")
+    }
+}
+
+impl std::error::Error for CeremonyRemoteCommitted {}
+
+fn finish_ceremony_cancel_projection<T>(operation_id: &str, result: Result<T>) -> Result<T> {
+    if result.is_err() {
+        emit_ceremony_local_projection_failure(operation_id);
+    }
+    result.context(CeremonyRemoteCommitted)
+}
+
+fn ceremony_cancel_remote_result<T, E>(operation_id: &str, result: Result<T, E>) -> Result<T, E> {
+    if result.is_ok() {
+        emit_machine_mutation("ceremony", Some(operation_id), "committed");
+    }
+    result
+}
+
+fn emit_ceremony_local_projection_failure(operation_id: &str) {
+    warn!(
+        event = "machine.local_projection_update_failed",
+        workflow = "ceremony",
+        operation_id,
+        remote_state = "committed",
+        error_kind = "local_projection"
+    );
 }
 
 async fn handle_operation(home: &HomeDir, command: OperationCmd) -> Result<String> {
@@ -3999,13 +4053,15 @@ mod tests {
     use tracing_subscriber::prelude::*;
 
     use super::{
-        Cli, Cmd, LegacyMigrationReceiptFile, MachineCommandEventClass, WalletCmd,
-        ceremony_projection_path, emit_machine_ready, endpoint_connection_error,
+        CeremonyCmd, Cli, Cmd, LegacyMigrationReceiptFile, MachineCommandEventClass, WalletCmd,
+        ceremony_cancel_remote_result, ceremony_projection_path, emit_machine_mutation,
+        emit_machine_mutation_rejection_if_needed, emit_machine_ready, endpoint_connection_error,
         enrollment_state_is_usable, execute_audit_command, execute_wallet_outbox_action,
-        format_petal_consent_net_rule, is_completed_policy_update_receipt,
-        launch_wallet_registration_via_vfs, load_ceremony_projection, long_running_role,
-        machine_command_event_fields, machine_error_from_anyhow, machine_wallet_lookup_error,
-        open_machine_audit_with_history, persist_ceremony_projection, request_body_with_wallet,
+        finish_ceremony_cancel_projection, format_petal_consent_net_rule, handle_ceremony,
+        is_completed_policy_update_receipt, launch_wallet_registration_via_vfs,
+        load_ceremony_projection, long_running_role, machine_command_event_fields,
+        machine_error_from_anyhow, machine_wallet_lookup_error, open_machine_audit_with_history,
+        persist_ceremony_projection, request_body_with_wallet,
     };
     use bloom_daemon::ipc::{MachineCeremonyAction, MachineCommand, MachineOperationAction};
 
@@ -4620,6 +4676,88 @@ mod tests {
                 MachineCommandEventClass::Read
             );
         }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn ceremony_cancel_pre_remote_failure_closes_started_mutation() {
+        let capture = bloom_service_observability::CapturedWriter::default();
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .json()
+                .with_writer(capture.clone()),
+        );
+        let operation_id = "not-an-operation-id";
+        let temp = tempfile::tempdir().unwrap();
+        let home = bloom_proto::HomeDir::at(temp.path());
+        let _guard = tracing::subscriber::set_default(subscriber);
+        emit_machine_mutation("ceremony", Some(operation_id), "started");
+        let result = handle_ceremony(
+            &home,
+            CeremonyCmd::Cancel {
+                operation_id: operation_id.into(),
+            },
+        )
+        .await;
+        assert!(result.is_err());
+        emit_machine_mutation_rejection_if_needed("ceremony", Some(operation_id), &result);
+        drop(_guard);
+
+        let events = capture
+            .text()
+            .lines()
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+            .collect::<Vec<_>>();
+        let states = events
+            .iter()
+            .filter(|event| event["fields"]["event"] == "machine.durable_mutation")
+            .map(|event| event["fields"]["state"].as_str().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(states, ["started", "rejected"]);
+    }
+
+    #[test]
+    fn ceremony_cancel_keeps_remote_commit_when_local_projection_fails() {
+        let capture = bloom_service_observability::CapturedWriter::default();
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .json()
+                .with_writer(capture.clone()),
+        );
+        let operation_id = "ef".repeat(32);
+        tracing::subscriber::with_default(subscriber, || {
+            emit_machine_mutation("ceremony", Some(&operation_id), "started");
+            ceremony_cancel_remote_result::<_, ()>(&operation_id, Ok(())).unwrap();
+            let result = finish_ceremony_cancel_projection::<()>(
+                &operation_id,
+                Err(anyhow::anyhow!("local projection failed")),
+            );
+            emit_machine_mutation_rejection_if_needed("ceremony", Some(&operation_id), &result);
+        });
+        let events = capture
+            .text()
+            .lines()
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+            .collect::<Vec<_>>();
+        assert!(events.iter().any(|event| {
+            event["fields"]["event"] == "machine.durable_mutation"
+                && event["fields"]["state"] == "committed"
+                && event["fields"]["operation_id"] == operation_id
+        }));
+        assert!(events.iter().any(|event| {
+            event["fields"]["event"] == "machine.local_projection_update_failed"
+                && event["fields"]["remote_state"] == "committed"
+        }));
+        let states = events
+            .iter()
+            .filter(|event| event["fields"]["event"] == "machine.durable_mutation")
+            .map(|event| event["fields"]["state"].as_str().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(states, ["started", "committed"]);
+        assert!(
+            !events
+                .iter()
+                .any(|event| event["fields"]["state"] == "rejected")
+        );
     }
 
     #[test]

--- a/crates/bloom/src/main.rs
+++ b/crates/bloom/src/main.rs
@@ -911,7 +911,7 @@ fn emit_machine_mutation_rejection_if_needed<T>(
     let Some(error) = result.as_ref().err() else {
         return;
     };
-    let remote_commit_recorded = workflow == "ceremony" && error.is::<CeremonyRemoteCommitted>();
+    let remote_commit_recorded = error.is::<RemoteMutationCommitted>();
     if !remote_commit_recorded {
         emit_machine_mutation(workflow, operation_id, "rejected");
     }
@@ -1324,9 +1324,7 @@ async fn execute_machine_command(
             assurance_level,
         } => prepare_policy_update(home, &name, &policy, &assurance_level).await?,
         MachineCommand::WalletPolicyCommit { operation_id } => {
-            let output = commit_policy_update(home, operation_id.clone()).await?;
-            emit_machine_mutation("policy_update", Some(&operation_id), "committed");
-            output
+            commit_policy_update(home, operation_id).await?
         }
         MachineCommand::WalletOutboxCancel {
             wallet,
@@ -1657,18 +1655,17 @@ async fn commit_policy_update(home: &HomeDir, operation_id: String) -> Result<St
         "policy commit requires the matching completed policy_update ceremony receipt"
     );
 
-    let receipt = client
-        .commit_policy_update(bloom_broker_api::PolicyCommitUpdateRequest {
-            operation_id: operation_id.clone(),
-            ceremony_receipt,
-        })
-        .await
-        .map_err(anyhow::Error::new)
-        .context("commit policy update through Broker and Signer compare-and-swap")?;
-    anyhow::ensure!(
-        receipt.operation_id == operation_id,
-        "Broker policy commit receipt operation identity mismatch"
-    );
+    let receipt = policy_commit_remote_result(
+        operation_id.as_str(),
+        client
+            .commit_policy_update(bloom_broker_api::PolicyCommitUpdateRequest {
+                operation_id: operation_id.clone(),
+                ceremony_receipt,
+            })
+            .await,
+    )
+    .map_err(anyhow::Error::new)
+    .context("commit policy update through Broker and Signer compare-and-swap")?;
     info!(
         event = "machine.policy_update.transition",
         operation_id = operation_id.as_str(),
@@ -1676,28 +1673,59 @@ async fn commit_policy_update(home: &HomeDir, operation_id: String) -> Result<St
         state = "committed"
     );
 
-    if let Ok(status) = client.ceremony_status(operation_id.clone()).await {
-        let now_ms = current_unix_ms();
-        let mut projection = match load_ceremony_projection(home, &operation_id)? {
-            Some(mut projection) => {
-                projection
-                    .reconcile_custody(&status, now_ms)
-                    .map_err(anyhow::Error::new)
-                    .context("reconcile committed policy-update projection")?;
-                projection
-            }
-            None => bloom_machine_client::CeremonyProjection::from_custody_status(&status, now_ms)
-                .map_err(anyhow::Error::new)
-                .context("rebuild committed policy-update projection")?,
-        };
-        projection.expire_launch_secret(now_ms);
-        persist_ceremony_projection(home, &projection)?;
-    }
+    let local_result = async {
+        anyhow::ensure!(
+            receipt.operation_id == operation_id,
+            "Broker policy commit receipt operation identity mismatch"
+        );
 
-    Ok(format!(
-        "{}\n",
-        serde_json::to_string_pretty(&receipt).context("encode policy commit receipt")?
-    ))
+        if let Ok(status) = client.ceremony_status(operation_id.clone()).await {
+            let now_ms = current_unix_ms();
+            let mut projection = match load_ceremony_projection(home, &operation_id)? {
+                Some(mut projection) => {
+                    projection
+                        .reconcile_custody(&status, now_ms)
+                        .map_err(anyhow::Error::new)
+                        .context("reconcile committed policy-update projection")?;
+                    projection
+                }
+                None => {
+                    bloom_machine_client::CeremonyProjection::from_custody_status(&status, now_ms)
+                        .map_err(anyhow::Error::new)
+                        .context("rebuild committed policy-update projection")?
+                }
+            };
+            projection.expire_launch_secret(now_ms);
+            persist_ceremony_projection(home, &projection)?;
+        }
+
+        Ok(format!(
+            "{}\n",
+            serde_json::to_string_pretty(&receipt).context("encode policy commit receipt")?
+        ))
+    }
+    .await;
+    finish_policy_commit_local_result(operation_id.as_str(), local_result)
+}
+
+fn policy_commit_remote_result<T, E>(operation_id: &str, result: Result<T, E>) -> Result<T, E> {
+    if result.is_ok() {
+        emit_machine_mutation("policy_update", Some(operation_id), "committed");
+    }
+    result
+}
+
+fn finish_policy_commit_local_result<T>(operation_id: &str, result: Result<T>) -> Result<T> {
+    if result.is_err() {
+        warn!(
+            event = "machine.local_post_commit_failed",
+            workflow = "policy_update",
+            operation_id,
+            remote_state = "committed",
+            error_kind = "local_processing"
+        );
+    }
+    result.context(RemoteMutationCommitted)
 }
 
 fn is_completed_policy_update_receipt(
@@ -1875,21 +1903,21 @@ async fn handle_ceremony(home: &HomeDir, command: CeremonyCmd) -> Result<String>
 }
 
 #[derive(Debug)]
-struct CeremonyRemoteCommitted;
+struct RemoteMutationCommitted;
 
-impl std::fmt::Display for CeremonyRemoteCommitted {
+impl std::fmt::Display for RemoteMutationCommitted {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str("Broker ceremony cancellation committed before local projection update")
+        formatter.write_str("remote mutation committed before local processing completed")
     }
 }
 
-impl std::error::Error for CeremonyRemoteCommitted {}
+impl std::error::Error for RemoteMutationCommitted {}
 
 fn finish_ceremony_cancel_projection<T>(operation_id: &str, result: Result<T>) -> Result<T> {
     if result.is_err() {
         emit_ceremony_local_projection_failure(operation_id);
     }
-    result.context(CeremonyRemoteCommitted)
+    result.context(RemoteMutationCommitted)
 }
 
 fn ceremony_cancel_remote_result<T, E>(operation_id: &str, result: Result<T, E>) -> Result<T, E> {
@@ -4054,14 +4082,15 @@ mod tests {
 
     use super::{
         CeremonyCmd, Cli, Cmd, LegacyMigrationReceiptFile, MachineCommandEventClass, WalletCmd,
-        ceremony_cancel_remote_result, ceremony_projection_path, emit_machine_mutation,
-        emit_machine_mutation_rejection_if_needed, emit_machine_ready, endpoint_connection_error,
-        enrollment_state_is_usable, execute_audit_command, execute_wallet_outbox_action,
-        finish_ceremony_cancel_projection, format_petal_consent_net_rule, handle_ceremony,
+        ceremony_cancel_remote_result, ceremony_projection_path, commit_policy_update,
+        emit_machine_mutation, emit_machine_mutation_rejection_if_needed, emit_machine_ready,
+        endpoint_connection_error, enrollment_state_is_usable, execute_audit_command,
+        execute_wallet_outbox_action, finish_ceremony_cancel_projection,
+        finish_policy_commit_local_result, format_petal_consent_net_rule, handle_ceremony,
         is_completed_policy_update_receipt, launch_wallet_registration_via_vfs,
         load_ceremony_projection, long_running_role, machine_command_event_fields,
         machine_error_from_anyhow, machine_wallet_lookup_error, open_machine_audit_with_history,
-        persist_ceremony_projection, request_body_with_wallet,
+        persist_ceremony_projection, policy_commit_remote_result, request_body_with_wallet,
     };
     use bloom_daemon::ipc::{MachineCeremonyAction, MachineCommand, MachineOperationAction};
 
@@ -4758,6 +4787,92 @@ mod tests {
                 .iter()
                 .any(|event| event["fields"]["state"] == "rejected")
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn policy_commit_pre_remote_and_rpc_failures_close_started_mutations() {
+        let capture = bloom_service_observability::CapturedWriter::default();
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .json()
+                .with_writer(capture.clone()),
+        );
+        let temp = tempfile::tempdir().unwrap();
+        let home = bloom_proto::HomeDir::at(temp.path());
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let invalid_operation_id = "not-an-operation-id";
+        emit_machine_mutation("policy_update", Some(invalid_operation_id), "started");
+        let pre_remote = commit_policy_update(&home, invalid_operation_id.into()).await;
+        assert!(pre_remote.is_err());
+        emit_machine_mutation_rejection_if_needed(
+            "policy_update",
+            Some(invalid_operation_id),
+            &pre_remote,
+        );
+
+        let rpc_operation_id = "cd".repeat(32);
+        emit_machine_mutation("policy_update", Some(&rpc_operation_id), "started");
+        let rpc_failure = policy_commit_remote_result::<(), _>(
+            &rpc_operation_id,
+            Err(anyhow::anyhow!("Broker RPC unavailable")),
+        );
+        emit_machine_mutation_rejection_if_needed(
+            "policy_update",
+            Some(&rpc_operation_id),
+            &rpc_failure,
+        );
+        drop(_guard);
+
+        let states = capture
+            .text()
+            .lines()
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+            .filter(|event| event["fields"]["event"] == "machine.durable_mutation")
+            .map(|event| event["fields"]["state"].as_str().unwrap().to_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(states, ["started", "rejected", "started", "rejected"]);
+    }
+
+    #[test]
+    fn policy_commit_keeps_remote_commit_when_local_processing_fails() {
+        let capture = bloom_service_observability::CapturedWriter::default();
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .json()
+                .with_writer(capture.clone()),
+        );
+        let operation_id = "ab".repeat(32);
+        tracing::subscriber::with_default(subscriber, || {
+            emit_machine_mutation("policy_update", Some(&operation_id), "started");
+            policy_commit_remote_result::<_, ()>(&operation_id, Ok(())).unwrap();
+            let local_result = finish_policy_commit_local_result::<()>(
+                &operation_id,
+                Err(anyhow::anyhow!("projection marker secret")),
+            );
+            emit_machine_mutation_rejection_if_needed(
+                "policy_update",
+                Some(&operation_id),
+                &local_result,
+            );
+        });
+        let output = capture.text();
+        assert!(!output.contains("projection marker secret"));
+        let events = output
+            .lines()
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+            .collect::<Vec<_>>();
+        assert!(events.iter().any(|event| {
+            event["fields"]["event"] == "machine.local_post_commit_failed"
+                && event["fields"]["workflow"] == "policy_update"
+                && event["fields"]["remote_state"] == "committed"
+        }));
+        let states = events
+            .iter()
+            .filter(|event| event["fields"]["event"] == "machine.durable_mutation")
+            .map(|event| event["fields"]["state"].as_str().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(states, ["started", "committed"]);
     }
 
     #[test]

--- a/crates/bloom/src/main.rs
+++ b/crates/bloom/src/main.rs
@@ -714,6 +714,16 @@ async fn launch_custody_ceremony(
             format!("custody requires the authenticated Machine-to-Broker edge: {error:#}"),
         )
     })?;
+    let workflow = if legacy_migration.is_some() {
+        "credential_migration"
+    } else {
+        match ceremony_kind {
+            bloom_broker_api::CeremonyKind::WalletImport => "wallet_import",
+            bloom_broker_api::CeremonyKind::CredentialReplace => "credential_rebind",
+            bloom_broker_api::CeremonyKind::WalletDelete => "wallet_delete",
+            _ => "wallet_custody",
+        }
+    };
     let (operation_id, exact_terms_digest, legacy_passkey_migration) =
         if let Some(migration) = legacy_migration {
             (
@@ -761,21 +771,26 @@ async fn launch_custody_ceremony(
         .await
         .map_err(anyhow::Error::new)
         .context("prepare Broker custody ceremony")?;
-    let projection = bloom_machine_client::CeremonyProjection::from_custody_prepare(
-        &response,
-        current_unix_ms(),
-    )
-    .map_err(anyhow::Error::new)
-    .context("construct Machine custody projection")?;
-    let projection_path = persist_ceremony_projection(home, &projection)?;
-    Ok(format!(
-        "operation_id: {}\nceremony_kind: {:?}\nceremony_url: {}\nceremony_expires_at_ms: {}\nprojection: {}\n",
-        response.custody_operation_id,
-        response.ceremony_kind,
-        response.ceremony_url,
-        response.ceremony_expires_at_ms.get(),
-        projection_path.display(),
-    ))
+    let prepared_operation_id = response.custody_operation_id.as_str().to_owned();
+    emit_remote_preparation(workflow, Some(&prepared_operation_id));
+    let local_result = (|| {
+        let projection = bloom_machine_client::CeremonyProjection::from_custody_prepare(
+            &response,
+            current_unix_ms(),
+        )
+        .map_err(anyhow::Error::new)
+        .context("construct Machine custody projection")?;
+        let projection_path = persist_ceremony_projection(home, &projection)?;
+        Ok(format!(
+            "operation_id: {}\nceremony_kind: {:?}\nceremony_url: {}\nceremony_expires_at_ms: {}\nprojection: {}\n",
+            response.custody_operation_id,
+            response.ceremony_kind,
+            response.ceremony_url,
+            response.ceremony_expires_at_ms.get(),
+            projection_path.display(),
+        ))
+    })();
+    finish_remote_preparation(workflow, Some(&prepared_operation_id), local_result)
 }
 
 #[derive(serde::Deserialize)]
@@ -864,12 +879,14 @@ impl MachineCommandService for DaemonMachineCommands {
                 MachineCommandEventClass::DurableMutation => {
                     emit_machine_mutation(workflow, operation_id.as_deref(), "started");
                 }
-                MachineCommandEventClass::Prepared => info!(
-                    event = "machine.workflow_transition",
-                    workflow,
-                    operation_id = operation_id.as_deref().unwrap_or(""),
-                    state = "started"
-                ),
+                MachineCommandEventClass::Prepared | MachineCommandEventClass::RemotePrepared => {
+                    info!(
+                        event = "machine.workflow_transition",
+                        workflow,
+                        operation_id = operation_id.as_deref().unwrap_or(""),
+                        state = "started"
+                    )
+                }
                 MachineCommandEventClass::Read => {}
             }
             let result = execute_machine_command(&self.home, &self.daemon, command).await;
@@ -891,6 +908,13 @@ impl MachineCommandService for DaemonMachineCommands {
                         "rejected"
                     }
                 ),
+                MachineCommandEventClass::RemotePrepared => {
+                    emit_machine_preparation_rejection_if_needed(
+                        workflow,
+                        operation_id.as_deref(),
+                        &result,
+                    );
+                }
                 MachineCommandEventClass::Read => debug!(
                     event = "machine.command_outcome",
                     workflow,
@@ -900,6 +924,24 @@ impl MachineCommandService for DaemonMachineCommands {
             }
             result.map_err(machine_error_from_anyhow)
         })
+    }
+}
+
+fn emit_machine_preparation_rejection_if_needed<T>(
+    workflow: &str,
+    operation_id: Option<&str>,
+    result: &Result<T>,
+) {
+    let Some(error) = result.as_ref().err() else {
+        return;
+    };
+    if !error.is::<RemotePreparationCompleted>() {
+        info!(
+            event = "machine.workflow_transition",
+            workflow,
+            operation_id = operation_id.unwrap_or(""),
+            state = "rejected"
+        );
     }
 }
 
@@ -934,6 +976,7 @@ fn emit_machine_ready() {
 enum MachineCommandEventClass {
     Read,
     Prepared,
+    RemotePrepared,
     DurableMutation,
 }
 
@@ -954,12 +997,16 @@ fn machine_command_event_fields(
                 MachineCustodyKind::Delete => "wallet_delete",
             },
             None,
-            MachineCommandEventClass::Prepared,
+            if matches!(kind, MachineCustodyKind::New) {
+                MachineCommandEventClass::Prepared
+            } else {
+                MachineCommandEventClass::RemotePrepared
+            },
         ),
         MachineCommand::WalletMigrate { .. } => (
             "credential_migration",
             None,
-            MachineCommandEventClass::Prepared,
+            MachineCommandEventClass::RemotePrepared,
         ),
         MachineCommand::WalletPolicyPrepare { .. } => {
             ("policy_update", None, MachineCommandEventClass::Prepared)
@@ -1306,7 +1353,7 @@ async fn execute_machine_command(
                 Some(migration.clone()),
             )
             .await?;
-            daemon
+            let local_result = daemon
                 .wallet_projections
                 .begin_legacy_migration(
                     &migration.operation_id,
@@ -1315,8 +1362,13 @@ async fn execute_machine_command(
                 )
                 .await
                 .map_err(anyhow::Error::new)
-                .context("record pending legacy migration")?;
-            output
+                .context("record pending legacy migration")
+                .map(|()| output);
+            finish_remote_preparation(
+                "credential_migration",
+                Some(migration.operation_id.as_str()),
+                local_result,
+            )?
         }
         MachineCommand::WalletPolicyPrepare {
             name,
@@ -1913,6 +1965,43 @@ impl std::fmt::Display for RemoteMutationCommitted {
 
 impl std::error::Error for RemoteMutationCommitted {}
 
+#[derive(Debug)]
+struct RemotePreparationCompleted;
+
+impl std::fmt::Display for RemotePreparationCompleted {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("remote preparation completed before local processing")
+    }
+}
+
+impl std::error::Error for RemotePreparationCompleted {}
+
+fn emit_remote_preparation(workflow: &str, operation_id: Option<&str>) {
+    info!(
+        event = "machine.workflow_transition",
+        workflow,
+        operation_id = operation_id.unwrap_or(""),
+        state = "prepared"
+    );
+}
+
+fn finish_remote_preparation<T>(
+    workflow: &str,
+    operation_id: Option<&str>,
+    result: Result<T>,
+) -> Result<T> {
+    if result.is_err() {
+        warn!(
+            event = "machine.local_post_prepare_failed",
+            workflow,
+            operation_id = operation_id.unwrap_or(""),
+            remote_state = "prepared",
+            error_kind = "local_processing"
+        );
+    }
+    result.context(RemotePreparationCompleted)
+}
+
 fn finish_ceremony_cancel_projection<T>(operation_id: &str, result: Result<T>) -> Result<T> {
     if result.is_err() {
         emit_ceremony_local_projection_failure(operation_id);
@@ -1953,11 +2042,12 @@ async fn handle_operation(home: &HomeDir, command: OperationCmd) -> Result<Strin
         )
     })?;
     let status = if cancel {
-        client
-            .cancel_operation(operation_id.clone())
-            .await
-            .map_err(anyhow::Error::new)
-            .context("cancel Broker operation before downstream acceptance")?
+        operation_cancel_remote_result(
+            operation_id.as_str(),
+            client.cancel_operation(operation_id.clone()).await,
+        )
+        .map_err(anyhow::Error::new)
+        .context("cancel Broker operation before downstream acceptance")?
     } else {
         client
             .operation_status(operation_id.clone())
@@ -1965,14 +2055,41 @@ async fn handle_operation(home: &HomeDir, command: OperationCmd) -> Result<Strin
             .map_err(anyhow::Error::new)
             .context("read Broker operation status")?
     };
-    anyhow::ensure!(
-        status.operation_id == operation_id,
-        "Broker operation status identity mismatch"
-    );
-    Ok(format!(
-        "{}\n",
-        serde_json::to_string_pretty(&status).context("encode Broker operation status")?
-    ))
+    let local_result = (|| {
+        anyhow::ensure!(
+            status.operation_id == operation_id,
+            "Broker operation status identity mismatch"
+        );
+        Ok(format!(
+            "{}\n",
+            serde_json::to_string_pretty(&status).context("encode Broker operation status")?
+        ))
+    })();
+    if cancel {
+        finish_operation_cancel_local_result(operation_id.as_str(), local_result)
+    } else {
+        local_result
+    }
+}
+
+fn operation_cancel_remote_result<T, E>(operation_id: &str, result: Result<T, E>) -> Result<T, E> {
+    if result.is_ok() {
+        emit_machine_mutation("operation", Some(operation_id), "committed");
+    }
+    result
+}
+
+fn finish_operation_cancel_local_result<T>(operation_id: &str, result: Result<T>) -> Result<T> {
+    if result.is_err() {
+        warn!(
+            event = "machine.local_post_commit_failed",
+            workflow = "operation",
+            operation_id,
+            remote_state = "committed",
+            error_kind = "local_processing"
+        );
+    }
+    result.context(RemoteMutationCommitted)
 }
 
 #[derive(Parser, Debug)]
@@ -4083,16 +4200,21 @@ mod tests {
     use super::{
         CeremonyCmd, Cli, Cmd, LegacyMigrationReceiptFile, MachineCommandEventClass, WalletCmd,
         ceremony_cancel_remote_result, ceremony_projection_path, commit_policy_update,
-        emit_machine_mutation, emit_machine_mutation_rejection_if_needed, emit_machine_ready,
+        emit_machine_mutation, emit_machine_mutation_rejection_if_needed,
+        emit_machine_preparation_rejection_if_needed, emit_machine_ready, emit_remote_preparation,
         endpoint_connection_error, enrollment_state_is_usable, execute_audit_command,
         execute_wallet_outbox_action, finish_ceremony_cancel_projection,
-        finish_policy_commit_local_result, format_petal_consent_net_rule, handle_ceremony,
+        finish_operation_cancel_local_result, finish_policy_commit_local_result,
+        finish_remote_preparation, format_petal_consent_net_rule, handle_ceremony,
         is_completed_policy_update_receipt, launch_wallet_registration_via_vfs,
         load_ceremony_projection, long_running_role, machine_command_event_fields,
         machine_error_from_anyhow, machine_wallet_lookup_error, open_machine_audit_with_history,
-        persist_ceremony_projection, policy_commit_remote_result, request_body_with_wallet,
+        operation_cancel_remote_result, persist_ceremony_projection, policy_commit_remote_result,
+        request_body_with_wallet,
     };
-    use bloom_daemon::ipc::{MachineCeremonyAction, MachineCommand, MachineOperationAction};
+    use bloom_daemon::ipc::{
+        MachineCeremonyAction, MachineCommand, MachineCustodyKind, MachineOperationAction,
+    };
 
     #[derive(Default)]
     struct RecordingOutboxHandler(Mutex<Vec<(String, Vec<u8>)>>);
@@ -4787,6 +4909,98 @@ mod tests {
                 .iter()
                 .any(|event| event["fields"]["state"] == "rejected")
         );
+    }
+
+    #[test]
+    fn operation_cancel_keeps_remote_commit_when_local_processing_fails() {
+        let capture = bloom_service_observability::CapturedWriter::default();
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .json()
+                .with_writer(capture.clone()),
+        );
+        let operation_id = "de".repeat(32);
+        let marker_secret = "MARKER_OPERATION_FORMAT_FAILURE_DO_NOT_LOG";
+        tracing::subscriber::with_default(subscriber, || {
+            emit_machine_mutation("operation", Some(&operation_id), "started");
+            operation_cancel_remote_result::<_, ()>(&operation_id, Ok(())).unwrap();
+            let result = finish_operation_cancel_local_result::<()>(
+                &operation_id,
+                Err(anyhow::anyhow!(marker_secret)),
+            );
+            emit_machine_mutation_rejection_if_needed("operation", Some(&operation_id), &result);
+        });
+
+        let output = capture.text();
+        assert!(!output.contains(marker_secret));
+        let events = output
+            .lines()
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+            .collect::<Vec<_>>();
+        let states = events
+            .iter()
+            .filter(|event| event["fields"]["event"] == "machine.durable_mutation")
+            .map(|event| event["fields"]["state"].as_str().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(states, ["started", "committed"]);
+        assert!(events.iter().any(|event| {
+            event["fields"]["event"] == "machine.local_post_commit_failed"
+                && event["fields"]["workflow"] == "operation"
+                && event["fields"]["remote_state"] == "committed"
+        }));
+    }
+
+    #[test]
+    fn custody_prepare_keeps_remote_transition_when_local_processing_fails() {
+        assert_eq!(
+            machine_command_event_fields(&MachineCommand::WalletCustody {
+                name: "wallet".into(),
+                kind: MachineCustodyKind::Import,
+            })
+            .2,
+            MachineCommandEventClass::RemotePrepared
+        );
+        let capture = bloom_service_observability::CapturedWriter::default();
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .json()
+                .with_writer(capture.clone()),
+        );
+        let operation_id = "ac".repeat(32);
+        let marker_secret = "MARKER_CUSTODY_PROJECTION_FAILURE_DO_NOT_LOG";
+        tracing::subscriber::with_default(subscriber, || {
+            info!(
+                event = "machine.workflow_transition",
+                workflow = "wallet_import",
+                operation_id = "",
+                state = "started"
+            );
+            emit_remote_preparation("wallet_import", Some(&operation_id));
+            let result = finish_remote_preparation::<()>(
+                "wallet_import",
+                Some(&operation_id),
+                Err(anyhow::anyhow!(marker_secret)),
+            );
+            emit_machine_preparation_rejection_if_needed("wallet_import", None, &result);
+        });
+
+        let output = capture.text();
+        assert!(!output.contains(marker_secret));
+        let events = output
+            .lines()
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+            .collect::<Vec<_>>();
+        let states = events
+            .iter()
+            .filter(|event| event["fields"]["event"] == "machine.workflow_transition")
+            .map(|event| event["fields"]["state"].as_str().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(states, ["started", "prepared"]);
+        assert!(events.iter().any(|event| {
+            event["fields"]["event"] == "machine.local_post_prepare_failed"
+                && event["fields"]["workflow"] == "wallet_import"
+                && event["fields"]["remote_state"] == "prepared"
+        }));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/bloom/src/main.rs
+++ b/crates/bloom/src/main.rs
@@ -35,10 +35,10 @@ use bloom_daemon::ipc::{
 };
 use bloom_machine_client::MachineJournalHeadProvider;
 use bloom_proto::{AuditIdentity, AuditLog, HomeDir, HomeWritePermit};
+use bloom_service_observability::LogOutput;
 use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::{Shell, generate};
-use tracing::{debug, info, trace};
-use tracing_subscriber::EnvFilter;
+use tracing::{Instrument as _, debug, info, trace};
 
 #[cfg(target_os = "linux")]
 const DEFAULT_MOUNT_PATH: &str = "/bloom";
@@ -510,7 +510,11 @@ fn build_write_daemon(home: HomeDir) -> Result<(Arc<HomeWritePermit>, Daemon)> {
         Err(error) => {
             #[cfg(debug_assertions)]
             {
-                debug!(error = %error, "authenticated Broker edge absent; using key-free debug Machine composition");
+                let _ = error;
+                debug!(
+                    error_kind = "broker_edge_unavailable",
+                    "authenticated Broker edge absent; using key-free debug Machine composition"
+                );
                 Daemon::from_home_with_permit_without_broker_for_debug(home, permit.clone())
                     .context("build key-free debug daemon")?
             }
@@ -855,10 +859,134 @@ struct DaemonMachineCommands {
 impl MachineCommandService for DaemonMachineCommands {
     fn execute(&self, command: MachineCommand) -> MachineCommandFuture<'_> {
         Box::pin(async move {
-            execute_machine_command(&self.home, &self.daemon, command)
-                .await
-                .map_err(machine_error_from_anyhow)
+            let (workflow, operation_id, class) = machine_command_event_fields(&command);
+            match class {
+                MachineCommandEventClass::DurableMutation => {
+                    emit_machine_mutation(workflow, operation_id.as_deref(), "started");
+                }
+                MachineCommandEventClass::Prepared => info!(
+                    event = "machine.workflow_transition",
+                    workflow,
+                    operation_id = operation_id.as_deref().unwrap_or(""),
+                    state = "started"
+                ),
+                MachineCommandEventClass::Read => {}
+            }
+            let result = execute_machine_command(&self.home, &self.daemon, command).await;
+            match class {
+                MachineCommandEventClass::DurableMutation if result.is_err() => {
+                    emit_machine_mutation(workflow, operation_id.as_deref(), "rejected");
+                }
+                MachineCommandEventClass::Prepared => info!(
+                    event = "machine.workflow_transition",
+                    workflow,
+                    operation_id = operation_id.as_deref().unwrap_or(""),
+                    state = if result.is_ok() {
+                        "prepared"
+                    } else {
+                        "rejected"
+                    }
+                ),
+                MachineCommandEventClass::Read => debug!(
+                    event = "machine.command_outcome",
+                    workflow,
+                    operation_id = operation_id.as_deref().unwrap_or(""),
+                    outcome = if result.is_ok() { "read" } else { "rejected" }
+                ),
+                MachineCommandEventClass::DurableMutation => {}
+            }
+            result.map_err(machine_error_from_anyhow)
         })
+    }
+}
+
+fn emit_machine_mutation(workflow: &str, operation_id: Option<&str>, state: &str) {
+    info!(
+        event = "machine.durable_mutation",
+        workflow,
+        operation_id = operation_id.unwrap_or(""),
+        state
+    );
+}
+
+fn emit_machine_ready() {
+    info!(event = "service.ready", listener_kind = "unix");
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MachineCommandEventClass {
+    Read,
+    Prepared,
+    DurableMutation,
+}
+
+fn machine_command_event_fields(
+    command: &MachineCommand,
+) -> (&'static str, Option<String>, MachineCommandEventClass) {
+    match command {
+        MachineCommand::AuditReconcile { correlation_id, .. } => (
+            "audit_reconcile",
+            Some(correlation_id.clone()),
+            MachineCommandEventClass::DurableMutation,
+        ),
+        MachineCommand::WalletCustody { kind, .. } => (
+            match kind {
+                MachineCustodyKind::New => "wallet_registration",
+                MachineCustodyKind::Import => "wallet_import",
+                MachineCustodyKind::Rebind => "credential_rebind",
+                MachineCustodyKind::Delete => "wallet_delete",
+            },
+            None,
+            MachineCommandEventClass::Prepared,
+        ),
+        MachineCommand::WalletMigrate { .. } => (
+            "credential_migration",
+            None,
+            MachineCommandEventClass::Prepared,
+        ),
+        MachineCommand::WalletPolicyPrepare { .. } => {
+            ("policy_update", None, MachineCommandEventClass::Prepared)
+        }
+        MachineCommand::WalletPolicyCommit { operation_id } => (
+            "policy_update",
+            Some(operation_id.clone()),
+            MachineCommandEventClass::DurableMutation,
+        ),
+        MachineCommand::WalletOutboxCancel { id, .. } => (
+            "wallet_outbox_cancel",
+            Some(id.clone()),
+            MachineCommandEventClass::DurableMutation,
+        ),
+        MachineCommand::WalletOutboxReplace { id, .. } => (
+            "wallet_outbox_replace",
+            Some(id.clone()),
+            MachineCommandEventClass::DurableMutation,
+        ),
+        MachineCommand::Ceremony {
+            action,
+            operation_id,
+        } => (
+            "ceremony",
+            Some(operation_id.clone()),
+            if matches!(action, MachineCeremonyAction::Cancel) {
+                MachineCommandEventClass::DurableMutation
+            } else {
+                MachineCommandEventClass::Read
+            },
+        ),
+        MachineCommand::Operation {
+            action,
+            operation_id,
+        } => (
+            "operation",
+            Some(operation_id.clone()),
+            if matches!(action, MachineOperationAction::Cancel) {
+                MachineCommandEventClass::DurableMutation
+            } else {
+                MachineCommandEventClass::Read
+            },
+        ),
+        _ => ("read", None, MachineCommandEventClass::Read),
     }
 }
 
@@ -1055,17 +1183,18 @@ async fn execute_machine_command(
             correlation_id,
             outcome,
             confirm,
-        } => format!(
-            "{}\n",
-            execute_audit_command(
+        } => {
+            let output = execute_audit_command(
                 &AuditCmd::Reconcile {
-                    correlation_id,
+                    correlation_id: correlation_id.clone(),
                     outcome,
                     confirm,
                 },
                 daemon.audit.as_ref(),
-            )?
-        ),
+            )?;
+            emit_machine_mutation("audit_reconcile", Some(&correlation_id), "committed");
+            format!("{output}\n")
+        }
         MachineCommand::WalletList => {
             let mut output = String::new();
             for projection in daemon.wallet_projections.list_wallets().await? {
@@ -1178,7 +1307,9 @@ async fn execute_machine_command(
             assurance_level,
         } => prepare_policy_update(home, &name, &policy, &assurance_level).await?,
         MachineCommand::WalletPolicyCommit { operation_id } => {
-            commit_policy_update(home, operation_id).await?
+            let output = commit_policy_update(home, operation_id.clone()).await?;
+            emit_machine_mutation("policy_update", Some(&operation_id), "committed");
+            output
         }
         MachineCommand::WalletOutboxCancel {
             wallet,
@@ -1195,6 +1326,7 @@ async fn execute_machine_command(
                 text.as_bytes(),
             )
             .await?;
+            emit_machine_mutation("wallet_outbox_cancel", Some(&id), "committed");
             format!("cancel submitted for {id}\n")
         }
         MachineCommand::WalletOutboxReplace {
@@ -1212,28 +1344,49 @@ async fn execute_machine_command(
                 intent.as_bytes(),
             )
             .await?;
+            emit_machine_mutation("wallet_outbox_replace", Some(&id), "committed");
             format!("replacement submitted for {id}\n")
         }
         MachineCommand::Ceremony {
             action,
             operation_id,
         } => {
+            let mutation = matches!(action, MachineCeremonyAction::Cancel);
             let command = match action {
-                MachineCeremonyAction::Status => CeremonyCmd::Status { operation_id },
-                MachineCeremonyAction::Cancel => CeremonyCmd::Cancel { operation_id },
-                MachineCeremonyAction::Result => CeremonyCmd::Result { operation_id },
+                MachineCeremonyAction::Status => CeremonyCmd::Status {
+                    operation_id: operation_id.clone(),
+                },
+                MachineCeremonyAction::Cancel => CeremonyCmd::Cancel {
+                    operation_id: operation_id.clone(),
+                },
+                MachineCeremonyAction::Result => CeremonyCmd::Result {
+                    operation_id: operation_id.clone(),
+                },
             };
-            handle_ceremony(home, command).await?
+            let output = handle_ceremony(home, command).await?;
+            if mutation {
+                emit_machine_mutation("ceremony", Some(&operation_id), "committed");
+            }
+            output
         }
         MachineCommand::Operation {
             action,
             operation_id,
         } => {
+            let mutation = matches!(action, MachineOperationAction::Cancel);
             let command = match action {
-                MachineOperationAction::Status => OperationCmd::Status { operation_id },
-                MachineOperationAction::Cancel => OperationCmd::Cancel { operation_id },
+                MachineOperationAction::Status => OperationCmd::Status {
+                    operation_id: operation_id.clone(),
+                },
+                MachineOperationAction::Cancel => OperationCmd::Cancel {
+                    operation_id: operation_id.clone(),
+                },
             };
-            handle_operation(home, command).await?
+            let output = handle_operation(home, command).await?;
+            if mutation {
+                emit_machine_mutation("operation", Some(&operation_id), "committed");
+            }
+            output
         }
         MachineCommand::UpdateStatus => handle_update(home, UpdateCmd::Status).await?.0,
         MachineCommand::UpdateCheck => {
@@ -1420,6 +1573,13 @@ async fn prepare_policy_update(
     let mut operation_bytes = [0_u8; 32];
     rand::thread_rng().fill_bytes(&mut operation_bytes);
     let operation_id = bloom_broker_api::OperationId::from_bytes(operation_bytes);
+    info!(
+        event = "machine.policy_update.transition",
+        operation_id = operation_id.as_str(),
+        wallet_id = wallet_id.as_str(),
+        baseline_version = baseline.version.get(),
+        state = "validation_requested"
+    );
     let request = bloom_broker_api::PolicyUpdateRequest {
         operation_id,
         wallet_id,
@@ -1437,6 +1597,12 @@ async fn prepare_policy_update(
         .await
         .map_err(anyhow::Error::new)
         .context("validate policy update and prepare Broker-originated custody ceremony")?;
+    info!(
+        event = "machine.policy_update.transition",
+        operation_id = response.operation_id.as_str(),
+        wallet_id = requested_name,
+        state = "ceremony_prepared"
+    );
     let projection =
         bloom_machine_client::CeremonyProjection::from_policy_prepare(&response, current_unix_ms())
             .map_err(anyhow::Error::new)
@@ -1456,6 +1622,11 @@ async fn prepare_policy_update(
 async fn commit_policy_update(home: &HomeDir, operation_id: String) -> Result<String> {
     let operation_id = bloom_broker_api::OperationId::new(operation_id)
         .context("operation ID must be 64 lowercase hexadecimal characters")?;
+    info!(
+        event = "machine.policy_update.transition",
+        operation_id = operation_id.as_str(),
+        state = "commit_requested"
+    );
     let client = configured_broker_client(home).map_err(|error| {
         machine_error(
             MachineErrorKind::Unavailable,
@@ -1485,6 +1656,12 @@ async fn commit_policy_update(home: &HomeDir, operation_id: String) -> Result<St
     anyhow::ensure!(
         receipt.operation_id == operation_id,
         "Broker policy commit receipt operation identity mismatch"
+    );
+    info!(
+        event = "machine.policy_update.transition",
+        operation_id = operation_id.as_str(),
+        policy_version = receipt.committed.version.get(),
+        state = "committed"
     );
 
     if let Ok(status) = client.ceremony_status(operation_id.clone()).await {
@@ -2137,16 +2314,36 @@ enum WalletCmd {
 async fn main() -> ExitCode {
     let cli = Cli::parse();
 
-    // RUST_LOG wins when set; otherwise default to `info`, or `error`
-    // under `--quiet` so `vfs cat`/`ls` output stays clean.
-    let default_level = if cli.quiet { "error" } else { "info" };
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_level)),
-        )
-        .with_target(false)
-        .with_writer(std::io::stderr)
-        .try_init();
+    let role = long_running_role(&cli);
+    if let Some(role) = role {
+        let output = if std::env::var("BLOOM_LOG_OUTPUT").as_deref() == Ok("json-stderr") {
+            LogOutput::JsonStderr
+        } else {
+            LogOutput::Interactive
+        };
+        if let Err(error) =
+            bloom_service_observability::init(role, env!("CARGO_PKG_VERSION"), output)
+        {
+            let _ = error;
+            eprintln!("Bloom service logging initialization failed");
+            return ExitCode::FAILURE;
+        }
+        if matches!(role, "session-sentinel" | "containment-monitor") {
+            native_lifecycle(role, "startup");
+        }
+    } else {
+        // Interactive commands retain the existing human-readable stderr and
+        // quiet behavior. Service startup uses the shared initializer above.
+        let default_level = if cli.quiet { "error" } else { "info" };
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::try_from_default_env()
+                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(default_level)),
+            )
+            .with_target(false)
+            .with_writer(std::io::stderr)
+            .try_init();
+    }
 
     match run(cli).await {
         Ok(()) => {
@@ -2157,9 +2354,59 @@ async fn main() -> ExitCode {
             ExitCode::SUCCESS
         }
         Err(e) => {
-            eprintln!("error: {:#}", e);
+            if let Some(role) = role {
+                tracing::error!(
+                    event = "service.fatal_exit",
+                    service_role = role,
+                    error_kind = "runtime"
+                );
+                if matches!(role, "session-sentinel" | "containment-monitor") {
+                    native_lifecycle(role, "fatal_exit");
+                }
+            }
+            if role.is_some() {
+                eprintln!("Bloom service exited after a runtime failure");
+            } else {
+                eprintln!("error: {:#}", e);
+            }
             ExitCode::FAILURE
         }
+    }
+}
+
+fn long_running_role(cli: &Cli) -> Option<&'static str> {
+    match cli.cmd.as_ref()? {
+        Cmd::Serve { internal: None, .. } => Some("machine"),
+        Cmd::Serve {
+            internal: Some(ServeInternal::TriadPfMonitor),
+            ..
+        } => Some("containment-monitor"),
+        Cmd::Serve {
+            internal: Some(ServeInternal::SessionSentinel),
+            ..
+        } => Some("session-sentinel"),
+        _ => None,
+    }
+}
+
+fn structured_service_output() -> bool {
+    std::env::var("BLOOM_LOG_OUTPUT").as_deref() == Ok("json-stderr")
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn native_lifecycle(category: &str, event: &str) {
+    oslog::OsLog::new("com.bloom.triad", category).default(event);
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn native_lifecycle(_category: &str, _event: &str) {}
+
+pub(crate) async fn termination_signal() -> Result<()> {
+    use tokio::signal::unix::{SignalKind, signal};
+    let mut sigterm = signal(SignalKind::terminate()).context("register SIGTERM handler")?;
+    tokio::select! {
+        result = tokio::signal::ctrl_c() => result.context("wait for Ctrl-C"),
+        _ = sigterm.recv() => Ok(()),
     }
 }
 
@@ -2394,6 +2641,7 @@ async fn run(cli: Cli) -> Result<()> {
         "--version cannot be combined with a command"
     );
     let lifecycle_command = matches!(cli.cmd.as_ref(), Some(Cmd::Init { .. } | Cmd::Serve { .. }));
+    let is_long_running = long_running_role(&cli).is_some();
     let (connect, ipc_socket) = if lifecycle_command {
         (None, None)
     } else if cli.connect.is_some() {
@@ -2421,7 +2669,9 @@ async fn run(cli: Cli) -> Result<()> {
         resolve_client_endpoint(&home, connect.as_deref(), ipc_socket.as_deref())
             .context("resolve Bloom endpoint")?
     };
-    trace!(cmd = ?cli.cmd, home = %home.root().display(), "cli.dispatch");
+    if !is_long_running {
+        trace!(cmd = ?cli.cmd, home = %home.root().display(), "cli.dispatch");
+    }
 
     if cli.version {
         let client_protocol = IpcProtocolRange::supported();
@@ -2522,7 +2772,9 @@ async fn run(cli: Cli) -> Result<()> {
                     .context("Bloom macOS identity rotation generation failed"),
                 };
             }
-            eprintln!("{ALPHA_DISCLOSURE}");
+            if !structured_service_output() {
+                eprintln!("{ALPHA_DISCLOSURE}");
+            }
             let (_home_permit, d) = build_write_daemon(home.clone()).context("init daemon")?;
             let preinstalled = github_source::ensure_preinstalled_petals(&home, &d)
                 .context("provision configured pre-installed Petals")?;
@@ -3036,27 +3288,52 @@ async fn run(cli: Cli) -> Result<()> {
                         .context("Bloom session sentinel failed"),
                 };
             }
-            eprintln!("{ALPHA_DISCLOSURE}");
+            if !structured_service_output() {
+                eprintln!("{ALPHA_DISCLOSURE}");
+            }
             let (_home_permit, d) = build_write_daemon(home.clone())?;
             github_source::ensure_preinstalled_petals(&home, &d)
                 .context("provision configured pre-installed Petals before serving")?;
             let mount_handle =
                 mount_bloom(&d, mount.as_deref(), mount_nfs_listen, mount_from_fstab).await?;
             let chains: Vec<String> = d.chains.list_names();
-            println!(
-                "bloom serve: home={} chains={:?}",
-                d.home.root().display(),
-                chains
-            );
-            if let Some(mount_path) = mount.as_deref() {
-                println!("mount: {}", mount_path.display());
+            if !structured_service_output() {
+                println!(
+                    "bloom serve: home={} chains={:?}",
+                    d.home.root().display(),
+                    chains
+                );
+                if let Some(mount_path) = mount.as_deref() {
+                    println!("mount: {}", mount_path.display());
+                }
             }
             let endpoint = resolve_server_endpoint(&d.home, endpoint.as_deref())
                 .context("resolve serve endpoint")?;
             let socket = endpoint.socket.clone();
-            println!("ipc endpoint: {}", endpoint.display);
-            println!("ipc socket: {}", socket.display());
-            info!(home = %d.home.root().display(), chains = ?chains, endpoint = %endpoint.display, socket = %socket.display(), mount = ?mount, "cli.serve.starting");
+            if !structured_service_output() {
+                println!("ipc endpoint: {}", endpoint.display);
+                println!("ipc socket: {}", socket.display());
+            }
+            let release_digest = std::env::var("BLOOM_RELEASE_DIGEST").ok();
+            info!(
+                event = "service.identity_loaded",
+                service_id = "bloom-machine",
+                enrolled_login_uid = rustix::process::geteuid().as_raw(),
+                release_digest = release_digest.as_deref()
+            );
+            let service_span = bloom_service_observability::service_span(
+                "machine",
+                env!("CARGO_PKG_VERSION"),
+                "bloom-machine",
+                Some(rustix::process::geteuid().as_raw()),
+                release_digest.as_deref(),
+            );
+            info!(
+                event = "service.configuration_loaded",
+                chain_count = chains.len(),
+                listener_kind = "unix",
+                mount_enabled = mount.is_some()
+            );
             let server = IpcServer::new(d.vfs.clone(), env!("CARGO_PKG_VERSION"), chains)
                 .with_petals(d.petals.clone())
                 .with_petal_runtime_endpoints(
@@ -3077,42 +3354,62 @@ async fn run(cli: Cli) -> Result<()> {
                 .with_machine_commands(Arc::new(DaemonMachineCommands {
                     home: home.clone(),
                     daemon: d.clone(),
-                }));
+                }))
+                .with_ready_callback(Arc::new(emit_machine_ready));
             // Start audited and durable background effects only after every
             // fallible serve setup step has succeeded. The handle is shut
             // down and awaited before the runtime can return.
-            let sweeper = d.spawn_background_tasks();
+            let sweeper = {
+                let _entered = service_span.enter();
+                d.spawn_background_tasks()
+            };
             let server2 = server.clone();
             // Trigger graceful shutdown on Ctrl-C or SIGTERM.
-            let shutdown = tokio::spawn(async move {
-                #[cfg(unix)]
-                {
-                    use tokio::signal::unix::{SignalKind, signal};
-                    let mut sigterm = signal(SignalKind::terminate())
-                        .expect("SIGTERM handler registration failed");
-                    tokio::select! {
-                        _ = tokio::signal::ctrl_c() => info!("cli.serve.ctrl_c_received"),
-                        _ = sigterm.recv() => info!("cli.serve.sigterm_received"),
+            let shutdown_span = service_span.clone();
+            let shutdown = tokio::spawn(
+                async move {
+                    #[cfg(unix)]
+                    {
+                        use tokio::signal::unix::{SignalKind, signal};
+                        let mut sigterm = signal(SignalKind::terminate())
+                            .expect("SIGTERM handler registration failed");
+                        tokio::select! {
+                            _ = tokio::signal::ctrl_c() => info!("cli.serve.ctrl_c_received"),
+                            _ = sigterm.recv() => info!("cli.serve.sigterm_received"),
+                        }
                     }
+                    #[cfg(not(unix))]
+                    {
+                        let _ = tokio::signal::ctrl_c().await;
+                        info!("cli.serve.ctrl_c_received");
+                    }
+                    server2.trigger_shutdown();
                 }
-                #[cfg(not(unix))]
-                {
-                    let _ = tokio::signal::ctrl_c().await;
-                    info!("cli.serve.ctrl_c_received");
-                }
-                server2.trigger_shutdown();
-            });
-            let serve_result = server.serve(&socket).await.context("ipc serve");
+                .instrument(shutdown_span),
+            );
+            let serve_result = async { server.serve(&socket).await }
+                .instrument(service_span.clone())
+                .await
+                .context("ipc serve");
             shutdown.abort();
             // Stop the outbox expiry sweeper (fix #3) and any other
             // daemon-owned workers (watch executor, etc., fix #6).
-            let unmount_result = unmount_bloom(mount_handle).await;
-            sweeper.shutdown().await;
-            d.shutdown().await;
+            let unmount_result = async {
+                let result = unmount_bloom(mount_handle).await;
+                sweeper.shutdown().await;
+                d.shutdown().await;
+                result
+            }
+            .instrument(service_span.clone())
+            .await;
             serve_result?;
             unmount_result?;
-            info!("cli.serve.shutdown_complete");
-            println!("shutting down");
+            service_span.in_scope(|| {
+                info!(event = "service.shutdown", "cli.serve.shutdown_complete");
+            });
+            if !structured_service_output() {
+                println!("shutting down");
+            }
             Ok(())
         }
         Cmd::Update(cmd) => {
@@ -3698,15 +3995,19 @@ mod tests {
 
     use async_trait::async_trait;
     use clap::Parser as _;
+    use tracing::info;
+    use tracing_subscriber::prelude::*;
 
     use super::{
-        Cli, Cmd, LegacyMigrationReceiptFile, WalletCmd, ceremony_projection_path,
-        endpoint_connection_error, enrollment_state_is_usable, execute_audit_command,
-        execute_wallet_outbox_action, format_petal_consent_net_rule,
-        is_completed_policy_update_receipt, launch_wallet_registration_via_vfs,
-        load_ceremony_projection, machine_error_from_anyhow, machine_wallet_lookup_error,
+        Cli, Cmd, LegacyMigrationReceiptFile, MachineCommandEventClass, WalletCmd,
+        ceremony_projection_path, emit_machine_ready, endpoint_connection_error,
+        enrollment_state_is_usable, execute_audit_command, execute_wallet_outbox_action,
+        format_petal_consent_net_rule, is_completed_policy_update_receipt,
+        launch_wallet_registration_via_vfs, load_ceremony_projection, long_running_role,
+        machine_command_event_fields, machine_error_from_anyhow, machine_wallet_lookup_error,
         open_machine_audit_with_history, persist_ceremony_projection, request_body_with_wallet,
     };
+    use bloom_daemon::ipc::{MachineCeremonyAction, MachineCommand, MachineOperationAction};
 
     #[derive(Default)]
     struct RecordingOutboxHandler(Mutex<Vec<(String, Vec<u8>)>>);
@@ -4230,6 +4531,95 @@ mod tests {
             Cli::try_parse_from(["bloom", "wallet", "sign-policy", "wallet"]).is_err(),
             "the legacy direct policy-signing path must stay removed"
         );
+    }
+
+    #[test]
+    fn only_long_running_modes_use_service_observability() {
+        let machine = Cli::try_parse_from(["bloom", "serve"]).unwrap();
+        assert_eq!(long_running_role(&machine), Some("machine"));
+        let session = Cli::try_parse_from(["bloom", "serve", "session-sentinel"]).unwrap();
+        assert_eq!(long_running_role(&session), Some("session-sentinel"));
+        let containment = Cli::try_parse_from(["bloom", "serve", "triad-pf-monitor"]).unwrap();
+        assert_eq!(long_running_role(&containment), Some("containment-monitor"));
+        let status = Cli::try_parse_from(["bloom", "status"]).unwrap();
+        assert_eq!(long_running_role(&status), None);
+    }
+
+    #[test]
+    fn machine_events_keep_metadata_and_omit_policy_marker_secret() {
+        let capture = bloom_service_observability::CapturedWriter::default();
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .json()
+                .with_current_span(true)
+                .with_span_list(true)
+                .with_writer(capture.clone()),
+        );
+        let marker = "BLOOM_MARKER_POLICY_SECRET_7f82";
+        let operation_id = "ab".repeat(32);
+        let command = MachineCommand::WalletPolicyPrepare {
+            name: "main".into(),
+            policy: marker.as_bytes().to_vec(),
+            assurance_level: "user_verified".into(),
+        };
+        tracing::subscriber::with_default(subscriber, || {
+            let service = bloom_service_observability::service_span(
+                "machine",
+                "1.2.3",
+                "bloom-machine",
+                Some(501),
+                Some("cdcd"),
+            );
+            let _entered = service.enter();
+            emit_machine_ready();
+            let (workflow, _, class) = machine_command_event_fields(&command);
+            assert_eq!(class, MachineCommandEventClass::Prepared);
+            info!(
+                event = "machine.workflow_transition",
+                workflow,
+                operation_id = operation_id.as_str(),
+                state = "prepared"
+            );
+        });
+        let output = capture.text();
+        assert!(!output.contains(marker));
+        let events = output
+            .lines()
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+            .collect::<Vec<_>>();
+        assert!(events.iter().any(|event| {
+            event["fields"]["event"] == "service.ready"
+                && event["spans"].as_array().is_some_and(|spans| {
+                    spans.iter().any(|span| {
+                        span["service_id"] == "bloom-machine" && span["enrolled_login_uid"] == 501
+                    })
+                })
+        }));
+        assert!(events.iter().any(|event| {
+            event["fields"]["event"] == "machine.workflow_transition"
+                && event["fields"]["operation_id"] == operation_id
+                && event["fields"]["workflow"] == "policy_update"
+                && event["fields"]["state"] == "prepared"
+        }));
+        for command in [
+            MachineCommand::Ceremony {
+                action: MachineCeremonyAction::Status,
+                operation_id: operation_id.clone(),
+            },
+            MachineCommand::Ceremony {
+                action: MachineCeremonyAction::Result,
+                operation_id: operation_id.clone(),
+            },
+            MachineCommand::Operation {
+                action: MachineOperationAction::Status,
+                operation_id,
+            },
+        ] {
+            assert_eq!(
+                machine_command_event_fields(&command).2,
+                MachineCommandEventClass::Read
+            );
+        }
     }
 
     #[test]

--- a/crates/bloom/src/pf_monitor.rs
+++ b/crates/bloom/src/pf_monitor.rs
@@ -45,11 +45,28 @@ pub async fn run() -> Result<()> {
     if std::env::consts::OS != "macos" {
         bail!("the packet-filter monitor requires macOS");
     }
+    tracing::info!(event = "service.ready", monitor = "packet-filter");
+    crate::native_lifecycle("containment-monitor", "ready");
+    let mut interval = tokio::time::interval(MONITOR_INTERVAL);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     loop {
-        if let Err(error) = run_once() {
-            eprintln!("Bloom packet-filter monitor refresh failed: {error:#}");
+        tokio::select! {
+            result = crate::termination_signal() => {
+                result.context("wait for containment shutdown signal")?;
+                tracing::info!(event = "service.shutdown", reason = "signal");
+                crate::native_lifecycle("containment-monitor", "shutdown");
+                return Ok(());
+            }
+            _ = interval.tick() => {
+                if let Err(error) = run_once() {
+                    let _ = error;
+                    tracing::warn!(
+                        event = "containment.refresh_failed",
+                        error_kind = "platform_status"
+                    );
+                }
+            }
         }
-        tokio::time::sleep(MONITOR_INTERVAL).await;
     }
 }
 

--- a/crates/bloom/src/session_sentinel.rs
+++ b/crates/bloom/src/session_sentinel.rs
@@ -129,7 +129,23 @@ pub async fn run() -> Result<()> {
         gid: socket_gid,
     };
 
-    serve_authenticated_services(listener, identity, [broker_acl, signer_acl]).await
+    tracing::info!(
+        event = "service.identity_loaded",
+        service_id = identity.service_id.as_str(),
+        enrolled_login_uid = effective_uid
+    );
+    tracing::info!(event = "service.ready", listener_kind = "unix");
+    crate::native_lifecycle("session-sentinel", "ready");
+
+    tokio::select! {
+        result = serve_authenticated_services(listener, identity, [broker_acl, signer_acl]) => result,
+        result = crate::termination_signal() => {
+            result.context("wait for session sentinel shutdown signal")?;
+            tracing::info!(event = "service.shutdown", reason = "signal");
+            crate::native_lifecycle("session-sentinel", "shutdown");
+            Ok(())
+        }
+    }
 }
 
 async fn serve_authenticated_services(
@@ -187,11 +203,14 @@ async fn serve_authenticated_services(
                     service_id = peer.service_id.as_str(),
                     "session_sentinel.unexpected_channel_data"
                 ),
-                Err(error) => tracing::warn!(
-                    %error,
-                    service_id = peer.service_id.as_str(),
-                    "session_sentinel.monitor_failed"
-                ),
+                Err(error) => {
+                    let _ = error;
+                    tracing::warn!(
+                        error_kind = "channel_read",
+                        service_id = peer.service_id.as_str(),
+                        "session_sentinel.monitor_failed"
+                    )
+                }
             }
         });
     }

--- a/crates/bloom/tests/cli.rs
+++ b/crates/bloom/tests/cli.rs
@@ -1664,10 +1664,11 @@ fn serve_refuses_when_home_write_lock_is_live() {
     let lock = home.path().join("run").join(".daemon.lock");
 
     let mut command = bloom_cmd(home.path());
-    command.arg("serve");
+    command.env("BLOOM_LOG_OUTPUT", "json-stderr").arg("serve");
     command.assert().failure().stderr(
-        predicate::str::contains("already open for writing")
-            .and(predicate::str::contains(lock.display().to_string())),
+        predicate::str::contains("Bloom service exited after a runtime failure")
+            .and(predicate::str::contains("service.fatal_exit"))
+            .and(predicate::str::contains(lock.display().to_string()).not()),
     );
 }
 

--- a/packaging/triad/linux/README.md
+++ b/packaging/triad/linux/README.md
@@ -90,3 +90,16 @@ service's state root and passes its absolute path through
 its checkpoint records. In particular, the Machine login and Broker cannot
 read the Signer checkpoint root. Runtime checkpoint writes reject symlinks,
 non-owned directories, sequence rollback, and replacement.
+
+## Service logs
+
+Machine, Broker, Signer, and the session sentinel emit JSON Lines to journald
+under stable identifiers. For example:
+
+```sh
+journalctl --user -u bloom-machine.service -o cat
+sudo journalctl -t bloom-broker-$(id -u) -o cat
+sudo journalctl -t bloom-signer-$(id -u) -o cat
+```
+
+Journal persistence, retention, and read access remain host policy.

--- a/packaging/triad/linux/systemd-user/bloom-machine.service
+++ b/packaging/triad/linux/systemd-user/bloom-machine.service
@@ -8,7 +8,11 @@ After=bloom-session.service network-online.target
 Type=simple
 EnvironmentFile=/etc/bloom/%U/machine.env
 Environment=BLOOM_MOUNT_FROM_FSTAB=true
+Environment=BLOOM_LOG_OUTPUT=json-stderr
 ExecStart=/usr/bin/bloom serve --mount %h/bloom
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=bloom-machine
 Restart=on-failure
 RestartSec=5s
 UMask=0077

--- a/packaging/triad/linux/systemd-user/bloom-session.service
+++ b/packaging/triad/linux/systemd-user/bloom-session.service
@@ -5,6 +5,10 @@ ConditionPathExists=/etc/bloom/%U/edge-manifest.json
 [Service]
 Type=simple
 ExecStart=/usr/libexec/bloom/bloom serve session-sentinel
+Environment=BLOOM_LOG_OUTPUT=json-stderr
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=bloom-session
 Restart=on-failure
 RestartSec=5s
 UMask=0077

--- a/packaging/triad/linux/systemd/bloom-broker@.service.in
+++ b/packaging/triad/linux/systemd/bloom-broker@.service.in
@@ -9,6 +9,9 @@ User=bloom-broker-%i
 Group=bloom-broker-%i
 UMask=0077
 ExecStart=@BLOOM_BROKER_BINARY@
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=bloom-broker-%i
 Environment=BLOOM_BROKER_IDENTITY=/etc/bloom/%i/broker/identity.json
 Environment=BLOOM_BROKER_CONFIG=/etc/bloom/%i/broker/config.json
 Environment=BLOOM_EDGE_MANIFEST=/etc/bloom/%i/edge-manifest.json

--- a/packaging/triad/linux/systemd/bloom-signer@.service.in
+++ b/packaging/triad/linux/systemd/bloom-signer@.service.in
@@ -7,6 +7,9 @@ User=bloom-signer-%i
 Group=bloom-signer-%i
 UMask=0077
 ExecStart=@BLOOM_SIGNER_BINARY@
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=bloom-signer-%i
 Environment=BLOOM_SIGNER_IDENTITY=/etc/bloom/%i/signer/identity.json
 Environment=BLOOM_SIGNER_CONFIG=/etc/bloom/%i/signer/config.json
 Environment=BLOOM_EDGE_MANIFEST=/etc/bloom/%i/edge-manifest.json

--- a/packaging/triad/macos/README.md
+++ b/packaging/triad/macos/README.md
@@ -107,3 +107,17 @@ Static template and staged-root tests are conformance inputs, not proof of an
 operating-system boundary. Tests that create accounts, load LaunchDaemons,
 change `pf`, or exercise multiple GUI users run only on disposable macOS VMs.
 The guarded harness and its current coverage are documented under `w0/`.
+
+## Service logs
+
+Broker and Signer write complete JSON Lines records to
+`/private/var/log/bloom/LOGIN_UID/{broker,signer}.jsonl`. The enrolled user can
+read these files without `sudo` but cannot modify them; service state remains
+private. Rotation is bounded by `/etc/newsyslog.d/bloom-LOGIN_UID.conf` and
+does not require restarting either daemon. Session and containment lifecycle
+messages use launchd's native process logging rather than the per-enrollment
+diagnostic files.
+
+Each daemon also has a small bounded `SERVICE-bootstrap.log` launchd stderr
+fallback. It is only for fixed, sanitized initialization failures that happen
+before the canonical app writer is available; routine events never use it.

--- a/packaging/triad/macos/launchdaemons/com.bloom.broker.plist.in
+++ b/packaging/triad/macos/launchdaemons/com.bloom.broker.plist.in
@@ -40,6 +40,12 @@
     <string>@BLOOM_SESSION_SOCKET@</string>
     <key>BLOOM_BROKER_STARTUP_STATUS</key>
     <string>@BLOOM_BROKER_STARTUP_STATUS@</string>
+    <key>BLOOM_BROKER_LOG_PATH</key>
+    <string>@BLOOM_BROKER_LOG_PATH@</string>
+    <key>BLOOM_BROKER_LOG_OWNER_UID</key>
+    <string>@BLOOM_BROKER_UID@</string>
+    <key>BLOOM_BROKER_LOG_READER_GID</key>
+    <string>@BLOOM_LOG_READER_GID@</string>
   </dict>
 
   <key>KeepAlive</key>
@@ -72,8 +78,8 @@
     <integer>64</integer>
   </dict>
   <key>StandardOutPath</key>
-  <string>@BLOOM_BROKER_LOG@</string>
+  <string>/dev/null</string>
   <key>StandardErrorPath</key>
-  <string>@BLOOM_BROKER_LOG@</string>
+  <string>@BLOOM_BROKER_BOOTSTRAP_LOG@</string>
 </dict>
 </plist>

--- a/packaging/triad/macos/launchdaemons/com.bloom.signer.plist.in
+++ b/packaging/triad/macos/launchdaemons/com.bloom.signer.plist.in
@@ -38,6 +38,12 @@
     <string>@BLOOM_SIGNER_CONTROL_SOCKET@</string>
     <key>BLOOM_SESSION_SOCKET</key>
     <string>@BLOOM_SESSION_SOCKET@</string>
+    <key>BLOOM_SIGNER_LOG_PATH</key>
+    <string>@BLOOM_SIGNER_LOG_PATH@</string>
+    <key>BLOOM_SIGNER_LOG_OWNER_UID</key>
+    <string>@BLOOM_SIGNER_UID@</string>
+    <key>BLOOM_SIGNER_LOG_READER_GID</key>
+    <string>@BLOOM_LOG_READER_GID@</string>
   </dict>
 
   <key>KeepAlive</key>
@@ -70,8 +76,8 @@
     <integer>64</integer>
   </dict>
   <key>StandardOutPath</key>
-  <string>@BLOOM_SIGNER_LOG@</string>
+  <string>/dev/null</string>
   <key>StandardErrorPath</key>
-  <string>@BLOOM_SIGNER_LOG@</string>
+  <string>@BLOOM_SIGNER_BOOTSTRAP_LOG@</string>
 </dict>
 </plist>

--- a/packaging/triad/macos/w0/run-packaged-machine-negative.sh
+++ b/packaging/triad/macos/w0/run-packaged-machine-negative.sh
@@ -271,6 +271,7 @@ sudo -H -u "$login_user" env \
   BLOOM_BROKER_SOCKET="$installed_broker_socket" \
   BLOOM_MACHINE_IDENTITY="$machine_identity" \
   BLOOM_EDGE_MANIFEST="$edge_manifest" \
+  BLOOM_LOG_OUTPUT=json-stderr \
   "$machine_binary" --home "$clean_home" serve \
     --endpoint "unix:$machine_socket" \
     >"$work/seed-machine-service.log" 2>&1 &
@@ -369,6 +370,72 @@ sudo -H -u "$login_user" env \
   "$machine_binary" --home "$clean_home" --connect "unix:$machine_socket" \
     wallet commit-policy "$policy_operation_id" \
   >"$work/policy-commit-live.log" 2>&1
+
+broker_log="/private/var/log/bloom/$login_uid/broker.jsonl"
+signer_log="/private/var/log/bloom/$login_uid/signer.jsonl"
+newsyslog_config="/etc/newsyslog.d/bloom-$login_uid.conf"
+for service_log in "$broker_log" "$signer_log"; do
+  sudo -u "$login_user" test -r "$service_log"
+  if sudo -u "$login_user" test -w "$service_log"; then
+    echo "enrolled user can write canonical service log $service_log" >&2
+    exit 1
+  fi
+done
+for protected_state in \
+  "/private/var/db/bloom/$login_uid/broker/journal.db" \
+  "/private/var/db/bloom/$login_uid/signer/journal.db"
+do
+  if sudo -u "$login_user" test -r "$protected_state"; then
+    echo "enrolled user can read protected service state $protected_state" >&2
+    exit 1
+  fi
+done
+grep -F "$policy_operation_id" "$broker_log" >/dev/null
+grep -F "$policy_operation_id" "$signer_log" >/dev/null
+/usr/bin/python3 - "$work/seed-machine-service.log" "$policy_operation_id" <<'PY'
+import json
+import pathlib
+import sys
+
+events = [json.loads(line) for line in pathlib.Path(sys.argv[1]).read_text().splitlines()]
+operation_id = sys.argv[2]
+if not any(
+    event.get("fields", {}).get("operation_id") == operation_id
+    and event.get("fields", {}).get("event") in {
+        "machine.policy_update.transition",
+        "machine.durable_mutation",
+        "rpc.request_completed",
+    }
+    for event in events
+):
+    raise SystemExit("Machine structured log omitted the policy operation ID")
+PY
+
+# Force the package-owned rotation while both services remain loaded. Their
+# per-event writers must reopen the canonical path rather than retaining the
+# renamed inode.
+/usr/sbin/newsyslog -F -f "$newsyslog_config"
+sudo -u "$login_user" "$machine_binary" serve triad-health-check "$(
+  plutil -extract build_digest raw -o - \
+    "/Library/Application Support/BloomTriad/config/$login_uid/broker/config.json"
+)" >/dev/null
+/usr/bin/python3 - "$broker_log.0" "$signer_log.0" "$broker_log" "$signer_log" <<'PY'
+import json
+import pathlib
+import sys
+
+for raw in sys.argv[1:]:
+    path = pathlib.Path(raw)
+    lines = path.read_text().splitlines()
+    if not lines:
+        raise SystemExit(f"rotated/current service log is empty: {path}")
+    for line in lines:
+        json.loads(line)
+PY
+for service_log in "$broker_log" "$signer_log"; do
+  sudo -u "$login_user" test -r "$service_log"
+  if sudo -u "$login_user" test -w "$service_log"; then exit 1; fi
+done
 sudo -H -u "$login_user" env \
   BLOOM_HOME="$clean_home" \
   BLOOM_MACHINE_IDENTITY="$machine_identity" \

--- a/packaging/triad/release/check-external-pins.py
+++ b/packaging/triad/release/check-external-pins.py
@@ -15,8 +15,8 @@ ROOT = pathlib.Path(__file__).resolve().parents[3]
 COMPAT = ROOT / "packaging/triad/release/compatibility-v1.toml"
 FULL = re.compile(r"^[0-9a-f]{40}$")
 EXPECTED = {
-    "broker_commit": ("bloom-directory/bloom-broker", "77c30ccedbd6904c0f2f2ad19e48c5587061b04e"),
-    "signer_commit": ("bloom-directory/bloom-signer", "f5139960b9c5b59803ad54a1ecc9ef4e86f82d0c"),
+    "broker_commit": ("bloom-directory/bloom-broker", "50050a272b90d2b0473d25c1014886a0ea8ae7d7"),
+    "signer_commit": ("bloom-directory/bloom-signer", "3e9473ce4354dfd17303c5ea68ed8218417c0b49"),
     "service_runtime_commit": ("bloom-directory/bloom-service-runtime", "bc88cc6760b00bbff0c6a6e5f56d42bb03004436"),
     "petal_contract_commit": ("bloom-directory/petal", "61938d0c127cfe03c7e3e55baed0ba1439bc5ca2"),
 }

--- a/packaging/triad/release/check-external-pins.py
+++ b/packaging/triad/release/check-external-pins.py
@@ -15,9 +15,9 @@ ROOT = pathlib.Path(__file__).resolve().parents[3]
 COMPAT = ROOT / "packaging/triad/release/compatibility-v1.toml"
 FULL = re.compile(r"^[0-9a-f]{40}$")
 EXPECTED = {
-    "broker_commit": ("bloom-directory/bloom-broker", "bdf5d36b48f6a476539ff992084c483becd67629"),
-    "signer_commit": ("bloom-directory/bloom-signer", "a9dcbbfef8a4057b9e6f94b17e010f051f7ab32e"),
-    "service_runtime_commit": ("bloom-directory/bloom-service-runtime", "d8229e51d80971505af69c387818334a3c44aef0"),
+    "broker_commit": ("bloom-directory/bloom-broker", "f001cb9242c60d3d80c348506d329fdcfb126eb0"),
+    "signer_commit": ("bloom-directory/bloom-signer", "b261bcf0467fb369904b05ed34622b9393c36764"),
+    "service_runtime_commit": ("bloom-directory/bloom-service-runtime", "67727b20476a5e12beea4be9734afd83bf74dea4"),
     "petal_contract_commit": ("bloom-directory/petal", "61938d0c127cfe03c7e3e55baed0ba1439bc5ca2"),
 }
 

--- a/packaging/triad/release/check-external-pins.py
+++ b/packaging/triad/release/check-external-pins.py
@@ -17,7 +17,7 @@ FULL = re.compile(r"^[0-9a-f]{40}$")
 EXPECTED = {
     "broker_commit": ("bloom-directory/bloom-broker", "77c30ccedbd6904c0f2f2ad19e48c5587061b04e"),
     "signer_commit": ("bloom-directory/bloom-signer", "f5139960b9c5b59803ad54a1ecc9ef4e86f82d0c"),
-    "service_runtime_commit": ("bloom-directory/bloom-service-runtime", "d2542a07a988261fe2f82b738462de2127b317d2"),
+    "service_runtime_commit": ("bloom-directory/bloom-service-runtime", "bc88cc6760b00bbff0c6a6e5f56d42bb03004436"),
     "petal_contract_commit": ("bloom-directory/petal", "61938d0c127cfe03c7e3e55baed0ba1439bc5ca2"),
 }
 

--- a/packaging/triad/release/check-external-pins.py
+++ b/packaging/triad/release/check-external-pins.py
@@ -15,9 +15,9 @@ ROOT = pathlib.Path(__file__).resolve().parents[3]
 COMPAT = ROOT / "packaging/triad/release/compatibility-v1.toml"
 FULL = re.compile(r"^[0-9a-f]{40}$")
 EXPECTED = {
-    "broker_commit": ("bloom-directory/bloom-broker", "f001cb9242c60d3d80c348506d329fdcfb126eb0"),
-    "signer_commit": ("bloom-directory/bloom-signer", "b261bcf0467fb369904b05ed34622b9393c36764"),
-    "service_runtime_commit": ("bloom-directory/bloom-service-runtime", "67727b20476a5e12beea4be9734afd83bf74dea4"),
+    "broker_commit": ("bloom-directory/bloom-broker", "77c30ccedbd6904c0f2f2ad19e48c5587061b04e"),
+    "signer_commit": ("bloom-directory/bloom-signer", "f5139960b9c5b59803ad54a1ecc9ef4e86f82d0c"),
+    "service_runtime_commit": ("bloom-directory/bloom-service-runtime", "d2542a07a988261fe2f82b738462de2127b317d2"),
     "petal_contract_commit": ("bloom-directory/petal", "61938d0c127cfe03c7e3e55baed0ba1439bc5ca2"),
 }
 

--- a/packaging/triad/release/compatibility-v1.toml
+++ b/packaging/triad/release/compatibility-v1.toml
@@ -1,9 +1,9 @@
 schema = "bloom.triad-compatibility/1"
 
 [revisions]
-broker_commit = "bdf5d36b48f6a476539ff992084c483becd67629"
-signer_commit = "a9dcbbfef8a4057b9e6f94b17e010f051f7ab32e"
-service_runtime_commit = "d8229e51d80971505af69c387818334a3c44aef0"
+broker_commit = "f001cb9242c60d3d80c348506d329fdcfb126eb0"
+signer_commit = "b261bcf0467fb369904b05ed34622b9393c36764"
+service_runtime_commit = "67727b20476a5e12beea4be9734afd83bf74dea4"
 petal_contract_commit = "61938d0c127cfe03c7e3e55baed0ba1439bc5ca2"
 
 [state.machine]

--- a/packaging/triad/release/compatibility-v1.toml
+++ b/packaging/triad/release/compatibility-v1.toml
@@ -1,9 +1,9 @@
 schema = "bloom.triad-compatibility/1"
 
 [revisions]
-broker_commit = "f001cb9242c60d3d80c348506d329fdcfb126eb0"
-signer_commit = "b261bcf0467fb369904b05ed34622b9393c36764"
-service_runtime_commit = "67727b20476a5e12beea4be9734afd83bf74dea4"
+broker_commit = "77c30ccedbd6904c0f2f2ad19e48c5587061b04e"
+signer_commit = "f5139960b9c5b59803ad54a1ecc9ef4e86f82d0c"
+service_runtime_commit = "d2542a07a988261fe2f82b738462de2127b317d2"
 petal_contract_commit = "61938d0c127cfe03c7e3e55baed0ba1439bc5ca2"
 
 [state.machine]

--- a/packaging/triad/release/compatibility-v1.toml
+++ b/packaging/triad/release/compatibility-v1.toml
@@ -1,8 +1,8 @@
 schema = "bloom.triad-compatibility/1"
 
 [revisions]
-broker_commit = "77c30ccedbd6904c0f2f2ad19e48c5587061b04e"
-signer_commit = "f5139960b9c5b59803ad54a1ecc9ef4e86f82d0c"
+broker_commit = "50050a272b90d2b0473d25c1014886a0ea8ae7d7"
+signer_commit = "3e9473ce4354dfd17303c5ea68ed8218417c0b49"
 service_runtime_commit = "bc88cc6760b00bbff0c6a6e5f56d42bb03004436"
 petal_contract_commit = "61938d0c127cfe03c7e3e55baed0ba1439bc5ca2"
 

--- a/packaging/triad/release/compatibility-v1.toml
+++ b/packaging/triad/release/compatibility-v1.toml
@@ -3,7 +3,7 @@ schema = "bloom.triad-compatibility/1"
 [revisions]
 broker_commit = "77c30ccedbd6904c0f2f2ad19e48c5587061b04e"
 signer_commit = "f5139960b9c5b59803ad54a1ecc9ef4e86f82d0c"
-service_runtime_commit = "d2542a07a988261fe2f82b738462de2127b317d2"
+service_runtime_commit = "bc88cc6760b00bbff0c6a6e5f56d42bb03004436"
 petal_contract_commit = "61938d0c127cfe03c7e3e55baed0ba1439bc5ca2"
 
 [state.machine]

--- a/packaging/triad/release/install-linux.sh
+++ b/packaging/triad/release/install-linux.sh
@@ -694,7 +694,8 @@ case "$action" in
     mkdir -p "$installed_config_root"
     chmod 0711 "$installed_config_root"
     machine_environment="$installed_config_root/.machine-env.source.$$"
-    printf 'BLOOM_NFS_LISTEN=127.0.0.1:%s\n' "$nfs_port" > "$machine_environment"
+    printf 'BLOOM_NFS_LISTEN=127.0.0.1:%s\nBLOOM_RELEASE_DIGEST=%s\n' \
+      "$nfs_port" "$release_digest" > "$machine_environment"
     atomic_install "$machine_environment" "$installed_config_root/machine.env" 0644
     rm -f -- "$machine_environment"
     install_linux_mount_authorization \

--- a/packaging/triad/release/install-macos.sh
+++ b/packaging/triad/release/install-macos.sh
@@ -143,8 +143,13 @@ load_ids() {
   BLOOM_MACOS_MACHINE_BROKER_GID="$(field "$enrollment" machine_broker_gid)"
   BLOOM_MACOS_BROKER_SIGNER_GID="$(field "$enrollment" broker_signer_gid)"
   BLOOM_MACOS_REVOKE_GID="$(field "$enrollment" revoke_gid)"
-  if BLOOM_MACOS_LOG_GID="$(field "$enrollment" log_gid 2>/dev/null)"; then return; fi
-  if [[ "$action" == uninstall ]]; then BLOOM_MACOS_LOG_GID=0; return; fi
+  if recorded_log_gid="$(field "$enrollment" log_gid 2>/dev/null)"; then
+    BLOOM_MACOS_LOG_GID="$recorded_log_gid"
+    return
+  fi
+  # Retained legacy records must remain legacy-shaped. Restore will then
+  # allocate/migrate the missing log group instead of trusting a fake GID.
+  if [[ "$action" == uninstall ]]; then BLOOM_MACOS_LOG_GID=""; return; fi
   if $live; then
     record_exists Groups "$log_group" && die "legacy enrollment has an unrecorded log group"
     BLOOM_MACOS_LOG_GID="$(next_id Groups PrimaryGroupID)"; new_group "$log_group" "$BLOOM_MACOS_LOG_GID"
@@ -308,11 +313,16 @@ rollback_failed_restore() {
 
 write_enrollment() {
   state="$1"; tmp="$enrollment.new.$$"
-  printf '{"schema":"bloom.macos-enrollment.1","state":"%s","login_uid":%s,"login_user":"%s","broker_user":"%s","broker_uid":%s,"broker_group":"%s","broker_gid":%s,"signer_user":"%s","signer_uid":%s,"signer_group":"%s","signer_gid":%s,"machine_broker_group":"%s","machine_broker_gid":%s,"broker_signer_group":"%s","broker_signer_gid":%s,"revoke_group":"%s","revoke_gid":%s,"log_group":"%s","log_gid":%s,"release_digest":"%s"}\n' \
+  if [[ -n "${BLOOM_MACOS_LOG_GID:-}" ]]; then
+    log_fields=",\"log_group\":\"$log_group\",\"log_gid\":$BLOOM_MACOS_LOG_GID"
+  else
+    log_fields=""
+  fi
+  printf '{"schema":"bloom.macos-enrollment.1","state":"%s","login_uid":%s,"login_user":"%s","broker_user":"%s","broker_uid":%s,"broker_group":"%s","broker_gid":%s,"signer_user":"%s","signer_uid":%s,"signer_group":"%s","signer_gid":%s,"machine_broker_group":"%s","machine_broker_gid":%s,"broker_signer_group":"%s","broker_signer_gid":%s,"revoke_group":"%s","revoke_gid":%s%s,"release_digest":"%s"}\n' \
     "$state" "$login_uid" "$login_user" "$broker_user" "$BLOOM_MACOS_BROKER_UID" "$broker_group" "$BLOOM_MACOS_BROKER_GID" \
     "$signer_user" "$BLOOM_MACOS_SIGNER_UID" "$signer_group" "$BLOOM_MACOS_SIGNER_GID" "$machine_broker_group" \
     "$BLOOM_MACOS_MACHINE_BROKER_GID" "$broker_signer_group" "$BLOOM_MACOS_BROKER_SIGNER_GID" "$revoke_group" \
-    "$BLOOM_MACOS_REVOKE_GID" "$log_group" "$BLOOM_MACOS_LOG_GID" "$BLOOM_RELEASE_DIGEST" >"$tmp"
+    "$BLOOM_MACOS_REVOKE_GID" "$log_fields" "$BLOOM_RELEASE_DIGEST" >"$tmp"
   chmod 0644 "$tmp"; $live && chown root:wheel "$tmp"; mv -f "$tmp" "$enrollment"
 }
 

--- a/packaging/triad/release/install-macos.sh
+++ b/packaging/triad/release/install-macos.sh
@@ -15,7 +15,7 @@ usage:
 
 Staged-root tests also supply BLOOM_MACOS_{BROKER,SIGNER}_{UID,GID},
 BLOOM_MACOS_{MACHINE_BROKER,BROKER_SIGNER,REVOKE}_GID, and
-BLOOM_RELEASE_DIGEST.
+BLOOM_MACOS_LOG_GID and BLOOM_RELEASE_DIGEST.
 EOF
   exit 64
 }
@@ -132,6 +132,7 @@ load_names() {
   signer_user="bloom-signer-$login_uid"; signer_group="$signer_user"
   machine_broker_group="bloom-machine-broker-$login_uid"
   broker_signer_group="bloom-broker-signer-$login_uid"; revoke_group="bloom-revoke-$login_uid"
+  log_group="bloom-log-$login_uid"
 }
 
 load_ids() {
@@ -142,6 +143,15 @@ load_ids() {
   BLOOM_MACOS_MACHINE_BROKER_GID="$(field "$enrollment" machine_broker_gid)"
   BLOOM_MACOS_BROKER_SIGNER_GID="$(field "$enrollment" broker_signer_gid)"
   BLOOM_MACOS_REVOKE_GID="$(field "$enrollment" revoke_gid)"
+  if BLOOM_MACOS_LOG_GID="$(field "$enrollment" log_gid 2>/dev/null)"; then return; fi
+  if [[ "$action" == uninstall ]]; then BLOOM_MACOS_LOG_GID=0; return; fi
+  if $live; then
+    record_exists Groups "$log_group" && die "legacy enrollment has an unrecorded log group"
+    BLOOM_MACOS_LOG_GID="$(next_id Groups PrimaryGroupID)"; new_group "$log_group" "$BLOOM_MACOS_LOG_GID"
+    join_group "$log_group" "$login_user"; dsmemberutil flushcache
+  else
+    [[ "${BLOOM_MACOS_LOG_GID:-}" =~ ^[1-9][0-9]*$ ]] || die "BLOOM_MACOS_LOG_GID must be positive decimal"
+  fi
 }
 
 allocate_accounts() {
@@ -150,6 +160,7 @@ allocate_accounts() {
   BLOOM_MACOS_MACHINE_BROKER_GID="$(next_id Groups PrimaryGroupID)"; new_group "$machine_broker_group" "$BLOOM_MACOS_MACHINE_BROKER_GID"
   BLOOM_MACOS_BROKER_SIGNER_GID="$(next_id Groups PrimaryGroupID)"; new_group "$broker_signer_group" "$BLOOM_MACOS_BROKER_SIGNER_GID"
   BLOOM_MACOS_REVOKE_GID="$(next_id Groups PrimaryGroupID)"; new_group "$revoke_group" "$BLOOM_MACOS_REVOKE_GID"
+  BLOOM_MACOS_LOG_GID="$(next_id Groups PrimaryGroupID)"; new_group "$log_group" "$BLOOM_MACOS_LOG_GID"
   BLOOM_MACOS_BROKER_UID="$(next_id Users UniqueID)"; new_user "$broker_user" "$BLOOM_MACOS_BROKER_UID" "$BLOOM_MACOS_BROKER_GID"
   BLOOM_MACOS_SIGNER_UID="$(next_id Users UniqueID)"; new_user "$signer_user" "$BLOOM_MACOS_SIGNER_UID" "$BLOOM_MACOS_SIGNER_GID"
   for pair in "$machine_broker_group:$login_user" "$machine_broker_group:$broker_user" \
@@ -157,6 +168,7 @@ allocate_accounts() {
     "$revoke_group:$login_user" "$revoke_group:$broker_user" "$revoke_group:$signer_user"; do
     join_group "${pair%%:*}" "${pair#*:}"
   done
+  join_group "$log_group" "$login_user"
   dsmemberutil flushcache
 }
 
@@ -187,7 +199,7 @@ verify_payload() {
   else
     [[ "$claim" == test-unclaimed && "${BLOOM_ALLOW_TEST_UNCLAIMED:-}" == true ]] || die "staged install requires test-unclaimed"
     [[ "${BLOOM_RELEASE_DIGEST:-}" =~ ^[0-9a-f]{64}$ ]] || die "invalid staged release digest"
-    for n in BROKER_UID SIGNER_UID BROKER_GID SIGNER_GID MACHINE_BROKER_GID BROKER_SIGNER_GID REVOKE_GID; do
+    for n in BROKER_UID SIGNER_UID BROKER_GID SIGNER_GID MACHINE_BROKER_GID BROKER_SIGNER_GID REVOKE_GID LOG_GID; do
       v="BLOOM_MACOS_$n"; [[ "${!v:-}" =~ ^[1-9][0-9]*$ ]] || die "$v must be positive decimal"
     done
   fi
@@ -217,7 +229,9 @@ render() {
     -e "s|@BLOOM_BROKER_STARTUP_STATUS@|$runtime/status/broker-startup.json|g" \
     -e "s|@BLOOM_CONTAINMENT_STATUS@|$runtime/containment/status.json|g" \
     -e "s|@BLOOM_PROVENANCE_CATALOG@|$config/provenance-catalog.json|g" \
-    -e "s|@BLOOM_BROKER_LOG@|$broker_state/broker.log|g" -e "s|@BLOOM_SIGNER_LOG@|$signer_state/signer.log|g" \
+    -e "s|@BLOOM_BROKER_LOG_PATH@|$broker_log|g" -e "s|@BLOOM_SIGNER_LOG_PATH@|$signer_log|g" \
+    -e "s|@BLOOM_BROKER_BOOTSTRAP_LOG@|$broker_bootstrap_log|g" -e "s|@BLOOM_SIGNER_BOOTSTRAP_LOG@|$signer_bootstrap_log|g" \
+    -e "s|@BLOOM_LOG_READER_GID@|$BLOOM_MACOS_LOG_GID|g" \
     "$src" >"$tmp"; chmod "$mode" "$tmp"; mv -f "$tmp" "$dst"
 }
 
@@ -229,11 +243,14 @@ paths() {
   if $live; then variable=/private/var; else variable="$root_prefix/var"; fi
   broker_state="$variable/db/bloom/$login_uid/broker"; signer_state="$variable/db/bloom/$login_uid/signer"
   machine_state="$variable/db/bloom/$login_uid/machine"; runtime="$variable/run/bloom/$login_uid"
+  log_root="$variable/log/bloom/$login_uid"; broker_log="$log_root/broker.jsonl"; signer_log="$log_root/signer.jsonl"
+  broker_bootstrap_log="$log_root/broker-bootstrap.log"; signer_bootstrap_log="$log_root/signer-bootstrap.log"
   broker_plist="$root_prefix/Library/LaunchDaemons/com.bloom.broker.$login_uid.plist"
   signer_plist="$root_prefix/Library/LaunchDaemons/com.bloom.signer.$login_uid.plist"
   containment_plist="$root_prefix/Library/LaunchDaemons/com.bloom.containment.plist"
   session_plist="$root_prefix/Library/LaunchAgents/com.bloom.session.plist"
   pf_anchor="$root_prefix/etc/pf.anchors/com.bloom.triad.$login_uid"
+  newsyslog_config="$root_prefix/etc/newsyslog.d/bloom-$login_uid.conf"
 }
 
 current_release_digest() {
@@ -284,18 +301,18 @@ rollback_failed_restore() {
     done
     pf_reference remove || return 1
   fi
-  rm -f "$broker_plist" "$signer_plist" "$pf_anchor" "$enrollments/$login_uid.json"
-  rm -rf "$runtime"
+  rm -f "$broker_plist" "$signer_plist" "$pf_anchor" "$newsyslog_config" "$enrollments/$login_uid.json"
+  rm -rf "$runtime" "$log_root"
   restore_pending=false
 }
 
 write_enrollment() {
   state="$1"; tmp="$enrollment.new.$$"
-  printf '{"schema":"bloom.macos-enrollment.1","state":"%s","login_uid":%s,"login_user":"%s","broker_user":"%s","broker_uid":%s,"broker_group":"%s","broker_gid":%s,"signer_user":"%s","signer_uid":%s,"signer_group":"%s","signer_gid":%s,"machine_broker_group":"%s","machine_broker_gid":%s,"broker_signer_group":"%s","broker_signer_gid":%s,"revoke_group":"%s","revoke_gid":%s,"release_digest":"%s"}\n' \
+  printf '{"schema":"bloom.macos-enrollment.1","state":"%s","login_uid":%s,"login_user":"%s","broker_user":"%s","broker_uid":%s,"broker_group":"%s","broker_gid":%s,"signer_user":"%s","signer_uid":%s,"signer_group":"%s","signer_gid":%s,"machine_broker_group":"%s","machine_broker_gid":%s,"broker_signer_group":"%s","broker_signer_gid":%s,"revoke_group":"%s","revoke_gid":%s,"log_group":"%s","log_gid":%s,"release_digest":"%s"}\n' \
     "$state" "$login_uid" "$login_user" "$broker_user" "$BLOOM_MACOS_BROKER_UID" "$broker_group" "$BLOOM_MACOS_BROKER_GID" \
     "$signer_user" "$BLOOM_MACOS_SIGNER_UID" "$signer_group" "$BLOOM_MACOS_SIGNER_GID" "$machine_broker_group" \
     "$BLOOM_MACOS_MACHINE_BROKER_GID" "$broker_signer_group" "$BLOOM_MACOS_BROKER_SIGNER_GID" "$revoke_group" \
-    "$BLOOM_MACOS_REVOKE_GID" "$BLOOM_RELEASE_DIGEST" >"$tmp"
+    "$BLOOM_MACOS_REVOKE_GID" "$log_group" "$BLOOM_MACOS_LOG_GID" "$BLOOM_RELEASE_DIGEST" >"$tmp"
   chmod 0644 "$tmp"; $live && chown root:wheel "$tmp"; mv -f "$tmp" "$enrollment"
 }
 
@@ -389,12 +406,12 @@ install_config() {
   mkdir -p "$enrollments" "$broker_config" "$signer_config" "$machine_config" "$session_config" "$installer_config" \
     "$broker_state/audit-checkpoints" "$signer_state/audit-checkpoints" "$machine_state/audit-checkpoints" \
     "$runtime/machine-broker" "$runtime/broker-signer" "$runtime/revoke/broker" "$runtime/revoke/signer" \
-    "$runtime/session" "$runtime/containment" "$runtime/status"
+    "$runtime/session" "$runtime/containment" "$runtime/status" "$variable/log/bloom" "$log_root"
   for directory in "$enrollments" "$broker_config" "$signer_config" "$machine_config" "$session_config" \
     "$installer_config" "$broker_state" "$signer_state" "$machine_state" "$broker_state/audit-checkpoints" \
     "$signer_state/audit-checkpoints" "$machine_state/audit-checkpoints" "$runtime" "$runtime/machine-broker" \
     "$runtime/broker-signer" "$runtime/revoke" "$runtime/revoke/broker" "$runtime/revoke/signer" "$runtime/session" \
-    "$runtime/containment" "$runtime/status"; do
+    "$runtime/containment" "$runtime/status" "$variable/log/bloom" "$log_root"; do
     [[ -d "$directory" && ! -L "$directory" ]] || die "security directory is missing or substituted: $directory"
   done
   chmod 0711 "$config" "$runtime" "$runtime/revoke"
@@ -404,6 +421,14 @@ install_config() {
   chmod 0710 "$runtime/machine-broker" "$runtime/broker-signer" "$runtime/revoke/broker" \
     "$runtime/revoke/signer" "$runtime/session"
   chmod 0755 "$runtime/containment"; chmod 0750 "$runtime/status"
+  # Service principals traverse to their owner-writable file; only the log
+  # group can read it. No principal can replace entries in this root directory.
+  chmod 0711 "$variable/log/bloom" "$log_root"
+  for service_log in "$broker_log" "$signer_log" "$broker_bootstrap_log" "$signer_bootstrap_log"; do
+    if [[ ! -e "$service_log" ]]; then install -m 0640 /dev/null "$service_log"; fi
+    [[ -f "$service_log" && ! -L "$service_log" ]] || die "service log is missing or substituted: $service_log"
+    chmod 0640 "$service_log"
+  done
   if [[ ! -f "$config/edge-manifest.json" ]]; then
     if $live; then
       scratch="$(mktemp -d "$product/.material.XXXXXX")"; templates="$scratch/templates"; material="$scratch/material"
@@ -445,10 +470,17 @@ install_assets() {
   render "$base/launchdaemons/com.bloom.containment.plist.in" "$containment_plist" 0644
   render "$base/launchagents/com.bloom.session.plist.in" "$session_plist" 0644
   render "$base/pf/com.bloom.login.conf.in" "$pf_anchor" 0600
+  mkdir -p "$(dirname "$newsyslog_config")"
+  newsyslog_tmp="$newsyslog_config.new.$$"
+  printf '%s %s:%s 640 5 1024 * BN\n%s %s:%s 640 5 1024 * BN\n%s %s:%s 640 2 128 * BN\n%s %s:%s 640 2 128 * BN\n' \
+    "$broker_log" "$broker_user" "$log_group" "$signer_log" "$signer_user" "$log_group" \
+    "$broker_bootstrap_log" "$broker_user" "$log_group" "$signer_bootstrap_log" "$signer_user" "$log_group" >"$newsyslog_tmp"
+  chmod 0644 "$newsyslog_tmp"; mv -f "$newsyslog_tmp" "$newsyslog_config"
 }
 
 secure_ownership() {
-  chown -R root:wheel "$release_base" "$product"; chown root:wheel "$broker_plist" "$signer_plist" "$containment_plist" "$session_plist" "$pf_anchor"
+  chown -R root:wheel "$release_base"
+  chown root:wheel "$product" "$enrollments" "$config" "$broker_plist" "$signer_plist" "$containment_plist" "$session_plist" "$pf_anchor" "$newsyslog_config"
   chown -R "$broker_user:$broker_group" "$broker_config" "$broker_state"
   chown -R "$signer_user:$signer_group" "$signer_config" "$signer_state"
   chown -R "$login_user:$machine_broker_group" "$machine_config" "$machine_state"
@@ -458,6 +490,9 @@ secure_ownership() {
   chown "$broker_user:$machine_broker_group" "$runtime/machine-broker" "$runtime/status"
   chown "$signer_user:$broker_signer_group" "$runtime/broker-signer"
   chown "$broker_user:$revoke_group" "$runtime/revoke/broker"; chown "$signer_user:$revoke_group" "$runtime/revoke/signer"
+  chown root:"$log_group" "$log_root"
+  chown "$broker_user:$log_group" "$broker_log"; chown "$signer_user:$log_group" "$signer_log"
+  chown "$broker_user:$log_group" "$broker_bootstrap_log"; chown "$signer_user:$log_group" "$signer_bootstrap_log"
 }
 
 start_and_check() {
@@ -488,6 +523,8 @@ stop_all_enrollments() {
 
 rewrite_all_enrollments() {
   local digest="$1" state="$2" record
+  # Provision every enrollment first. Ownership is a separate pass so
+  # securing one enrollment cannot disturb an enrollment already repaired.
   for record in "$enrollments"/*.json; do
     [[ -f "$record" && ! -L "$record" ]] || continue
     login_uid="${record##*/}"; login_uid="${login_uid%.json}"; enrollment="$record"
@@ -497,8 +534,17 @@ rewrite_all_enrollments() {
       plutil -replace build_digest -string "$digest" "$broker_config/config.json"
       plutil -replace build_digest -string "$digest" "$signer_config/config.json"
     fi
+    install_config
     install_assets
   done
+  if $live; then
+    for record in "$enrollments"/*.json; do
+      [[ -f "$record" && ! -L "$record" ]] || continue
+      login_uid="${record##*/}"; login_uid="${login_uid%.json}"; enrollment="$record"
+      login_user="$(field "$record" login_user)"; load_names; paths; load_ids
+      secure_ownership
+    done
+  fi
 }
 
 activate_installed_set() {
@@ -636,17 +682,18 @@ case "$action" in
       for label in "system/com.bloom.broker.$login_uid" "system/com.bloom.signer.$login_uid" "gui/$login_uid/com.bloom.session"; do launchctl bootout "$label" 2>/dev/null || true; done
       pf_reference remove
     fi
-    rm -f "$broker_plist" "$signer_plist" "$pf_anchor"
+    rm -f "$broker_plist" "$signer_plist" "$pf_anchor" "$newsyslog_config"
     if $retain; then
       mkdir -p "$product/retained"; enrollment="$retained"; write_enrollment retained
-      rm -f "$enrollments/$login_uid.json"; rm -rf "$runtime"
+      rm -f "$enrollments/$login_uid.json"; rm -rf "$runtime" "$log_root"
       echo "Bloom macOS runtime removed; custody retained for restore"
     else
-      rm -f "$enrollments/$login_uid.json" "$retained"; rm -rf "$config" "$variable/db/bloom/$login_uid" "$runtime"
+      rm -f "$enrollments/$login_uid.json" "$retained"; rm -rf "$config" "$variable/db/bloom/$login_uid" "$runtime" "$log_root"
     fi
     if $live && ! $retain; then
       for name in "$broker_user" "$signer_user"; do dscl . -delete "/Users/$name"; done
       for name in "$broker_group" "$signer_group" "$machine_broker_group" "$broker_signer_group" "$revoke_group"; do dscl . -delete "/Groups/$name"; done
+      record_exists Groups "$log_group" && dscl . -delete "/Groups/$log_group"
       dsmemberutil flushcache
     fi
     if ! find "$enrollments" -type f -name '*.json' -maxdepth 1 2>/dev/null | grep . >/dev/null; then

--- a/packaging/triad/release/verify-bundle.sh
+++ b/packaging/triad/release/verify-bundle.sh
@@ -86,8 +86,8 @@ for support_edge in signer_control session; do
   require_compat_value "protocols.$support_edge" minor_min 0
   require_compat_value "protocols.$support_edge" minor_max 1
 done
-require_compat_value revisions broker_commit '"77c30ccedbd6904c0f2f2ad19e48c5587061b04e"'
-require_compat_value revisions signer_commit '"f5139960b9c5b59803ad54a1ecc9ef4e86f82d0c"'
+require_compat_value revisions broker_commit '"50050a272b90d2b0473d25c1014886a0ea8ae7d7"'
+require_compat_value revisions signer_commit '"3e9473ce4354dfd17303c5ea68ed8218417c0b49"'
 require_compat_value revisions service_runtime_commit '"bc88cc6760b00bbff0c6a6e5f56d42bb03004436"'
 require_compat_value revisions petal_contract_commit '"61938d0c127cfe03c7e3e55baed0ba1439bc5ca2"'
 for state_owner in machine broker signer; do

--- a/packaging/triad/release/verify-bundle.sh
+++ b/packaging/triad/release/verify-bundle.sh
@@ -86,9 +86,9 @@ for support_edge in signer_control session; do
   require_compat_value "protocols.$support_edge" minor_min 0
   require_compat_value "protocols.$support_edge" minor_max 1
 done
-require_compat_value revisions broker_commit '"bdf5d36b48f6a476539ff992084c483becd67629"'
-require_compat_value revisions signer_commit '"a9dcbbfef8a4057b9e6f94b17e010f051f7ab32e"'
-require_compat_value revisions service_runtime_commit '"d8229e51d80971505af69c387818334a3c44aef0"'
+require_compat_value revisions broker_commit '"f001cb9242c60d3d80c348506d329fdcfb126eb0"'
+require_compat_value revisions signer_commit '"b261bcf0467fb369904b05ed34622b9393c36764"'
+require_compat_value revisions service_runtime_commit '"67727b20476a5e12beea4be9734afd83bf74dea4"'
 require_compat_value revisions petal_contract_commit '"61938d0c127cfe03c7e3e55baed0ba1439bc5ca2"'
 for state_owner in machine broker signer; do
   require_compat_value "state.$state_owner" current 1

--- a/packaging/triad/release/verify-bundle.sh
+++ b/packaging/triad/release/verify-bundle.sh
@@ -88,7 +88,7 @@ for support_edge in signer_control session; do
 done
 require_compat_value revisions broker_commit '"77c30ccedbd6904c0f2f2ad19e48c5587061b04e"'
 require_compat_value revisions signer_commit '"f5139960b9c5b59803ad54a1ecc9ef4e86f82d0c"'
-require_compat_value revisions service_runtime_commit '"d2542a07a988261fe2f82b738462de2127b317d2"'
+require_compat_value revisions service_runtime_commit '"bc88cc6760b00bbff0c6a6e5f56d42bb03004436"'
 require_compat_value revisions petal_contract_commit '"61938d0c127cfe03c7e3e55baed0ba1439bc5ca2"'
 for state_owner in machine broker signer; do
   require_compat_value "state.$state_owner" current 1

--- a/packaging/triad/release/verify-bundle.sh
+++ b/packaging/triad/release/verify-bundle.sh
@@ -86,9 +86,9 @@ for support_edge in signer_control session; do
   require_compat_value "protocols.$support_edge" minor_min 0
   require_compat_value "protocols.$support_edge" minor_max 1
 done
-require_compat_value revisions broker_commit '"f001cb9242c60d3d80c348506d329fdcfb126eb0"'
-require_compat_value revisions signer_commit '"b261bcf0467fb369904b05ed34622b9393c36764"'
-require_compat_value revisions service_runtime_commit '"67727b20476a5e12beea4be9734afd83bf74dea4"'
+require_compat_value revisions broker_commit '"77c30ccedbd6904c0f2f2ad19e48c5587061b04e"'
+require_compat_value revisions signer_commit '"f5139960b9c5b59803ad54a1ecc9ef4e86f82d0c"'
+require_compat_value revisions service_runtime_commit '"d2542a07a988261fe2f82b738462de2127b317d2"'
 require_compat_value revisions petal_contract_commit '"61938d0c127cfe03c7e3e55baed0ba1439bc5ca2"'
 for state_owner in machine broker signer; do
   require_compat_value "state.$state_owner" current 1


### PR DESCRIPTION
## Summary

- add structured Machine and workflow/checkpoint/degradation events with authenticated operation correlation
- add lifecycle logging for session/containment and explicit Linux journal configuration
- provision secure per-enrollment macOS Broker/Signer logs, bounded newsyslog rotation, bootstrap fallback, upgrade/repair/uninstall handling
- extend W0 policy acceptance for structured correlation, read-only permissions, protected state, and live rotation
- pin the reviewed runtime, Signer, and Broker observability revisions

## Validation

- cargo check --workspace --all-features
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- targeted Machine/checkpoint/redaction/degradation tests
- triad release and two-enrollment macOS upgrade regressions
- cargo fmt --all -- --check
- installer shell syntax, external-pin, stale-revision, path-dependency, and git diff checks

The full local all-feature run also encountered host-state-only failures from an already-installed Broker checkpoint and an occupied canonical Machine port; all failures introduced by this change were fixed and rerun successfully.

Depends on bloom-service-runtime#11, bloom-signer#16, and bloom-broker#22 via immutable reviewed commit pins.

## Checklist

- [x] Tests added or updated for behavior changes
- [x] Architecture docs updated — N/A: operational observability only; no authority or sealed-approval contract changes
- [x] Sealed Approval invariants respected — no signing, grant, PRF, or execution semantics changed
- [x] Agent Documentation updated — N/A: no agent-facing VFS or Petal behavior changed