### PR TITLE
fix: align release guidance and conformance with v0.2 contract

### DIFF
--- a/docs/operations/release-process.md
+++ b/docs/operations/release-process.md
@@ -1,191 +1,108 @@
 # Release process
 
-## Overview
+## Current release contract
 
-Releases start from a reviewed version-bump PR followed by a `vX.Y.Z` tag
-push. The optional `propose-release.yml` workflow prepares the PR; it never
-writes to the default branch, creates a stable tag, or publishes a release.
-The `release.yml` workflow:
+Bloom v0.2 releases contain signed triad bundles for **Linux x86_64** and
+**macOS aarch64**. Each archive includes Machine (`bloom`), Broker, Signer,
+`bloom-signer-migrate`, public configuration templates, and installers. The
+published assets are:
 
-1. Validates the tag shape.
-2. Verifies that the tagged commit is reachable from the default branch and
-   already has workspace version `X.Y.Z`.
-3. Builds the exact commit SHA on four runner platforms (Linux x86_64 +
-   aarch64, macOS x86_64 + aarch64) with `--locked`, including both glibc
-   and static musl artifacts for Linux aarch64.
-4. Verifies the resulting binary's `bloom --version` matches the tag.
-5. Verifies the tag still resolves to the built SHA, then creates a
-   GitHub release `vX.Y.Z` with the five tarballs and a `SHA256SUMS`
-   file. It advances GitHub's latest-release alias only when this version is
-   at least as new as the current latest release; failures resolving that
-   release abort publication rather than treating the result as empty.
+- `bloom-triad-linux-x86_64.tar.gz` plus `.sha256`, `.sig`, and `.pub` sidecars;
+- `bloom-triad-macos-aarch64.tar.gz` plus `.sha256`, `.sig`, and `.pub` sidecars.
 
-The floating `latest` git tag is intentionally NOT created by the
-workflow. It is owned by the old (now-retired) branch-driven
-`release.yml`. The legacy `Latest master build` release and the
-`latest` tag are removed in the cleanup step below. GitHub's
-`/releases/latest/download/...` route follows the release marked
-latest; it does not require a git tag literally named `latest`.
+Both platforms use the reviewed key at
+[`packaging/triad/release/bloom-release-v1.pub`](../../packaging/triad/release/bloom-release-v1.pub).
+The archive checksum signature uses the `bloom-release-archive-v1` SSHSIG
+namespace; the internal manifest uses `bloom-release-payload-v1`. Obtain the
+trusted key independently of the downloaded archive. A bundled `.pub` file
+alone does not establish trust. The installers authenticate a private
+root-owned snapshot against a separately provisioned, root-owned,
+non-writable pin before changing services or installation state.
 
-Linux aarch64 releases include two variants. Use
-`bloom-linux-aarch64.tar.gz` on glibc distributions and
-`bloom-linux-aarch64-musl.tar.gz` on Termux/Android, Alpine Linux, and
-minimal Linux systems without glibc. The musl binary is statically linked.
+Production macOS uses the `macos-unix-principals` claim. Tart conformance is
+optional manual validation: `MACOS_CONFORMANCE_REPORT.json`, `.sig`, and
+`.pub` are not required release assets, signing inputs, or install prerequisites.
+The guarded `macos-unix-principals-w0` claim remains for disposable testing.
+See the [package contract](../../packaging/triad/release/README.md) for
+verification, enrollment, upgrade, and custody-retention behavior.
 
-## CI-proposed release
+## Prepare a reviewed version bump
 
-Configure a `RELEASE_PR_TOKEN` repository secret backed by a GitHub App token
-or fine-grained token with Contents read/write and Pull requests read/write.
-The token is needed because a PR created with `GITHUB_TOKEN` does not receive
-the normal pull-request workflow events.
+Releases start from a version-bump PR followed by a `vX.Y.Z` tag on the reviewed
+commit. The optional `propose-release.yml` workflow creates that PR; it never
+writes to the default branch, tags a release, or publishes assets. Configure
+`RELEASE_PR_TOKEN` as a fine-grained token with Contents and Pull requests
+read/write permissions so the generated PR receives normal pull-request CI.
+A GitHub App integration would instead need to mint its installation token in
+the workflow.
 
