### PR TITLE
fix(petals): enforce manifest-derived key scopes

### DIFF
--- a/crates/bloom-daemon/src/lib.rs
+++ b/crates/bloom-daemon/src/lib.rs
@@ -1473,6 +1473,8 @@ impl PetalHost for DaemonPetalHost {
         let broker = self.broker.as_ref().ok_or_else(|| {
             HostError::Backend("SERVICE_UNAVAILABLE: Broker client is not configured".into())
         })?;
+        let wallet_id = bloom_broker_api::Token::new(req.wallet.clone())
+            .map_err(|error| HostError::Invalid(format!("wallet: {error}")))?;
         let context = req.context.as_ref().ok_or_else(|| {
             warn!(
                 wallet = %req.wallet,
@@ -1672,8 +1674,7 @@ impl PetalHost for DaemonPetalHost {
             .transpose()
             .map_err(|error| HostError::Invalid(error.to_string()))?;
         let trusted_request = TrustedPetalSignRequest {
-            wallet_id: bloom_broker_api::Token::new(req.wallet)
-                .map_err(|error| HostError::Invalid(error.to_string()))?,
+            wallet_id,
             preimage: req.preimage,
             claimed_hash: bloom_broker_api::Digest32::from_bytes(req.claimed_hash),
             crypto_suite,
@@ -1737,6 +1738,8 @@ impl PetalHost for DaemonPetalHost {
         let broker = self.broker.as_ref().ok_or_else(|| {
             HostError::Backend("SERVICE_UNAVAILABLE: Broker client is not configured".into())
         })?;
+        bloom_broker_api::Token::new(req.wallet.clone())
+            .map_err(|error| HostError::Invalid(format!("wallet: {error}")))?;
         let context = req.context.as_ref().ok_or_else(|| {
             HostError::Denied("payload batch signing requires trusted Petal provenance".into())
         })?;
@@ -5273,6 +5276,15 @@ mod tests {
             key_ref: None,
             context: Some(context),
         };
+
+        let mut malformed_wallet = request.clone();
+        malformed_wallet.wallet = "0x0000000000000000000000000000000000000001".into();
+        let error = host
+            .sign_payload_outcome(malformed_wallet)
+            .await
+            .unwrap_err();
+        assert!(matches!(error, HostError::Invalid(_)));
+        assert!(error.to_string().contains("wallet"));
 
         let SignOutcome::ApprovalPending(pending) =
             host.sign_payload_outcome(request.clone()).await.unwrap()

--- a/crates/bloom-petals/src/package.rs
+++ b/crates/bloom-petals/src/package.rs
@@ -148,6 +148,14 @@ struct KeyPolicyToml {
 struct KeyDerivePolicyToml {
     route: String,
     operation_classes: Vec<String>,
+    #[serde(default)]
+    allowed_routes: Vec<String>,
+}
+
+#[derive(Debug)]
+struct ValidatedKeyDerivePolicy {
+    operation_classes: Vec<String>,
+    allowed_route_ids: Vec<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -334,6 +342,8 @@ pub struct RouteIndexRecord {
     pub install_metadata: InstallRouteMetadata,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub key_derive_operation_classes: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub key_derive_allowed_routes: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -488,7 +498,7 @@ impl PreparedPetalPackage {
                 manifest.name
             )));
         }
-        let key_derive_operation_classes =
+        let key_derive_policies =
             validate_key_derive_policy(&manifest.key, &route_files, &allowed_sign_intents)?;
         let policy_hash = hex::encode(blake3::hash(manifest_bytes).as_bytes());
         let mut route_index = RouteIndex {
@@ -575,9 +585,12 @@ impl PreparedPetalPackage {
                 }
                 source_validation
             };
-            let route_key_derive_operation_classes = key_derive_operation_classes
-                .get(&route.pattern)
-                .cloned()
+            let route_key_derive_policy = key_derive_policies.get(&route.pattern);
+            let route_key_derive_operation_classes = route_key_derive_policy
+                .map(|policy| policy.operation_classes.clone())
+                .unwrap_or_default();
+            let route_key_derive_allowed_routes = route_key_derive_policy
+                .map(|policy| policy.allowed_route_ids.clone())
                 .unwrap_or_default();
             if !route_key_derive_operation_classes.is_empty()
                 && !validation
@@ -635,8 +648,10 @@ impl PreparedPetalPackage {
                 specificity: route.specificity.as_array(),
                 install_metadata,
                 key_derive_operation_classes: route_key_derive_operation_classes,
+                key_derive_allowed_routes: route_key_derive_allowed_routes,
             });
         }
+        validate_resolved_key_derive_scopes(&route_index.routes)?;
 
         Ok(Self {
             hash,
@@ -3849,14 +3864,14 @@ fn validate_key_derive_policy(
     policy: &KeyPolicyToml,
     routes: &[RouteRecord],
     allowed_sign_intents: &BTreeSet<String>,
-) -> Result<BTreeMap<String, Vec<String>>, PetalError> {
-    let route_patterns = routes
+) -> Result<BTreeMap<String, ValidatedKeyDerivePolicy>, PetalError> {
+    let routes_by_pattern = routes
         .iter()
-        .map(|route| route.pattern.as_str())
-        .collect::<BTreeSet<_>>();
+        .map(|route| (route.pattern.as_str(), route.route_id.as_str()))
+        .collect::<BTreeMap<_, _>>();
     let mut declarations = BTreeMap::new();
     for declaration in &policy.derive_routes {
-        if !route_patterns.contains(declaration.route.as_str()) {
+        if !routes_by_pattern.contains_key(declaration.route.as_str()) {
             return Err(PetalError::InvalidWasm(format!(
                 "Petal [[key.derive]] declares unknown route {:?}",
                 declaration.route
@@ -3884,8 +3899,36 @@ fn validate_key_derive_policy(
                 )));
             }
         }
+        let mut allowed_patterns = BTreeSet::new();
+        for pattern in &declaration.allowed_routes {
+            if !routes_by_pattern.contains_key(pattern.as_str()) {
+                return Err(PetalError::InvalidWasm(format!(
+                    "Petal [[key.derive]] route {:?} allows unknown route {pattern:?}",
+                    declaration.route
+                )));
+            }
+            if !allowed_patterns.insert(pattern.clone()) {
+                return Err(PetalError::InvalidWasm(format!(
+                    "Petal [[key.derive]] route {:?} has duplicate allowed route {pattern:?}",
+                    declaration.route
+                )));
+            }
+        }
+        if !declaration.allowed_routes.is_empty() {
+            allowed_patterns.insert(declaration.route.clone());
+        }
+        let allowed_route_ids = allowed_patterns
+            .iter()
+            .map(|pattern| routes_by_pattern[pattern.as_str()].to_string())
+            .collect();
         if declarations
-            .insert(declaration.route.clone(), classes.into_iter().collect())
+            .insert(
+                declaration.route.clone(),
+                ValidatedKeyDerivePolicy {
+                    operation_classes: classes.into_iter().collect(),
+                    allowed_route_ids,
+                },
+            )
             .is_some()
         {
             return Err(PetalError::InvalidWasm(format!(
@@ -3895,6 +3938,52 @@ fn validate_key_derive_policy(
         }
     }
     Ok(declarations)
+}
+
+fn validate_resolved_key_derive_scopes(routes: &[RouteIndexRecord]) -> Result<(), PetalError> {
+    let routes_by_id = routes
+        .iter()
+        .map(|route| (route.route_id.as_str(), route))
+        .collect::<BTreeMap<_, _>>();
+    for origin in routes {
+        if origin.key_derive_allowed_routes.is_empty() {
+            continue;
+        }
+        if !origin
+            .key_derive_allowed_routes
+            .iter()
+            .any(|route_id| route_id == &origin.route_id)
+        {
+            return Err(PetalError::InvalidWasm(format!(
+                "Petal [[key.derive]] route {:?} must include its own resolved route id",
+                origin.pattern
+            )));
+        }
+        for route_id in &origin.key_derive_allowed_routes {
+            let target = routes_by_id.get(route_id.as_str()).ok_or_else(|| {
+                PetalError::InvalidWasm(format!(
+                    "Petal [[key.derive]] route {:?} resolves missing route id {route_id:?}",
+                    origin.pattern
+                ))
+            })?;
+            if target.route_id == origin.route_id {
+                continue;
+            }
+            let Some(sign_intent) = target.install_metadata.sign_intent.as_ref() else {
+                return Err(PetalError::InvalidWasm(format!(
+                    "Petal [[key.derive]] route {:?} allows route {:?} without a signing intent",
+                    origin.pattern, target.pattern
+                )));
+            };
+            if !origin.key_derive_operation_classes.contains(sign_intent) {
+                return Err(PetalError::InvalidWasm(format!(
+                    "Petal [[key.derive]] route {:?} allows route {:?} with incompatible signing intent {sign_intent:?}",
+                    origin.pattern, target.pattern
+                )));
+            }
+        }
+    }
+    Ok(())
 }
 
 fn store_policy_from_manifest(manifest: &PetalToml) -> StoreNamespacePolicy {
@@ -5764,6 +5853,7 @@ name = "echo"
                 sign_intent: None,
             },
             key_derive_operation_classes: Vec::new(),
+            key_derive_allowed_routes: Vec::new(),
         };
         let metadata = ComponentRouteMetadata {
             kind: ComponentRouteEntryKind::File,
@@ -5805,6 +5895,7 @@ name = "echo"
                 sign_intent: None,
             },
             key_derive_operation_classes: Vec::new(),
+            key_derive_allowed_routes: Vec::new(),
         };
         let metadata = ComponentRouteMetadata {
             kind: ComponentRouteEntryKind::File,
@@ -6081,6 +6172,7 @@ imports = ["components/helper.wasm"]
                 sign_intent: None,
             },
             key_derive_operation_classes: Vec::new(),
+            key_derive_allowed_routes: Vec::new(),
         };
         let metadata = ComponentRouteMetadata {
             kind: ComponentRouteEntryKind::File,
@@ -6620,6 +6712,7 @@ namespaces = ["fixture-public"]
 [[key.derive]]
 route = "session.json"
 operation_classes = ["fixture.secondary", "fixture.payload"]
+allowed_routes = ["session.json"]
 "#,
         )
         .unwrap();
@@ -6638,19 +6731,29 @@ operation_classes = ["fixture.secondary", "fixture.payload"]
                 .key_derive_operation_classes
                 .contains(&"fixture.unrelated".to_string())
         );
+        assert_eq!(route.key_derive_allowed_routes, vec!["r000001"]);
 
         let serialized = serde_json::to_value(route).unwrap();
         assert_eq!(
             serialized["key_derive_operation_classes"],
             serde_json::json!(["fixture.payload", "fixture.secondary"])
         );
+        assert_eq!(
+            serialized["key_derive_allowed_routes"],
+            serde_json::json!(["r000001"])
+        );
         let mut legacy = serialized;
         legacy
             .as_object_mut()
             .unwrap()
             .remove("key_derive_operation_classes");
+        legacy
+            .as_object_mut()
+            .unwrap()
+            .remove("key_derive_allowed_routes");
         let legacy: RouteIndexRecord = serde_json::from_value(legacy).unwrap();
         assert!(legacy.key_derive_operation_classes.is_empty());
+        assert!(legacy.key_derive_allowed_routes.is_empty());
     }
 
     #[test]
@@ -6716,6 +6819,24 @@ operation_class = ["fixture.payload"]
 operation_classes = ["fixture.payload"]
 "#,
                 "unknown field `operation_class`",
+            ),
+            (
+                "unknown allowed route",
+                r#"[[key.derive]]
+route = "session.json"
+operation_classes = ["fixture.payload"]
+allowed_routes = ["missing.json"]
+"#,
+                "allows unknown route",
+            ),
+            (
+                "duplicate allowed route",
+                r#"[[key.derive]]
+route = "session.json"
+operation_classes = ["fixture.payload"]
+allowed_routes = ["session.json", "session.json"]
+"#,
+                "duplicate allowed route",
             ),
         ];
 

--- a/crates/bloom-petals/src/package.rs
+++ b/crates/bloom-petals/src/package.rs
@@ -3887,6 +3887,15 @@ fn validate_sign_policy(
     Ok(())
 }
 
+/// Accept exactly the suites `bloom_broker_api::CryptoSuite` defines, so the
+/// manifest contract cannot drift from the enum Broker and Signer agree on.
+fn is_supported_crypto_suite(value: &str) -> bool {
+    serde_json::from_value::<bloom_broker_api::CryptoSuite>(serde_json::Value::String(
+        value.to_owned(),
+    ))
+    .is_ok()
+}
+
 fn validate_key_derive_policy(
     policy: &KeyPolicyToml,
     routes: &[RouteRecord],
@@ -3955,12 +3964,7 @@ fn validate_key_derive_policy(
         }
         let mut crypto_suites = BTreeSet::new();
         for suite in &declaration.allowed_crypto_suites {
-            if !matches!(
-                suite.as_str(),
-                "secp256k1-keccak256-recoverable"
-                    | "secp256k1-sha256-recoverable"
-                    | "ed25519-message"
-            ) {
+            if !is_supported_crypto_suite(suite) {
                 return Err(PetalError::InvalidWasm(format!(
                     "Petal [[key.derive]] route {:?} has unsupported crypto suite {suite:?}",
                     declaration.route

--- a/crates/bloom-petals/src/package.rs
+++ b/crates/bloom-petals/src/package.rs
@@ -150,12 +150,19 @@ struct KeyDerivePolicyToml {
     operation_classes: Vec<String>,
     #[serde(default)]
     allowed_routes: Vec<String>,
+    #[serde(default)]
+    allowed_crypto_suites: Vec<String>,
+    #[serde(default)]
+    maximum_lifetime_ms: Option<u64>,
 }
 
 #[derive(Debug)]
 struct ValidatedKeyDerivePolicy {
     operation_classes: Vec<String>,
     allowed_route_ids: Vec<String>,
+    scope_declared: bool,
+    allowed_crypto_suites: Vec<String>,
+    maximum_lifetime_ms: Option<u64>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -344,6 +351,16 @@ pub struct RouteIndexRecord {
     pub key_derive_operation_classes: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub key_derive_allowed_routes: Vec<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub key_derive_scope_declared: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub key_derive_allowed_crypto_suites: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key_derive_maximum_lifetime_ms: Option<u64>,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -592,6 +609,13 @@ impl PreparedPetalPackage {
             let route_key_derive_allowed_routes = route_key_derive_policy
                 .map(|policy| policy.allowed_route_ids.clone())
                 .unwrap_or_default();
+            let route_key_derive_scope_declared =
+                route_key_derive_policy.is_some_and(|policy| policy.scope_declared);
+            let route_key_derive_allowed_crypto_suites = route_key_derive_policy
+                .map(|policy| policy.allowed_crypto_suites.clone())
+                .unwrap_or_default();
+            let route_key_derive_maximum_lifetime_ms =
+                route_key_derive_policy.and_then(|policy| policy.maximum_lifetime_ms);
             if !route_key_derive_operation_classes.is_empty()
                 && !validation
                     .required_caps
@@ -649,6 +673,9 @@ impl PreparedPetalPackage {
                 install_metadata,
                 key_derive_operation_classes: route_key_derive_operation_classes,
                 key_derive_allowed_routes: route_key_derive_allowed_routes,
+                key_derive_scope_declared: route_key_derive_scope_declared,
+                key_derive_allowed_crypto_suites: route_key_derive_allowed_crypto_suites,
+                key_derive_maximum_lifetime_ms: route_key_derive_maximum_lifetime_ms,
             });
         }
         validate_resolved_key_derive_scopes(&route_index.routes)?;
@@ -3899,6 +3926,53 @@ fn validate_key_derive_policy(
                 )));
             }
         }
+        let scope_declared = !declaration.allowed_routes.is_empty()
+            || !declaration.allowed_crypto_suites.is_empty()
+            || declaration.maximum_lifetime_ms.is_some();
+        if scope_declared && declaration.allowed_routes.is_empty() {
+            return Err(PetalError::InvalidWasm(format!(
+                "Petal [[key.derive]] route {:?} manifest scope requires non-empty allowed_routes",
+                declaration.route
+            )));
+        }
+        if scope_declared && declaration.allowed_crypto_suites.is_empty() {
+            return Err(PetalError::InvalidWasm(format!(
+                "Petal [[key.derive]] route {:?} manifest scope requires non-empty allowed_crypto_suites",
+                declaration.route
+            )));
+        }
+        if scope_declared && declaration.maximum_lifetime_ms.is_none() {
+            return Err(PetalError::InvalidWasm(format!(
+                "Petal [[key.derive]] route {:?} manifest scope requires maximum_lifetime_ms",
+                declaration.route
+            )));
+        }
+        if declaration.maximum_lifetime_ms == Some(0) {
+            return Err(PetalError::InvalidWasm(format!(
+                "Petal [[key.derive]] route {:?} maximum_lifetime_ms must be greater than zero",
+                declaration.route
+            )));
+        }
+        let mut crypto_suites = BTreeSet::new();
+        for suite in &declaration.allowed_crypto_suites {
+            if !matches!(
+                suite.as_str(),
+                "secp256k1-keccak256-recoverable"
+                    | "secp256k1-sha256-recoverable"
+                    | "ed25519-message"
+            ) {
+                return Err(PetalError::InvalidWasm(format!(
+                    "Petal [[key.derive]] route {:?} has unsupported crypto suite {suite:?}",
+                    declaration.route
+                )));
+            }
+            if !crypto_suites.insert(suite.clone()) {
+                return Err(PetalError::InvalidWasm(format!(
+                    "Petal [[key.derive]] route {:?} has duplicate crypto suite {suite:?}",
+                    declaration.route
+                )));
+            }
+        }
         let mut allowed_patterns = BTreeSet::new();
         for pattern in &declaration.allowed_routes {
             if !routes_by_pattern.contains_key(pattern.as_str()) {
@@ -3927,6 +4001,9 @@ fn validate_key_derive_policy(
                 ValidatedKeyDerivePolicy {
                     operation_classes: classes.into_iter().collect(),
                     allowed_route_ids,
+                    scope_declared,
+                    allowed_crypto_suites: crypto_suites.into_iter().collect(),
+                    maximum_lifetime_ms: declaration.maximum_lifetime_ms,
                 },
             )
             .is_some()
@@ -3946,8 +4023,27 @@ fn validate_resolved_key_derive_scopes(routes: &[RouteIndexRecord]) -> Result<()
         .map(|route| (route.route_id.as_str(), route))
         .collect::<BTreeMap<_, _>>();
     for origin in routes {
-        if origin.key_derive_allowed_routes.is_empty() {
+        if !origin.key_derive_scope_declared {
+            if !origin.key_derive_allowed_routes.is_empty()
+                || !origin.key_derive_allowed_crypto_suites.is_empty()
+                || origin.key_derive_maximum_lifetime_ms.is_some()
+            {
+                return Err(PetalError::InvalidWasm(format!(
+                    "Petal [[key.derive]] route {:?} has scope bounds without a declared manifest scope",
+                    origin.pattern
+                )));
+            }
             continue;
+        }
+        if origin.key_derive_allowed_routes.is_empty()
+            || origin.key_derive_operation_classes.is_empty()
+            || origin.key_derive_allowed_crypto_suites.is_empty()
+            || origin.key_derive_maximum_lifetime_ms.is_none()
+        {
+            return Err(PetalError::InvalidWasm(format!(
+                "Petal [[key.derive]] route {:?} has an incomplete manifest scope",
+                origin.pattern
+            )));
         }
         if !origin
             .key_derive_allowed_routes
@@ -5854,6 +5950,9 @@ name = "echo"
             },
             key_derive_operation_classes: Vec::new(),
             key_derive_allowed_routes: Vec::new(),
+            key_derive_scope_declared: false,
+            key_derive_allowed_crypto_suites: Vec::new(),
+            key_derive_maximum_lifetime_ms: None,
         };
         let metadata = ComponentRouteMetadata {
             kind: ComponentRouteEntryKind::File,
@@ -5896,6 +5995,9 @@ name = "echo"
             },
             key_derive_operation_classes: Vec::new(),
             key_derive_allowed_routes: Vec::new(),
+            key_derive_scope_declared: false,
+            key_derive_allowed_crypto_suites: Vec::new(),
+            key_derive_maximum_lifetime_ms: None,
         };
         let metadata = ComponentRouteMetadata {
             kind: ComponentRouteEntryKind::File,
@@ -6173,6 +6275,9 @@ imports = ["components/helper.wasm"]
             },
             key_derive_operation_classes: Vec::new(),
             key_derive_allowed_routes: Vec::new(),
+            key_derive_scope_declared: false,
+            key_derive_allowed_crypto_suites: Vec::new(),
+            key_derive_maximum_lifetime_ms: None,
         };
         let metadata = ComponentRouteMetadata {
             kind: ComponentRouteEntryKind::File,
@@ -6713,6 +6818,8 @@ namespaces = ["fixture-public"]
 route = "session.json"
 operation_classes = ["fixture.secondary", "fixture.payload"]
 allowed_routes = ["session.json"]
+allowed_crypto_suites = ["secp256k1-keccak256-recoverable"]
+maximum_lifetime_ms = 60000
 "#,
         )
         .unwrap();
@@ -6732,6 +6839,12 @@ allowed_routes = ["session.json"]
                 .contains(&"fixture.unrelated".to_string())
         );
         assert_eq!(route.key_derive_allowed_routes, vec!["r000001"]);
+        assert!(route.key_derive_scope_declared);
+        assert_eq!(
+            route.key_derive_allowed_crypto_suites,
+            vec!["secp256k1-keccak256-recoverable"]
+        );
+        assert_eq!(route.key_derive_maximum_lifetime_ms, Some(60_000));
 
         let serialized = serde_json::to_value(route).unwrap();
         assert_eq!(
@@ -6742,6 +6855,7 @@ allowed_routes = ["session.json"]
             serialized["key_derive_allowed_routes"],
             serde_json::json!(["r000001"])
         );
+        assert_eq!(serialized["key_derive_scope_declared"], true);
         let mut legacy = serialized;
         legacy
             .as_object_mut()
@@ -6751,9 +6865,93 @@ allowed_routes = ["session.json"]
             .as_object_mut()
             .unwrap()
             .remove("key_derive_allowed_routes");
+        legacy
+            .as_object_mut()
+            .unwrap()
+            .remove("key_derive_scope_declared");
+        legacy
+            .as_object_mut()
+            .unwrap()
+            .remove("key_derive_allowed_crypto_suites");
+        legacy
+            .as_object_mut()
+            .unwrap()
+            .remove("key_derive_maximum_lifetime_ms");
         let legacy: RouteIndexRecord = serde_json::from_value(legacy).unwrap();
         assert!(legacy.key_derive_operation_classes.is_empty());
         assert!(legacy.key_derive_allowed_routes.is_empty());
+        assert!(!legacy.key_derive_scope_declared);
+        assert!(legacy.key_derive_allowed_crypto_suites.is_empty());
+        assert_eq!(legacy.key_derive_maximum_lifetime_ms, None);
+    }
+
+    #[test]
+    fn petal_key_derive_manifest_scope_survives_unrelated_route_insertion() {
+        let manifest = br#"schema = "bloom.petal.package.v1"
+name = "triad-authority-fixture"
+[caps]
+allowed = ["bloom:key.derive", "bloom:sign", "bloom:store"]
+
+[sign]
+allowed_intents = ["fixture.payload"]
+
+[store]
+namespaces = ["fixture-public"]
+
+[[key.derive]]
+route = "session.json"
+operation_classes = ["fixture.payload"]
+allowed_routes = ["session.json"]
+allowed_crypto_suites = ["secp256k1-keccak256-recoverable"]
+maximum_lifetime_ms = 60000
+"#;
+        let original = prepared_triad_fixture_with_manifest(manifest).unwrap();
+
+        let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../tests/fixtures/triad-authority-petal");
+        let mut files = collect_package_dir(&fixture).unwrap();
+        files
+            .iter_mut()
+            .find(|file| file.path == "petal.toml")
+            .unwrap()
+            .bytes = manifest.to_vec();
+        files.retain(|file| !file.path.starts_with("artifacts/"));
+        files.push(NormalizedPackageFile {
+            path: "petal/triad-authority-fixture/aaa.txt.wasm".into(),
+            bytes: route_component_no_imports().to_vec(),
+        });
+        let inserted = PreparedPetalPackage::from_files(files).unwrap();
+
+        let original_route = original
+            .route_index
+            .routes
+            .iter()
+            .find(|route| route.pattern == "session.json")
+            .unwrap();
+        let inserted_route = inserted
+            .route_index
+            .routes
+            .iter()
+            .find(|route| route.pattern == "session.json")
+            .unwrap();
+        assert_ne!(original_route.route_id, inserted_route.route_id);
+        for (package, origin) in [(&original, original_route), (&inserted, inserted_route)] {
+            let patterns = origin
+                .key_derive_allowed_routes
+                .iter()
+                .map(|id| {
+                    package
+                        .route_index
+                        .routes
+                        .iter()
+                        .find(|route| &route.route_id == id)
+                        .unwrap()
+                        .pattern
+                        .as_str()
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(patterns, ["session.json"]);
+        }
     }
 
     #[test]
@@ -6826,6 +7024,8 @@ operation_classes = ["fixture.payload"]
 route = "session.json"
 operation_classes = ["fixture.payload"]
 allowed_routes = ["missing.json"]
+allowed_crypto_suites = ["secp256k1-keccak256-recoverable"]
+maximum_lifetime_ms = 60000
 "#,
                 "allows unknown route",
             ),
@@ -6835,8 +7035,63 @@ allowed_routes = ["missing.json"]
 route = "session.json"
 operation_classes = ["fixture.payload"]
 allowed_routes = ["session.json", "session.json"]
+allowed_crypto_suites = ["secp256k1-keccak256-recoverable"]
+maximum_lifetime_ms = 60000
 "#,
                 "duplicate allowed route",
+            ),
+            (
+                "scope requires suites",
+                r#"[[key.derive]]
+route = "session.json"
+operation_classes = ["fixture.payload"]
+allowed_routes = ["session.json"]
+maximum_lifetime_ms = 60000
+"#,
+                "requires non-empty allowed_crypto_suites",
+            ),
+            (
+                "scope requires lifetime",
+                r#"[[key.derive]]
+route = "session.json"
+operation_classes = ["fixture.payload"]
+allowed_routes = ["session.json"]
+allowed_crypto_suites = ["secp256k1-keccak256-recoverable"]
+"#,
+                "requires maximum_lifetime_ms",
+            ),
+            (
+                "unsupported suite",
+                r#"[[key.derive]]
+route = "session.json"
+operation_classes = ["fixture.payload"]
+allowed_routes = ["session.json"]
+allowed_crypto_suites = ["unknown-suite"]
+maximum_lifetime_ms = 60000
+"#,
+                "unsupported crypto suite",
+            ),
+            (
+                "duplicate suite",
+                r#"[[key.derive]]
+route = "session.json"
+operation_classes = ["fixture.payload"]
+allowed_routes = ["session.json"]
+allowed_crypto_suites = ["ed25519-message", "ed25519-message"]
+maximum_lifetime_ms = 60000
+"#,
+                "duplicate crypto suite",
+            ),
+            (
+                "zero lifetime",
+                r#"[[key.derive]]
+route = "session.json"
+operation_classes = ["fixture.payload"]
+allowed_routes = ["session.json"]
+allowed_crypto_suites = ["ed25519-message"]
+maximum_lifetime_ms = 0
+"#,
+                "must be greater than zero",
             ),
         ];
 

--- a/crates/bloom-petals/src/runner.rs
+++ b/crates/bloom-petals/src/runner.rs
@@ -521,6 +521,7 @@ impl PetalRunner {
             Some(mask) => declared_store_policy.intersect(&mask),
             None => declared_store_policy,
         });
+        opts.key_derive_allowed_routes = matched.route.key_derive_allowed_routes.clone();
         self.vm
             .dispatch_component_route(
                 &wasm,

--- a/crates/bloom-petals/src/runner.rs
+++ b/crates/bloom-petals/src/runner.rs
@@ -521,7 +521,12 @@ impl PetalRunner {
             Some(mask) => declared_store_policy.intersect(&mask),
             None => declared_store_policy,
         });
+        opts.key_derive_scope_declared = matched.route.key_derive_scope_declared;
         opts.key_derive_allowed_routes = matched.route.key_derive_allowed_routes.clone();
+        opts.key_derive_operation_classes = matched.route.key_derive_operation_classes.clone();
+        opts.key_derive_allowed_crypto_suites =
+            matched.route.key_derive_allowed_crypto_suites.clone();
+        opts.key_derive_maximum_lifetime_ms = matched.route.key_derive_maximum_lifetime_ms;
         self.vm
             .dispatch_component_route(
                 &wasm,

--- a/crates/bloom-petals/src/vm.rs
+++ b/crates/bloom-petals/src/vm.rs
@@ -74,6 +74,7 @@ pub struct StoreData {
     petal_hash: String,
     net_policy: NetPolicy,
     sign_context: Option<PetalRouteContext>,
+    key_derive_allowed_routes: Vec<String>,
     sign_intents: Option<BTreeSet<String>>,
     store_namespaces: Option<StoreNamespacePolicy>,
     http_response_cap: usize,
@@ -116,6 +117,9 @@ pub struct RunOptions {
     /// Optional private-store namespace policy. `None` preserves legacy/direct
     /// VM behavior; Petal package dispatch sets this from `[store]`.
     pub store_namespaces: Option<StoreNamespacePolicy>,
+    /// Manifest-declared route IDs resolved from canonical patterns at package
+    /// validation time. Empty preserves the legacy guest-supplied scope.
+    pub key_derive_allowed_routes: Vec<String>,
     pub http_response_cap: usize,
     pub private_store_root: Option<PathBuf>,
     /// Force mediated env helpers to deterministic values for install-time checks.
@@ -134,6 +138,7 @@ impl Default for RunOptions {
             net_policy: None,
             sign_intents: None,
             store_namespaces: None,
+            key_derive_allowed_routes: Vec::new(),
             http_response_cap: DEFAULT_HTTP_RESPONSE_CAP,
             private_store_root: None,
             deterministic_env: false,
@@ -261,6 +266,7 @@ impl PetalVm {
                 petal_hash: petal_hash.to_string(),
                 net_policy: opts.net_policy.clone().unwrap_or_else(NetPolicy::deny_all),
                 sign_context: None,
+                key_derive_allowed_routes: opts.key_derive_allowed_routes.clone(),
                 sign_intents: opts.sign_intents.clone(),
                 store_namespaces: opts.store_namespaces.clone(),
                 http_response_cap: opts.http_response_cap,
@@ -335,6 +341,7 @@ impl PetalVm {
                         .iter()
                         .find_map(|(name, value)| (name == "actor").then(|| value.clone())),
                 }),
+                key_derive_allowed_routes: opts.key_derive_allowed_routes.clone(),
                 sign_intents: opts.sign_intents.clone(),
                 store_namespaces: opts.store_namespaces.clone(),
                 http_response_cap: opts.http_response_cap,
@@ -408,6 +415,7 @@ impl PetalVm {
                 petal_hash: petal_hash.to_string(),
                 net_policy: opts.net_policy.clone().unwrap_or_else(NetPolicy::deny_all),
                 sign_context: None,
+                key_derive_allowed_routes: opts.key_derive_allowed_routes.clone(),
                 sign_intents: opts.sign_intents.clone(),
                 store_namespaces: opts.store_namespaces.clone(),
                 http_response_cap: opts.http_response_cap,
@@ -1447,6 +1455,9 @@ async fn component_petal_key_request(
         }
     };
     let mut request = PetalKeyRequest::from(guest);
+    if !store.data().key_derive_allowed_routes.is_empty() {
+        request.allowed_routes = store.data().key_derive_allowed_routes.clone();
+    }
     request.context = store.data().sign_context.clone();
     let host = store.data().host.clone();
     match host.petal_key_request(request).await {
@@ -3931,6 +3942,7 @@ paths = ["/status"]
             actor: None,
         };
         store.data_mut().sign_context = Some(context.clone());
+        store.data_mut().key_derive_allowed_routes = vec!["r000007".into(), "r000008".into()];
 
         let attempted_override = serde_json::to_vec(&serde_json::json!({
             "request_id": "agent-a",
@@ -3956,7 +3968,7 @@ paths = ["/status"]
         let request = serde_json::to_vec(&serde_json::json!({
             "wallet_id": "primary",
             "key_slot": "desk-a",
-            "allowed_routes": ["r000007"],
+            "allowed_routes": ["r999999"],
             "allowed_operation_classes": ["order.place"],
             "allowed_crypto_suites": ["secp256k1-keccak256-recoverable"],
             "maximum_lifetime_ms": 60_000
@@ -3979,6 +3991,7 @@ paths = ["/status"]
         let calls = host.petal_key_calls.lock();
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].context, Some(context));
+        assert_eq!(calls[0].allowed_routes, ["r000007", "r000008"]);
     }
 
     #[tokio::test]
@@ -4913,6 +4926,7 @@ paths = ["/status"]
                 petal_hash: VALID_HASH.into(),
                 net_policy,
                 sign_context: None,
+                key_derive_allowed_routes: Vec::new(),
                 sign_intents: None,
                 store_namespaces: None,
                 http_response_cap: DEFAULT_HTTP_RESPONSE_CAP,

--- a/crates/bloom-petals/src/vm.rs
+++ b/crates/bloom-petals/src/vm.rs
@@ -74,7 +74,11 @@ pub struct StoreData {
     petal_hash: String,
     net_policy: NetPolicy,
     sign_context: Option<PetalRouteContext>,
+    key_derive_scope_declared: bool,
     key_derive_allowed_routes: Vec<String>,
+    key_derive_operation_classes: Vec<String>,
+    key_derive_allowed_crypto_suites: Vec<String>,
+    key_derive_maximum_lifetime_ms: Option<u64>,
     sign_intents: Option<BTreeSet<String>>,
     store_namespaces: Option<StoreNamespacePolicy>,
     http_response_cap: usize,
@@ -117,9 +121,18 @@ pub struct RunOptions {
     /// Optional private-store namespace policy. `None` preserves legacy/direct
     /// VM behavior; Petal package dispatch sets this from `[store]`.
     pub store_namespaces: Option<StoreNamespacePolicy>,
+    /// Whether this route has a complete manifest-declared key scope. False
+    /// preserves the compatibility path for packages created before scopes.
+    pub key_derive_scope_declared: bool,
     /// Manifest-declared route IDs resolved from canonical patterns at package
-    /// validation time. Empty preserves the legacy guest-supplied scope.
+    /// validation time.
     pub key_derive_allowed_routes: Vec<String>,
+    /// Manifest-declared upper bound for delegated operation classes.
+    pub key_derive_operation_classes: Vec<String>,
+    /// Manifest-declared upper bound for derived-key crypto suites.
+    pub key_derive_allowed_crypto_suites: Vec<String>,
+    /// Manifest-declared upper bound for derived-key lifetime.
+    pub key_derive_maximum_lifetime_ms: Option<u64>,
     pub http_response_cap: usize,
     pub private_store_root: Option<PathBuf>,
     /// Force mediated env helpers to deterministic values for install-time checks.
@@ -138,7 +151,11 @@ impl Default for RunOptions {
             net_policy: None,
             sign_intents: None,
             store_namespaces: None,
+            key_derive_scope_declared: false,
             key_derive_allowed_routes: Vec::new(),
+            key_derive_operation_classes: Vec::new(),
+            key_derive_allowed_crypto_suites: Vec::new(),
+            key_derive_maximum_lifetime_ms: None,
             http_response_cap: DEFAULT_HTTP_RESPONSE_CAP,
             private_store_root: None,
             deterministic_env: false,
@@ -266,7 +283,11 @@ impl PetalVm {
                 petal_hash: petal_hash.to_string(),
                 net_policy: opts.net_policy.clone().unwrap_or_else(NetPolicy::deny_all),
                 sign_context: None,
+                key_derive_scope_declared: opts.key_derive_scope_declared,
                 key_derive_allowed_routes: opts.key_derive_allowed_routes.clone(),
+                key_derive_operation_classes: opts.key_derive_operation_classes.clone(),
+                key_derive_allowed_crypto_suites: opts.key_derive_allowed_crypto_suites.clone(),
+                key_derive_maximum_lifetime_ms: opts.key_derive_maximum_lifetime_ms,
                 sign_intents: opts.sign_intents.clone(),
                 store_namespaces: opts.store_namespaces.clone(),
                 http_response_cap: opts.http_response_cap,
@@ -341,7 +362,11 @@ impl PetalVm {
                         .iter()
                         .find_map(|(name, value)| (name == "actor").then(|| value.clone())),
                 }),
+                key_derive_scope_declared: opts.key_derive_scope_declared,
                 key_derive_allowed_routes: opts.key_derive_allowed_routes.clone(),
+                key_derive_operation_classes: opts.key_derive_operation_classes.clone(),
+                key_derive_allowed_crypto_suites: opts.key_derive_allowed_crypto_suites.clone(),
+                key_derive_maximum_lifetime_ms: opts.key_derive_maximum_lifetime_ms,
                 sign_intents: opts.sign_intents.clone(),
                 store_namespaces: opts.store_namespaces.clone(),
                 http_response_cap: opts.http_response_cap,
@@ -415,7 +440,11 @@ impl PetalVm {
                 petal_hash: petal_hash.to_string(),
                 net_policy: opts.net_policy.clone().unwrap_or_else(NetPolicy::deny_all),
                 sign_context: None,
+                key_derive_scope_declared: opts.key_derive_scope_declared,
                 key_derive_allowed_routes: opts.key_derive_allowed_routes.clone(),
+                key_derive_operation_classes: opts.key_derive_operation_classes.clone(),
+                key_derive_allowed_crypto_suites: opts.key_derive_allowed_crypto_suites.clone(),
+                key_derive_maximum_lifetime_ms: opts.key_derive_maximum_lifetime_ms,
                 sign_intents: opts.sign_intents.clone(),
                 store_namespaces: opts.store_namespaces.clone(),
                 http_response_cap: opts.http_response_cap,
@@ -1410,6 +1439,61 @@ async fn component_sign_hashes(
     set_component_result(results, component_host_err(legacy_signing_unsupported()))
 }
 
+fn apply_manifest_key_scope(
+    data: &StoreData,
+    request: &mut PetalKeyRequest,
+) -> Result<(), HostError> {
+    if !data.key_derive_scope_declared {
+        return Ok(());
+    }
+    let maximum_lifetime_ms = data.key_derive_maximum_lifetime_ms.ok_or_else(|| {
+        HostError::Invalid("installed Petal key scope has no lifetime bound".into())
+    })?;
+    if data.key_derive_allowed_routes.is_empty()
+        || data.key_derive_operation_classes.is_empty()
+        || data.key_derive_allowed_crypto_suites.is_empty()
+    {
+        return Err(HostError::Invalid(
+            "installed Petal key scope is incomplete".into(),
+        ));
+    }
+    let requested_classes = request
+        .allowed_operation_classes
+        .iter()
+        .collect::<BTreeSet<_>>();
+    if requested_classes.is_empty()
+        || requested_classes.len() != request.allowed_operation_classes.len()
+        || requested_classes
+            .iter()
+            .any(|class| !data.key_derive_operation_classes.contains(class))
+    {
+        return Err(HostError::Invalid(
+            "Petal key operation classes must be a non-empty subset of the manifest scope".into(),
+        ));
+    }
+    let requested_suites = request
+        .allowed_crypto_suites
+        .iter()
+        .collect::<BTreeSet<_>>();
+    if requested_suites.is_empty()
+        || requested_suites.len() != request.allowed_crypto_suites.len()
+        || requested_suites
+            .iter()
+            .any(|suite| !data.key_derive_allowed_crypto_suites.contains(suite))
+    {
+        return Err(HostError::Invalid(
+            "Petal key crypto suites must be a non-empty subset of the manifest scope".into(),
+        ));
+    }
+    if request.maximum_lifetime_ms == 0 || request.maximum_lifetime_ms > maximum_lifetime_ms {
+        return Err(HostError::Invalid(format!(
+            "Petal key lifetime must be between 1 and {maximum_lifetime_ms} ms"
+        )));
+    }
+    request.allowed_routes = data.key_derive_allowed_routes.clone();
+    Ok(())
+}
+
 async fn component_petal_key_request(
     store: StoreContextMut<'_, StoreData>,
     params: &[ComponentVal],
@@ -1455,8 +1539,8 @@ async fn component_petal_key_request(
         }
     };
     let mut request = PetalKeyRequest::from(guest);
-    if !store.data().key_derive_allowed_routes.is_empty() {
-        request.allowed_routes = store.data().key_derive_allowed_routes.clone();
+    if let Err(error) = apply_manifest_key_scope(store.data(), &mut request) {
+        return set_component_result(results, component_host_err(error));
     }
     request.context = store.data().sign_context.clone();
     let host = store.data().host.clone();
@@ -3942,7 +4026,12 @@ paths = ["/status"]
             actor: None,
         };
         store.data_mut().sign_context = Some(context.clone());
+        store.data_mut().key_derive_scope_declared = true;
         store.data_mut().key_derive_allowed_routes = vec!["r000007".into(), "r000008".into()];
+        store.data_mut().key_derive_operation_classes = vec!["order.place".into()];
+        store.data_mut().key_derive_allowed_crypto_suites =
+            vec!["secp256k1-keccak256-recoverable".into()];
+        store.data_mut().key_derive_maximum_lifetime_ms = Some(60_000);
 
         let attempted_override = serde_json::to_vec(&serde_json::json!({
             "request_id": "agent-a",
@@ -3963,6 +4052,26 @@ paths = ["/status"]
         .await
         .unwrap();
         assert_component_err_contains(&denied[0], "unknown field");
+        assert!(host.petal_key_calls.lock().is_empty());
+
+        let widened = serde_json::to_vec(&serde_json::json!({
+            "wallet_id": "primary",
+            "key_slot": "desk-a",
+            "allowed_routes": [],
+            "allowed_operation_classes": ["order.cancel"],
+            "allowed_crypto_suites": ["secp256k1-keccak256-recoverable"],
+            "maximum_lifetime_ms": 60_000
+        }))
+        .unwrap();
+        let mut denied = vec![ComponentVal::Bool(false)];
+        component_petal_key_request(
+            store.as_context_mut(),
+            &[component_bytes(widened)],
+            &mut denied,
+        )
+        .await
+        .unwrap();
+        assert_component_err_contains(&denied[0], "subset of the manifest scope");
         assert!(host.petal_key_calls.lock().is_empty());
 
         let request = serde_json::to_vec(&serde_json::json!({
@@ -4926,7 +5035,11 @@ paths = ["/status"]
                 petal_hash: VALID_HASH.into(),
                 net_policy,
                 sign_context: None,
+                key_derive_scope_declared: false,
                 key_derive_allowed_routes: Vec::new(),
+                key_derive_operation_classes: Vec::new(),
+                key_derive_allowed_crypto_suites: Vec::new(),
+                key_derive_maximum_lifetime_ms: None,
                 sign_intents: None,
                 store_namespaces: None,
                 http_response_cap: DEFAULT_HTTP_RESPONSE_CAP,

--- a/crates/bloom-petals/tests/triad_authority_fixture.rs
+++ b/crates/bloom-petals/tests/triad_authority_fixture.rs
@@ -178,13 +178,17 @@ fn fixture_is_an_installable_package_with_only_scoped_authority_imports() {
     assert_eq!(package.name, "triad-authority-fixture");
     assert_eq!(
         package.hash,
-        "d1e895bb0ee3fd58a2a0d434724cb6060adb769f8604286a2906fd9b8295e9c6"
+        "91d4eb2d0ba536c101743c734ea089364c0b1572139bb17afa353cefa48fcd43"
     );
     assert_eq!(package.route_index.routes.len(), 1);
     assert_eq!(package.route_index.routes[0].pattern, "session.json");
     assert_eq!(
         package.route_index.routes[0].key_derive_operation_classes,
         ["fixture.payload"]
+    );
+    assert_eq!(
+        package.route_index.routes[0].key_derive_allowed_routes,
+        ["r000001"]
     );
     let component = std::fs::read(format!(
         "{FIXTURE}/petal/triad-authority-fixture/session.json.wasm"

--- a/crates/bloom-petals/tests/triad_authority_fixture.rs
+++ b/crates/bloom-petals/tests/triad_authority_fixture.rs
@@ -178,7 +178,7 @@ fn fixture_is_an_installable_package_with_only_scoped_authority_imports() {
     assert_eq!(package.name, "triad-authority-fixture");
     assert_eq!(
         package.hash,
-        "91d4eb2d0ba536c101743c734ea089364c0b1572139bb17afa353cefa48fcd43"
+        "d219b74707f3c0d013cb4c4fab4f13818060869bca1e49e649b65452eba1a3c2"
     );
     assert_eq!(package.route_index.routes.len(), 1);
     assert_eq!(package.route_index.routes[0].pattern, "session.json");
@@ -189,6 +189,15 @@ fn fixture_is_an_installable_package_with_only_scoped_authority_imports() {
     assert_eq!(
         package.route_index.routes[0].key_derive_allowed_routes,
         ["r000001"]
+    );
+    assert!(package.route_index.routes[0].key_derive_scope_declared);
+    assert_eq!(
+        package.route_index.routes[0].key_derive_allowed_crypto_suites,
+        ["secp256k1-sha256-recoverable"]
+    );
+    assert_eq!(
+        package.route_index.routes[0].key_derive_maximum_lifetime_ms,
+        Some(300_000)
     );
     let component = std::fs::read(format!(
         "{FIXTURE}/petal/triad-authority-fixture/session.json.wasm"

--- a/crates/bloom/src/triad_enrollment.rs
+++ b/crates/bloom/src/triad_enrollment.rs
@@ -1062,6 +1062,7 @@ mod tests {
                 "fixture.delegated".into(),
                 "fixture.immediate".into(),
             ],
+            key_derive_allowed_routes: vec!["r000001".into()],
         };
 
         let classes = developer_route_operation_classes(&route)

--- a/crates/bloom/src/triad_enrollment.rs
+++ b/crates/bloom/src/triad_enrollment.rs
@@ -1063,6 +1063,9 @@ mod tests {
                 "fixture.immediate".into(),
             ],
             key_derive_allowed_routes: vec!["r000001".into()],
+            key_derive_scope_declared: true,
+            key_derive_allowed_crypto_suites: vec!["secp256k1-keccak256-recoverable".into()],
+            key_derive_maximum_lifetime_ms: Some(60_000),
         };
 
         let classes = developer_route_operation_classes(&route)

--- a/docs/architecture/Petal derived key succession.md
+++ b/docs/architecture/Petal derived key succession.md
@@ -11,6 +11,13 @@ Signer-owned derived key. It covers local development and production, including:
 - arbitrary Petals installed by an end user; and
 - new versions of those user-installed Petals.
 
+Current production policy is deliberately narrower than the proposal below:
+derived-key authority remains bound to one immutable package hash. Installing a
+new package version does not inherit that authority; the Petal must request a new
+key/session and the user must authorize it. Succession is deferred until a
+durable-key caller requires continuity and the full user-authorized transition
+can be implemented end to end.
+
 The central rule is:
 
 > Installing package bytes is not authorization to use a key. Key access is a

--- a/docs/architecture/Sealed Approvals.md
+++ b/docs/architecture/Sealed Approvals.md
@@ -163,6 +163,13 @@ scope and installer-signed provenance. Machine retains the public approval
 binding with the `KeyRef`; the Petal receives neither an approval capability
 nor another ceremony for each matching action.
 
+For manifest-scoped Petals, canonical route patterns, operation classes,
+crypto suites, and the maximum lifetime are authenticated package bounds. The
+component may request narrower classes, suites, or lifetime, but Machine
+rejects widening and supplies the resolved route IDs itself. Packages predating
+that complete manifest scope retain their legacy request semantics only as a
+compatibility path.
+
 Venue-specific custody and signing protocols do not belong in Machine, Broker,
 or Signer. An installed Hyperliquid Petal, for example, uses this generic scope
 instead of a native Machine agent-session key.

--- a/docs/petals/authoring-petals.md
+++ b/docs/petals/authoring-petals.md
@@ -82,13 +82,22 @@ the exact route pattern that imports `bloom:key/derive@0.1.0`:
 [[key.derive]]
 route = "[network]/agent_sessions/[wallet]/new.json"
 operation_classes = ["venue.agent_action"]
+allowed_routes = [
+  "[network]/agent_sessions/[wallet]/cancel.json",
+  "[network]/orders/[wallet]/new.json",
+]
 ```
 
 Every listed class must also appear in `[sign].allowed_intents`. Bloom rejects
 unknown or duplicate routes, empty or duplicate class lists, invalid class
 tokens, and declarations on routes without the key-derivation import. The
-installer records only the route's immediate signing intent and these explicit
-delegated classes; other package-level signing intents are not inherited.
+installer resolves `allowed_routes` from canonical manifest patterns to the
+immutable route IDs in that package and always includes the derivation route
+itself. Each allowed route must have a signing intent included in the declared
+operation classes. Components do not choose route IDs at runtime. Omitting
+`allowed_routes` retains the legacy guest-supplied route scope for compatibility;
+new Petals should declare it. Other package-level signing intents are not
+inherited.
 
 ## Routes and ABI
 

--- a/docs/petals/authoring-petals.md
+++ b/docs/petals/authoring-petals.md
@@ -102,6 +102,21 @@ cannot widen any bound; Bloom supplies the resolved routes. A manifest scope
 must declare all three bounds: `allowed_routes`, `allowed_crypto_suites`, and
 `maximum_lifetime_ms`.
 
+A crypto suite selects which hash runs over a payload before the child key
+signs it. `allowed_crypto_suites` accepts exactly the values of `CryptoSuite`
+in `bloom-broker-api`, and Bloom rejects anything else at install:
+
+| Value | Wallet | Use for |
+| --- | --- | --- |
+| `secp256k1-keccak256-recoverable` | EVM | keccak256, what Ethereum verifies: transactions, EIP-712, EIP-191 |
+| `secp256k1-sha256-recoverable` | EVM | SHA-256, for off-chain use such as signed venue API requests; no chain accepts these |
+| `ed25519-message` | Solana | the only suite a Solana wallet permits |
+
+The wallet's derivation profile is the ceiling: an EVM wallet permits both
+secp256k1 suites, a Solana wallet permits only `ed25519-message`. Declare the
+narrowest set the Petal actually needs, since a key limited to
+`secp256k1-sha256-recoverable` cannot produce a signature an EVM node accepts.
+
 Omitting all three bounds retains the legacy guest-supplied scope only for
 packages created before this manifest contract. New Petals should always
 declare the complete scope. Other package-level signing intents are not

--- a/docs/petals/authoring-petals.md
+++ b/docs/petals/authoring-petals.md
@@ -86,6 +86,8 @@ allowed_routes = [
   "[network]/agent_sessions/[wallet]/cancel.json",
   "[network]/orders/[wallet]/new.json",
 ]
+allowed_crypto_suites = ["secp256k1-keccak256-recoverable"]
+maximum_lifetime_ms = 86400000
 ```
 
 Every listed class must also appear in `[sign].allowed_intents`. Bloom rejects
@@ -94,9 +96,15 @@ tokens, and declarations on routes without the key-derivation import. The
 installer resolves `allowed_routes` from canonical manifest patterns to the
 immutable route IDs in that package and always includes the derivation route
 itself. Each allowed route must have a signing intent included in the declared
-operation classes. Components do not choose route IDs at runtime. Omitting
-`allowed_routes` retains the legacy guest-supplied route scope for compatibility;
-new Petals should declare it. Other package-level signing intents are not
+operation classes. At runtime the component may request non-empty subsets of
+the declared operation classes and crypto suites and a shorter lifetime, but it
+cannot widen any bound; Bloom supplies the resolved routes. A manifest scope
+must declare all three bounds: `allowed_routes`, `allowed_crypto_suites`, and
+`maximum_lifetime_ms`.
+
+Omitting all three bounds retains the legacy guest-supplied scope only for
+packages created before this manifest contract. New Petals should always
+declare the complete scope. Other package-level signing intents are not
 inherited.
 
 ## Routes and ABI

--- a/tests/fixtures/triad-authority-petal/petal.toml
+++ b/tests/fixtures/triad-authority-petal/petal.toml
@@ -14,6 +14,8 @@ allowed_intents = ["fixture.payload", "fixture.unrelated"]
 route = "session.json"
 operation_classes = ["fixture.payload"]
 allowed_routes = ["session.json"]
+allowed_crypto_suites = ["secp256k1-sha256-recoverable"]
+maximum_lifetime_ms = 300000
 
 [store]
 namespaces = ["fixture-public"]

--- a/tests/fixtures/triad-authority-petal/petal.toml
+++ b/tests/fixtures/triad-authority-petal/petal.toml
@@ -13,6 +13,7 @@ allowed_intents = ["fixture.payload", "fixture.unrelated"]
 [[key.derive]]
 route = "session.json"
 operation_classes = ["fixture.payload"]
+allowed_routes = ["session.json"]
 
 [store]
 namespaces = ["fixture-public"]


### PR DESCRIPTION
## Summary

Closes bloom-directory/petal#20.

A declared `[[key.derive]]` scope is now complete and authenticated: canonical `allowed_routes`, `operation_classes`, `allowed_crypto_suites`, and `maximum_lifetime_ms`. Packaging resolves route patterns to immutable route IDs, includes the derivation route, and rejects missing, unknown, duplicate, unsigned, unsupported-suite, zero-lifetime, or operation-class-incompatible declarations.

At runtime Bloom replaces guest route IDs with the packaged scope and permits only strict narrowing of operation classes, crypto suites, and lifetime. Attempts to widen any bound fail before the host derivation call. The package-contract regression inserts an unrelated earlier-sorting route and proves the semantic scope is unchanged despite route-ID renumbering.

For migration compatibility, packages that omit all new manifest scope bounds retain the legacy guest-supplied request. Once any new bound is present, all are required. Bloom also validates wallet IDs at the daemon signing boundary so malformed IDs fail as input errors instead of opaque permission denials.

Derived-key authority remains bound to one immutable package hash. Succession is intentionally deferred: upgrades request a new key/session with fresh user authorization.

## Validation

- `cargo test -p bloom-petals` (170 unit tests plus integration tests)
- focused bloom-daemon approval test
- clippy for bloom-petals and bloom-daemon with warnings denied
- rustfmt and diff checks
- exact built 70-route Hyperliquid archive contract via bloom-directory/bloom-petal-hyperliquid#17

## Checklist

- [x] Tests added or updated for behavior changes
- [x] Architecture docs updated for complete scopes and package-bound succession
- [x] Sealed Approval invariants respected: authenticated bounds can only narrow authority
- [x] Agent Documentation updated: Petal authoring guidance documents every scope field