### PR TITLE
feat(petals): add browser-only private input handoff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,7 +973,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde 1.8.3",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -994,7 +994,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde 2.0.5",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -1265,7 +1265,7 @@ checksum = "e8597d36d546e1dab822345ad563243ec3920e199322cb554ce56c8ef1a1e2e7"
 dependencies = [
  "alloy-json-rpc 1.8.3",
  "alloy-transport 1.8.3",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "reqwest 0.13.4",
  "serde_json",
  "tower",
@@ -1281,7 +1281,7 @@ checksum = "b273587487921274f4f5d0ef2c7ef36944dcbb75a4e2318e69eae822bd263f91"
 dependencies = [
  "alloy-json-rpc 2.0.5",
  "alloy-transport 2.0.5",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "reqwest 0.13.4",
  "serde_json",
  "tower",
@@ -2184,7 +2184,7 @@ dependencies = [
 [[package]]
 name = "bloom-broker-api"
 version = "0.1.0"
-source = "git+https://github.com/bloom-directory/bloom-broker.git?rev=815ace0fe558e7b2bed5b0270e10c9a37d9e373e#815ace0fe558e7b2bed5b0270e10c9a37d9e373e"
+source = "git+https://github.com/bloom-directory/bloom-broker.git?rev=62d64b28bfc55c466c796e6819b402bad99399c6#62d64b28bfc55c466c796e6819b402bad99399c6"
 dependencies = [
  "bloom-rpc-wire",
  "serde",
@@ -2221,6 +2221,7 @@ dependencies = [
  "fs2",
  "futures",
  "hex",
+ "open",
  "parking_lot",
  "reqwest 0.12.28",
  "rustix 1.1.4",
@@ -2445,7 +2446,7 @@ dependencies = [
 [[package]]
 name = "bloom-petal-contract"
 version = "0.1.0"
-source = "git+https://github.com/bloom-directory/petal?rev=864a80b407387871bae06aabe77b91865e55f7bc#864a80b407387871bae06aabe77b91865e55f7bc"
+source = "git+https://github.com/bloom-directory/petal?rev=21ebc9cfc0a4e4c4a303a9c1486d36cb1add3cd1#21ebc9cfc0a4e4c4a303a9c1486d36cb1add3cd1"
 dependencies = [
  "sha2 0.10.9",
 ]
@@ -2869,7 +2870,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2898,7 +2899,7 @@ dependencies = [
  "maybe-owned",
  "rustix 1.1.4",
  "rustix-linux-procfs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "winx",
 ]
 
@@ -3073,7 +3074,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4050,7 +4051,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4166,7 +4167,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4288,7 +4289,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5183,7 +5184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
  "io-lifetimes",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5197,6 +5198,25 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -5955,6 +5975,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "open"
+version = "5.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c603ab8300cf18bc3b14146b19fe3dfcc4843ae5a400cd0e7a30b95aa366634"
+dependencies = [
+ "is-wsl",
+ "libc",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6496,7 +6526,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7471,7 +7501,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7484,7 +7514,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7552,7 +7582,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8300,7 +8330,7 @@ dependencies = [
  "fd-lock",
  "io-lifetimes",
  "rustix 0.38.44",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "winx",
 ]
 
@@ -8337,7 +8367,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9790,7 +9820,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10154,7 +10184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2184,7 +2184,7 @@ dependencies = [
 [[package]]
 name = "bloom-broker-api"
 version = "0.1.0"
-source = "git+https://github.com/bloom-directory/bloom-broker.git?rev=62d64b28bfc55c466c796e6819b402bad99399c6#62d64b28bfc55c466c796e6819b402bad99399c6"
+source = "git+https://github.com/bloom-directory/bloom-broker.git?rev=c75e931b75c00436c22268b37776fb34c45ba7f2#c75e931b75c00436c22268b37776fb34c45ba7f2"
 dependencies = [
  "bloom-rpc-wire",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,10 +120,10 @@ bloom-ens      = { path = "crates/bloom-ens" }
 bloom-prices   = { path = "crates/bloom-prices" }
 bloom-revert   = { path = "crates/bloom-revert" }
 bloom-petals   = { path = "crates/bloom-petals" }
-bloom-petal-contract = { git = "https://github.com/bloom-directory/petal", rev = "864a80b407387871bae06aabe77b91865e55f7bc" }
+bloom-petal-contract = { git = "https://github.com/bloom-directory/petal", rev = "21ebc9cfc0a4e4c4a303a9c1486d36cb1add3cd1" }
 bloom-daemon   = { path = "crates/bloom-daemon" }
 bloom-update   = { path = "crates/bloom-update" }
-bloom-broker-api = { git = "https://github.com/bloom-directory/bloom-broker.git", rev = "815ace0fe558e7b2bed5b0270e10c9a37d9e373e" }
+bloom-broker-api = { git = "https://github.com/bloom-directory/bloom-broker.git", rev = "62d64b28bfc55c466c796e6819b402bad99399c6" }
 bloom-rpc-wire = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "d8229e51d80971505af69c387818334a3c44aef0" }
 bloom-triad-local-transport = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "d8229e51d80971505af69c387818334a3c44aef0" }
 bloom-service-activation = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "d8229e51d80971505af69c387818334a3c44aef0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ bloom-petals   = { path = "crates/bloom-petals" }
 bloom-petal-contract = { git = "https://github.com/bloom-directory/petal", rev = "21ebc9cfc0a4e4c4a303a9c1486d36cb1add3cd1" }
 bloom-daemon   = { path = "crates/bloom-daemon" }
 bloom-update   = { path = "crates/bloom-update" }
-bloom-broker-api = { git = "https://github.com/bloom-directory/bloom-broker.git", rev = "62d64b28bfc55c466c796e6819b402bad99399c6" }
+bloom-broker-api = { git = "https://github.com/bloom-directory/bloom-broker.git", rev = "c75e931b75c00436c22268b37776fb34c45ba7f2" }
 bloom-rpc-wire = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "d8229e51d80971505af69c387818334a3c44aef0" }
 bloom-triad-local-transport = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "d8229e51d80971505af69c387818334a3c44aef0" }
 bloom-service-activation = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "d8229e51d80971505af69c387818334a3c44aef0" }

--- a/crates/bloom-daemon/Cargo.toml
+++ b/crates/bloom-daemon/Cargo.toml
@@ -61,6 +61,7 @@ futures.workspace = true
 fs2.workspace = true
 hex.workspace = true
 reqwest = { workspace = true, features = ["stream"] }
+open.workspace = true
 rustix.workspace = true
 tempfile.workspace = true
 

--- a/crates/bloom-daemon/src/lib.rs
+++ b/crates/bloom-daemon/src/lib.rs
@@ -10,6 +10,7 @@ pub mod ipc;
 mod ens_resolver;
 mod price_oracle;
 
+use std::collections::BTreeMap;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -229,6 +230,7 @@ struct DaemonPetalHost {
     provenance_catalog: Option<bloom_broker_api::ProvenanceCatalog>,
     petal_key_state_root: Option<PathBuf>,
     petal_key_lock: tokio::sync::Mutex<()>,
+    private_input_launches: tokio::sync::Mutex<BTreeMap<String, String>>,
     petal_signing_state_root: Option<PathBuf>,
     petal_signing_lock: tokio::sync::Mutex<()>,
 }
@@ -363,6 +365,7 @@ impl DaemonPetalHost {
             provenance_catalog: None,
             petal_key_state_root: None,
             petal_key_lock: tokio::sync::Mutex::new(()),
+            private_input_launches: tokio::sync::Mutex::new(BTreeMap::new()),
             petal_signing_state_root: None,
             petal_signing_lock: tokio::sync::Mutex::new(()),
         }
@@ -924,6 +927,101 @@ impl PetalHost for DaemonPetalHost {
     async fn vfs_write(&self, path: &str, bytes: &[u8]) -> Result<(), HostError> {
         Self::authorize_guest_vfs_path(path)?;
         self.vfs.vfs_write(path, bytes).await
+    }
+
+    async fn private_input_request(
+        &self,
+        req: bloom_petals::PrivateInputRequest,
+    ) -> Result<bloom_petals::PrivateInputOutcome, HostError> {
+        let broker = self.broker.as_ref().ok_or_else(|| {
+            HostError::Backend("SERVICE_UNAVAILABLE: Broker client is not configured".into())
+        })?;
+        let route = req.context.as_ref().ok_or_else(|| {
+            HostError::Denied("Private input requires trusted route provenance".into())
+        })?;
+        Self::petal_execution_origin(route)?;
+        if req.id.trim().is_empty() {
+            return Err(HostError::Invalid(
+                "Private-input request id must not be empty".into(),
+            ));
+        }
+        let identity = serde_jcs::to_vec(&serde_json::json!({
+            "domain": "bloom-machine-private-input/v1",
+            "request": {
+                "id": req.id,
+                "kind": match req.kind {
+                    bloom_petals::PrivateInputKind::EvmAddress => "evm_address",
+                },
+                "context": {
+                    "network": req.display_context.network,
+                    "asset": req.display_context.asset,
+                    "amount_base_units": req.display_context.amount_base_units,
+                    "decimals": req.display_context.decimals,
+                    "source": req.display_context.source,
+                },
+            },
+            "route": {
+                "petal_root": route.petal_root,
+                "package_hash": route.package_hash,
+                "route_id": route.route_id,
+                "op": route.op,
+                "path": route.path,
+                "params": route.params,
+                "actor": route.actor,
+            },
+        }))
+        .map_err(|error| HostError::Backend(format!("encode private-input identity: {error}")))?;
+        let operation_id =
+            bloom_broker_api::OperationId::from_bytes(sha2::Sha256::digest(&identity).into());
+        let response = broker
+            .owner_input(bloom_broker_api::OwnerInputRequest {
+                operation_id: operation_id.clone(),
+                kind: match req.kind {
+                    bloom_petals::PrivateInputKind::EvmAddress => {
+                        bloom_broker_api::OwnerInputKind::EvmAddress
+                    }
+                },
+                context: bloom_broker_api::OwnerInputDisplayContext {
+                    network: req.display_context.network,
+                    asset: req.display_context.asset,
+                    amount_base_units: req.display_context.amount_base_units,
+                    decimals: req.display_context.decimals,
+                    source: req.display_context.source,
+                },
+            })
+            .await
+            .map_err(|error| HostError::Backend(format!("Broker private-input: {error}")))?;
+        match response {
+            bloom_broker_api::OwnerInputResponse::Pending {
+                operation_id,
+                ceremony_url,
+                expires_at_ms,
+            } => {
+                let mut launches = self.private_input_launches.lock().await;
+                let should_launch = launches.get(operation_id.as_str()) != Some(&ceremony_url);
+                if should_launch {
+                    open::that_detached(&ceremony_url).map_err(|error| {
+                        HostError::Backend(format!("launch private-input browser form: {error}"))
+                    })?;
+                    launches.insert(operation_id.as_str().to_owned(), ceremony_url.clone());
+                }
+                Ok(bloom_petals::PrivateInputOutcome::Pending {
+                    operation_id: operation_id.as_str().to_owned(),
+                    expires_ms: expires_at_ms.get(),
+                    ceremony_url,
+                })
+            }
+            bloom_broker_api::OwnerInputResponse::Ready {
+                operation_id,
+                value,
+            } => {
+                self.private_input_launches
+                    .lock()
+                    .await
+                    .remove(operation_id.as_str());
+                Ok(bloom_petals::PrivateInputOutcome::Ready(value))
+            }
+        }
     }
 
     async fn petal_key_request(

--- a/crates/bloom-machine-client/src/lib.rs
+++ b/crates/bloom-machine-client/src/lib.rs
@@ -47,12 +47,12 @@ use bloom_broker_api::{
     CeremonyState, CredentialPublic, CryptoSuite, CustodyPrepareRequest, CustodyPrepareResponse,
     CustodyResult, DecimalU64, Digest32, IdRequest, KeyPublic, KeyRef, KeyRequest, KeyRole,
     MachineBrokerRequest, MachineBrokerResponse, MachineBrokerService, MachineSignRequest,
-    OperationId, OperationPublicStatus, OperationRequest, PetalUseClaim, PolicyCommitReceipt,
-    PolicyCommitUpdateRequest, PolicyUpdatePrepareResponse, PolicyUpdateRequest, ProtocolError,
-    ProtocolErrorCode, ProvenanceCatalog, ProvenanceSubject, RequestNonce, RevocationState,
-    RevokeRequest, SealedApprovalPrepareResponse, SealedApprovalTerms, SignedPolicySnapshot,
-    SigningPayloads, SigningResult, Token, TypedRequestMethod, WalletOperationRequest,
-    WalletPublic, WalletRequest, is_read_only_method,
+    OperationId, OperationPublicStatus, OperationRequest, OwnerInputRequest, OwnerInputResponse,
+    PetalUseClaim, PolicyCommitReceipt, PolicyCommitUpdateRequest, PolicyUpdatePrepareResponse,
+    PolicyUpdateRequest, ProtocolError, ProtocolErrorCode, ProvenanceCatalog, ProvenanceSubject,
+    RequestNonce, RevocationState, RevokeRequest, SealedApprovalPrepareResponse,
+    SealedApprovalTerms, SignedPolicySnapshot, SigningPayloads, SigningResult, Token,
+    TypedRequestMethod, WalletOperationRequest, WalletPublic, WalletRequest, is_read_only_method,
 };
 use bloom_triad_local_transport::{LocalIdentity, PeerAcl};
 use serde::{Deserialize, Serialize};
@@ -438,6 +438,30 @@ impl MachineBrokerClient {
             MachineBrokerResponse::SigningSignBatch(result) => expected.validate(result),
             _ => Err(response_mismatch("signing.sign_batch")),
         }
+    }
+
+    /// Request or poll a Broker-hosted browser input form. This path carries
+    /// application data, not signing authority or Signer custody material.
+    pub async fn owner_input(
+        &self,
+        request: OwnerInputRequest,
+    ) -> Result<OwnerInputResponse, ProtocolError> {
+        let expected = request.operation_id.clone();
+        let response = match self
+            .request(MachineBrokerRequest::OwnerInputRequest(request))
+            .await?
+        {
+            MachineBrokerResponse::OwnerInputRequest(response) => response,
+            _ => return Err(response_mismatch("owner_input.request")),
+        };
+        let actual = match &response {
+            OwnerInputResponse::Pending { operation_id, .. }
+            | OwnerInputResponse::Ready { operation_id, .. } => operation_id,
+        };
+        if actual != &expected {
+            return Err(response_identity_mismatch("owner_input.request"));
+        }
+        Ok(response)
     }
 
     /// Validate and translate a payload-bearing Petal request. Provenance is

--- a/crates/bloom-petals/src/abi.rs
+++ b/crates/bloom-petals/src/abi.rs
@@ -177,6 +177,40 @@ pub struct PetalRouteContext {
     pub actor: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrivateInputKind {
+    EvmAddress,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrivateInputDisplayContext {
+    pub network: String,
+    pub asset: String,
+    pub amount_base_units: String,
+    pub decimals: u8,
+    pub source: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrivateInputRequest {
+    pub id: String,
+    pub kind: PrivateInputKind,
+    pub display_context: PrivateInputDisplayContext,
+    pub context: Option<PetalRouteContext>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PrivateInputOutcome {
+    Pending {
+        operation_id: String,
+        expires_ms: u64,
+        /// Owner-only launch material. The VM adapter strips this before the
+        /// result crosses into guest Wasm.
+        ceremony_url: String,
+    },
+    Ready(String),
+}
+
 /// Guest-supplied, provenance-free request for a Signer-owned Petal sub-key.
 ///
 /// The component ABI carries this as JSON bytes so the interface can evolve

--- a/crates/bloom-petals/src/host.rs
+++ b/crates/bloom-petals/src/host.rs
@@ -11,8 +11,8 @@ use async_trait::async_trait;
 use crate::abi::{
     ChainRequest, ChainResponse, EvmOutboxInspection, EvmOutboxOutcome, EvmTransactionRequest,
     HttpRequest, HttpResponse, PayloadBatchSignOutcome, PayloadBatchSignRequest,
-    PayloadSignRequest, PetalKeyOutcome, PetalKeyRequest, PetalRouteContext, SignBatchOutcome,
-    SignBatchRequest, SignOutcome, SignRequest,
+    PayloadSignRequest, PetalKeyOutcome, PetalKeyRequest, PetalRouteContext, PrivateInputOutcome,
+    PrivateInputRequest, SignBatchOutcome, SignBatchRequest, SignOutcome, SignRequest,
 };
 use crate::policy::NetPolicy;
 
@@ -138,6 +138,15 @@ pub trait PetalHost: Send + Sync {
     /// only.
     async fn petal_key_request(&self, _req: PetalKeyRequest) -> Result<PetalKeyOutcome, HostError> {
         Err(HostError::Denied("petal_key_request".into()))
+    }
+
+    /// Collect a short-lived value through Broker's owner-facing browser
+    /// form. Implementations inject and bind the trusted route context.
+    async fn private_input_request(
+        &self,
+        _req: PrivateInputRequest,
+    ) -> Result<PrivateInputOutcome, HostError> {
+        Err(HostError::Denied("private_input_request".into()))
     }
 
     /// Stage a generic EVM transaction in the daemon outbox. Hosts default to

--- a/crates/bloom-petals/src/lib.rs
+++ b/crates/bloom-petals/src/lib.rs
@@ -25,10 +25,12 @@ pub use abi::{
     DispatchRequest, DispatchResponse, EvmOutboxInspection, EvmOutboxOutcome,
     EvmTransactionRequest, HttpRequest, HttpResponse, PayloadBatchSignOutcome,
     PayloadBatchSignRequest, PayloadSignItem, PayloadSignRequest, PetalKeyGuestRequest,
-    PetalKeyOutcome, PetalKeyRequest, SignBatchOutcome, SignBatchRequest, SignOutcome, SignRequest,
-    decode_dispatch_request, decode_dispatch_response, decode_http_request, decode_http_response,
-    decode_sign_request, decode_string_list, encode_dispatch_request, encode_dispatch_response,
-    encode_http_request, encode_http_response, encode_sign_request, encode_string_list,
+    PetalKeyOutcome, PetalKeyRequest, PrivateInputDisplayContext, PrivateInputKind,
+    PrivateInputOutcome, PrivateInputRequest, SignBatchOutcome, SignBatchRequest, SignOutcome,
+    SignRequest, decode_dispatch_request, decode_dispatch_response, decode_http_request,
+    decode_http_response, decode_sign_request, decode_string_list, encode_dispatch_request,
+    encode_dispatch_response, encode_http_request, encode_http_response, encode_sign_request,
+    encode_string_list,
 };
 pub use error::PetalError;
 pub use host::{DenyHost, HostError, HostVfsEntry, HostVfsEntryKind, PetalHost};

--- a/crates/bloom-petals/src/meta.rs
+++ b/crates/bloom-petals/src/meta.rs
@@ -32,6 +32,9 @@ pub enum Capability {
     /// May request a Signer-owned, provenance-bound Petal sub-key.
     #[serde(rename = "key.derive")]
     KeyDerive,
+    /// May request a short-lived value through Broker's browser form.
+    #[serde(rename = "private.input")]
+    PrivateInput,
 }
 
 impl Capability {
@@ -45,6 +48,7 @@ impl Capability {
             Capability::Chain => "chain",
             Capability::TxOutbox => "tx.outbox",
             Capability::KeyDerive => "key.derive",
+            Capability::PrivateInput => "private.input",
         }
     }
 
@@ -58,6 +62,7 @@ impl Capability {
             "chain" => Some(Capability::Chain),
             "tx.outbox" => Some(Capability::TxOutbox),
             "key.derive" => Some(Capability::KeyDerive),
+            "private.input" => Some(Capability::PrivateInput),
             _ => None,
         }
     }
@@ -156,6 +161,7 @@ pub fn validate_mode_caps(
                     | Capability::Chain
                     | Capability::TxOutbox
                     | Capability::KeyDerive
+                    | Capability::PrivateInput
             )
         );
         if !ok {
@@ -181,6 +187,7 @@ mod tests {
         assert_eq!(Capability::Store.as_str(), "store");
         assert_eq!(Capability::Chain.as_str(), "chain");
         assert_eq!(Capability::TxOutbox.as_str(), "tx.outbox");
+        assert_eq!(Capability::PrivateInput.as_str(), "private.input");
         assert_eq!(Capability::parse("vfs.read"), Some(Capability::VfsRead));
         assert_eq!(Capability::parse("vfs.write"), Some(Capability::VfsWrite));
         assert_eq!(Capability::parse("net.fetch"), Some(Capability::NetFetch));
@@ -188,6 +195,10 @@ mod tests {
         assert_eq!(Capability::parse("store"), Some(Capability::Store));
         assert_eq!(Capability::parse("chain"), Some(Capability::Chain));
         assert_eq!(Capability::parse("tx.outbox"), Some(Capability::TxOutbox));
+        assert_eq!(
+            Capability::parse("private.input"),
+            Some(Capability::PrivateInput)
+        );
         assert_eq!(Capability::parse("nope"), None);
     }
 

--- a/crates/bloom-petals/src/package.rs
+++ b/crates/bloom-petals/src/package.rs
@@ -2400,6 +2400,7 @@ enum ComponentHostInterface {
     SignSigningV1,
     SignSigningV2,
     KeyDerive,
+    PrivateInput,
     TxOutbox,
     ChainRead,
     VfsReadwrite,
@@ -2425,7 +2426,8 @@ fn component_host_interface(name: &str) -> Option<ComponentHostInterface> {
         ContractHostInterface::ChainRead => Some(ComponentHostInterface::ChainRead),
         ContractHostInterface::VfsReadwrite => Some(ComponentHostInterface::VfsReadwrite),
         ContractHostInterface::EnvRuntime => Some(ComponentHostInterface::EnvRuntime),
-        ContractHostInterface::RouteTypes | ContractHostInterface::PrivateInputCeremony => None,
+        ContractHostInterface::PrivateInputCeremony => Some(ComponentHostInterface::PrivateInput),
+        ContractHostInterface::RouteTypes => None,
     }
 }
 
@@ -2663,6 +2665,12 @@ enum HostTypeExport {
     PetalSignSelector,
     SignBatchResultStructured,
     PayloadBatchSignResultStructured,
+    PrivateInputKind,
+    PrivateInputDisplayContext,
+    PrivateInputRequest,
+    PrivateInputOperationId,
+    PrivateInputPending,
+    PrivateInputResult,
 }
 
 #[derive(Clone, Copy)]
@@ -2679,6 +2687,7 @@ enum HostFuncExport {
     SafeSignPayloadStructured,
     PayloadBatchSignStructured,
     PetalKeyRequest,
+    PrivateInputRequest,
     EvmTxStage,
     EvmTxConfirm,
     EvmTxInspect,
@@ -2837,6 +2846,24 @@ fn host_type_export(interface: ComponentHostInterface, name: &str) -> Option<Hos
         (ComponentHostInterface::SignSigningV1, "sign-batch-result") => {
             Some(HostTypeExport::SignBatchResultStructured)
         }
+        (ComponentHostInterface::PrivateInput, "input-kind") => {
+            Some(HostTypeExport::PrivateInputKind)
+        }
+        (ComponentHostInterface::PrivateInput, "display-context") => {
+            Some(HostTypeExport::PrivateInputDisplayContext)
+        }
+        (ComponentHostInterface::PrivateInput, "request") => {
+            Some(HostTypeExport::PrivateInputRequest)
+        }
+        (ComponentHostInterface::PrivateInput, "operation-id") => {
+            Some(HostTypeExport::PrivateInputOperationId)
+        }
+        (ComponentHostInterface::PrivateInput, "pending-input") => {
+            Some(HostTypeExport::PrivateInputPending)
+        }
+        (ComponentHostInterface::PrivateInput, "input-result") => {
+            Some(HostTypeExport::PrivateInputResult)
+        }
         _ => None,
     }
 }
@@ -2865,6 +2892,9 @@ fn host_func_export(interface: ComponentHostInterface, name: &str) -> Option<Hos
             Some(HostFuncExport::PayloadBatchSignStructured)
         }
         (ComponentHostInterface::KeyDerive, "request") => Some(HostFuncExport::PetalKeyRequest),
+        (ComponentHostInterface::PrivateInput, "request-input") => {
+            Some(HostFuncExport::PrivateInputRequest)
+        }
         (ComponentHostInterface::TxOutbox, "stage") => Some(HostFuncExport::EvmTxStage),
         (ComponentHostInterface::TxOutbox, "confirm") => Some(HostFuncExport::EvmTxConfirm),
         (ComponentHostInterface::TxOutbox, "inspect") => Some(HostFuncExport::EvmTxInspect),
@@ -2916,6 +2946,14 @@ fn host_type_export_matches(
         HostTypeExport::PayloadBatchSignResultStructured => {
             is_payload_batch_sign_result_petal(&ty, types, 0)
         }
+        HostTypeExport::PrivateInputKind => is_private_input_kind(&ty, types, 0),
+        HostTypeExport::PrivateInputDisplayContext => {
+            is_private_input_display_context(&ty, types, 0)
+        }
+        HostTypeExport::PrivateInputRequest => is_private_input_request(&ty, types, 0),
+        HostTypeExport::PrivateInputOperationId => is_private_input_operation_id(&ty, types, 0),
+        HostTypeExport::PrivateInputPending => is_private_input_pending(&ty, types, 0),
+        HostTypeExport::PrivateInputResult => is_private_input_result(&ty, types, 0),
     }
 }
 
@@ -3032,6 +3070,10 @@ fn host_func_export_matches(
             params_match(params, types, &[("request", is_byte_list)])
                 && result_matches(&ty.result, types, HostOkType::Bytes)
         }
+        HostFuncExport::PrivateInputRequest => {
+            params_match(params, types, &[("request", is_private_input_request)])
+                && result_matches(&ty.result, types, HostOkType::PrivateInputResult)
+        }
         HostFuncExport::EvmTxStage => {
             params_match(params, types, &[("tx", is_evm_transaction)])
                 && result_matches(&ty.result, types, HostOkType::StagedTransaction)
@@ -3130,6 +3172,7 @@ enum HostOkType {
     PayloadBatchSignResultStructured,
     StagedTransaction,
     OutboxInspection,
+    PrivateInputResult,
 }
 
 fn result_matches(
@@ -3169,9 +3212,122 @@ fn result_matches(
             }
             (HostOkType::StagedTransaction, Some(ty)) => is_staged_transaction(ty, types, depth),
             (HostOkType::OutboxInspection, Some(ty)) => is_outbox_inspection(ty, types, depth),
+            (HostOkType::PrivateInputResult, Some(ty)) => is_private_input_result(ty, types, depth),
             _ => false,
         };
         ok_matches && err.is_some_and(|ty| is_string(&ty))
+    })
+}
+
+fn is_private_input_kind(
+    ty: &ComponentValType,
+    types: &[ComponentTypeEntry<'_>],
+    depth: usize,
+) -> bool {
+    with_defined_type(
+        ty,
+        types,
+        depth,
+        |defined, _, _| matches!(defined, ComponentDefinedType::Enum(names) if names.as_ref() == ["evm-address"]),
+    )
+}
+
+fn is_private_input_display_context(
+    ty: &ComponentValType,
+    types: &[ComponentTypeEntry<'_>],
+    depth: usize,
+) -> bool {
+    with_defined_type(ty, types, depth, |defined, types, depth| {
+        let ComponentDefinedType::Record(fields) = defined else {
+            return false;
+        };
+        let fields = fields.as_ref();
+        fields.len() == 5
+            && fields[0].0 == "network"
+            && is_string(&fields[0].1)
+            && fields[1].0 == "asset"
+            && is_string(&fields[1].1)
+            && fields[2].0 == "amount-base-units"
+            && is_string(&fields[2].1)
+            && fields[3].0 == "decimals"
+            && is_u8(&fields[3].1, types, depth)
+            && fields[4].0 == "source"
+            && is_string(&fields[4].1)
+    })
+}
+
+fn is_private_input_operation_id(
+    ty: &ComponentValType,
+    types: &[ComponentTypeEntry<'_>],
+    depth: usize,
+) -> bool {
+    with_defined_type(ty, types, depth, |defined, _, _| {
+        matches!(
+            defined,
+            ComponentDefinedType::Primitive(ComponentPrimitiveValType::String)
+        )
+    })
+}
+
+fn is_private_input_request(
+    ty: &ComponentValType,
+    types: &[ComponentTypeEntry<'_>],
+    depth: usize,
+) -> bool {
+    with_defined_type(ty, types, depth, |defined, types, depth| {
+        let ComponentDefinedType::Record(fields) = defined else {
+            return false;
+        };
+        let fields = fields.as_ref();
+        fields.len() == 3
+            && fields[0].0 == "id"
+            && is_string(&fields[0].1)
+            && fields[1].0 == "kind"
+            && is_private_input_kind(&fields[1].1, types, depth)
+            && fields[2].0 == "context"
+            && is_private_input_display_context(&fields[2].1, types, depth)
+    })
+}
+
+fn is_private_input_pending(
+    ty: &ComponentValType,
+    types: &[ComponentTypeEntry<'_>],
+    depth: usize,
+) -> bool {
+    with_defined_type(ty, types, depth, |defined, types, depth| {
+        let ComponentDefinedType::Record(fields) = defined else {
+            return false;
+        };
+        let fields = fields.as_ref();
+        fields.len() == 2
+            && fields[0].0 == "operation-id"
+            && is_private_input_operation_id(&fields[0].1, types, depth)
+            && fields[1].0 == "expires-ms"
+            && is_u64(&fields[1].1, types, depth)
+    })
+}
+
+fn is_private_input_result(
+    ty: &ComponentValType,
+    types: &[ComponentTypeEntry<'_>],
+    depth: usize,
+) -> bool {
+    with_defined_type(ty, types, depth, |defined, types, depth| {
+        let ComponentDefinedType::Variant(cases) = defined else {
+            return false;
+        };
+        let cases = cases.as_ref();
+        cases.len() == 2
+            && cases[0].name == "pending"
+            && cases[0]
+                .ty
+                .as_ref()
+                .is_some_and(|ty| is_private_input_pending(ty, types, depth))
+            && cases[1].name == "ready"
+            && cases[1]
+                .ty
+                .as_ref()
+                .is_some_and(|ty| is_string_type(ty, types, depth))
     })
 }
 
@@ -6387,6 +6543,55 @@ paths = ["/*"]
                     (func (param "request" $bytes) (result $outcome)))
                   (export "request" (func (type $request)))))
               (import "bloom:key/derive@0.1.0"
+                (instance (type $interface))))"#,
+        ));
+    }
+
+    #[test]
+    fn petal_component_private_input_shape_and_capability_are_explicit() {
+        assert_eq!(
+            component_import_caps("bloom:private-input/ceremony@0.2.0"),
+            Some(&["bloom:private-input"][..])
+        );
+        assert!(matches!(
+            component_host_interface("bloom:private-input/ceremony@0.2.0"),
+            Some(ComponentHostInterface::PrivateInput)
+        ));
+        assert!(component_host_interface("bloom:private-input/ceremony@0.1.0").is_none());
+        assert!(host_import_instance_matches(
+            ComponentHostInterface::PrivateInput,
+            r#"(component
+              (type $interface
+                (instance
+                  (type $kind (enum "evm-address"))
+                  (export "input-kind" (type $kind-export (eq $kind)))
+                  (type $display (record
+                    (field "network" string)
+                    (field "asset" string)
+                    (field "amount-base-units" string)
+                    (field "decimals" u8)
+                    (field "source" string)))
+                  (export "display-context" (type $display-export (eq $display)))
+                  (type $request (record
+                    (field "id" string)
+                    (field "kind" $kind-export)
+                    (field "context" $display-export)))
+                  (export "request" (type $request-export (eq $request)))
+                  (type $operation-id string)
+                  (export "operation-id" (type $operation-id-export (eq $operation-id)))
+                  (type $pending (record
+                    (field "operation-id" $operation-id-export)
+                    (field "expires-ms" u64)))
+                  (export "pending-input" (type $pending-export (eq $pending)))
+                  (type $input-result (variant
+                    (case "pending" $pending-export)
+                    (case "ready" string)))
+                  (export "input-result" (type $input-result-export (eq $input-result)))
+                  (type $outcome (result $input-result-export (error string)))
+                  (type $request-func
+                    (func (param "request" $request-export) (result $outcome)))
+                  (export "request-input" (func (type $request-func)))))
+              (import "bloom:private-input/ceremony@0.2.0"
                 (instance (type $interface))))"#,
         ));
     }

--- a/crates/bloom-petals/src/runner.rs
+++ b/crates/bloom-petals/src/runner.rs
@@ -693,6 +693,7 @@ fn petal_capability(cap: &str) -> Option<Capability> {
         "bloom:chain" => Some(Capability::Chain),
         "bloom:tx.outbox" => Some(Capability::TxOutbox),
         "bloom:key.derive" => Some(Capability::KeyDerive),
+        "bloom:private-input" => Some(Capability::PrivateInput),
         "bloom:vfs.read" => Some(Capability::VfsRead),
         "bloom:vfs.write" => Some(Capability::VfsWrite),
         _ => Capability::parse(cap),

--- a/crates/bloom-petals/src/vm.rs
+++ b/crates/bloom-petals/src/vm.rs
@@ -46,7 +46,8 @@ use crate::abi::{
     ChainRequest, ChainResponse, DispatchOp, DispatchRequest, DispatchResponse,
     EvmOutboxInspection, EvmOutboxOutcome, EvmTransactionRequest, PayloadBatchSignOutcome,
     PayloadBatchSignRequest, PayloadSignItem, PayloadSignRequest, PetalKeyGuestRequest,
-    PetalKeyRequest, PetalRouteContext, SignOutcome,
+    PetalKeyRequest, PetalRouteContext, PrivateInputDisplayContext, PrivateInputKind,
+    PrivateInputOutcome, PrivateInputRequest, SignOutcome,
 };
 use crate::error::PetalError;
 use crate::host::{HostError, HostVfsEntry, HostVfsEntryKind, PetalHost};
@@ -845,6 +846,12 @@ fn link_component_host_imports(linker: &mut ComponentLinker<StoreData>) -> anyho
         })?;
     }
     {
+        let mut input = linker.instance("bloom:private-input/ceremony@0.2.0")?;
+        input.func_new_async("request-input", |store, params, results| {
+            Box::new(async move { component_private_input_request(store, params, results).await })
+        })?;
+    }
+    {
         let mut tx = linker.instance("bloom:tx/outbox@0.1.0")?;
         tx.func_new_async("stage", |store, params, results| {
             Box::new(async move { component_evm_tx_stage(store, params, results).await })
@@ -1464,6 +1471,110 @@ async fn component_petal_key_request(
             // reason reaches neither the Petal nor the mount. Record it
             // host-side, where it is not observable by an evaluated agent.
             log_host_error(store.data(), "component_petal_key_request", &error);
+            set_component_result(results, component_host_err(error))
+        }
+    }
+}
+
+async fn component_private_input_request(
+    store: StoreContextMut<'_, StoreData>,
+    params: &[ComponentVal],
+    results: &mut [ComponentVal],
+) -> anyhow::Result<()> {
+    if !store.data().caps.contains(&Capability::PrivateInput) {
+        log_denied(store.data(), "component_private_input_request");
+        return set_component_result(
+            results,
+            component_host_err(HostError::Denied("private.input".into())),
+        );
+    }
+    let [ComponentVal::Record(fields)] = params else {
+        return set_component_result(
+            results,
+            component_host_err(HostError::Invalid(
+                "invalid bloom:private-input request".into(),
+            )),
+        );
+    };
+    let parsed = (|| {
+        let string = |fields, name| {
+            component_string_field(fields, name)
+                .map_err(|error| HostError::Invalid(error.to_string()))
+        };
+        let id = string(fields, "id")?;
+        let kind = match component_enum_field(fields, "kind")
+            .map_err(|error| HostError::Invalid(error.to_string()))?
+            .as_str()
+        {
+            "evm-address" => PrivateInputKind::EvmAddress,
+            other => {
+                return Err(HostError::Invalid(format!(
+                    "unsupported private-input kind {other:?}"
+                )));
+            }
+        };
+        let context = match component_field(fields, "context")
+            .map_err(|error| HostError::Invalid(error.to_string()))?
+        {
+            ComponentVal::Record(context) => context,
+            other => {
+                return Err(HostError::Invalid(format!(
+                    "private-input context is not a record: {other:?}"
+                )));
+            }
+        };
+        let decimals = match component_field(context, "decimals")
+            .map_err(|error| HostError::Invalid(error.to_string()))?
+        {
+            ComponentVal::U8(value) => *value,
+            other => {
+                return Err(HostError::Invalid(format!(
+                    "private-input decimals is not a u8: {other:?}"
+                )));
+            }
+        };
+        Ok(PrivateInputRequest {
+            id,
+            kind,
+            display_context: PrivateInputDisplayContext {
+                network: string(context, "network")?,
+                asset: string(context, "asset")?,
+                amount_base_units: string(context, "amount-base-units")?,
+                decimals,
+                source: string(context, "source")?,
+            },
+            context: store.data().sign_context.clone(),
+        })
+    })();
+    let request = match parsed {
+        Ok(request) => request,
+        Err(error) => return set_component_result(results, component_host_err(error)),
+    };
+    let host = store.data().host.clone();
+    match host.private_input_request(request).await {
+        Ok(PrivateInputOutcome::Pending {
+            operation_id,
+            expires_ms,
+            ceremony_url: _,
+        }) => set_component_result(
+            results,
+            component_ok(Some(ComponentVal::Variant(
+                "pending".into(),
+                Some(Box::new(ComponentVal::Record(vec![
+                    ("operation-id".into(), ComponentVal::String(operation_id)),
+                    ("expires-ms".into(), ComponentVal::U64(expires_ms)),
+                ]))),
+            ))),
+        ),
+        Ok(PrivateInputOutcome::Ready(value)) => set_component_result(
+            results,
+            component_ok(Some(ComponentVal::Variant(
+                "ready".into(),
+                Some(Box::new(ComponentVal::String(value))),
+            ))),
+        ),
+        Err(error) => {
+            log_host_error(store.data(), "component_private_input_request", &error);
             set_component_result(results, component_host_err(error))
         }
     }
@@ -3121,6 +3232,8 @@ mod tests {
         payload_batch_outcome: Mutex<Option<PayloadBatchSignOutcome>>,
         petal_key_calls: Mutex<Vec<PetalKeyRequest>>,
         petal_key_outcomes: Mutex<Vec<crate::abi::PetalKeyOutcome>>,
+        private_input_calls: Mutex<Vec<PrivateInputRequest>>,
+        private_input_outcome: Mutex<Option<PrivateInputOutcome>>,
         authority_calls: Mutex<Vec<&'static str>>,
         tx_stage_calls: Mutex<Vec<EvmTransactionRequest>>,
         tx_confirm_calls: Mutex<Vec<TxConfirmCall>>,
@@ -3232,6 +3345,22 @@ mod tests {
                 operation_id: "11".repeat(32),
                 scope_digest: "22".repeat(32),
             })
+        }
+
+        async fn private_input_request(
+            &self,
+            req: PrivateInputRequest,
+        ) -> Result<PrivateInputOutcome, HostError> {
+            self.private_input_calls.lock().push(req);
+            Ok(self
+                .private_input_outcome
+                .lock()
+                .clone()
+                .unwrap_or_else(|| PrivateInputOutcome::Pending {
+                    operation_id: "33".repeat(32),
+                    expires_ms: 9_000,
+                    ceremony_url: "http://127.0.0.1:18734/input/owner-secret".into(),
+                }))
         }
 
         async fn evm_tx_stage(
@@ -3979,6 +4108,67 @@ paths = ["/status"]
         let calls = host.petal_key_calls.lock();
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].context, Some(context));
+    }
+
+    #[tokio::test]
+    async fn component_private_input_injects_provenance_and_strips_launch_url() {
+        let host = Arc::new(MockHost::default());
+        let mut store = component_test_store(
+            BTreeSet::from([Capability::PrivateInput]),
+            None,
+            host.clone(),
+        );
+        let context = PetalRouteContext {
+            petal_root: "privacy-pools".into(),
+            package_hash: VALID_HASH.into(),
+            route_id: "r000042".into(),
+            op: "write".into(),
+            path: "withdrawals/alice/note-1.json".into(),
+            params: Vec::new(),
+            actor: None,
+        };
+        store.data_mut().sign_context = Some(context.clone());
+        let request = ComponentVal::Record(vec![
+            (
+                "id".into(),
+                ComponentVal::String("privacy-pools/withdraw/alice/note-1".into()),
+            ),
+            ("kind".into(), ComponentVal::Enum("evm-address".into())),
+            (
+                "context".into(),
+                ComponentVal::Record(vec![
+                    ("network".into(), ComponentVal::String("ethereum".into())),
+                    ("asset".into(), ComponentVal::String("eth".into())),
+                    (
+                        "amount-base-units".into(),
+                        ComponentVal::String("1000000000000000000".into()),
+                    ),
+                    ("decimals".into(), ComponentVal::U8(18)),
+                    ("source".into(), ComponentVal::String("alice/note-1".into())),
+                ]),
+            ),
+        ]);
+        let mut result = vec![ComponentVal::Bool(false)];
+        component_private_input_request(store.as_context_mut(), &[request], &mut result)
+            .await
+            .unwrap();
+
+        let ComponentVal::Result(Ok(Some(outcome))) = &result[0] else {
+            panic!("expected private-input result: {:?}", result[0]);
+        };
+        let ComponentVal::Variant(name, Some(pending)) = outcome.as_ref() else {
+            panic!("expected pending private-input result: {outcome:?}");
+        };
+        assert_eq!(name, "pending");
+        let ComponentVal::Record(fields) = pending.as_ref() else {
+            panic!("expected pending record: {pending:?}");
+        };
+        assert_eq!(fields.len(), 2, "guest result must contain no launch URL");
+        assert!(fields.iter().all(|(name, _)| name != "ceremony-url"));
+        let calls = host.private_input_calls.lock();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].context, Some(context));
+        assert_eq!(calls[0].display_context.decimals, 18);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Implements a narrow browser-to-Petal private-input handoff and supersedes #178's broader ceremony design.