-Run **Actions → Propose Release → Run workflow**, enter the next version
-without the `v` prefix, and review the generated PR. The workflow updates only
-`Cargo.toml` and the workspace metadata in `Cargo.lock`, and refuses to
-upgrade unrelated external dependencies. After the PR is merged, push a tag
-from the merge commit:
+Run **Actions → Propose Release → Run workflow** with the next version without
+`v`. Review changes to `Cargo.toml`, workspace metadata in `Cargo.lock`, and
+the Machine version in `packaging/triad/release/compatibility-v1.toml`. The
+workflow refuses to upgrade unrelated external dependencies. The compatibility
+matrix also pins the reviewed Broker and Signer source commits; changes to
+those pins require review independently of the version bump.
 
-```bash
-VERSION="0.1.1"
-git switch master
-git pull --ff-only origin master
-test "$(sed -n -E 's/^version = "([0-9]+\.[0-9]+\.[0-9]+)"/\1/p' Cargo.toml | head -n 1)" = "$VERSION"
-git tag "v$VERSION"
-git push origin "v$VERSION"
+After merging the PR, tag the reviewed commit and push that tag. The release
+workflow requires the commit to be reachable from the default branch and both
+the workspace and compatibility-matrix Machine version to equal the tag.
+Repository rules should restrict creation and updates of `v*` tags to release
+maintainers.
+
+## Build and validate candidates
+
+The local and CI entry point is:
+
+```sh
+packaging/triad/release.sh build linux --output-dir /tmp/bloom-linux-candidate
+# On a separate Darwin arm64 host:
+packaging/triad/release.sh build macos --output-dir /tmp/bloom-macos-candidate
 ```
 
-The tag push starts the release workflow. It verifies that the tag points to a
-commit reachable from the default branch, that the tag and workspace version
-agree, builds that immutable commit, and publishes the release only after all
-build jobs pass.
+Linux builds require a Linux x86_64 host; macOS builds require Darwin arm64.
+By default the command uses `../bloom-broker` and `../bloom-signer`; explicit
+`--broker-root` and `--signer-root` options select other checkouts. All three
+source trees must be clean, including untracked files, and the authority
+checkouts must match the committed compatibility pins. Builds use locked
+Cargo dependencies and reject forbidden production Machine features.
 
-Repository rules should require review before merging the proposal PR and
-limit creation or update of `v*` tags to release maintainers. The release
-workflow's write token is used only by the publish job for GitHub release
-metadata and assets.
+The build validates versions, architecture, packaging and installer checks,
+then assembles and verifies the bundle twice to prove deterministic output.
+It emits `bloom-triad-test-unclaimed.tar.gz` and its three sidecars signed by
+an ephemeral candidate key. Source-wide formatting, Clippy, and test suites
+remain separate CI gates; a candidate build is not a full acceptance run.
+Never replace this entry point with a single-binary `--all-features` build.
 
-## Local release
+Before merging changes to the release workflow, dispatch the branch with
+`dry_run=true`. That runs both candidate builds and uploads Actions artifacts,
+while skipping production signing and GitHub publication. It does not create
+commits or tags. Installing a candidate additionally requires a trusted
+root-owned pin of its ephemeral key and the explicit
+`BLOOM_ALLOW_TEST_UNCLAIMED=true` installer opt-in.
 
-Run the first `vX.Y.Z` release locally so you can verify the build
-before pushing the tag:
+## Sign and publish
 
-```bash
-# 1. Decide on the version. For a first release from the existing
-#    master at workspace version 0.1.0, this is likely 0.1.1 (a
-#    small bump that signals "first proper release") or 0.2.0
-#    (signals "now we have update checks + the workflow"). Pick
-#    deliberately and document the choice in the PR description.
-VERSION="0.1.1"
-BRANCH="release-prep/v$VERSION"
-git switch master
-git pull --ff-only origin master
-git switch -c "$BRANCH"
+A `vX.Y.Z` tag push runs `release.yml`. A manual dispatch with `dry_run=false`
+retries an existing tag; select that tag as the workflow ref as well. The run
+must originate from the tagged commit and builds its exact source SHA, using
+Linux x86_64 and `macos-15` arm64 runners.
 
