### PR TITLE
release: v0.2.1 with Broker btrfs fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
       github.ref_name == 'triad-architecture'
     uses: ./.github/workflows/macos-unix-conformance.yml
     with:
-      broker_ref: 56252977c99238151c89bb44649fe8f5d1c91ae8
+      broker_ref: 582d3dd3add7efb2640b900f005e32a5a52f17c0
       signer_ref: 0126ba4589ad8cf504d2f04c8e36471727964089
 
   linux_w0_isolation:

--- a/.github/workflows/macos-two-login-conformance.yml
+++ b/.github/workflows/macos-two-login-conformance.yml
@@ -7,7 +7,7 @@ on:
         description: Public bloom-broker ref
         required: false
         type: string
-        default: 56252977c99238151c89bb44649fe8f5d1c91ae8
+        default: 582d3dd3add7efb2640b900f005e32a5a52f17c0
       signer_ref:
         description: Public bloom-signer ref
         required: false
@@ -34,7 +34,7 @@ on:
       broker_ref:
         description: Public bloom-broker ref
         required: true
-        default: 56252977c99238151c89bb44649fe8f5d1c91ae8
+        default: 582d3dd3add7efb2640b900f005e32a5a52f17c0
       signer_ref:
         description: Public bloom-signer ref
         required: true
@@ -75,7 +75,7 @@ jobs:
       - name: Reject mutable sibling refs
         shell: bash
         env:
-          BROKER_REF: ${{ inputs.broker_ref || '56252977c99238151c89bb44649fe8f5d1c91ae8' }}
+          BROKER_REF: ${{ inputs.broker_ref || '582d3dd3add7efb2640b900f005e32a5a52f17c0' }}
           SIGNER_REF: ${{ inputs.signer_ref || '0126ba4589ad8cf504d2f04c8e36471727964089' }}
         run: |
           [[ "$BROKER_REF" =~ ^[0-9a-f]{40}$ ]]
@@ -84,7 +84,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: bloom-directory/bloom-broker
-          ref: ${{ inputs.broker_ref || '56252977c99238151c89bb44649fe8f5d1c91ae8' }}
+          ref: ${{ inputs.broker_ref || '582d3dd3add7efb2640b900f005e32a5a52f17c0' }}
           path: bloom-broker
       - name: Check out Signer
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/macos-unix-conformance.yml
+++ b/.github/workflows/macos-unix-conformance.yml
@@ -7,7 +7,7 @@ on:
         description: Public bloom-broker ref
         required: false
         type: string
-        default: 56252977c99238151c89bb44649fe8f5d1c91ae8
+        default: 582d3dd3add7efb2640b900f005e32a5a52f17c0
       signer_ref:
         description: Public bloom-signer ref
         required: false
@@ -18,7 +18,7 @@ on:
       broker_ref:
         description: Public bloom-broker ref
         required: true
-        default: 56252977c99238151c89bb44649fe8f5d1c91ae8
+        default: 582d3dd3add7efb2640b900f005e32a5a52f17c0
       signer_ref:
         description: Public bloom-signer ref
         required: true
@@ -42,7 +42,7 @@ jobs:
       - name: Reject mutable sibling refs
         shell: bash
         env:
-          BROKER_REF: ${{ inputs.broker_ref || '56252977c99238151c89bb44649fe8f5d1c91ae8' }}
+          BROKER_REF: ${{ inputs.broker_ref || '582d3dd3add7efb2640b900f005e32a5a52f17c0' }}
           SIGNER_REF: ${{ inputs.signer_ref || '0126ba4589ad8cf504d2f04c8e36471727964089' }}
         run: |
           [[ "$BROKER_REF" =~ ^[0-9a-f]{40}$ ]]
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: bloom-directory/bloom-broker
-          ref: ${{ inputs.broker_ref || '56252977c99238151c89bb44649fe8f5d1c91ae8' }}
+          ref: ${{ inputs.broker_ref || '582d3dd3add7efb2640b900f005e32a5a52f17c0' }}
           path: bloom-broker
       - name: Check out Signer
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -109,7 +109,7 @@ jobs:
       - name: Reject mutable sibling refs
         shell: bash
         env:
-          BROKER_REF: ${{ inputs.broker_ref || '56252977c99238151c89bb44649fe8f5d1c91ae8' }}
+          BROKER_REF: ${{ inputs.broker_ref || '582d3dd3add7efb2640b900f005e32a5a52f17c0' }}
           SIGNER_REF: ${{ inputs.signer_ref || '0126ba4589ad8cf504d2f04c8e36471727964089' }}
         run: |
           [[ "$BROKER_REF" =~ ^[0-9a-f]{40}$ ]]
@@ -118,7 +118,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: bloom-directory/bloom-broker
-          ref: ${{ inputs.broker_ref || '56252977c99238151c89bb44649fe8f5d1c91ae8' }}
+          ref: ${{ inputs.broker_ref || '582d3dd3add7efb2640b900f005e32a5a52f17c0' }}
           path: bloom-broker
       - name: Check out Signer
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,12 +2186,12 @@ dependencies = [
 [[package]]
 name = "bloom-broker-api"
 version = "0.1.0"
-source = "git+https://github.com/bloom-directory/bloom-broker.git?rev=56252977c99238151c89bb44649fe8f5d1c91ae8#56252977c99238151c89bb44649fe8f5d1c91ae8"
+source = "git+https://github.com/bloom-directory/bloom-broker.git?rev=582d3dd3add7efb2640b900f005e32a5a52f17c0#582d3dd3add7efb2640b900f005e32a5a52f17c0"
 dependencies = [
  "bloom-rpc-wire",
  "serde",
  "serde_jcs",
- "sha2 0.10.9",
+ "sha2 0.11.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2121,7 +2121,7 @@ dependencies = [
 
 [[package]]
 name = "bloom"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy 2.0.5",
  "anyhow",
@@ -2196,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-daemon"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy 2.0.5",
  "anyhow",
@@ -2241,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-ens"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy 2.0.5",
  "bloom-evm",
@@ -2256,7 +2256,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-etherscan"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy 2.0.5",
  "async-trait",
@@ -2274,7 +2274,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-evm"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy 2.0.5",
  "bloom-proto",
@@ -2292,7 +2292,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-it"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy 2.0.5",
  "alloy-signer-local 2.0.5",
@@ -2321,7 +2321,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-machine"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "bloom-broker-api",
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-machine-client"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "bloom-audit-checkpoint",
@@ -2361,7 +2361,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-mempool"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy 2.0.5",
  "alloy-signer-local 2.0.5",
@@ -2383,7 +2383,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-mount"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "bloom-vfs",
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-paid-http"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -2415,7 +2415,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-paid-mpp"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy 2.0.5",
  "async-trait",
@@ -2432,7 +2432,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-paid-x402"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy 2.0.5",
  "async-trait",
@@ -2457,7 +2457,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-petals"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2492,7 +2492,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-prices"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "parking_lot",
  "reqwest 0.12.28",
@@ -2505,7 +2505,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-proto"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy 2.0.5",
  "blake3",
@@ -2526,7 +2526,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-revert"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy 2.0.5",
  "alloy-dyn-abi",
@@ -2548,7 +2548,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-rpc"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy 2.0.5",
  "bloom-proto",
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-tools"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy 2.0.5",
  "alloy-dyn-abi",
@@ -2642,7 +2642,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-tx"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy 2.0.5",
  "alloy-signer-local 2.0.5",
@@ -2674,7 +2674,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-update"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "parking_lot",
  "reqwest 0.12.28",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-vfs"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy 2.0.5",
  "async-trait",
@@ -2735,7 +2735,7 @@ dependencies = [
 
 [[package]]
 name = "bloom-watch"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy 2.0.5",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ bloom-petals   = { path = "crates/bloom-petals" }
 bloom-petal-contract = { git = "https://github.com/bloom-directory/petal", rev = "61938d0c127cfe03c7e3e55baed0ba1439bc5ca2" }
 bloom-daemon   = { path = "crates/bloom-daemon" }
 bloom-update   = { path = "crates/bloom-update" }
-bloom-broker-api = { git = "https://github.com/bloom-directory/bloom-broker.git", rev = "56252977c99238151c89bb44649fe8f5d1c91ae8" }
+bloom-broker-api = { git = "https://github.com/bloom-directory/bloom-broker.git", rev = "582d3dd3add7efb2640b900f005e32a5a52f17c0" }
 bloom-rpc-wire = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "bc88cc6760b00bbff0c6a6e5f56d42bb03004436" }
 bloom-triad-local-transport = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "bc88cc6760b00bbff0c6a6e5f56d42bb03004436" }
 bloom-service-activation = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "bc88cc6760b00bbff0c6a6e5f56d42bb03004436" }