- recognizes and strictly validates `bloom:private-input/ceremony@0.2.0`
- adds an explicit `private.input` Petal capability
- injects trusted route provenance into the Broker request
- derives an idempotent operation ID from the exact request plus trusted context
- asks the Broker to host the browser form and launches its owner-only URL
- returns only the operation ID/expiry to guest code while pending, then the submitted value when ready
- keeps URLs, bearer tokens, and entered values out of guest state, VFS, and generic agent-facing surfaces

There is intentionally no Signer integration, passkey, approval, execution binding, durable receipt, or consume/ack protocol. This mechanism protects input from the evaluated agent; it does not authorize the resulting action.

## Verification

- `cargo fmt --all --check`
- `cargo clippy -p bloom-petals -p bloom-machine-client -p bloom-daemon --all-targets --locked -- -D warnings`
- bloom-petals: 171 tests
- bloom-daemon: 79 tests
- bloom-machine-client: 29 tests
- `git diff --check`

## Stack

- Depends on bloom-directory/petal#18
- Depends on bloom-directory/bloom-broker#34
- Consumed by bloom-directory/bloom-petal-privacy-pools#4

## Checklist

- [x] Tests added or updated for behavior changes
- [x] Architecture docs (`docs/architecture/`) updated if contracts or behavior changed — N/A; this narrows and implements the existing Broker-owned boundary without changing the Triad architecture
- [x] Sealed Approval invariants respected (no signing outside a grant or bounded capability, no PRF/grant persistence, execution from sealed bytes) — no signing or approval path is added
- [x] Agent Documentation updated (`crates/bloom-vfs/src/docs/agent-guidance.md` and affected Petal READMEs) — the affected Privacy Pools Petal documentation is updated in bloom-directory/bloom-petal-privacy-pools#4; no generic agent-facing surface is added here