-# 2. Bump the workspace version. `sed` is enough — every member
-#    crate uses `version.workspace = true` and picks up the new
-#    number at compile time. `cargo check --workspace` refreshes only
-#    the lockfile metadata required by the version change; it does not
-#    proactively upgrade compatible transitive dependencies.
-sed -i -E "s/^version = \"[0-9]+\\.[0-9]+\\.[0-9]+\"/version = \"$VERSION\"/" Cargo.toml
-cargo check --workspace
+After both candidate builds succeed, the protected `production-release`
+environment supplies the release key only to the signing step. The isolated
+`release.sh sign linux|macos` pass verifies candidate version, source revisions,
+and target architecture without executing candidate-owned code. It replaces
+the ephemeral inner signature, repacks deterministically, and signs the outer
+checksum with a private key matching the reviewed public key. Both final
+archives are verified against that pin before publication.
 
-# 3. Sanity: the diff is exactly Cargo.toml + Cargo.lock.
-git diff -- Cargo.toml Cargo.lock
+The publish job rechecks that the tag still names the built SHA, then publishes
+both platforms together as a normal GitHub Release. A retry compares existing
+assets byte for byte, rejects unexpected or changed assets, and uploads only
+missing assets. The current retry path marks the release latest; maintainers
+should account for that when retrying an older tag. GitHub's
+`/releases/latest/download/...` routes follow the release marked latest and do
+not need a floating `latest` Git tag.
 
