### PR TITLE
fix(ci): build the macOS W0 conformance payload under the W0 platform claim

### DIFF
--- a/.github/workflows/macos-unix-conformance.yml
+++ b/.github/workflows/macos-unix-conformance.yml
@@ -86,6 +86,27 @@ jobs:
             "$RUNNER_TEMP/triad-dist/bloom-triad-test-unclaimed.tar.gz" \
             -C "$RUNNER_TEMP/verified"
 
+          # The W0 checks refuse the smoke-test candidate's test-unclaimed
+          # platform claim. Re-bundle the same verified payload under the W0
+          # claim with its own release key, exactly as the two-login
+          # conformance workflow builds its fixture payloads.
+          ssh-keygen -q -t ed25519 -N '' -f "$RUNNER_TEMP/w0-release-key"
+          mkdir "$RUNNER_TEMP/verified-w0"
+          BLOOM_PLATFORM_CLAIM=macos-unix-principals-w0 \
+            BLOOM_ALLOW_MACOS_UNIX_W0=true \
+            BLOOM_MACHINE_SHA="$(git -C bloom rev-parse HEAD)" \
+            BLOOM_BROKER_SHA="$(git -C bloom-broker rev-parse HEAD)" \
+            BLOOM_SIGNER_SHA="$(git -C bloom-signer rev-parse HEAD)" \
+            BLOOM_COMPATIBILITY_FILE="$RUNNER_TEMP/verified/bloom-triad/compatibility-v1.toml" \
+            bloom/packaging/triad/release/build-bundle.sh \
+            "$RUNNER_TEMP/verified/bloom-triad" \
+            "$RUNNER_TEMP/triad-dist/bloom-triad-macos-unix-principals-w0.tar.gz" \
+            "$RUNNER_TEMP/w0-release-key" \
+            1700000000
+          tar -xzf \
+            "$RUNNER_TEMP/triad-dist/bloom-triad-macos-unix-principals-w0.tar.gz" \
+            -C "$RUNNER_TEMP/verified-w0"
+
       - name: Upload verified macOS candidate
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -93,6 +114,9 @@ jobs:
           path: |
             ${{ runner.temp }}/triad-dist
             ${{ runner.temp }}/verified/bloom-triad
+            ${{ runner.temp }}/verified-w0/bloom-triad
+            ${{ runner.temp }}/w0-release-key
+            ${{ runner.temp }}/w0-release-key.pub
           if-no-files-found: error
           retention-days: 7
           overwrite: true
@@ -163,7 +187,7 @@ jobs:
             -o root \
             -g wheel \
             -m 0644 \
-            "$RUNNER_TEMP/verified/bloom-triad/RELEASE_PUBLIC_KEY.pem" \
+            "$RUNNER_TEMP/verified-w0/bloom-triad/RELEASE_PUBLIC_KEY.pem" \
             /private/var/db/bloom-w0-release-key.pem
 
       - name: Run destructive W0 isolation checks
@@ -184,7 +208,7 @@ jobs:
             BLOOM_MACOS_ACCEPTANCE_CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}" \
             BLOOM_MACOS_ACCEPTANCE_RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}" \
             bloom/tests/conformance/macos-unix-principals/run-disposable.sh \
-            "$RUNNER_TEMP/verified/bloom-triad" \
+            "$RUNNER_TEMP/verified-w0/bloom-triad" \
             "$login_uid" \
             "$login_user"
 

--- a/.github/workflows/macos-unix-conformance.yml
+++ b/.github/workflows/macos-unix-conformance.yml
@@ -87,19 +87,31 @@ jobs:
             -C "$RUNNER_TEMP/verified"
 
           # The W0 checks refuse the smoke-test candidate's test-unclaimed
-          # platform claim. Re-bundle the same verified payload under the W0
-          # claim with its own release key, exactly as the two-login
-          # conformance workflow builds its fixture payloads.
+          # platform claim. Re-bundle the verified candidate's binaries under
+          # the W0 claim with its own release key, staging them fresh exactly
+          # as the two-login conformance workflow builds its fixtures;
+          # build-bundle.sh nests the Linux installer copy when staging
+          # already carries an installer/ tree.
           ssh-keygen -q -t ed25519 -N '' -f "$RUNNER_TEMP/w0-release-key"
