### PR TITLE
Fix macOS Bloom CLI discovery and legacy migration

### DIFF
--- a/crates/bloom-it/tests/macos_launchagent.rs
+++ b/crates/bloom-it/tests/macos_launchagent.rs
@@ -302,6 +302,10 @@ fn macos_installer_manages_the_path_entry_and_migrates_legacy_cli_post_activatio
         "resolve_login_home",
         "/usr/bin/sudo -u \"$login_user\" -- /bin/rm -f -- \"$legacy\"",
         "Bloom is healthy, but legacy CLI cleanup failed",
+        "report_legacy_wallet_migrations",
+        "Legacy Bloom wallets were not modified and remain at",
+        "Only the staging command requires sudo",
+        "wallet migrate-passkey",
     ] {
         assert!(
             source.contains(required),
@@ -336,7 +340,12 @@ fn macos_installer_does_not_regenerate_custody_during_lifecycle_operations() {
     for forbidden in ["triad-render-macos-identity-rotation", "rotate-identities"] {
         assert!(!source.contains(forbidden));
     }
-    assert!(!source.contains("source "));
+    assert!(
+        !source
+            .lines()
+            .any(|line| line.trim_start().starts_with("source ")),
+        "installer must not execute shell source commands"
+    );
 }
 
 #[test]

--- a/crates/bloom-it/tests/macos_launchagent.rs
+++ b/crates/bloom-it/tests/macos_launchagent.rs
@@ -1,3 +1,5 @@
+#[cfg(target_os = "macos")]
+use std::process::Command;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -285,6 +287,46 @@ fn macos_installer_has_a_forward_only_custody_preserving_lifecycle() {
         assert!(source.contains(required), "lifecycle is missing {required}");
     }
     assert!(!source.contains("rollback_upgrade"));
+}
+
+#[test]
+fn macos_installer_manages_the_path_entry_and_migrates_legacy_cli_post_activation() {
+    let source =
+        fs::read_to_string(workspace().join("packaging/triad/release/install-macos.sh")).unwrap();
+    for required in [
+        "../libexec/bloom/current/bloom",
+        "preflight_cli_link",
+        "refusing to overwrite unrelated Bloom CLI",
+        "install_cli_link",
+        "remove_cli_link",
+        "resolve_login_home",
+        "/usr/bin/sudo -u \"$login_user\" -- /bin/rm -f -- \"$legacy\"",
+        "Bloom is healthy, but legacy CLI cleanup failed",
+    ] {
+        assert!(
+            source.contains(required),
+            "CLI lifecycle is missing {required}"
+        );
+    }
+    assert_ordered(
+        &source,
+        &[
+            "activate_current_enrollment ||",
+            "write_state_schema",
+            "remove_legacy_cli || die \"Bloom is healthy",
+        ],
+    );
+    assert!(!source.contains("rm -rf -- \"$login_home/.local"));
+}
+
+#[test]
+#[cfg(target_os = "macos")]
+fn staged_macos_installer_cli_lifecycle_passes() {
+    let status = Command::new("bash")
+        .arg(workspace().join("tests/packaging/macos-installer-staged.sh"))
+        .status()
+        .expect("run staged macOS installer CLI lifecycle");
+    assert!(status.success());
 }
 
 #[test]

--- a/crates/bloom-it/tests/triad_release.rs
+++ b/crates/bloom-it/tests/triad_release.rs
@@ -2513,6 +2513,29 @@ fn macos_active_legacy_enrollment_migrates_log_identity_before_upgrade() {
         format!("{}\n", "33".repeat(32)),
     )
     .unwrap();
+    let rollback_archive = transaction.join("rollback-state.tar");
+    let rollback = Command::new("tar")
+        .current_dir(&root)
+        .args([
+            "-cpf",
+            rollback_archive.to_str().unwrap(),
+            "Library/Application Support/BloomTriad/enrollments",
+            "Library/Application Support/BloomTriad/config",
+            "Library/LaunchDaemons/com.bloom.containment.plist",
+            "Library/LaunchAgents/com.bloom.session.plist",
+            "Library/LaunchAgents/com.bloom.machine.plist",
+            "Library/LaunchDaemons/com.bloom.broker.501.plist",
+            "Library/LaunchDaemons/com.bloom.signer.501.plist",
+            "etc/pf.anchors/com.bloom.triad.501",
+            "etc/newsyslog.d/bloom-501.conf",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        rollback.status.success(),
+        "{}",
+        String::from_utf8_lossy(&rollback.stderr)
+    );
 
     let migrated = stage_macos_install_digest(&installer, &root, &candidate, &new_digest);
     assert!(

--- a/packaging/triad/macos/README.md
+++ b/packaging/triad/macos/README.md
@@ -99,6 +99,17 @@ back healthy custody. Other `bloom` commands on `PATH` are not scanned or
 deleted. After migration, a shell that cached the old command may need `hash -r`
 (POSIX shells), `rehash` (zsh/csh), or a new terminal.
 
+Legacy wallet data is not deleted with the standalone command. When
+`~/.bloom/keystore` exists, successful activation prints its resolved absolute
+location and exact staging and ceremony commands for every detected v1 passkey
+wallet. The staging command uses the packaged `bloom-signer-migrate`, the
+installed Signer configuration, and the enrollment's actual login and Signer
+UID/GID. It requires `sudo` to enter Signer's private state and assign isolated
+ownership. The subsequent `/usr/local/bin/bloom wallet migrate-passkey`
+command must run without `sudo` as the enrolled login. Other legacy wallet
+kinds are unsupported by this bounded converter and remain untouched at the
+reported legacy location.
+
 `uninstall --retain-custody / LOGIN_UID` removes launchd, packet-filter, and
 runtime integration while preserving service principals, identities, and
 encrypted state. `restore` accepts only the exact signed retained release and

--- a/packaging/triad/macos/README.md
+++ b/packaging/triad/macos/README.md
@@ -76,6 +76,29 @@ interruption; an upgrade that fails authenticated health restores the prior
 release when it can still pass the same check. Compatibility metadata is mandatory and
 a state-schema downgrade is rejected before services are stopped.
 
+Canonical executables live under
+`/usr/local/libexec/bloom/releases/RELEASE_DIGEST`; the root-owned `current`
+selector moves atomically between those immutable directories. The supported
+interactive command is the relative symlink
+`/usr/local/bin/bloom -> ../libexec/bloom/current/bloom`, so it follows every
+repair and upgrade without putting `libexec` itself on `PATH`. Installer
+preflight accepts only that exact managed symlink and refuses to overwrite a
+regular file, directory, or differently targeted link. The command remains
+available while any login has an active enrollment and is removed when the last
+active enrollment is retained or purged; restore recreates it.
+
+Once authenticated activation has committed, the installer migrates the
+enrolled login away from the supported historical standalone location
+`~/.local/bin/bloom`. The home is resolved from Directory Service, and only a
+regular file or final-component symlink at that exact path is unlinked with the
+login user's authority. Parent symlinks and unexpected filesystem objects are
+rejected, and no user-owned binary is executed for identification. Cleanup is
+deliberately post-activation: a failed activation preserves the old command,
+while a cleanup failure reports the installation as incomplete without rolling
+back healthy custody. Other `bloom` commands on `PATH` are not scanned or
+deleted. After migration, a shell that cached the old command may need `hash -r`
+(POSIX shells), `rehash` (zsh/csh), or a new terminal.
+
 `uninstall --retain-custody / LOGIN_UID` removes launchd, packet-filter, and
 runtime integration while preserving service principals, identities, and
 encrypted state. `restore` accepts only the exact signed retained release and

--- a/packaging/triad/release.sh
+++ b/packaging/triad/release.sh
@@ -167,12 +167,18 @@ smoke_macos_installer() {
       install "$work/macos-root" 501 releaseuser "$payload"
   [[ -x "$work/macos-root/usr/local/libexec/bloom/current/bloom-broker" ]] ||
     die "staged macOS installer did not install Broker"
+  [[ -L "$work/macos-root/usr/local/bin/bloom" &&
+    "$(readlink "$work/macos-root/usr/local/bin/bloom")" == ../libexec/bloom/current/bloom ]] ||
+    die "staged macOS installer did not install the CLI PATH symlink"
   [[ -f "$work/macos-root/Library/Application Support/BloomTriad/enrollments/501.json" ]] ||
     die "staged macOS installer did not install enrollment"
   "$payload/installer/release/install-macos.sh" \
     uninstall "$work/macos-root" 501 delete-bloom-login-501
   [[ ! -e "$work/macos-root/Library/Application Support/BloomTriad/enrollments/501.json" ]] ||
     die "staged macOS uninstaller retained enrollment"
+  [[ ! -e "$work/macos-root/usr/local/bin/bloom" &&
+    ! -L "$work/macos-root/usr/local/bin/bloom" ]] ||
+    die "staged macOS uninstaller retained the CLI PATH symlink"
 }
 
 build_candidate() {

--- a/packaging/triad/release.sh
+++ b/packaging/triad/release.sh
@@ -167,9 +167,10 @@ smoke_macos_installer() {
       install "$work/macos-root" 501 releaseuser "$payload"
   [[ -x "$work/macos-root/usr/local/libexec/bloom/current/bloom-broker" ]] ||
     die "staged macOS installer did not install Broker"
-  [[ -L "$work/macos-root/usr/local/bin/bloom" &&
-    "$(readlink "$work/macos-root/usr/local/bin/bloom")" == ../libexec/bloom/current/bloom ]] ||
+  [[ -L "$work/macos-root/usr/local/bin/bloom" ]] ||
     die "staged macOS installer did not install the CLI PATH symlink"
+  [[ "$(readlink "$work/macos-root/usr/local/bin/bloom")" == ../libexec/bloom/current/bloom ]] ||
+    die "staged macOS installer installed the wrong CLI PATH symlink"
   [[ -f "$work/macos-root/Library/Application Support/BloomTriad/enrollments/501.json" ]] ||
     die "staged macOS installer did not install enrollment"
   "$payload/installer/release/install-macos.sh" \

--- a/packaging/triad/release/README.md
+++ b/packaging/triad/release/README.md
@@ -209,6 +209,14 @@ files, and health. Custody and identity directories are never regenerated or
 replaced during this sequence. The candidate state schemas must be at least the
 installed schemas.
 
+The macOS release remains rooted at `/usr/local/libexec/bloom`, with the
+user-facing `/usr/local/bin/bloom` symlink following its atomic `current`
+selector. Activation then removes the enrolled user's supported legacy
+`~/.local/bin/bloom` file or symlink using that user's authority. Foreign PATH
+entries fail preflight, and legacy cleanup runs only after authenticated health
+has committed; users may need `hash -r`, `rehash`, or a new terminal to clear a
+cached command location.
+
 `uninstall --retain-custody` removes runtime integration while preserving the
 exact service principals, private configuration, and custody state. `restore`
 requires the exact signed retained release and publishes Machine access only

--- a/packaging/triad/release/README.md
+++ b/packaging/triad/release/README.md
@@ -217,6 +217,17 @@ entries fail preflight, and legacy cleanup runs only after authenticated health
 has committed; users may need `hash -r`, `rehash`, or a new terminal to clear a
 cached command location.
 
+The legacy command migration does not remove old wallet data. If the resolved
+login home contains `~/.bloom/keystore`, the installer prints that exact
+location and a principal-bound two-command conversion for each detected v1
+passkey wallet. The first command runs the packaged `bloom-signer-migrate` as
+an administrator because it must read the Signer-owned configuration, stage
+data in Signer's private state, and set the isolated Signer ownership. The
+second `/usr/local/bin/bloom wallet migrate-passkey RECEIPT` command runs as
+the login user and opens the normal Broker ceremony. Unsupported legacy wallet
+kinds are identified but never modified; the staging tool supports only the
+single v1 passkey format.
+
 `uninstall --retain-custody` removes runtime integration while preserving the
 exact service principals, private configuration, and custody state. `restore`
 requires the exact signed retained release and publishes Machine access only

--- a/packaging/triad/release/install-linux.sh
+++ b/packaging/triad/release/install-linux.sh
@@ -696,7 +696,13 @@ upgrade_old_digest=""
 
 begin_linux_upgrade() {
   local install_root="$1" old_digest="$2" new_digest="$3"
-  upgrade_transaction="$install_root/var/lib/bloom/upgrade-transaction"
+  local transaction_root="$install_root/var/lib/bloom"
+  mkdir -p "$transaction_root"
+  [[ -d "$transaction_root" && ! -L "$transaction_root" ]] || {
+    echo "Linux upgrade transaction root is unsafe" >&2
+    return 65
+  }
+  upgrade_transaction="$transaction_root/upgrade-transaction"
   [[ ! -e "$upgrade_transaction" && ! -L "$upgrade_transaction" ]] || {
     echo "an interrupted Linux upgrade must be recovered first" >&2
     return 65

--- a/packaging/triad/release/install-macos.sh
+++ b/packaging/triad/release/install-macos.sh
@@ -31,6 +31,7 @@ created_groups=""
 upgrade_transaction=""
 upgrade_old_digest=""
 restore_pending=false
+legacy_cli_removed=false
 
 cleanup() {
   rc=$?
@@ -387,11 +388,67 @@ remove_legacy_cli() {
       rm -f -- "$legacy"
     fi
     [[ ! -e "$legacy" && ! -L "$legacy" ]] || return 1
+    legacy_cli_removed=true
     echo "Removed legacy $legacy; run 'hash -r' or 'rehash', or open a new terminal"
     return 0
   fi
   echo "legacy Bloom CLI is not a regular file or symlink: $legacy" >&2
   return 1
+}
+
+report_legacy_wallet_migrations() {
+  local wallet_root wallet_dir kind_file kind wallet_name receipt
+  local found_wallet=false found_supported=false
+  resolve_login_home
+  wallet_root="$login_home/.bloom/keystore"
+  if [[ ! -e "$wallet_root" && ! -L "$wallet_root" ]]; then
+    if $legacy_cli_removed; then
+      echo "Legacy Bloom wallets, if present, remain under $wallet_root"
+    fi
+    return 0
+  fi
+  if [[ ! -d "$wallet_root" || -L "$wallet_root" ]]; then
+    echo "Legacy Bloom wallet path is unsafe and was not inspected: $wallet_root" >&2
+    return 0
+  fi
+
+  echo "Legacy Bloom wallets were not modified and remain at: $wallet_root"
+  for wallet_dir in "$wallet_root"/*; do
+    [[ -e "$wallet_dir" || -L "$wallet_dir" ]] || continue
+    found_wallet=true
+    wallet_name="${wallet_dir##*/}"
+    if [[ ! -d "$wallet_dir" || -L "$wallet_dir" ]]; then
+      echo "Skipping unexpected legacy wallet entry: $wallet_dir" >&2
+      continue
+    fi
+    kind_file="$wallet_dir/kind"
+    if [[ ! -f "$kind_file" || -L "$kind_file" ]]; then
+      echo "Legacy wallet $wallet_name has no safe kind file; it was not modified" >&2
+      continue
+    fi
+    if ! kind="$(/bin/cat "$kind_file")"; then
+      echo "Legacy wallet $wallet_name could not be inspected; it was not modified" >&2
+      continue
+    fi
+    if [[ "$kind" != passkey ]]; then
+      echo "Legacy wallet $wallet_name uses unsupported kind '$kind'; only v1 passkey wallets can be migrated automatically" >&2
+      continue
+    fi
+
+    found_supported=true
+    receipt="$login_home/.bloom/$wallet_name.triad-migration-receipt.json"
+    echo "Migrate legacy passkey wallet $wallet_name with these two commands. Only the staging command requires sudo:"
+    printf '  sudo %q stage --source %q --config %q --source-uid %q --signer-uid %q --signer-gid %q --receipt %q\n' \
+      "$release_base/current/bloom-signer-migrate" "$wallet_dir" \
+      "$signer_config/config.json" "$login_uid" "$BLOOM_MACOS_SIGNER_UID" \
+      "$BLOOM_MACOS_SIGNER_GID" "$receipt"
+    printf '  %q wallet migrate-passkey %q\n' "$cli_link" "$receipt"
+  done
+  if ! $found_wallet; then
+    echo "No legacy wallets were found in $wallet_root"
+  elif ! $found_supported; then
+    echo "No supported v1 passkey wallets were detected; legacy wallet data was left in place"
+  fi
 }
 
 current_release_digest() {
@@ -888,6 +945,7 @@ case "$action" in
       upgrade_release "$shared_digest" "$BLOOM_RELEASE_DIGEST"
       login_uid="$requested_uid"; login_user="$requested_user"
       remove_legacy_cli || die "Bloom is healthy, but legacy CLI cleanup failed; remove ~/.local/bin/bloom and retry"
+      report_legacy_wallet_migrations
       echo "Bloom macOS release upgraded atomically"
       exit 0
     fi
@@ -895,6 +953,7 @@ case "$action" in
       upgrade_release "$upgrade_old_digest" "$BLOOM_RELEASE_DIGEST"
       login_uid="$requested_uid"; login_user="$requested_user"
       remove_legacy_cli || die "Bloom is healthy, but legacy CLI cleanup failed; remove ~/.local/bin/bloom and retry"
+      report_legacy_wallet_migrations
       echo "Bloom macOS release upgraded atomically"
       exit 0
     fi
@@ -908,6 +967,7 @@ case "$action" in
     write_state_schema
     if $restoring; then rm -f "$retained"; restore_pending=false; fi
     remove_legacy_cli || die "Bloom is healthy, but legacy CLI cleanup failed; remove ~/.local/bin/bloom and retry"
+    report_legacy_wallet_migrations
     if $restoring; then echo "Bloom macOS retained custody restored"; else echo "Bloom macOS enrollment installed or repaired"; fi
     ;;
   uninstall)

--- a/packaging/triad/release/install-macos.sh
+++ b/packaging/triad/release/install-macos.sh
@@ -299,6 +299,7 @@ render() {
 paths() {
   product="$root_prefix/Library/Application Support/BloomTriad"; enrollments="$product/enrollments"
   enrollment="$enrollments/$login_uid.json"; release_base="$root_prefix/usr/local/libexec/bloom"
+  cli_bin_dir="$root_prefix/usr/local/bin"; cli_link="$cli_bin_dir/bloom"
   config="$product/config/$login_uid"; broker_config="$config/broker"; signer_config="$config/signer"
   machine_config="$config/machine"; session_config="$config/session"; installer_config="$config/installer"
   if $live; then variable=/private/var; else variable="$root_prefix/var"; fi
@@ -313,6 +314,84 @@ paths() {
   machine_plist="$root_prefix/Library/LaunchAgents/com.bloom.machine.plist"
   pf_anchor="$root_prefix/etc/pf.anchors/com.bloom.triad.$login_uid"
   newsyslog_config="$root_prefix/etc/newsyslog.d/bloom-$login_uid.conf"
+}
+
+preflight_cli_link() {
+  local directory target
+  for directory in "$root_prefix/usr" "$root_prefix/usr/local" "$cli_bin_dir"; do
+    [[ ! -e "$directory" && ! -L "$directory" ]] && continue
+    [[ -d "$directory" && ! -L "$directory" ]] || die "Bloom CLI parent path is unsafe: $directory"
+  done
+  [[ ! -e "$cli_link" && ! -L "$cli_link" ]] && return 0
+  [[ -L "$cli_link" ]] || die "refusing to overwrite unrelated Bloom CLI at $cli_link"
+  target="$(readlink "$cli_link")"
+  [[ "$target" == ../libexec/bloom/current/bloom ]] ||
+    die "refusing to overwrite unrelated Bloom CLI symlink at $cli_link"
+}
+
+install_cli_link() {
+  local replacement="$cli_link.new.$$"
+  mkdir -p "$cli_bin_dir"
+  ln -s ../libexec/bloom/current/bloom "$replacement"
+  $live && chown -h root:wheel "$replacement"
+  if [[ "$(uname -s)" == Darwin ]]; then
+    mv -fh "$replacement" "$cli_link"
+  else
+    mv -fT "$replacement" "$cli_link"
+  fi
+}
+
+remove_cli_link() {
+  local target
+  [[ ! -e "$cli_link" && ! -L "$cli_link" ]] && return 0
+  if [[ -L "$cli_link" ]]; then
+    target="$(readlink "$cli_link")"
+    if [[ "$target" == ../libexec/bloom/current/bloom ]]; then
+      rm -f -- "$cli_link"
+      return 0
+    fi
+  fi
+  echo "leaving unrelated Bloom CLI in place at $cli_link" >&2
+}
+
+resolve_login_home() {
+  if $live; then
+    login_home="$(dscl . -read "/Users/$login_user" NFSHomeDirectory |
+      awk 'NR==1{sub(/^NFSHomeDirectory:[[:space:]]*/,"");print}')"
+  else
+    # Staged installs intentionally never resolve or touch the invoking user's
+    # real home. This path also gives lifecycle tests an isolated migration root.
+    login_home="$root_prefix/Users/$login_user"
+  fi
+  [[ "$login_home" == /* && "$login_home" != / &&
+    "$login_home" != *$'\n'* && "$login_home" != *$'\r'* ]] ||
+    die "cannot safely resolve home for $login_user"
+}
+
+remove_legacy_cli() {
+  local parent legacy
+  resolve_login_home
+  for parent in "$login_home" "$login_home/.local" "$login_home/.local/bin"; do
+    [[ ! -e "$parent" && ! -L "$parent" ]] && return 0
+    [[ -d "$parent" && ! -L "$parent" ]] || {
+      echo "legacy Bloom CLI parent path is unsafe: $parent" >&2
+      return 1
+    }
+  done
+  legacy="$login_home/.local/bin/bloom"
+  [[ ! -e "$legacy" && ! -L "$legacy" ]] && return 0
+  if [[ -L "$legacy" || ( -f "$legacy" && ! -L "$legacy" ) ]]; then
+    if $live; then
+      /usr/bin/sudo -u "$login_user" -- /bin/rm -f -- "$legacy"
+    else
+      rm -f -- "$legacy"
+    fi
+    [[ ! -e "$legacy" && ! -L "$legacy" ]] || return 1
+    echo "Removed legacy $legacy; run 'hash -r' or 'rehash', or open a new terminal"
+    return 0
+  fi
+  echo "legacy Bloom CLI is not a regular file or symlink: $legacy" >&2
+  return 1
 }
 
 current_release_digest() {
@@ -367,13 +446,14 @@ rollback_failed_restore() {
   fi
   rm -f "$broker_plist" "$signer_plist" "$pf_anchor" "$newsyslog_config" "$enrollments/$login_uid.json"
   rm -rf "$runtime" "$log_root"
+  has_active_enrollments || remove_cli_link
   restore_pending=false
 }
 rollback_failed_fresh() {
   for label in "gui/$login_uid/com.bloom.machine" "user/$login_uid/com.bloom.machine" "system/com.bloom.broker.$login_uid" "system/com.bloom.signer.$login_uid" "gui/$login_uid/com.bloom.session" "user/$login_uid/com.bloom.session"; do launchctl bootout "$label" 2>/dev/null || true; done
   pf_reference remove || true; rm -f "$broker_plist" "$signer_plist" "$pf_anchor" "$newsyslog_config" "$enrollment"
   rm -rf "$config" "$variable/db/bloom/$login_uid" "$runtime" "$log_root"
-  has_active_enrollments || { launchctl bootout system/com.bloom.containment 2>/dev/null || true; rm -f "$containment_plist" "$session_plist" "$machine_plist"; }
+  has_active_enrollments || { launchctl bootout system/com.bloom.containment 2>/dev/null || true; rm -f "$containment_plist" "$session_plist" "$machine_plist"; remove_cli_link; }
 }
 write_enrollment() {
   state="$1"; tmp="$enrollment.new.$$"
@@ -717,7 +797,7 @@ snapshot_macos_upgrade_state() {
   done
   (cd "${root_prefix:-/}" && tar -cpf "$archive" "${paths[@]}")
   chmod 0600 "$archive"
-  $live && chown root:wheel "$archive"
+  if $live; then chown root:wheel "$archive"; fi
 }
 
 restore_macos_upgrade_state() {
@@ -758,11 +838,12 @@ upgrade_release() {
   if ! reload_installed_set || ! activate_installed_set; then
     echo "new Bloom release failed authenticated activation; restoring $old" >&2; stop_all_enrollments || true
     restore_macos_upgrade_state; switch_release "$old"
-    if reload_installed_set && activate_installed_set; then rm -rf -- "$upgrade_transaction"; upgrade_transaction=""
+    if reload_installed_set && activate_installed_set; then install_cli_link; rm -rf -- "$upgrade_transaction"; upgrade_transaction=""
       echo "previous Bloom release restored after failed activation" >&2
     else echo "automatic restoration of the previous Bloom release failed" >&2; fi
     return 1
   fi
+  install_cli_link
   write_state_schema
   rm -rf -- "$upgrade_transaction"; upgrade_transaction=""; upgrade_old_digest=""
 }
@@ -773,6 +854,7 @@ case "$action" in
     [[ "$login_user" =~ ^[a-z_][a-z0-9_-]*$ ]] || { echo "unsafe LOGIN_USER" >&2; exit 64; }
     $live && { lock_installer; [[ "$(id -u "$login_user")" == "$login_uid" ]] || die "LOGIN_USER does not match LOGIN_UID"; launchctl print "gui/$login_uid" >/dev/null 2>&1 || die "LOGIN_USER has no active GUI domain"; snapshot_live_payload; }
     requested_uid="$login_uid"; requested_user="$login_user"; load_names; paths; verify_payload; preflight_compatibility; prepare_verified_payload_for_execution
+    preflight_cli_link
     find_interrupted_upgrade
     login_uid="$requested_uid"; login_user="$requested_user"; load_names; paths
     shared_digest="$(current_release_digest)"
@@ -804,11 +886,15 @@ case "$action" in
     install_release
     if [[ "$had_active" == true && "$shared_digest" != "$BLOOM_RELEASE_DIGEST" && "$restoring" == false ]]; then
       upgrade_release "$shared_digest" "$BLOOM_RELEASE_DIGEST"
+      login_uid="$requested_uid"; login_user="$requested_user"
+      remove_legacy_cli || die "Bloom is healthy, but legacy CLI cleanup failed; remove ~/.local/bin/bloom and retry"
       echo "Bloom macOS release upgraded atomically"
       exit 0
     fi
     if [[ -n "$upgrade_transaction" ]]; then
       upgrade_release "$upgrade_old_digest" "$BLOOM_RELEASE_DIGEST"
+      login_uid="$requested_uid"; login_user="$requested_user"
+      remove_legacy_cli || die "Bloom is healthy, but legacy CLI cleanup failed; remove ~/.local/bin/bloom and retry"
       echo "Bloom macOS release upgraded atomically"
       exit 0
     fi
@@ -818,8 +904,11 @@ case "$action" in
       activate_current_enrollment || { $fresh && rollback_failed_fresh; die "Bloom failed full activation"; }
       created_users=""; created_groups=""
     fi
+    install_cli_link
     write_state_schema
-    if $restoring; then rm -f "$retained"; restore_pending=false; echo "Bloom macOS retained custody restored"; else echo "Bloom macOS enrollment installed or repaired"; fi
+    if $restoring; then rm -f "$retained"; restore_pending=false; fi
+    remove_legacy_cli || die "Bloom is healthy, but legacy CLI cleanup failed; remove ~/.local/bin/bloom and retry"
+    if $restoring; then echo "Bloom macOS retained custody restored"; else echo "Bloom macOS enrollment installed or repaired"; fi
     ;;
   uninstall)
     retain=false
@@ -851,6 +940,7 @@ case "$action" in
     fi
     if ! has_active_enrollments; then
       $live && launchctl bootout system/com.bloom.containment 2>/dev/null || true; rm -f "$containment_plist" "$session_plist" "$machine_plist"
+      remove_cli_link
       if ! has_active_enrollments "$product/retained"; then rm -rf "$release_base"; fi
     fi
     $retain || echo "Bloom macOS enrollment permanently purged; custody is unrecoverable"

--- a/tests/conformance/macos-unix-principals/run-two-login.sh
+++ b/tests/conformance/macos-unix-principals/run-two-login.sh
@@ -169,6 +169,7 @@ assert_unused_enrollment "$login_uid_b"
 installed_a=true
 release_digest="$(field "$login_uid_a" release_digest)"
 [[ "$(field "$login_uid_a" state)" == "active" ]]
+[[ -L /usr/local/bin/bloom ]]
 [[ "$(readlink /usr/local/bin/bloom)" == ../libexec/bloom/current/bloom ]]
 [[ "$(stat -f '%u' /usr/local/bin/bloom)" == 0 ]]
 sudo -u "$login_user_a" \
@@ -215,6 +216,7 @@ fi
 [[ "$(shasum -a 256 "$identity_a" | awk '{print $1}')" == "$identity_before" ]]
 "$installer" restore / "$login_uid_a" "$login_user_a" "$tested_payload"
 [[ ! -e "/Library/Application Support/BloomTriad/retained/$login_uid_a.json" ]]
+[[ -L /usr/local/bin/bloom ]]
 [[ "$(readlink /usr/local/bin/bloom)" == ../libexec/bloom/current/bloom ]]
 [[ "$(shasum -a 256 "$identity_a" | awk '{print $1}')" == "$identity_before" ]]
 sudo -u "$login_user_a" "$machine_binary" serve triad-health-check "$release_digest"
@@ -422,6 +424,7 @@ fi
 
 "$installer" uninstall / "$login_uid_b" "delete-bloom-login-$login_uid_b"
 installed_b=false
+[[ -L /usr/local/bin/bloom ]]
 [[ "$(readlink /usr/local/bin/bloom)" == ../libexec/bloom/current/bloom ]]
 "$installer" uninstall / "$login_uid_a" "delete-bloom-login-$login_uid_a"
 installed_a=false

--- a/tests/conformance/macos-unix-principals/run-two-login.sh
+++ b/tests/conformance/macos-unix-principals/run-two-login.sh
@@ -169,6 +169,8 @@ assert_unused_enrollment "$login_uid_b"
 installed_a=true
 release_digest="$(field "$login_uid_a" release_digest)"
 [[ "$(field "$login_uid_a" state)" == "active" ]]
+[[ "$(readlink /usr/local/bin/bloom)" == ../libexec/bloom/current/bloom ]]
+[[ "$(stat -f '%u' /usr/local/bin/bloom)" == 0 ]]
 sudo -u "$login_user_a" \
   "$machine_binary" serve triad-health-check "$release_digest"
 
@@ -187,6 +189,16 @@ if [[ -n "$upgrade_payload" ]]; then
   printf '%s\n' bloom.macos-upgrade-transaction.2 >"$transaction/schema"
   printf '%s\n' "$release_digest" >"$transaction/old-digest"
   printf '%s\n' "$(payload_release_digest "$payload")" >"$transaction/new-digest"
+  (cd / && tar -cpf "$transaction/rollback-state.tar" \
+    "Library/Application Support/BloomTriad/enrollments" \
+    "Library/Application Support/BloomTriad/config" \
+    Library/LaunchDaemons/com.bloom.containment.plist \
+    Library/LaunchAgents/com.bloom.session.plist \
+    Library/LaunchAgents/com.bloom.machine.plist \
+    "Library/LaunchDaemons/com.bloom.broker.$login_uid_a.plist" \
+    "Library/LaunchDaemons/com.bloom.signer.$login_uid_a.plist" \
+    "etc/pf.anchors/com.bloom.triad.$login_uid_a" \
+    "etc/newsyslog.d/bloom-$login_uid_a.conf")
   chown -R root:wheel "$transaction"
   chmod 0600 "$transaction"/*
   "$installer" install / "$login_uid_a" "$login_user_a" "$tested_payload"
@@ -199,9 +211,11 @@ fi
 "$installer" uninstall --retain-custody / "$login_uid_a"
 [[ ! -e "/Library/Application Support/BloomTriad/enrollments/$login_uid_a.json" ]]
 [[ -f "/Library/Application Support/BloomTriad/retained/$login_uid_a.json" ]]
+[[ ! -e /usr/local/bin/bloom && ! -L /usr/local/bin/bloom ]]
 [[ "$(shasum -a 256 "$identity_a" | awk '{print $1}')" == "$identity_before" ]]
 "$installer" restore / "$login_uid_a" "$login_user_a" "$tested_payload"
 [[ ! -e "/Library/Application Support/BloomTriad/retained/$login_uid_a.json" ]]
+[[ "$(readlink /usr/local/bin/bloom)" == ../libexec/bloom/current/bloom ]]
 [[ "$(shasum -a 256 "$identity_a" | awk '{print $1}')" == "$identity_before" ]]
 sudo -u "$login_user_a" "$machine_binary" serve triad-health-check "$release_digest"
 
@@ -405,5 +419,12 @@ if [[ -n "${BLOOM_MACOS_W0_EVIDENCE_DIR:-}" ]]; then
     mv -f "$temporary" "$evidence_dir/mui_09.pass"
   fi
 fi
+
+"$installer" uninstall / "$login_uid_b" "delete-bloom-login-$login_uid_b"
+installed_b=false
+[[ "$(readlink /usr/local/bin/bloom)" == ../libexec/bloom/current/bloom ]]
+"$installer" uninstall / "$login_uid_a" "delete-bloom-login-$login_uid_a"
+installed_a=false
+[[ ! -e /usr/local/bin/bloom && ! -L /usr/local/bin/bloom ]]
 
 echo "two-login macOS Unix-principal W0 passed"

--- a/tests/packaging/macos-installer-staged.sh
+++ b/tests/packaging/macos-installer-staged.sh
@@ -63,16 +63,38 @@ done
 
 root="$work/lifecycle-root"
 legacy="$root/Users/releaseuser/.local/bin/bloom"
+legacy_wallet="$root/Users/releaseuser/.bloom/keystore/alice"
+unsupported_wallet="$root/Users/releaseuser/.bloom/keystore/watch-only"
 mkdir -p "$(dirname "$legacy")"
 printf 'old Bloom\n' >"$legacy"
+mkdir -p "$legacy_wallet" "$unsupported_wallet"
+printf 'passkey\n' >"$legacy_wallet/kind"
+printf 'watch\n' >"$unsupported_wallet/kind"
+resolved_root="$(cd "$root" && pwd -P)"
 
 # Fresh install exposes the exact relative link and removes only the staged
-# login's supported legacy entry after enrollment convergence.
-run_installer "$digest_a" install "$root" 501 releaseuser "$payload_a"
+# login's supported legacy entry after enrollment convergence. Wallet sources
+# remain untouched, and the notice renders exact principal-bound commands.
+install_output="$(run_installer "$digest_a" install "$root" 501 releaseuser "$payload_a" 2>&1)"
 [[ -L "$root/usr/local/bin/bloom" ]]
 [[ "$(readlink "$root/usr/local/bin/bloom")" == ../libexec/bloom/current/bloom ]]
 [[ ! -e "$legacy" && ! -L "$legacy" ]]
+[[ -d "$legacy_wallet" && -f "$legacy_wallet/kind" ]]
 [[ "$(readlink "$root/usr/local/libexec/bloom/current")" == "releases/$digest_a" ]]
+grep -F "Legacy Bloom wallets were not modified and remain at: $resolved_root/Users/releaseuser/.bloom/keystore" <<<"$install_output" >/dev/null
+printf -v stage_command '  sudo %q stage --source %q --config %q --source-uid %q --signer-uid %q --signer-gid %q --receipt %q' \
+  "$resolved_root/usr/local/libexec/bloom/current/bloom-signer-migrate" \
+  "$resolved_root/Users/releaseuser/.bloom/keystore/alice" \
+  "$resolved_root/Library/Application Support/BloomTriad/config/501/signer/config.json" \
+  501 250502 260500 \
+  "$resolved_root/Users/releaseuser/.bloom/alice.triad-migration-receipt.json"
+printf -v finish_command '  %q wallet migrate-passkey %q' \
+  "$resolved_root/usr/local/bin/bloom" \
+  "$resolved_root/Users/releaseuser/.bloom/alice.triad-migration-receipt.json"
+grep -F "$stage_command" <<<"$install_output" >/dev/null
+grep -F "$finish_command" <<<"$install_output" >/dev/null
+grep -F "Only the staging command requires sudo" <<<"$install_output" >/dev/null
+grep -F "Legacy wallet watch-only uses unsupported kind 'watch'" <<<"$install_output" >/dev/null
 
 # The exact managed link is accepted and same-digest repair is idempotent.
 run_installer "$digest_a" install "$root" 501 releaseuser "$payload_a"

--- a/tests/packaging/macos-installer-staged.sh
+++ b/tests/packaging/macos-installer-staged.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+workspace="$(cd "$(dirname "$0")/../.." && pwd -P)"
+installer="$workspace/packaging/triad/release/install-macos.sh"
+work="$(mktemp -d)"
+trap 'find "$work" -depth -delete' EXIT
+digest_a="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+digest_b="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+make_payload() {
+  local target="$1" marker="$2" name
+  mkdir -p "$target/bin" "$target/config" "$target/installer"
+  cp -R "$workspace/packaging/triad/macos" "$target/installer/macos"
+  mkdir -p "$target/installer/release"
+  cp "$installer" "$target/installer/release/install-macos.sh"
+  cp "$workspace/packaging/triad/release/compatibility-v1.toml" "$target/"
+  printf 'test-unclaimed\n' >"$target/PLATFORM_CLAIM"
+  for name in bloom bloom-broker bloom-signer bloom-signer-migrate; do
+    printf '#!/bin/sh\nprintf "%%s\\n" "%s"\n' "$marker" >"$target/bin/$name"
+    chmod 0755 "$target/bin/$name"
+  done
+  for name in edge-manifest.json broker.json signer.json machine-identity.json \
+    broker-identity.json signer-identity.json revoke-identity.json \
+    session-identity.json installer-identity.json provenance-catalog.json
+  do
+    printf '{}\n' >"$target/config/$name"
+  done
+}
+
+run_installer() {
+  local digest="$1"; shift
+  BLOOM_ALLOW_TEST_UNCLAIMED=true \
+    BLOOM_MACOS_BROKER_UID=250501 BLOOM_MACOS_SIGNER_UID=250502 \
+    BLOOM_MACOS_BROKER_GID=260499 BLOOM_MACOS_SIGNER_GID=260500 \
+    BLOOM_MACOS_MACHINE_BROKER_GID=260501 \
+    BLOOM_MACOS_BROKER_SIGNER_GID=260502 BLOOM_MACOS_REVOKE_GID=260503 \
+    BLOOM_MACOS_LOG_GID=260504 BLOOM_RELEASE_DIGEST="$digest" \
+    "$installer" "$@"
+}
+
+payload_a="$work/payload-a"
+payload_b="$work/payload-b"
+make_payload "$payload_a" release-a
+make_payload "$payload_b" release-b
+
+# Foreign CLI entries fail before release, enrollment, or custody paths exist.
+for conflict in file symlink directory; do
+  root="$work/conflict-$conflict"
+  mkdir -p "$root/usr/local/bin"
+  case "$conflict" in
+    file) printf 'foreign\n' >"$root/usr/local/bin/bloom" ;;
+    symlink) ln -s /opt/foreign/bloom "$root/usr/local/bin/bloom" ;;
+    directory) mkdir "$root/usr/local/bin/bloom" ;;
+  esac
+  if run_installer "$digest_a" install "$root" 501 releaseuser "$payload_a"; then
+    echo "installer overwrote a foreign CLI $conflict" >&2
+    exit 1
+  fi
+  [[ ! -e "$root/usr/local/libexec/bloom" ]]
+  [[ ! -e "$root/Library/Application Support/BloomTriad" ]]
+done
+
+root="$work/lifecycle-root"
+legacy="$root/Users/releaseuser/.local/bin/bloom"
+mkdir -p "$(dirname "$legacy")"
+printf 'old Bloom\n' >"$legacy"
+
+# Fresh install exposes the exact relative link and removes only the staged
+# login's supported legacy entry after enrollment convergence.
+run_installer "$digest_a" install "$root" 501 releaseuser "$payload_a"
+[[ -L "$root/usr/local/bin/bloom" ]]
+[[ "$(readlink "$root/usr/local/bin/bloom")" == ../libexec/bloom/current/bloom ]]
+[[ ! -e "$legacy" && ! -L "$legacy" ]]
+[[ "$(readlink "$root/usr/local/libexec/bloom/current")" == "releases/$digest_a" ]]
+
+# The exact managed link is accepted and same-digest repair is idempotent.
+run_installer "$digest_a" install "$root" 501 releaseuser "$payload_a"
+[[ "$(readlink "$root/usr/local/bin/bloom")" == ../libexec/bloom/current/bloom ]]
+
+# Upgrade leaves the stable PATH entry following the new current release.
+run_installer "$digest_b" install "$root" 501 releaseuser "$payload_b"
+[[ "$(readlink "$root/usr/local/libexec/bloom/current")" == "releases/$digest_b" ]]
+[[ "$("$root/usr/local/bin/bloom")" == release-b ]]
+
+# Retaining the final active enrollment removes the command; restore recreates
+# it without requiring release-tree deletion.
+"$installer" uninstall --retain-custody "$root" 501
+[[ ! -e "$root/usr/local/bin/bloom" && ! -L "$root/usr/local/bin/bloom" ]]
+[[ -d "$root/usr/local/libexec/bloom" ]]
+run_installer "$digest_b" restore "$root" 501 releaseuser "$payload_b"
+[[ "$(readlink "$root/usr/local/bin/bloom")" == ../libexec/bloom/current/bloom ]]
+
+# A second active login shares the command. Partial removal keeps it; removal
+# of the final active login removes it even when the first custody is retained.
+run_installer "$digest_b" install "$root" 502 seconduser "$payload_b"
+"$installer" uninstall --retain-custody "$root" 501
+[[ -L "$root/usr/local/bin/bloom" ]]
+"$installer" uninstall "$root" 502 delete-bloom-login-502
+[[ ! -e "$root/usr/local/bin/bloom" && ! -L "$root/usr/local/bin/bloom" ]]
+
+# A legacy symlink is unlinked without following its target, and staged mode
+# cannot touch a same-named entry outside the staged root.
+root="$work/symlink-root"
+outside="$work/outside-home/.local/bin/bloom"
+legacy="$root/Users/releaseuser/.local/bin/bloom"
+mkdir -p "$(dirname "$legacy")" "$(dirname "$outside")"
+printf 'outside\n' >"$outside"
+ln -s "$outside" "$legacy"
+run_installer "$digest_a" install "$root" 501 releaseuser "$payload_a"
+[[ ! -L "$legacy" && -f "$outside" ]]
+
+# An unexpected object is never deleted. Cleanup fails after the enrollment
+# and CLI have converged, documenting the non-rollback post-activation policy.
+root="$work/unsafe-legacy-root"
+legacy="$root/Users/releaseuser/.local/bin/bloom"
+mkdir -p "$legacy"
+if run_installer "$digest_a" install "$root" 501 releaseuser "$payload_a"; then
+  echo "installer accepted an unsafe legacy CLI object" >&2
+  exit 1
+fi
+[[ -d "$legacy" ]]
+[[ -f "$root/Library/Application Support/BloomTriad/enrollments/501.json" ]]
+[[ -L "$root/usr/local/bin/bloom" ]]
+
+echo "staged macOS installer CLI lifecycle passed"


### PR DESCRIPTION
## Summary

- expose the immutable macOS release through a fail-closed, lifecycle-managed `/usr/local/bin/bloom` symlink
- remove only the enrolled login legacy `~/.local/bin/bloom` after authenticated activation and print shell-cache reload guidance
- preserve legacy wallets under the resolved `~/.bloom/keystore`, identify supported v1 passkey wallets, and print exact shell-escaped staging and ceremony commands with resolved paths and principal IDs
- state explicitly that only `bloom-signer-migrate stage` requires `sudo`; the subsequent `bloom wallet migrate-passkey` ceremony runs as the enrolled login
- cover fresh install, repair, upgrade, restore, multi-login removal, conflict handling, wallet guidance, and interrupted-upgrade fixtures
- address both Copilot `readlink` comments with explicit symlink guards

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p bloom-it --test macos_launchagent --locked` — 20 passed
- `cargo test -p bloom-it --test triad_release macos_ --locked` — 12 passed
- `tests/packaging/macos-installer-staged.sh`
- `bash -n` on changed shell scripts
- `git diff --check`

A full local candidate build was not rerun because the local sibling checkout does not match the release compatibility pin.

## Checklist

- [x] Tests added or updated for behavior changes
- [x] Architecture docs (`docs/architecture/`) updated if contracts or behavior changed — N/A: this changes macOS packaging and installer UX; both packaging documents are updated
- [x] Sealed Approval invariants respected (no signing outside a grant or bounded capability, no PRF/grant persistence, execution from sealed bytes) — wallet conversion continues through the existing Broker ceremony
- [x] Agent Documentation updated (`crates/bloom-vfs/src/docs/agent-guidance.md` and affected Petal READMEs) — N/A: no agent-facing VFS or Petal behavior changed