--- a/crates/bloom-it/tests/triad_release.rs
+++ b/crates/bloom-it/tests/triad_release.rs
@@ -325,7 +325,7 @@ fn build(staging: &Path, output: &Path, key: &Path) -> std::process::Output {
         &compatibility,
         compatibility_source
             .replace(
-                "broker_commit = \"56252977c99238151c89bb44649fe8f5d1c91ae8\"",
+                "broker_commit = \"582d3dd3add7efb2640b900f005e32a5a52f17c0\"",
                 &format!("broker_commit = \"{}\"", "22".repeat(20)),
             )
             .replace(

--- a/packaging/triad/release/compatibility-v1.toml
+++ b/packaging/triad/release/compatibility-v1.toml
@@ -1,7 +1,7 @@
 schema = "bloom.triad-compatibility/1"
 
 [revisions]
-broker_commit = "56252977c99238151c89bb44649fe8f5d1c91ae8"
+broker_commit = "582d3dd3add7efb2640b900f005e32a5a52f17c0"
 signer_commit = "0126ba4589ad8cf504d2f04c8e36471727964089"
 service_runtime_commit = "bc88cc6760b00bbff0c6a6e5f56d42bb03004436"
 petal_contract_commit = "61938d0c127cfe03c7e3e55baed0ba1439bc5ca2"

--- a/packaging/triad/release/compatibility-v1.toml
+++ b/packaging/triad/release/compatibility-v1.toml
@@ -39,7 +39,7 @@ minor_min = 0
 minor_max = 1
 
 [[bundles]]
-machine = "0.2.0"
+machine = "0.2.1"
 broker = "0.1.0"
 signer = "0.1.0"
 backends = ["local", "aws-kms"]


### PR DESCRIPTION
Prepare Bloom 0.2.1 and include the Broker-side btrfs status-directory fix that complements the Machine fix already merged in #240. The workspace version, workspace lockfile entries, and compatibility-matrix Machine version are now 0.2.1.

Advance Broker from `56252977c99238151c89bb44649fe8f5d1c91ae8` to `582d3dd3add7efb2640b900f005e32a5a52f17c0` (bloom-directory/bloom-broker#53). Keep the compatibility manifest, Cargo API revision/lockfile, CI and macOS conformance defaults, and release-test literal aligned. This five-commit range also includes Broker CI automation and crypto dependency updates; the Machine lockfile changes Broker API's SHA-2 dependency from the existing 0.10.9 to the existing 0.11.0. Signer, Service Runtime, Petal, and EmbedNFS pins remain unchanged.

Validation: `cargo check --workspace` and `git diff --check` passed. `cargo test -p bloom-it --locked --test triad_release` passed 46 tests; three Linux installer tests failed on this macOS host because BSD `mv` does not support GNU `-T`. Linux CI will validate those cases. The earlier version-only commit passed CI. A production release build will compile and package the newly pinned Broker source.

After merge, tag the merged commit `v0.2.1` and push the tag to trigger the release workflow.

## Checklist

- [x] Tests added or updated for behavior changes — updated the triad-release pin fixture; the Broker fix includes its upstream regression test.
- [x] Architecture docs (`docs/architecture/`) updated if contracts or behavior changed — N/A: no architecture or protocol contract changes.
- [x] Sealed Approval invariants respected (no signing outside a grant or bounded capability, no PRF/grant persistence, execution from sealed bytes) — no approval-boundary changes.
- [x] Agent Documentation updated (`crates/bloom-vfs/src/docs/agent-guidance.md` and affected Petal READMEs) — N/A: no agent interface changes.
