### PR TITLE
Pin bloom-petal-contract to landed petal revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2450,7 +2450,7 @@ dependencies = [
 [[package]]
 name = "bloom-petal-contract"
 version = "0.1.0"
-source = "git+https://github.com/bloom-directory/petal?rev=61938d0c127cfe03c7e3e55baed0ba1439bc5ca2#61938d0c127cfe03c7e3e55baed0ba1439bc5ca2"
+source = "git+https://github.com/bloom-directory/petal?rev=9ad7a5c635f092bbcdf8f00a06b23676806ff70c#9ad7a5c635f092bbcdf8f00a06b23676806ff70c"
 dependencies = [
  "sha2 0.10.9",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ bloom-ens      = { path = "crates/bloom-ens" }
 bloom-prices   = { path = "crates/bloom-prices" }
 bloom-revert   = { path = "crates/bloom-revert" }
 bloom-petals   = { path = "crates/bloom-petals" }
-bloom-petal-contract = { git = "https://github.com/bloom-directory/petal", rev = "61938d0c127cfe03c7e3e55baed0ba1439bc5ca2" }
+bloom-petal-contract = { git = "https://github.com/bloom-directory/petal", rev = "9ad7a5c635f092bbcdf8f00a06b23676806ff70c" }
 bloom-daemon   = { path = "crates/bloom-daemon" }
 bloom-update   = { path = "crates/bloom-update" }
 bloom-broker-api = { git = "https://github.com/bloom-directory/bloom-broker.git", rev = "582d3dd3add7efb2640b900f005e32a5a52f17c0" }

--- a/packaging/triad/release/compatibility-v1.toml
+++ b/packaging/triad/release/compatibility-v1.toml
@@ -4,7 +4,7 @@ schema = "bloom.triad-compatibility/1"
 broker_commit = "582d3dd3add7efb2640b900f005e32a5a52f17c0"
 signer_commit = "0126ba4589ad8cf504d2f04c8e36471727964089"
 service_runtime_commit = "bc88cc6760b00bbff0c6a6e5f56d42bb03004436"
-petal_contract_commit = "61938d0c127cfe03c7e3e55baed0ba1439bc5ca2"
+petal_contract_commit = "9ad7a5c635f092bbcdf8f00a06b23676806ff70c"
 
 [state.machine]
 current = 1

--- a/packaging/triad/release/verify-bundle.sh
+++ b/packaging/triad/release/verify-bundle.sh
@@ -113,7 +113,7 @@ signer_revision="$(source_revision BLOOM_SIGNER_SHA)"
   exit 65
 }
 require_compat_value revisions service_runtime_commit '"bc88cc6760b00bbff0c6a6e5f56d42bb03004436"'
-require_compat_value revisions petal_contract_commit '"61938d0c127cfe03c7e3e55baed0ba1439bc5ca2"'
+require_compat_value revisions petal_contract_commit '"9ad7a5c635f092bbcdf8f00a06b23676806ff70c"'
 for state_owner in machine broker signer; do
   require_compat_value "state.$state_owner" current 1
   require_compat_value "state.$state_owner" downgrade_floor 1


### PR DESCRIPTION
## Why

bloom master records `petal_contract_commit = 61938d0c…`, a mid-branch commit of petal#21 reachable only from closed petal PR refs. It never landed on petal master, so `bin/bloom-worktree pins` fails on master itself and every master-based bloom PR (#214, #232, #239, #188, #222, #224) inherits the failing petal group.

The original reason not to repin was petal#17's `PrivateInputCeremony` interface: any landed petal revision dragged it into bloom. petal#33 "Remove the unused private-input ceremony interface" (9ad7a5c635f092bbcdf8f00a06b23676806ff70c, merged 2026-09-09) removed it, so a landed petal revision is now usable.

## What

Repin `bloom-petal-contract` from `61938d0c…` to `9ad7a5c6…` (petal#33 squash, ancestor of petal master) in all four recorded locations:

- `Cargo.toml` — build pin
- `Cargo.lock` — lockfile entry
- `packaging/triad/release/compatibility-v1.toml` — release-compatibility pin
- `packaging/triad/release/verify-bundle.sh` — bundle verifier literal

## Release compatibility group changed

This changes the release-compatibility group: `petal_contract_commit` moves. Broker/signer release pins are untouched (`582d3dd3…` / `0126ba45…`), so the two macOS conformance workflows are not required for this PR alone; the Linux release build at the compatibility revisions will be covered by the downstream merges that refresh those PRs against this master. Reason the group may move without them: the bloom-petal-contract sources bloom depends on (`src/`, `wit/`, root `Cargo.toml` of the petal repo) are byte-identical between `61938d0c` and `9ad7a5c6` — petal#17 added the private-input interface and petal#33 removed it, netting zero. The 8 differing files (`.github/`, `crates/petal-{sdk,builder,cli}`, `skills/`, `templates/`) are not consumed by bloom, so this is a hash-only repin for bloom.

## Verification

Forward merge: master moved to 98e9e556 (#232) after this PR opened; the branch merges master forward — merge head 55ed96f5, clean, no conflicts (#232 touches only `crates/bloom-vfs/`).

At head 55ed96f5:

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo nextest run --workspace --all-targets` with CI's Linux filter (`not test(/^macos_/)`, per the integration_test job) — 1528 passed, 0 failed, 19 skipped (1521 passed at ba8867cb before the merge; #232 added the rest); diagnostic build change: linked with `CARGO_PROFILE_DEV_DEBUG=line-tables-only` and `-j 2` because the host OOM-killed default-profile link jobs
- `cargo test --workspace --doc` — ok
- `bin/bloom-worktree pins <worktree>` — 0 errors, 9 dependency groups checked
- CI on 55ed96f5 — all lanes green (fmt, clippy, unit, local integration, external e2e, doctests, locked release build, checklist; docker/macOS lanes skip by design)
- `git -C repos/petal diff --quiet 61938d0c… 9ad7a5c6… -- src wit Cargo.toml` — identical (re-verified after the merge); `merge-base --is-ancestor 9ad7a5c6… origin/master` — true

Base was master dea8fbe0. Downstream, #214/#232/#239/#188 merge master forward after this lands; bloom#170 already pins exactly 9ad7a5c6, so its forward merge resolves the pin to identical values.

## Checklist

Every item must be checked before merge. Non-applicable items are checked and marked N/A.

- [x] Tests added or updated for behavior changes — N/A: hash-only pin repin, no behavior change; existing suite run green (fmt, clippy -D warnings, nextest 1528 passed / 0 failed with CI's Linux `not test(/^macos_/)` filter, doc tests) — see Verification
- [x] Architecture docs (`docs/architecture/`) updated if contracts or behavior changed — N/A: no contract or behavior change; the pinned bloom-petal-contract sources (`src/`, `wit/`, root `Cargo.toml`) are byte-identical between 61938d0c… and 9ad7a5c6…
- [x] Sealed Approval invariants respected (no signing outside a grant or bounded capability, no PRF/grant persistence, execution from sealed bytes) — see `docs/architecture/Sealed Approvals.md` — N/A: no signing, grant, PRF, or execution-path change; dependency hash bump only
- [x] Agent Documentation updated (`crates/bloom-vfs/src/docs/agent-guidance.md` and affected Petal READMEs) — see `docs/architecture/Agent-native Documentation.md` — N/A: no agent-facing behavior or docs surface change