+          mkdir -p "$RUNNER_TEMP/w0-staging/bin"
+          cp -p \
+            "$RUNNER_TEMP/verified/bloom-triad/bin/bloom" \
+            "$RUNNER_TEMP/verified/bloom-triad/bin/bloom-broker" \
+            "$RUNNER_TEMP/verified/bloom-triad/bin/bloom-signer" \
+            "$RUNNER_TEMP/verified/bloom-triad/bin/bloom-signer-migrate" \
+            "$RUNNER_TEMP/w0-staging/bin/"
+          cp -p \
+            "$RUNNER_TEMP/verified/bloom-triad/compatibility-v1.toml" \
+            "$RUNNER_TEMP/w0-staging/compatibility-v1.toml"
           mkdir "$RUNNER_TEMP/verified-w0"
           BLOOM_PLATFORM_CLAIM=macos-unix-principals-w0 \
             BLOOM_ALLOW_MACOS_UNIX_W0=true \
             BLOOM_MACHINE_SHA="$(git -C bloom rev-parse HEAD)" \
             BLOOM_BROKER_SHA="$(git -C bloom-broker rev-parse HEAD)" \
             BLOOM_SIGNER_SHA="$(git -C bloom-signer rev-parse HEAD)" \
-            BLOOM_COMPATIBILITY_FILE="$RUNNER_TEMP/verified/bloom-triad/compatibility-v1.toml" \
+            BLOOM_COMPATIBILITY_FILE="$RUNNER_TEMP/w0-staging/compatibility-v1.toml" \
             bloom/packaging/triad/release/build-bundle.sh \
-            "$RUNNER_TEMP/verified/bloom-triad" \
+            "$RUNNER_TEMP/w0-staging" \
             "$RUNNER_TEMP/triad-dist/bloom-triad-macos-unix-principals-w0.tar.gz" \
             "$RUNNER_TEMP/w0-release-key" \
             1700000000
@@ -115,8 +127,6 @@ jobs:
             ${{ runner.temp }}/triad-dist
             ${{ runner.temp }}/verified/bloom-triad
             ${{ runner.temp }}/verified-w0/bloom-triad
-            ${{ runner.temp }}/w0-release-key
-            ${{ runner.temp }}/w0-release-key.pub
           if-no-files-found: error
           retention-days: 7
           overwrite: true
@@ -226,13 +236,14 @@ jobs:
         shell: bash
         run: |
           set -Eeuo pipefail
-          payload="$RUNNER_TEMP/verified/bloom-triad"
+          payload="$RUNNER_TEMP/verified-w0/bloom-triad"
           subject="$(
             bloom/packaging/triad/release/macos-conformance-subject.sh \
               "$payload"
           )"
           archive_sha="$(
