### PR TITLE
feat(config): add Arc Testnet to default networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,10 @@ Bloom gives an agent a safe wallet workspace:
 
 Bloom ships read-ready RPC defaults for major EVM networks — Ethereum,
 Base, Tempo, Robinhood Chain, Arbitrum, Optimism, Polygon, BNB Smart Chain,
-Avalanche, Gnosis, Linea, and HyperEVM — plus local Anvil. Per-chain
-broadcasting is enabled by default; set `allow_broadcast = false` on a chain to
-disable it.
+Avalanche, Gnosis, Linea, and HyperEVM — plus Arc Testnet and local Anvil.
+Arc coverage is testnet-only for now; an Arc mainnet entry is pending Arc
+mainnet launch. Per-chain broadcasting is enabled by default; set
+`allow_broadcast = false` on a chain to disable it.
 Public reads, simulations, and planning work without adding API keys;
 local devnet sends require a running Anvil node.
 

--- a/crates/bloom-proto/src/config.rs
+++ b/crates/bloom-proto/src/config.rs
@@ -388,6 +388,13 @@ fn default_chains() -> BTreeMap<String, ChainSpec> {
             "HyperEVM",
             "HYPE",
         ),
+        evm_chain(
+            "arc-testnet",
+            5042002,
+            &["https://rpc.testnet.arc.io"],
+            "Arc Testnet",
+            "USDC",
+        ),
         ChainSpec::anvil_default(),
     ] {
         chains.insert(spec.name.clone(), spec);
@@ -631,7 +638,7 @@ mod tests {
         assert!(cfg.etherscan.is_none());
         assert!(cfg.enso.is_none());
         assert_eq!(cfg.petals.preinstalled, ["near-intents", "enso"]);
-        assert_eq!(cfg.chains.len(), 13);
+        assert_eq!(cfg.chains.len(), 14);
         let ethereum = cfg.chains.get("ethereum").expect("ethereum entry");
         assert_eq!(ethereum.chain_id, 1);
         assert!(ethereum.allow_broadcast);
@@ -651,6 +658,16 @@ mod tests {
         assert_eq!(robinhood.native_symbol, "ETH");
         let hyperliquid = cfg.chains.get("hyperliquid").expect("hyperliquid entry");
         assert_eq!(hyperliquid.chain_id, 999);
+        let arc_testnet = cfg.chains.get("arc-testnet").expect("arc-testnet entry");
+        assert_eq!(arc_testnet.chain_id, 5_042_002);
+        assert_eq!(arc_testnet.rpc_urls, vec!["https://rpc.testnet.arc.io"]);
+        assert_eq!(arc_testnet.display_name.as_deref(), Some("Arc Testnet"));
+        assert!(arc_testnet.allow_broadcast);
+        assert!(!arc_testnet.op_stack);
+        // Arc meters gas in USDC, but the native balance is still an
+        // 18-decimal EVM quantity — the testnet base fee reads in gwei.
+        assert_eq!(arc_testnet.native_symbol, "USDC");
+        assert_eq!(arc_testnet.native_decimals, 18);
         let anvil = cfg.chains.get("anvil").expect("anvil entry");
         assert_eq!(anvil.chain_id, 31337);
         assert!(!anvil.rpc_urls.is_empty());
@@ -665,6 +682,53 @@ mod tests {
     #[test]
     fn local_default_validates() {
         Config::local_default().validate().unwrap();
+    }
+
+    /// Arc ships testnet-only until Arc mainnet launches.
+    ///
+    /// Adding an `arc` mainnet entry is a deliberate change, not an
+    /// incidental one: the README, the VFS `docs/README.md` the agent
+    /// reads, and `docs/AGENTIC_WALLET.md` all state that Arc is
+    /// testnet-only. Update those alongside this assertion.
+    #[test]
+    fn arc_ships_testnet_only_until_mainnet_launches() {
+        let cfg = Config::local_default();
+        assert!(
+            cfg.chains.contains_key("arc-testnet"),
+            "arc-testnet must remain the Arc default entry"
+        );
+        assert!(
+            !cfg.chains.contains_key("arc"),
+            "an `arc` mainnet entry landed; update the README, the VFS \
+             docs/README.md, and docs/AGENTIC_WALLET.md, which all say Arc \
+             is testnet-only"
+        );
+    }
+
+    /// The chain key is a valid `bloom-rpc-wire` protocol token.
+    ///
+    /// Chain names cross the triad as `Token` in Broker/Signer policy and
+    /// approval terms, so a name the token grammar rejects would break
+    /// broadcast on that chain rather than failing here.
+    #[test]
+    fn default_chain_names_are_valid_protocol_tokens() {
+        for name in Config::local_default().chains.keys() {
+            let bytes = name.as_bytes();
+            assert!(
+                !bytes.is_empty() && bytes.len() <= 64,
+                "chain name {name:?} must be 1-64 bytes"
+            );
+            assert!(
+                bytes[0].is_ascii_lowercase(),
+                "chain name {name:?} must start with a lowercase ASCII letter"
+            );
+            assert!(
+                bytes.iter().all(|byte| byte.is_ascii_lowercase()
+                    || byte.is_ascii_digit()
+                    || matches!(byte, b'.' | b'_' | b'-' | b'/')),
+                "chain name {name:?} must be a lowercase ASCII protocol token"
+            );
+        }
     }
 
     #[test]

--- a/crates/bloom-vfs/src/docs/README.md
+++ b/crates/bloom-vfs/src/docs/README.md
@@ -32,8 +32,11 @@ All paths below are relative to the Bloom VFS root.
 
 Default config includes read-ready RPCs for Ethereum, Base, Tempo, Robinhood
 Chain, Arbitrum, Optimism, Polygon, BNB Smart Chain, Avalanche, Gnosis, Linea,
-HyperEVM, and local Anvil. Per-chain broadcasting is enabled by default;
-value-moving actions still require the applicable approval gates.
+HyperEVM, Arc Testnet (`arc-testnet`), and local Anvil. Arc is testnet-only for
+now — there is no Arc mainnet entry until Arc mainnet launches, so do not assume
+an `arc` chain exists. Note that `arc-testnet` pays gas in USDC rather than ETH.
+Per-chain broadcasting is enabled by default; value-moving actions still require
+the applicable approval gates.
 
 ## Reading
 

--- a/docs/AGENTIC_WALLET.md
+++ b/docs/AGENTIC_WALLET.md
@@ -37,7 +37,9 @@ An agent using Bloom can:
   challenges staged for review before any x402 or Tempo MPP credential is
   signed;
 - enforce wallet policy: spend caps, allow/deny lists, contract-call gates, private orderflow preferences, and audit logging;
-- use twelve read-ready public EVM networks immediately after `bloom init`: Ethereum, Base, Tempo, Robinhood Chain, Arbitrum, Optimism, Polygon, BNB Smart Chain, Avalanche, Gnosis, Linea, and HyperEVM, plus local Anvil.
+- use twelve read-ready public EVM mainnets immediately after `bloom init`: Ethereum, Base, Tempo, Robinhood Chain, Arbitrum, Optimism, Polygon, BNB Smart Chain, Avalanche, Gnosis, Linea, and HyperEVM, plus Arc Testnet (`arc-testnet`) and local Anvil.
+
+Arc support is testnet-only at present: `arc-testnet` (chain ID 5042002) is the sole Arc entry, and an Arc mainnet entry is pending Arc mainnet launch. Unlike the other default networks, Arc pays gas in USDC rather than ETH, so plan previews on that chain are denominated in USDC.
 
 Mainnet and L2 broadcast routing is enabled by default. Live sends still require the applicable signing, policy, confirmation, and Sealed Approval gates.
 


### PR DESCRIPTION
Add Arc Testnet (chain ID 5042002, https://rpc.testnet.arc.io) to default_chains(), bringing the read-ready default set to 14 entries.

Arc meters gas in USDC rather than ETH, so the entry sets native_symbol = "USDC" while keeping native_decimals = 18: the native balance is still an ordinary 18-decimal EVM quantity, confirmed against the live testnet, whose base fee reads ~20 gwei. TxPreview::render already takes symbol and decimals as parameters, so plan previews denominate in USDC with no rendering change.

Chain ID and RPC endpoint were verified against the live network (eth_chainId returns 0x4cef52) and the head advances through the VFS at /chains/arc-testnet/head/number.

Arc support is testnet-only: Arc mainnet has not launched, so there is no `arc` entry. The three chain lists that enumerate the defaults are updated to say so — README.md, docs/AGENTIC_WALLET.md, and the agent-facing crates/bloom-vfs/src/docs/README.md, which additionally notes the USDC gas denomination so agents do not assume ETH.

Tests:
- local_default_shape asserts the full Arc spec (RPC, display name, broadcast, op_stack, symbol, decimals), not just the chain ID
- arc_ships_testnet_only_until_mainnet_launches fails if an `arc` mainnet key appears, naming the three docs to update alongside it
- default_chain_names_are_valid_protocol_tokens checks every chain key against the bloom-rpc-wire Token grammar, since chain names cross the triad in Broker and Signer policy and approval terms

No Broker or Signer change is required: `chain` is an opaque Token whose grammar admits the hyphen in "arc-testnet", and neither service holds a chain registry or allowlist.

Known gap, not addressed here: Config::load_or_init loads an existing config.toml verbatim and never merges newly added default chains, so installs that already ran `bloom init` will not see Arc without a migration.

## Summary

<!-- What does this PR do and why? -->

## Checklist

Every item must be checked before merge (enforced by the `checklist-complete`
status check). If an item does not apply, check it and write `N/A` in place
of the link or after the item.

- [x] Tests added or updated for behavior changes
- [x] Architecture docs (`docs/architecture/`) updated if contracts or
      behavior changed
- [x] Sealed Approval invariants respected (no signing outside a grant or
      bounded capability, no PRF/grant persistence, execution from sealed
      bytes) — see `docs/architecture/Sealed Approvals.md`
- [x] Agent Documentation updated (`crates/bloom-vfs/src/docs/agent-guidance.md`
      and affected Petal READMEs) — see
      `docs/architecture/Agent-native Documentation.md`