-# 4. Build and verify the binary.
-cargo build --release -p bloom --all-features --locked
-./target/release/bloom --version    # first line must print "bloom $VERSION"
-
-# 5. Commit the bump on a release-prep branch and open a PR. Do not
-#    push directly to master; the default branch requires its status
-#    checks to pass through a PR.
-git add Cargo.toml Cargo.lock
-git commit -m "release: v$VERSION"
-git push -u origin "$BRANCH"
-gh pr create --base master --head "$BRANCH" \
-  --title "release: v$VERSION" \
-  --body "Bump the workspace version for v$VERSION."
-
-# 6. After that PR passes checks and is merged, update local master.
-#    Rebuild so the tag is attached to the exact commit you tested
-#    even if another PR merged in the meantime.
-git switch master
-git pull --ff-only origin master
-test "$(sed -n -E 's/^version = "([0-9]+\.[0-9]+\.[0-9]+)"/\1/p' Cargo.toml | head -n 1)" = "$VERSION"
-cargo build --release -p bloom --all-features --locked
-./target/release/bloom --version    # first line must print "bloom $VERSION"
-git tag "v$VERSION"
-git push origin "v$VERSION"
-```
-
-The tag push starts the workflow automatically. Because the tag already
-points at the reviewed version-bumped commit, the build jobs use that exact
-SHA and the publish job creates the `v$VERSION` release with the five
-tarballs and `SHA256SUMS`. A manual `release.yml` run is available only to
-retry an existing tag and never creates commits or tags.
-
-## Legacy cleanup (one-time, manual)
-
-After the first `vX.Y.Z` release is published and marked latest,
-GitHub's `/releases/latest` API and download routes point to it. The
-legacy `Latest master build` release and floating `latest` git tag can
-then be deleted as cleanup:
-
-```bash
-# 1. Delete the legacy release whose tag is literally "latest".
-gh release delete latest --yes
-
-# 2. Delete its floating git tag.
-git push origin :refs/tags/latest
-```
-
-The stable `/releases/latest/download/...` URLs continue to work: they
-follow the `vX.Y.Z` release marked latest, independently of the deleted
-floating tag.
-
-## Verifying the UpdateChecker
-
-After the first versioned release, the daemon's `/status/update`
-subtree should be meaningful. Verify from any machine running the
-binary:
-
-```bash
-# First-run: no cache file → available=unknown, latest=empty.
-bloom vfs cat /status/update/available    # → unknown\n
-bloom vfs cat /status/update/latest       # → \n
-
-# After 5 minutes (or after `bloom update check`): the snapshot
-# should be populated.
-bloom update check                         # prints snapshot as JSON, exit 0/1/2
-bloom vfs cat /status/update/latest        # → e.g. "0.1.1\n"
-bloom vfs cat /status/update/available     # → out_of_date | up_to_date
-```
-
-Before the first versioned release, GitHub may return the legacy tag
-`latest`. That is a successful HTTP response but not semver, so
-`bloom update check` reports `available: unknown` and exits 2 rather
-than claiming the binary is up to date. An HTTP 404 means no eligible
-published release exists yet.
-
-To disable automatic daemon polling on a host while retaining explicit
-checks, set `BLOOM_DISABLE_UPDATE_CHECK=1` in the service environment.
-
-## What is intentionally NOT in the workflow
-
-- **`cargo install cargo-edit`**: not needed. `sed` is faster and
-  doesn't need a fresh toolchain.
-- **`--config 'package.version="X.Y.Z"'`**: doesn't exist in Cargo.
-  Verified against the Cargo configuration reference.
-- **A floating `latest` git tag**: removed during legacy cleanup. The
-  versioned URL is canonical, while GitHub's latest-release URL remains
-  a stable convenience alias.
-- **Cross-architecture builds**: each artifact is built on a runner with the
-  matching CPU architecture. The release workflow selects explicit Rust
-  targets, including musl on the native aarch64 runner, but does not emulate
-  or cross-compile between CPU architectures.
-- **Windows builds**: intentionally out of scope. Historical commit
-  `cce4250 remove Windows release builds` removed them; the current
-  CI has no Windows tests.
-- **`bloom update install`**: not implemented. Atomicity, macOS
-  SIP/Gatekeeper, and Windows self-overwrite are unsolved. Users
-  download a new release manually.
+Linux aarch64/musl and macOS x86_64 single-binary archives from the older
+pipeline are not outputs of the current triad workflow. Windows builds are
+also outside this workflow.

--- a/packaging/triad/release/README.md
+++ b/packaging/triad/release/README.md
@@ -2,7 +2,7 @@
 
 `compatibility-v1.toml` is the closed v1 service matrix. It declares each edge
 independently: the Machine–Broker and Broker–Signer authority APIs require
-exactly 1.3, while Signer control and login-session liveness accept 1.0–1.1.
+exactly 1.4, while Signer control and login-session liveness accept 1.0–1.1.
 Service packages may advance independently when every edge remains inside its
 declared range; incompatible edges fail closed.
 It also records the reviewed Broker, Signer, service-runtime, and
@@ -145,12 +145,13 @@ installed executable, unit, account template, and configuration template is
 read from that verified snapshot. The public key is data, not another time
 service or software package.
 
-Linux binaries are shared by all enrolled logins, so an install first requires
-every active or retained enrollment and both service configurations to name the
-candidate release digest. Digest-distinct reinstall and restore are rejected
-before services stop or files change; a future Linux release upgrade requires a
-separate coordinated host-wide transaction. Retained records preserve the exact
-release digest and allocated NFS port.
+Linux binaries are shared by all enrolled logins. Digest-distinct installs use
+an immutable release directory and a coordinated host-wide transaction: stop
+all active enrollments, atomically switch `current`, update the release digest
+in active and retained configuration, and validate active services before
+committing. Active enrollments require available user session buses. Failed
+activation and interrupted transactions restore the previous release. Custody,
+identity material, and allocated NFS ports are preserved.
 
 Linux installs provide `bloom-uninstall`. Its default `--retain-custody` mode
 stops and disables the selected enrollment, removes runtime integration, and
@@ -215,9 +216,10 @@ The Linux AWS KMS profile requires credentials and a non-wildcard reviewed
 CIDR allowlist together; reinstall without that pair removes any prior
 instance credential and egress drop-in.
 
-The root-requiring macOS Unix-principal templates remain conformance inputs,
-not a production platform claim. A release may claim
-`macos-unix-principals` only after the disposable W0 lane proves the effective
+The root-requiring macOS Unix-principal templates implement the production
+`macos-unix-principals` profile. The optional disposable W0 lane exercises its
 UID/group, filesystem, launchd, listener, network, lifecycle, and rollback
-boundaries and a digest-bound conformance report is included. The rootless
+boundaries; a digest-bound conformance report is supplementary evidence, not a
+required release asset. Machine and session jobs run in the `user/UID` launchd
+domain, while Broker and Signer jobs run in the system domain. The rootless
 code-identity architecture remains a separate future profile.

--- a/tests/conformance/macos-unix-principals/README.md
+++ b/tests/conformance/macos-unix-principals/README.md
@@ -51,8 +51,11 @@ then reruns the triad protocol, transport, activation, checkpoint, Machine
 client, policy-update, Broker, and Signer acceptance sources while the real
 installed services remain active. Fault injection stays confined to test
 executables. It also rejects provisioning profiles, Developer-ID authorities,
-or Team IDs and executes the production builder without conformance inputs to
-prove that claim generation fails. A final process/health recheck precedes
+or Team IDs. `check-release-contract.sh PAYLOAD MAIN_ROOT` builds and verifies a
+production-claim archive without conformance reports using an ephemeral test
+key, then proves that verification against the reviewed release key rejects
+it. This check never installs its archive and can also run unprivileged on a
+Darwin host with compatible binaries. A final process/health recheck precedes
 digest-bound `mui_01.pass`, `mui_11.pass`, `installed_ac_01_35.pass`, and
 `mui_12.pass` evidence.
 

--- a/tests/conformance/macos-unix-principals/check-release-contract.sh
+++ b/tests/conformance/macos-unix-principals/check-release-contract.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+[[ $# -eq 2 ]] || {
+  echo 'usage: check-release-contract.sh PAYLOAD MAIN_ROOT' >&2
+  exit 64
+}
+payload="$(cd "$1" && pwd -P)"
+main_root="$(cd "$2" && pwd -P)"
+release_dir="$main_root/packaging/triad/release"
+work="$(mktemp -d)"
+trap 'rm -rf -- "$work"' EXIT
+mkdir -p "$work/staging/bin"
+for binary in bloom bloom-broker bloom-signer bloom-signer-migrate; do
+  cp "$payload/bin/$binary" "$work/staging/bin/$binary"
+done
+
+# An optional conformance report must not block production-claim assembly.
+# This ephemeral key exercises the format, not production release authorization.
+/usr/bin/ssh-keygen -q -t ed25519 -N '' -f "$work/release-key"
+archive="$work/production-claim.tar.gz"
+env \
+  BLOOM_PLATFORM_CLAIM=macos-unix-principals \
+  BLOOM_MACOS_CONFORMANCE_REPORT= \
+  BLOOM_MACOS_CONFORMANCE_SIGNATURE= \
+  BLOOM_MACOS_CONFORMANCE_PUBLIC_KEY= \
+  BLOOM_MACOS_CONFORMANCE_KEY_SHA256= \
+  BLOOM_MACHINE_SHA="$(sed -n 's/^BLOOM_MACHINE_SHA=//p' "$payload/SOURCE_REVISIONS")" \
+  BLOOM_BROKER_SHA="$(sed -n 's/^BLOOM_BROKER_SHA=//p' "$payload/SOURCE_REVISIONS")" \
+  BLOOM_SIGNER_SHA="$(sed -n 's/^BLOOM_SIGNER_SHA=//p' "$payload/SOURCE_REVISIONS")" \
+  "$release_dir/build-bundle.sh" \
+  "$work/staging" "$archive" "$work/release-key" 1700000000
+"$release_dir/verify-bundle.sh" \
+  "$archive" "$archive.sha256" "$archive.sig" "$archive.pub"
+tar -tzf "$archive" > "$work/entries"
+if grep -E '^bloom-triad/MACOS_CONFORMANCE_REPORT\.(json|pub|sig)$' "$work/entries"; then
+  echo 'report-free contract check unexpectedly included a conformance report' >&2
+  exit 1
+fi
+[[ "$(tar -xOzf "$archive" bloom-triad/PLATFORM_CLAIM)" == macos-unix-principals ]]
+
+# A production claim and self-consistent signatures cannot replace the pin.
+if "$release_dir/verify-bundle.sh" \
+  "$archive" "$archive.sha256" "$archive.sig" \
+  "$release_dir/bloom-release-v1.pub" > "$work/untrusted-key.log" 2>&1
+then
+  echo 'production-claim archive signed by an untrusted key was accepted' >&2
+  exit 1
+fi
+echo 'report-free macOS release contract and reviewed-key rejection passed'

--- a/tests/conformance/macos-unix-principals/check-release-contract.sh
+++ b/tests/conformance/macos-unix-principals/check-release-contract.sh
@@ -25,9 +25,9 @@ env \
   BLOOM_MACOS_CONFORMANCE_SIGNATURE= \
   BLOOM_MACOS_CONFORMANCE_PUBLIC_KEY= \
   BLOOM_MACOS_CONFORMANCE_KEY_SHA256= \
-  BLOOM_MACHINE_SHA="$(sed -n 's/^BLOOM_MACHINE_SHA=//p' "$payload/SOURCE_REVISIONS")" \
-  BLOOM_BROKER_SHA="$(sed -n 's/^BLOOM_BROKER_SHA=//p' "$payload/SOURCE_REVISIONS")" \
-  BLOOM_SIGNER_SHA="$(sed -n 's/^BLOOM_SIGNER_SHA=//p' "$payload/SOURCE_REVISIONS")" \
+  BLOOM_MACHINE_SHA="$(sed -n -E 's/^BLOOM_MACHINE_SHA=([0-9a-f]{40})$/\1/p' "$payload/SOURCE_REVISIONS")" \
+  BLOOM_BROKER_SHA="$(sed -n -E 's/^BLOOM_BROKER_SHA=([0-9a-f]{40})$/\1/p' "$payload/SOURCE_REVISIONS")" \
+  BLOOM_SIGNER_SHA="$(sed -n -E 's/^BLOOM_SIGNER_SHA=([0-9a-f]{40})$/\1/p' "$payload/SOURCE_REVISIONS")" \
   "$release_dir/build-bundle.sh" \
   "$work/staging" "$archive" "$work/release-key" 1700000000
 "$release_dir/verify-bundle.sh" \

--- a/tests/conformance/macos-unix-principals/run-disposable.sh
+++ b/tests/conformance/macos-unix-principals/run-disposable.sh
@@ -70,7 +70,7 @@ capture_failure_evidence() {
       > "$evidence_dir/$service-launchctl.txt" 2>&1 || true
     chmod 0644 "$evidence_dir/$service-launchctl.txt" 2>/dev/null || true
   done
-  launchctl print "gui/$login_uid/com.bloom.session" \
+  launchctl print "user/$login_uid/com.bloom.session" \
     > "$evidence_dir/session-launchctl.txt" 2>&1 || true
   chmod 0644 "$evidence_dir/session-launchctl.txt" 2>/dev/null || true
   find "/private/var/run/bloom/$login_uid" -xdev -ls \
@@ -261,7 +261,7 @@ sudo -u "bloom-signer-$login_uid" test ! -r \
 
 launchctl print "system/com.bloom.broker.$login_uid" >/dev/null
 launchctl print "system/com.bloom.signer.$login_uid" >/dev/null
-launchctl print "gui/$login_uid/com.bloom.session" >/dev/null
+launchctl print "user/$login_uid/com.bloom.session" >/dev/null
 
 broker_checkpoint_dir="/private/var/db/bloom/$login_uid/broker/audit-checkpoints"
 signer_checkpoint_dir="/private/var/db/bloom/$login_uid/signer/audit-checkpoints"
@@ -342,7 +342,7 @@ assert_metadata \
 release_digest="$(field release_digest)"
 machine_binary="/usr/local/libexec/bloom/current/bloom"
 session_socket="/private/var/run/bloom/$login_uid/session/session.sock"
-session_label="gui/$login_uid/com.bloom.session"
+session_label="user/$login_uid/com.bloom.session"
 session_plist="/Library/LaunchAgents/com.bloom.session.plist"
 broker_label="system/com.bloom.broker.$login_uid"
 signer_label="system/com.bloom.signer.$login_uid"
@@ -530,7 +530,7 @@ if curl --silent --max-time 1 http://127.0.0.1:18734/ >/dev/null 2>&1; then
 fi
 launchctl print "$broker_label" >/dev/null
 launchctl print "$signer_label" >/dev/null
-launchctl bootstrap "gui/$login_uid" "$session_plist"
+launchctl bootstrap "user/$login_uid" "$session_plist"
 deadline=$((SECONDS + 20))
 while [[ $SECONDS -lt $deadline ]]; do
   if [[ -S "$session_socket" ]] &&

--- a/tests/conformance/macos-unix-principals/run-installed-acceptance.sh
+++ b/tests/conformance/macos-unix-principals/run-installed-acceptance.sh
@@ -101,37 +101,9 @@ for binary in bloom bloom-broker bloom-signer bloom-signer-migrate; do
   fi
 done
 
-# Prove the same Mach-O binaries cannot be relabelled as production without
-# supplying the separately reviewed conformance report and pinned public key.
-mkdir -p "$static_work/staging/bin"
-for binary in bloom bloom-broker bloom-signer bloom-signer-migrate; do
-  cp "$payload/bin/$binary" "$static_work/staging/bin/$binary"
-done
-printf '%s\n' 'intentionally invalid: conformance rejection must precede signing' \
-  > "$static_work/release-key.pem"
-chmod 0600 "$static_work/release-key.pem"
-set +e
-env \
-  BLOOM_PLATFORM_CLAIM=macos-unix-principals \
-  BLOOM_MACOS_CONFORMANCE_REPORT= \
-  BLOOM_MACOS_CONFORMANCE_SIGNATURE= \
-  BLOOM_MACOS_CONFORMANCE_PUBLIC_KEY= \
-  BLOOM_MACOS_CONFORMANCE_KEY_SHA256= \
-  "$main_root/packaging/triad/release/build-bundle.sh" \
-  "$static_work/staging" \
-  "$static_work/forbidden-production.tar.gz" \
-  "$static_work/release-key.pem" \
-  1700000000 \
-  >"$static_work/production-gate.log" 2>&1
-production_gate_status=$?
-set -e
-[[ "$production_gate_status" -ne 0 ]] || {
-  echo "release gate emitted a production macOS claim without conformance evidence" >&2
-  exit 1
-}
-grep -F \
-  'BLOOM_MACOS_CONFORMANCE_REPORT must name a regular conformance input' \
-  "$static_work/production-gate.log" >/dev/null
+# Exercise the report-free release contract without installing the test archive.
+"$main_root/tests/conformance/macos-unix-principals/check-release-contract.sh" \
+  "$payload" "$main_root"
 
 assert_installed_process() {
   process_name="$1"
@@ -159,7 +131,7 @@ assert_installed_process bloom-broker "$broker_uid" "$release_root/bloom-broker"
 assert_installed_process bloom-signer "$signer_uid" "$release_root/bloom-signer"
 sudo -u "$login_user" \
   "$release_root/bloom" serve triad-health-check "$release_digest"
-machine_label="gui/$login_uid/com.bloom.machine"
+machine_label="user/$login_uid/com.bloom.machine"
 machine_plist="/Library/LaunchAgents/com.bloom.machine.plist"
 machine_pid="$(launchctl print "$machine_label" | sed -n 's/^[[:space:]]*pid = //p')"
 [[ "$machine_pid" =~ ^[1-9][0-9]*$ ]]
@@ -236,7 +208,7 @@ ditto "$runtime_negative_snapshot/broker" "$broker_state"
 ditto "$runtime_negative_snapshot/signer" "$signer_state"
 launchctl bootstrap system "$signer_plist"
 launchctl bootstrap system "$broker_plist"
-launchctl bootstrap "gui/$login_uid" "$machine_plist"
+launchctl bootstrap "user/$login_uid" "$machine_plist"
 launchctl kickstart -k "$machine_label"
 
 # The restored installed Broker and Signer must return to authenticated health.

--- a/tests/conformance/macos-unix-principals/run-two-login.sh
+++ b/tests/conformance/macos-unix-principals/run-two-login.sh
@@ -223,7 +223,7 @@ sudo -u "$login_user_a" "$machine_binary" serve triad-health-check "$release_dig
 
 # Leave A enrolled and its socket-activated LaunchDaemons loaded, but remove its
 # login-session sentinel so B can become the first canonical-listener owner.
-launchctl bootout "gui/$login_uid_a/com.bloom.session"
+launchctl bootout "user/$login_uid_a/com.bloom.session"
 wait_for_services_to_stop "$login_uid_a"
 if /usr/bin/nc -z -w 1 127.0.0.1 18734; then
   echo "login A retained the canonical listener after its sentinel stopped" >&2
@@ -237,7 +237,7 @@ installed_b=true
 sudo -u "$login_user_b" \
   "$machine_binary" serve triad-health-check "$release_digest"
 
-launchctl bootstrap "gui/$login_uid_a" "$session_plist"
+launchctl bootstrap "user/$login_uid_a" "$session_plist"
 session_socket_a="/private/var/run/bloom/$login_uid_a/session/session.sock"
 deadline=$((SECONDS + 15))
 while [[ $SECONDS -lt $deadline && ! -S "$session_socket_a" ]]; do


### PR DESCRIPTION
The macOS disposable acceptance harness still expected production assembly to fail without a conformance report, although v0.2 authenticates production macOS bundles with the reviewed release key and makes Tart reports optional. It now builds and verifies a report-free archive with an ephemeral key and proves that the reviewed production key rejects that archive. The standalone check never installs its output.

The conformance harnesses also use `user/UID` for Machine/session service operations, matching the installer, while retaining GUI login/logout checks. Release documentation now describes the current two-platform triad pipeline, optional reports, protocol 1.4, and coordinated Linux upgrades instead of the retired single-binary pipeline and contradictory requirements.

Validation:

- `bash -n` passed for all four changed shell scripts; `git diff --check` passed.
- `check-release-contract.sh` passed unprivileged against the downloaded v0.2.0 macOS payload: report-free build, full archive/payload verification, production claim, and rejection under the reviewed release key.
- Focused `cargo test --locked -p bloom-it --test triad_release` filters passed: `macos` (12 tests), `installed_acceptance` (1), and `tart_conformance` (1).
- The full `triad_release` suite passed 46/49 tests. Three Linux staging tests fail on this macOS host because BSD `mv` does not support GNU `-T`: `linux_installer_allocates_distinct_ports_and_rejects_mixed_release_sets`, `linux_installer_rejects_missing_service_configs_before_replacement`, and `linux_installer_upgrade_rotation_and_confirmed_uninstall_are_staged_safely`.

The destructive disposable-host/Tart suite was not run. No live installation or service changes were performed.

## Checklist

- [x] Tests added or updated for behavior changes — added `check-release-contract.sh` and updated the macOS conformance harnesses; validation results are above.
- [x] Architecture docs (`docs/architecture/`) updated if contracts or behavior changed — N/A: production behavior and contracts are unchanged; release and conformance documentation now match the existing v0.2 contract.
- [x] Sealed Approval invariants respected (no signing outside a grant or bounded capability, no PRF/grant persistence, execution from sealed bytes) — no wallet signing, approval, or grant behavior changed; the test uses an ephemeral release-signing key only.
- [x] Agent Documentation updated (`crates/bloom-vfs/src/docs/agent-guidance.md` and affected Petal READMEs) — N/A: no VFS guidance or Petal behavior changed.