-            shasum -a 256 "$RUNNER_TEMP/triad-dist/bloom-triad-test-unclaimed.tar.gz" |
+            shasum -a 256 \
+              "$RUNNER_TEMP/triad-dist/bloom-triad-macos-unix-principals-w0.tar.gz" |
               awk '{print $1}'
           )"
           {

--- a/.github/workflows/macos-unix-conformance.yml
+++ b/.github/workflows/macos-unix-conformance.yml
@@ -169,6 +169,15 @@ jobs:
           name: macos-conformance-candidate-${{ github.run_id }}
           path: ${{ runner.temp }}
 
+      # The candidate crosses jobs through the artifact store, which does not
+      # preserve executable bits; the installer refuses a payload whose
+      # binaries cannot run. Restore the modes the bundle recorded.
+      - name: Restore candidate executable modes
+        shell: bash
+        run: |
+          chmod 0755 "$RUNNER_TEMP/verified/bloom-triad/bin/"*
+          chmod 0755 "$RUNNER_TEMP/verified-w0/bloom-triad/bin/"*
+
       - name: Prove disposable host prerequisites
         shell: bash
         run: |

--- a/.github/workflows/macos-unix-conformance.yml
+++ b/.github/workflows/macos-unix-conformance.yml
@@ -185,8 +185,9 @@ jobs:
       - name: Restore candidate executable modes
         shell: bash
         run: |
-          chmod 0755 "$RUNNER_TEMP/verified/bloom-triad/bin/"*
-          chmod 0755 "$RUNNER_TEMP/verified-w0/bloom-triad/bin/"*
+          chmod 0755 \
+            "$RUNNER_TEMP/verified/bloom-triad/bin/"{bloom,bloom-broker,bloom-signer,bloom-signer-migrate} \
+            "$RUNNER_TEMP/verified-w0/bloom-triad/bin/"{bloom,bloom-broker,bloom-signer,bloom-signer-migrate}
 
       - name: Prove disposable host prerequisites
         shell: bash

--- a/tests/conformance/macos-unix-principals/run-disposable.sh
+++ b/tests/conformance/macos-unix-principals/run-disposable.sh
@@ -73,10 +73,10 @@ capture_failure_evidence() {
   launchctl print "user/$login_uid/com.bloom.session" \
     > "$evidence_dir/session-launchctl.txt" 2>&1 || true
   chmod 0644 "$evidence_dir/session-launchctl.txt" 2>/dev/null || true
-  # The Machine launchagent's launchd state carries its last exit status and
-  # run count — often the only surviving record once the installer's
-  # fresh-install rollback has removed the runtime tree.
-  launchctl print "gui/$login_uid/com.bloom.machine" \
+  # The Machine launchagent is bootstrapped into the user domain; its launchd
+  # state carries the last exit status and run count. Best effort only: the
+  # installer's rollback may have booted the job out before this runs.
+  launchctl print "user/$login_uid/com.bloom.machine" \
     > "$evidence_dir/machine-launchctl.txt" 2>&1 || true
   chmod 0644 "$evidence_dir/machine-launchctl.txt" 2>/dev/null || true
   login_home="$(dscl . -read "/Users/$login_user" NFSHomeDirectory 2>/dev/null |

--- a/tests/conformance/macos-unix-principals/run-disposable.sh
+++ b/tests/conformance/macos-unix-principals/run-disposable.sh
@@ -82,7 +82,7 @@ capture_failure_evidence() {
   login_home="$(dscl . -read "/Users/$login_user" NFSHomeDirectory 2>/dev/null |
     awk 'NR==1{sub(/^NFSHomeDirectory:[[:space:]]*/,"");print}')" || true
   if [[ -n "$login_home" && -d "$login_home/.bloom" ]]; then
-    find "$login_home/.bloom" -xdev -ls \
+    find "$login_home/.bloom" -xdev -maxdepth 5 -ls \
       > "$evidence_dir/machine-home-tree.txt" 2>&1 || true
     chmod 0644 "$evidence_dir/machine-home-tree.txt" 2>/dev/null || true
     if [[ -d "$login_home/.bloom/logs" ]]; then

--- a/tests/conformance/macos-unix-principals/run-disposable.sh
+++ b/tests/conformance/macos-unix-principals/run-disposable.sh
@@ -73,6 +73,19 @@ capture_failure_evidence() {
   launchctl print "user/$login_uid/com.bloom.session" \
     > "$evidence_dir/session-launchctl.txt" 2>&1 || true
   chmod 0644 "$evidence_dir/session-launchctl.txt" 2>/dev/null || true
+  # The Machine launchagent's launchd state carries its last exit status and
+  # run count — often the only surviving record once the installer's
+  # fresh-install rollback has removed the runtime tree.
+  launchctl print "gui/$login_uid/com.bloom.machine" \
+    > "$evidence_dir/machine-launchctl.txt" 2>&1 || true
+  chmod 0644 "$evidence_dir/machine-launchctl.txt" 2>/dev/null || true
+  login_home="$(dscl . -read "/Users/$login_user" NFSHomeDirectory 2>/dev/null |
+    awk 'NR==1{sub(/^NFSHomeDirectory:[[:space:]]*/,"");print}')" || true
+  if [[ -n "$login_home" && -d "$login_home/.bloom" ]]; then
+    find "$login_home/.bloom" -xdev -ls \
+      > "$evidence_dir/machine-home-tree.txt" 2>&1 || true
+    chmod 0644 "$evidence_dir/machine-home-tree.txt" 2>/dev/null || true
+  fi
   find "/private/var/run/bloom/$login_uid" -xdev -ls \
     > "$evidence_dir/runtime-tree.txt" 2>&1 || true
   chmod 0644 "$evidence_dir/runtime-tree.txt" 2>/dev/null || true

--- a/tests/conformance/macos-unix-principals/run-disposable.sh
+++ b/tests/conformance/macos-unix-principals/run-disposable.sh
@@ -85,6 +85,13 @@ capture_failure_evidence() {
     find "$login_home/.bloom" -xdev -ls \
       > "$evidence_dir/machine-home-tree.txt" 2>&1 || true
     chmod 0644 "$evidence_dir/machine-home-tree.txt" 2>/dev/null || true
+    if [[ -d "$login_home/.bloom/logs" ]]; then
+      for service_log in "$login_home/.bloom/logs/"*.jsonl; do
+        [[ -f "$service_log" && ! -L "$service_log" ]] || continue
+        install -m 0644 "$service_log" \
+          "$evidence_dir/machine-$(basename "$service_log")" || true
+      done
+    fi
   fi
   find "/private/var/run/bloom/$login_uid" -xdev -ls \
     > "$evidence_dir/runtime-tree.txt" 2>&1 || true


### PR DESCRIPTION
## Problem

The macOS Unix-principal conformance workflow cannot pass as committed, for two reasons that had never been exercised because the workflow had never been dispatched; and when it does run, its failure evidence is missing the records needed to debug it:

1. Its build job produces the smoke-test candidate — always claim `test-unclaimed` — and the disposable-conformance job hands that payload to `run-disposable.sh`, which exits `W0 payload has the wrong platform claim` unless `PLATFORM_CLAIM` is `macos-unix-principals-w0`.
2. The candidate payloads cross the build/use job boundary through the artifact store, which does not preserve executable bits, so the installer's candidate-execution preflight fails with `Permission denied`.
3. The failure-evidence collector captured neither the Machine launchagent's launchd state (last exit status, run count) nor the Machine daemon's own jsonl log under the login home, which survives the installer's fresh-install rollback — so activation failures left no diagnostics.

## Change

Four commits, CI and conformance-script only:

- The build job re-bundles the verified candidate under the W0 claim with its own release key — the same `build-bundle.sh` invocation the two-login workflow already uses — uploads it with the candidate, and the disposable job trusts that payload's key and runs the W0 checks against it.
- The disposable job restores executable modes after the artifact download.
- The W0 collector records the Machine agent's launchd state.
- The W0 collector copies the Machine daemon's jsonl log.

## Verification

Dispatched four times against the current Solana combination (Machine `agent/opencode/triad-combo`, Broker at the bloom-broker#55 head, Signer at the bloom-signer#28 head):

- Run 1 failed at the claim check (the original bug).
- Run 2 passed the claim check, installed the candidate, and loaded the pf rules — then failed on `Permission denied` executing the candidate binary (bug 2).
- Run 3 passed both, completed authenticated activation (Broker and Signer up), and failed at full activation: the Machine daemon started, published its IPC socket, served the first health check, was shut down by the installer's agent reload, and the second bootstrap never launched.
- Run 4 reproduced run 3 and, with the new evidence capture, produced the daemon log and launchd state that established that sequence.

The remaining full-activation failure is a launchd reload race in the installer's `reload_launchagent_job` (bootout immediately followed by bootstrap of the same label) on a never-before-run path; it is not specific to the combination under test — the daemon demonstrably starts, serves, and shuts down cleanly on the first load. Tracking in #241.

## Checklist

- [x] Tests added or updated — the workflow's dispatches are the test; evidence improvements are the diagnostics.
- [x] Architecture docs — N/A.
- [x] Sealed Approval invariants respected — N/A.
- [x] Agent Documentation updated — N/A.