### PR TITLE
Fix macOS architecture validation on Linux signing hosts

### DIFF
--- a/packaging/triad/release.sh
+++ b/packaging/triad/release.sh
@@ -85,7 +85,8 @@ require_staged_architecture() {
           die "$binary is not an x86-64 ELF release binary"
         ;;
       macos)
-        [[ "$description" == *"Mach-O 64-bit executable arm64"* ]] ||
+        [[ "$description" == *"Mach-O 64-bit executable arm64"* ||
+          "$description" == *"Mach-O 64-bit arm64 executable"* ]] ||
           die "$binary is not an arm64 Mach-O release binary"
         ;;
     esac


### PR DESCRIPTION
## Summary

Production macOS signing runs on Ubuntu, where `file` reports `Mach-O 64-bit arm64 executable`. The validator only accepted macOS's `Mach-O 64-bit executable arm64`, causing signing to fail. Accept both forms while retaining the 64-bit ARM executable requirement.

Verified all four candidate binaries against the updated check on macOS and Ubuntu 24.04. Shell syntax and diff checks pass.

## Checklist

- [x] Tests added or updated for behavior changes — N/A for additional automated tests; directly exercised the changed validator against all four actual candidate binaries on macOS and Ubuntu 24.04.
- [x] Architecture docs (`docs/architecture/`) updated if contracts or behavior changed — N/A; fixes host-dependent tool output parsing without changing architecture or supported artifacts.
- [x] Sealed Approval invariants respected (no signing outside a grant or bounded capability, no PRF/grant persistence, execution from sealed bytes) — unchanged; no wallet signing changes.
- [x] Agent Documentation updated (`crates/bloom-vfs/src/docs/agent-guidance.md` and affected Petal READMEs) — N/A; no agent-facing or Petal behavior changes.
