### PR TITLE
Send a User-Agent on Solana RPC requests

### DIFF
--- a/crates/bloom-solana/src/transport.rs
+++ b/crates/bloom-solana/src/transport.rs
@@ -31,6 +31,14 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 /// Active probe interval, matching `bloom-rpc`'s cadence.
 const PROBE_INTERVAL: Duration = Duration::from_secs(15);
 
+/// Identifies this client to public RPC providers. `reqwest` sends no
+/// `User-Agent` unless one is set, and several public Solana endpoints —
+/// `solana-rpc.publicnode.com` among them — answer an unidentified request
+/// with `403 Forbidden`. That reads as an endpoint outage rather than as a
+/// rejected client, so the transport silently sheds every weighted endpoint
+/// that enforces the rule and concentrates load on whichever one does not.
+const RPC_USER_AGENT: &str = concat!("bloom-solana/", env!("CARGO_PKG_VERSION"));
+
 /// One configured endpoint and its pre-built client.
 struct Endpoint {
     url: String,
@@ -67,6 +75,7 @@ impl SolanaRpcClient {
     pub fn build(spec: &crate::SolanaSpec) -> Result<Self, SolanaRpcError> {
         let client = reqwest::Client::builder()
             .timeout(REQUEST_TIMEOUT)
+            .user_agent(RPC_USER_AGENT)
             .build()
             .map_err(|e| SolanaRpcError::Transport(e.to_string()))?;
         let mut endpoints = Vec::new();

--- a/crates/bloom-solana/tests/transport.rs
+++ b/crates/bloom-solana/tests/transport.rs
@@ -468,3 +468,69 @@ fn broadcast_requires_an_expected_genesis_hash() {
         "{error}"
     );
 }
+
+/// A stub that mirrors `solana-rpc.publicnode.com`: it refuses any request
+/// that arrives without a `User-Agent` header, exactly as several public
+/// Solana providers do, and otherwise answers normally.
+async fn spawn_user_agent_enforcing_stub(seen: Arc<std::sync::Mutex<Vec<String>>>) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                break;
+            };
+            let seen = Arc::clone(&seen);
+            tokio::spawn(async move {
+                use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                let mut buf = vec![0u8; 8192];
+                let n = socket.read(&mut buf).await.unwrap_or(0);
+                let request = String::from_utf8_lossy(&buf[..n]).to_string();
+                let agent = request
+                    .split("\r\n")
+                    .find_map(|line| {
+                        line.strip_prefix("user-agent: ")
+                            .or_else(|| line.strip_prefix("User-Agent: "))
+                    })
+                    .map(str::to_owned);
+                if let Some(agent) = agent.clone() {
+                    seen.lock().unwrap().push(agent);
+                }
+                let response = match agent {
+                    None => {
+                        "HTTP/1.1 403 Forbidden\r\ncontent-length: 0\r\nconnection: close\r\n\r\n"
+                            .to_string()
+                    }
+                    Some(_) => {
+                        let body = r#"{"jsonrpc":"2.0","id":1,"result":12345}"#;
+                        format!(
+                            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                            body.len(),
+                            body
+                        )
+                    }
+                };
+                let _ = socket.write_all(response.as_bytes()).await;
+            });
+        }
+    });
+    format!("http://{addr}/")
+}
+
+#[tokio::test]
+async fn requests_identify_the_client_to_public_providers() {
+    let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let endpoint = spawn_user_agent_enforcing_stub(Arc::clone(&seen)).await;
+    let client = SolanaClient::build(&spec(&endpoint)).unwrap();
+
+    // Without a User-Agent this endpoint answers 403 and the transport would
+    // shed it as though the provider were down.
+    assert_eq!(client.get_slot().await.unwrap(), 12345);
+
+    let seen = seen.lock().unwrap();
+    assert!(!seen.is_empty(), "no request carried a User-Agent");
+    assert!(
+        seen.iter().all(|agent| agent.starts_with("bloom-solana/")),
+        "expected every request to identify as bloom-solana, saw {seen:?}"
+    );
+}


### PR DESCRIPTION
## Problem

`reqwest` sends no `User-Agent` header unless one is set. Several public Solana
RPC providers reject requests without one. `solana-rpc.publicnode.com` returns
`403 Forbidden`, and it is the weight-100 endpoint in the developer triad's
mainnet configuration.

The transport treats a `403` as an endpoint failure, so it drops every provider
that enforces the rule and sends all traffic to whichever one does not. A
configured two-endpoint failover silently becomes a single endpoint, and that
endpoint is rate limited. In practice this surfaced as intermittent
`getFeeForMessage` failures and staged Solana transfers expiring before they
could be broadcast.

Observed by the author before opening this PR:

```
no User-Agent            -> HTTP 403 Forbidden
"bloom-solana/0.2.0"     -> HTTP 200
```

Not reproducible on 2026-09-07; the provider's policy appears to vary. The
header is still the right default because reqwest otherwise sends none.

Any identifying string is accepted; only its absence is rejected. No browser
impersonation is used.

## Change

- `crates/bloom-solana/src/transport.rs`: the shared `reqwest::Client` sets `.user_agent("bloom-solana/<version>")`.
- `crates/bloom-solana/tests/transport.rs`: a loopback stub that returns `403` to any request without the header, asserting every request identifies itself.

## Verification

`cargo fmt --check` clean. `cargo test -p bloom-solana --test transport` — 14 passed, 0 failed.


## Checklist

- [x] Tests added or updated for behavior changes
- [x] Architecture docs (`docs/architecture/`) updated if contracts or behavior changed — N/A
- [x] Sealed Approval invariants respected (no signing outside a grant or bounded capability, no PRF/grant persistence, execution from sealed bytes)
- [x] Agent Documentation updated (`crates/bloom-vfs/src/docs/agent-guidance.md` and affected Petal READMEs) — N/A




Landing order: bloom-directory/bloom#241
