### PR TITLE
Pin Broker master into #238 and fix Linux upgrade recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,8 +213,8 @@ jobs:
       github.ref_name == 'triad-architecture'
     uses: ./.github/workflows/macos-unix-conformance.yml
     with:
-      broker_ref: cd1e31e9f33c74355bf3e7fa244af12159716064
-      signer_ref: 9abe7917b8380d8b6d31af0b376a79c26e816764
+      broker_ref: bd85885bb4fc2c05f20af1f4410683ffbebca6a9
+      signer_ref: 941dd376568b52ccd269ecf495bcff7dcd9af504
 
   linux_w0_isolation:
     name: Linux W0 principal and socket isolation

--- a/.github/workflows/macos-two-login-conformance.yml
+++ b/.github/workflows/macos-two-login-conformance.yml
@@ -7,12 +7,12 @@ on:
         description: Public bloom-broker ref
         required: false
         type: string
-        default: cd1e31e9f33c74355bf3e7fa244af12159716064
+        default: bd85885bb4fc2c05f20af1f4410683ffbebca6a9
       signer_ref:
         description: Public bloom-signer ref
         required: false
         type: string
-        default: 9abe7917b8380d8b6d31af0b376a79c26e816764
+        default: 941dd376568b52ccd269ecf495bcff7dcd9af504
       login_uid_a:
         description: First active GUI login UID
         required: true
@@ -34,11 +34,11 @@ on:
       broker_ref:
         description: Public bloom-broker ref
         required: true
-        default: cd1e31e9f33c74355bf3e7fa244af12159716064
+        default: bd85885bb4fc2c05f20af1f4410683ffbebca6a9
       signer_ref:
         description: Public bloom-signer ref
         required: true
-        default: 9abe7917b8380d8b6d31af0b376a79c26e816764
+        default: 941dd376568b52ccd269ecf495bcff7dcd9af504
       login_uid_a:
         description: First active GUI login UID
         required: true
@@ -75,8 +75,8 @@ jobs:
       - name: Reject mutable sibling refs
         shell: bash
         env:
-          BROKER_REF: ${{ inputs.broker_ref || 'cd1e31e9f33c74355bf3e7fa244af12159716064' }}
-          SIGNER_REF: ${{ inputs.signer_ref || '9abe7917b8380d8b6d31af0b376a79c26e816764' }}
+          BROKER_REF: ${{ inputs.broker_ref || 'bd85885bb4fc2c05f20af1f4410683ffbebca6a9' }}
+          SIGNER_REF: ${{ inputs.signer_ref || '941dd376568b52ccd269ecf495bcff7dcd9af504' }}
         run: |
           [[ "$BROKER_REF" =~ ^[0-9a-f]{40}$ ]]
           [[ "$SIGNER_REF" =~ ^[0-9a-f]{40}$ ]]
@@ -84,13 +84,13 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: bloom-directory/bloom-broker
-          ref: ${{ inputs.broker_ref || 'cd1e31e9f33c74355bf3e7fa244af12159716064' }}
+          ref: ${{ inputs.broker_ref || 'bd85885bb4fc2c05f20af1f4410683ffbebca6a9' }}
           path: bloom-broker
       - name: Check out Signer
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: bloom-directory/bloom-signer
-          ref: ${{ inputs.signer_ref || '9abe7917b8380d8b6d31af0b376a79c26e816764' }}
+          ref: ${{ inputs.signer_ref || '941dd376568b52ccd269ecf495bcff7dcd9af504' }}
           path: bloom-signer
       - name: Install Rust toolchain
         run: rustup toolchain install "$RUSTUP_TOOLCHAIN" --profile minimal

--- a/.github/workflows/macos-unix-conformance.yml
+++ b/.github/workflows/macos-unix-conformance.yml
@@ -7,22 +7,22 @@ on:
         description: Public bloom-broker ref
         required: false
         type: string
-        default: cd1e31e9f33c74355bf3e7fa244af12159716064
+        default: bd85885bb4fc2c05f20af1f4410683ffbebca6a9
       signer_ref:
         description: Public bloom-signer ref
         required: false
         type: string
-        default: 9abe7917b8380d8b6d31af0b376a79c26e816764
+        default: 941dd376568b52ccd269ecf495bcff7dcd9af504
   workflow_dispatch:
     inputs:
       broker_ref:
         description: Public bloom-broker ref
         required: true
-        default: cd1e31e9f33c74355bf3e7fa244af12159716064
+        default: bd85885bb4fc2c05f20af1f4410683ffbebca6a9
       signer_ref:
         description: Public bloom-signer ref
         required: true
-        default: 9abe7917b8380d8b6d31af0b376a79c26e816764
+        default: 941dd376568b52ccd269ecf495bcff7dcd9af504
 
 permissions:
   contents: read
@@ -42,8 +42,8 @@ jobs:
       - name: Reject mutable sibling refs
         shell: bash
         env:
-          BROKER_REF: ${{ inputs.broker_ref || 'cd1e31e9f33c74355bf3e7fa244af12159716064' }}
-          SIGNER_REF: ${{ inputs.signer_ref || '9abe7917b8380d8b6d31af0b376a79c26e816764' }}
+          BROKER_REF: ${{ inputs.broker_ref || 'bd85885bb4fc2c05f20af1f4410683ffbebca6a9' }}
+          SIGNER_REF: ${{ inputs.signer_ref || '941dd376568b52ccd269ecf495bcff7dcd9af504' }}
         run: |
           [[ "$BROKER_REF" =~ ^[0-9a-f]{40}$ ]]
           [[ "$SIGNER_REF" =~ ^[0-9a-f]{40}$ ]]
@@ -51,13 +51,13 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: bloom-directory/bloom-broker
-          ref: ${{ inputs.broker_ref || 'cd1e31e9f33c74355bf3e7fa244af12159716064' }}
+          ref: ${{ inputs.broker_ref || 'bd85885bb4fc2c05f20af1f4410683ffbebca6a9' }}
           path: bloom-broker
       - name: Check out Signer
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: bloom-directory/bloom-signer
-          ref: ${{ inputs.signer_ref || '9abe7917b8380d8b6d31af0b376a79c26e816764' }}
+          ref: ${{ inputs.signer_ref || '941dd376568b52ccd269ecf495bcff7dcd9af504' }}
           path: bloom-signer
       - name: Install Rust toolchain
         run: rustup toolchain install "$RUSTUP_TOOLCHAIN" --profile minimal
@@ -109,8 +109,8 @@ jobs:
       - name: Reject mutable sibling refs
         shell: bash
         env:
-          BROKER_REF: ${{ inputs.broker_ref || 'cd1e31e9f33c74355bf3e7fa244af12159716064' }}
-          SIGNER_REF: ${{ inputs.signer_ref || '9abe7917b8380d8b6d31af0b376a79c26e816764' }}
+          BROKER_REF: ${{ inputs.broker_ref || 'bd85885bb4fc2c05f20af1f4410683ffbebca6a9' }}
+          SIGNER_REF: ${{ inputs.signer_ref || '941dd376568b52ccd269ecf495bcff7dcd9af504' }}
         run: |
           [[ "$BROKER_REF" =~ ^[0-9a-f]{40}$ ]]
           [[ "$SIGNER_REF" =~ ^[0-9a-f]{40}$ ]]
@@ -118,13 +118,13 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: bloom-directory/bloom-broker
-          ref: ${{ inputs.broker_ref || 'cd1e31e9f33c74355bf3e7fa244af12159716064' }}
+          ref: ${{ inputs.broker_ref || 'bd85885bb4fc2c05f20af1f4410683ffbebca6a9' }}
           path: bloom-broker
       - name: Check out Signer
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: bloom-directory/bloom-signer
-          ref: ${{ inputs.signer_ref || '9abe7917b8380d8b6d31af0b376a79c26e816764' }}
+          ref: ${{ inputs.signer_ref || '941dd376568b52ccd269ecf495bcff7dcd9af504' }}
           path: bloom-signer
       - name: Install Rust toolchain
         run: rustup toolchain install "$RUSTUP_TOOLCHAIN" --profile minimal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2200,7 +2200,7 @@ dependencies = [
 [[package]]
 name = "bloom-broker-api"
 version = "0.1.0"
-source = "git+https://github.com/bloom-directory/bloom-broker.git?rev=cd1e31e9f33c74355bf3e7fa244af12159716064#cd1e31e9f33c74355bf3e7fa244af12159716064"
+source = "git+https://github.com/bloom-directory/bloom-broker.git?rev=bd85885bb4fc2c05f20af1f4410683ffbebca6a9#bd85885bb4fc2c05f20af1f4410683ffbebca6a9"
 dependencies = [
  "bloom-rpc-wire",
  "serde",
@@ -2632,7 +2632,7 @@ dependencies = [
 [[package]]
 name = "bloom-signer-derive"
 version = "0.1.0"
-source = "git+https://github.com/bloom-directory/bloom-signer.git?rev=9abe7917b8380d8b6d31af0b376a79c26e816764#9abe7917b8380d8b6d31af0b376a79c26e816764"
+source = "git+https://github.com/bloom-directory/bloom-signer.git?rev=941dd376568b52ccd269ecf495bcff7dcd9af504#941dd376568b52ccd269ecf495bcff7dcd9af504"
 dependencies = [
  "bip39",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ bloom-petals   = { path = "crates/bloom-petals" }
 bloom-petal-contract = { git = "https://github.com/bloom-directory/petal", rev = "9ad7a5c635f092bbcdf8f00a06b23676806ff70c" }
 bloom-daemon   = { path = "crates/bloom-daemon" }
 bloom-update   = { path = "crates/bloom-update" }
-bloom-broker-api = { git = "https://github.com/bloom-directory/bloom-broker.git", rev = "cd1e31e9f33c74355bf3e7fa244af12159716064" }
+bloom-broker-api = { git = "https://github.com/bloom-directory/bloom-broker.git", rev = "bd85885bb4fc2c05f20af1f4410683ffbebca6a9" }
 bloom-rpc-wire = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "bc88cc6760b00bbff0c6a6e5f56d42bb03004436" }
 bloom-triad-local-transport = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "bc88cc6760b00bbff0c6a6e5f56d42bb03004436" }
 bloom-service-activation = { git = "https://github.com/bloom-directory/bloom-service-runtime.git", rev = "bc88cc6760b00bbff0c6a6e5f56d42bb03004436" }

--- a/crates/bloom-daemon/src/lib.rs
+++ b/crates/bloom-daemon/src/lib.rs
@@ -1287,7 +1287,7 @@ impl PetalHost for DaemonPetalHost {
                     petal_key_scope: Some(scope.clone()),
                     legacy_passkey_migration: None,
                     wallet_seed_profile: None,
-                    derivation_request: None,
+                    derivation_requests: Vec::new(),
                     account_terms: None,
                 },
             )

--- a/crates/bloom-it/Cargo.toml
+++ b/crates/bloom-it/Cargo.toml
@@ -22,7 +22,7 @@ bloom-daemon.workspace = true
 bloom-solana-tx.workspace = true
 bloom-machine-client.workspace = true
 bloom-broker-api.workspace = true
-bloom-signer-derive = { git = "https://github.com/bloom-directory/bloom-signer.git", rev = "9abe7917b8380d8b6d31af0b376a79c26e816764" }
+bloom-signer-derive = { git = "https://github.com/bloom-directory/bloom-signer.git", rev = "941dd376568b52ccd269ecf495bcff7dcd9af504" }
 ed25519-dalek.workspace = true
 bs58.workspace = true
 bloom-revert.workspace = true

--- a/crates/bloom-it/tests/macos_launchagent.rs
+++ b/crates/bloom-it/tests/macos_launchagent.rs
@@ -476,14 +476,18 @@ fn privileged_w0_harness_requires_an_external_disposable_host_marker() {
     assert!(source.contains("/private/var/db/bloom-w0-disposable-host"));
     assert!(source.contains("bloom-macos-unix-w0-disposable-v1"));
     assert!(source.contains("macos-unix-principals-w0"));
-    assert!(source.contains("/usr/bin/nc -lk 127.0.0.1 18734"));
+    // A foreign listener on either loopback family must block the Broker.
+    assert!(source.contains("/usr/bin/nc \"-$family\" -lk \"$address\" 18734"));
+    assert!(source.contains("assert_foreign_ceremony_conflict 4 127.0.0.1 127.0.0.1"));
+    assert!(source.contains("assert_foreign_ceremony_conflict 6 ::1 '[::1]'"));
+    assert!(source.contains("for ceremony_host in 127.0.0.1 '[::1]'; do"));
     assert!(source.contains("Broker opened a fallback TCP listener"));
     assert!(source.contains("ceremony_listeners_unavailable"));
     assert!(source.contains(
         "Bloom Broker startup failed: could not acquire both ceremony loopback listeners"
     ));
     let foreign_bind = source
-        .find("/usr/bin/nc -lk 127.0.0.1 18734")
+        .find("/usr/bin/nc \"-$family\" -lk \"$address\" 18734")
         .expect("foreign listener bind");
     let broker_bootstrap = source[foreign_bind..]
         .find("launchctl bootstrap system \"$broker_plist\"")
@@ -501,7 +505,11 @@ fn privileged_w0_harness_requires_an_external_disposable_host_marker() {
     assert!(source.contains("Machine login sampled"));
     assert!(source.contains("session sentinel did not reject an unauthorized login-UID peer"));
     assert!(source.contains("services did not drain after the login-session sentinel disappeared"));
-    assert!(source.contains("Broker retained the ceremony listener after session logout"));
+    assert!(
+        source.contains(
+            "Broker retained the ceremony listener on $ceremony_host after session logout"
+        )
+    );
     assert!(source.contains("launchctl bootstrap \"user/$login_uid\" \"$session_plist\""));
     assert!(source.contains("run-installed-acceptance.sh"));
     assert!(source.contains("BLOOM_MACOS_INSTALLED_ACCEPTANCE_MAIN_ROOT"));

--- a/crates/bloom-it/tests/triad_release.rs
+++ b/crates/bloom-it/tests/triad_release.rs
@@ -1,7 +1,7 @@
 use sha2::{Digest as _, Sha256};
 use std::{
     fs,
-    os::unix::fs::{MetadataExt as _, PermissionsExt as _},
+    os::unix::fs::PermissionsExt as _,
     path::{Path, PathBuf},
     process::Command,
 };
@@ -3465,118 +3465,9 @@ fn linux_upgrade_recovery_failure_preserves_the_transaction_and_retries() {
     assert!(!root.join("var/lib/bloom/upgrade-transaction").exists());
 }
 
-/// The AWS KMS Signer drop-in and the credential it loads are Bloom-owned
-/// and deleted or rewritten by an installation. A rollback must return both
-/// with their bytes, modes, and owners — or remove them when the previous
-/// installation had neither — so the previous Signer never starts loading a
-/// credential that is not there.
-#[test]
-fn linux_upgrade_recovery_restores_the_signer_kms_dropin_and_credential() {
-    let directory = tempfile::tempdir().unwrap();
-    let harness = write_linux_upgrade_harness(directory.path());
-    let installer = release_script("install-linux.sh");
-    let dropin = "usr/lib/systemd/system/bloom-signer@1000.service.d/50-aws-kms.conf";
-    let credential = "etc/bloom/1000/signer/aws-credentials";
-    let dropin_bytes = b"[Service]\nIPAddressAllow=192.0.2.0/24\nLoadCredential=aws-credentials:/etc/bloom/%i/signer/aws-credentials\n";
-    let credential_bytes = b"[default]\naws_access_key_id=previous\n";
-
-    // Present before the upgrade; the candidate payload has no KMS overlay
-    // and deletes both.
-    let removed_root = tempfile::tempdir().unwrap();
-    let (root, layout, old_digest, new_digest) = {
-        let (root, layout, old_digest, new_digest, _) =
-            stage_linux_upgrade_root(removed_root.path(), &harness, "interrupt", "all", |root| {
-                for (relative, bytes, mode) in [
-                    (dropin, &dropin_bytes[..], 0o644),
-                    (credential, &credential_bytes[..], 0o600),
-                ] {
-                    let path = root.join(relative);
-                    fs::create_dir_all(path.parent().unwrap()).unwrap();
-                    fs::write(&path, bytes).unwrap();
-                    set_linux_mode(&path, mode);
-                }
-            });
-        (root, layout, old_digest, new_digest)
-    };
-    let manifest =
-        fs::read_to_string(root.join("var/lib/bloom/upgrade-transaction/units/manifest")).unwrap();
-    for relative in [dropin, credential] {
-        assert!(
-            manifest
-                .lines()
-                .any(|line| line.starts_with("present ") && line.ends_with(relative)),
-            "the snapshot must record {relative}: {manifest}"
-        );
-    }
-    let owner = {
-        let metadata = fs::metadata(root.join(credential)).unwrap();
-        (metadata.uid(), metadata.gid())
-    };
-    fs::remove_file(root.join(credential)).unwrap();
-    fs::remove_dir_all(root.join(dropin).parent().unwrap()).unwrap();
-    let recovered = run_linux_upgrade_harness(
-        &harness,
-        &installer,
-        &root,
-        "recover",
-        &removed_root.path().join("recover.log"),
-        &[&old_digest, &new_digest],
-    );
-    assert!(
-        recovered.status.success(),
-        "{}",
-        String::from_utf8_lossy(&recovered.stderr)
-    );
-    assert_pre_ipv6_linux_contract(&root, &layout);
-    for (relative, bytes, mode) in [
-        (dropin, &dropin_bytes[..], 0o644),
-        (credential, &credential_bytes[..], 0o600),
-    ] {
-        let path = root.join(relative);
-        assert_eq!(fs::read(&path).unwrap(), bytes, "{relative} bytes");
-        let metadata = fs::metadata(&path).unwrap();
-        assert_eq!(
-            metadata.permissions().mode() & 0o777,
-            mode,
-            "{relative} mode"
-        );
-        assert_eq!((metadata.uid(), metadata.gid()), owner, "{relative} owner");
-    }
-
-    // Absent before the upgrade; the candidate added both. Restoration
-    // removes them and the emptied drop-in directory.
-    let added_root = tempfile::tempdir().unwrap();
-    let (root, _layout, old_digest, new_digest, _) =
-        stage_linux_upgrade_root(added_root.path(), &harness, "interrupt", "all", |root| {
-            fs::remove_file(root.join(credential)).unwrap();
-            fs::remove_dir_all(root.join(dropin).parent().unwrap()).unwrap();
-        });
-    for relative in [dropin, credential] {
-        let path = root.join(relative);
-        fs::create_dir_all(path.parent().unwrap()).unwrap();
-        fs::write(&path, b"candidate").unwrap();
-    }
-    let recovered = run_linux_upgrade_harness(
-        &harness,
-        &installer,
-        &root,
-        "recover",
-        &added_root.path().join("recover.log"),
-        &[&old_digest, &new_digest],
-    );
-    assert!(
-        recovered.status.success(),
-        "{}",
-        String::from_utf8_lossy(&recovered.stderr)
-    );
-    assert!(!root.join(credential).exists());
-    assert!(!root.join(dropin).parent().unwrap().exists());
-}
-
-/// The snapshot covers every enrolled login's Signer drop-in and credential,
-/// and restoration checks it against the enrollments present at that time.
-/// Uninstalling a login in between would leave a transaction no later run can
-/// restore, so uninstall refuses until recovery has run.
+/// Uninstall refuses while an interrupted upgrade is pending: the installed
+/// units, binaries, and release metadata may be mixed until recovery restores
+/// the previous installation. Once recovery has run, uninstall proceeds.
 #[test]
 fn linux_uninstall_refuses_while_an_interrupted_upgrade_is_pending() {
     let directory = tempfile::tempdir().unwrap();

--- a/crates/bloom-it/tests/triad_release.rs
+++ b/crates/bloom-it/tests/triad_release.rs
@@ -1,7 +1,7 @@
 use sha2::{Digest as _, Sha256};
 use std::{
     fs,
-    os::unix::fs::PermissionsExt as _,
+    os::unix::fs::{MetadataExt as _, PermissionsExt as _},
     path::{Path, PathBuf},
     process::Command,
 };
@@ -2673,18 +2673,41 @@ fn installer_upgrade_transactions_preserve_recovery_state_atomically() {
                 .find("\"$payload/installer/linux/systemd/bloom-broker-ceremony@.socket\"")
                 .unwrap()
     );
+    let restore = &linux[linux.find("restore_linux_previous_release() {").unwrap()
+        ..linux.find("rollback_linux_upgrade() {").unwrap()];
+    assert!(
+        restore.contains("restore_linux_upgrade_units \"$upgrade_root\" \"$upgrade_transaction\""),
+        "restoring the previous release must restore its installed unit contract"
+    );
+    assert!(!restore.contains("start_linux_release_set"));
     let rollback = &linux[linux.find("rollback_linux_upgrade() {").unwrap()
         ..linux.find("finish_linux_upgrade() {").unwrap()];
     assert!(
-        rollback
-            .find("restore_linux_upgrade_units \"$upgrade_root\" \"$upgrade_transaction\"")
-            .unwrap()
+        rollback.find("restore_linux_previous_release").unwrap()
             < rollback
                 .find("start_linux_release_set \"$upgrade_root\"")
                 .unwrap(),
         "rollback must restore the installed unit contract before any restart"
     );
+    // Recovery restores without starting: it must not depend on the previous
+    // release passing its health gate.
+    let recovery = &linux[linux.find("recover_interrupted_linux_upgrade() {").unwrap()
+        ..linux.find("allocate_linux_nfs_port() {").unwrap()];
+    assert!(recovery.contains("restore_linux_previous_release"));
+    assert!(!recovery.contains("start_linux_release_set"));
+    assert!(!recovery.contains("rollback_linux_upgrade"));
+    assert!(!recovery.contains("upgrade_rollback_required=true"));
     assert!(!linux.contains("completing interrupted"));
+    // IPv6 loopback is checked after recovery and before anything new is
+    // installed.
+    let ipv6 = linux.find("require_linux_ipv6_loopback /proc").unwrap();
+    assert!(
+        linux
+            .find("recover_interrupted_linux_upgrade \"$root\"")
+            .unwrap()
+            < ipv6
+    );
+    assert!(ipv6 < linux.find("install_linux_release \"$root\"").unwrap());
 
     let daemon = fs::read_to_string(workspace().join("crates/bloom-daemon/src/lib.rs")).unwrap();
     assert!(daemon.contains(".require_outbox_petal_eligibility(&request.wallet, chain_name, id)"));
@@ -2851,9 +2874,10 @@ fn make_linux_candidate_payload(
 /// `begin_linux_upgrade` and then performs the candidate unit writes up to
 /// the requested boundary — `none`, `sockets`, `services`, or `all` — and
 /// exits without the EXIT-trap rollback, simulating an interrupted process.
-/// `recover` runs `recover_interrupted_linux_upgrade` on the preserved
-/// transaction. The start stub fingerprints the units it observes, so a
-/// startup attempt over mixed state is detectable in the log.
+/// `rollback` performs the same writes and then runs the in-process rollback
+/// the EXIT trap would. `recover` runs `recover_interrupted_linux_upgrade` on
+/// the preserved transaction. The start stub fingerprints the units it
+/// observes, so a startup attempt over mixed state is detectable in the log.
 fn write_linux_upgrade_harness(directory: &Path) -> PathBuf {
     let script = directory.join("linux-upgrade-harness.sh");
     fs::write(
@@ -2881,28 +2905,36 @@ start_linux_release_set() {
     "$(sha256sum "$1/usr/lib/systemd/system/bloom-broker@.service" | cut -d' ' -f1)" \
     "$(test -e "$1/usr/lib/systemd/system/bloom-broker-ceremony-ipv6@.socket" && echo present || echo absent)" >> "$log"
 }
+write_candidate_units() {
+  unit_root="$root/usr/lib/systemd/system"
+  user_unit_root="$root/usr/lib/systemd/user"
+  if [[ "$stage" != none ]]; then
+    printf 'candidate v4 socket\n' > "$unit_root/bloom-broker-ceremony@.socket"
+    printf 'candidate v6 socket\n' > "$unit_root/bloom-broker-ceremony-ipv6@.socket"
+    printf 'candidate session path\n' > "$unit_root/bloom-session@.path"
+  fi
+  if [[ "$stage" == services || "$stage" == all ]]; then
+    printf 'candidate session unit\n' > "$user_unit_root/bloom-session.service"
+    printf 'candidate machine unit\n' > "$user_unit_root/bloom-machine.service"
+    printf 'candidate broker unit\n' > "$unit_root/bloom-broker@.service"
+    printf 'candidate signer unit\n' > "$unit_root/bloom-signer@.service"
+  fi
+  if [[ "$stage" == all ]]; then
+    rm -f -- "$unit_root/bloom-signer-rpc@.socket" \
+      "$unit_root/bloom-signer-control@.socket" \
+      "$unit_root/bloom-broker-rpc@.socket" \
+      "$unit_root/bloom-broker-control@.socket"
+  fi
+}
 case "$mode" in
   interrupt)
     begin_linux_upgrade "$root" "$old_digest" "$new_digest"
-    unit_root="$root/usr/lib/systemd/system"
-    user_unit_root="$root/usr/lib/systemd/user"
-    if [[ "$stage" != none ]]; then
-      printf 'candidate v4 socket\n' > "$unit_root/bloom-broker-ceremony@.socket"
-      printf 'candidate v6 socket\n' > "$unit_root/bloom-broker-ceremony-ipv6@.socket"
-      printf 'candidate session path\n' > "$unit_root/bloom-session@.path"
-    fi
-    if [[ "$stage" == services || "$stage" == all ]]; then
-      printf 'candidate session unit\n' > "$user_unit_root/bloom-session.service"
-      printf 'candidate machine unit\n' > "$user_unit_root/bloom-machine.service"
-      printf 'candidate broker unit\n' > "$unit_root/bloom-broker@.service"
-      printf 'candidate signer unit\n' > "$unit_root/bloom-signer@.service"
-    fi
-    if [[ "$stage" == all ]]; then
-      rm -f -- "$unit_root/bloom-signer-rpc@.socket" \
-        "$unit_root/bloom-signer-control@.socket" \
-        "$unit_root/bloom-broker-rpc@.socket" \
-        "$unit_root/bloom-broker-control@.socket"
-    fi
+    write_candidate_units
+    ;;
+  rollback)
+    begin_linux_upgrade "$root" "$old_digest" "$new_digest"
+    write_candidate_units
+    rollback_linux_upgrade
     ;;
   recover)
     recover_interrupted_linux_upgrade "$root"
@@ -2940,6 +2972,26 @@ fn stage_interrupted_linux_root(
     harness: &Path,
     stage: &str,
 ) -> (PathBuf, Vec<LinuxTrackedUnit>, String, String) {
+    let (root, layout, old_digest, new_digest, _) =
+        stage_linux_upgrade_root(directory, harness, "interrupt", stage, |_| {});
+    (root, layout, old_digest, new_digest)
+}
+
+/// Like `stage_interrupted_linux_root`, but runs the harness in `mode` and
+/// lets the caller shape the installed tree before the upgrade snapshots it.
+fn stage_linux_upgrade_root(
+    directory: &Path,
+    harness: &Path,
+    mode: &str,
+    stage: &str,
+    prepare: impl FnOnce(&Path),
+) -> (
+    PathBuf,
+    Vec<LinuxTrackedUnit>,
+    String,
+    String,
+    std::process::Output,
+) {
     let root = directory.join("root");
     fs::create_dir(&root).unwrap();
     let payload = make_installer_payload(&directory.join("release-a"));
@@ -2954,22 +3006,25 @@ fn stage_interrupted_linux_root(
         String::from_utf8_lossy(&installed.stderr)
     );
     let layout = apply_pre_ipv6_linux_layout(&root);
+    prepare(&root);
     let new_digest = hex::encode(Sha256::digest(b"upgraded manifest\n"));
-    let log = directory.join(format!("interrupt-{stage}.log"));
-    let interrupted = run_linux_upgrade_harness(
+    let log = directory.join(format!("{mode}-{stage}.log"));
+    let staged = run_linux_upgrade_harness(
         harness,
         &release_script("install-linux.sh"),
         &root,
-        "interrupt",
+        mode,
         &log,
         &[stage, &old_digest, &new_digest],
     );
-    assert!(
-        interrupted.status.success(),
-        "{}",
-        String::from_utf8_lossy(&interrupted.stderr)
-    );
-    (root, layout, old_digest, new_digest)
+    if mode == "interrupt" {
+        assert!(
+            staged.status.success(),
+            "{}",
+            String::from_utf8_lossy(&staged.stderr)
+        );
+    }
+    (root, layout, old_digest, new_digest, staged)
 }
 
 #[test]
@@ -3114,28 +3169,22 @@ fn linux_interrupted_upgrade_recovery_restores_before_any_restart() {
         let stop = log
             .find("stop\n")
             .unwrap_or_else(|| panic!("no stop at {stage}"));
-        let start = log
-            .find("start current=")
-            .unwrap_or_else(|| panic!("no start at {stage}"));
+        let rewrite = log
+            .find(&format!("rewrite {old_digest} active"))
+            .unwrap_or_else(|| panic!("no metadata restore at {stage}"));
         assert!(
-            stop < start,
-            "the release set must stop before restarting at {stage}"
+            stop < rewrite,
+            "the release set must stop before it is restored at {stage}"
         );
-        let start_line = &log[start..log.len().min(start + 400)];
-        let start_line = &start_line[..start_line.find('\n').unwrap_or(start_line.len())];
-        let old_v4 = hex::encode(Sha256::digest(&layout[0].bytes));
-        let old_broker = hex::encode(Sha256::digest(&layout[1].bytes));
+        // Recovery restores the previous release without starting it; the
+        // retried installation is the first thing to start anything.
         assert!(
-            start_line.contains(&format!("current=releases/{old_digest}"))
-                && start_line.contains(&format!("v4={old_v4}"))
-                && start_line.contains(&format!("broker={old_broker}"))
-                && start_line.contains("v6=absent"),
-            "restart at {stage} observed mixed binaries or units: {start_line}"
+            !log.contains("start"),
+            "recovery must not start a release at {stage}: {log}"
         );
         assert_eq!(
-            log.matches("start current=").count(),
-            1,
-            "recovery must attempt exactly one restart at {stage}"
+            fs::read_link(root.join("usr/libexec/bloom/current")).unwrap(),
+            format!("releases/{old_digest}")
         );
         assert_pre_ipv6_linux_contract(&root, &layout);
         assert!(
@@ -3344,14 +3393,30 @@ fn linux_upgrade_recovery_failure_preserves_the_transaction_and_retries() {
     assert_pre_ipv6_linux_contract(&root, &layout);
     assert!(!root.join("var/lib/bloom/upgrade-transaction").exists());
 
-    // A failed health gate also preserves the transaction; the retry starts
-    // only after the fault clears.
+    // A previous release that cannot pass its health gate — the release a
+    // host is upgrading away from — must not strand the host. The in-process
+    // rollback restores it coherently, fails its health gate, and keeps the
+    // transaction. Recovery then restores without starting it, and the
+    // retried upgrade to the candidate completes.
     let health_root = tempfile::tempdir().unwrap();
-    let (root, layout, old_digest, new_digest) =
-        stage_interrupted_linux_root(health_root.path(), &harness, "all");
-    fs::write(root.join("var/lib/bloom/start-fails"), b"1").unwrap();
+    let (root, layout, old_digest, new_digest, rolled_back) =
+        stage_linux_upgrade_root(health_root.path(), &harness, "rollback", "all", |root| {
+            fs::write(root.join("var/lib/bloom/start-fails"), b"1").unwrap();
+        });
+    assert!(!rolled_back.status.success());
+    let rollback_log = fs::read_to_string(health_root.path().join("rollback-all.log")).unwrap();
+    assert!(rollback_log.contains("start refused"));
+    assert!(
+        String::from_utf8_lossy(&rolled_back.stderr).contains("transaction preserved for retry")
+    );
+    assert!(
+        root.join("var/lib/bloom/upgrade-transaction/schema")
+            .is_file()
+    );
+    assert_pre_ipv6_linux_contract(&root, &layout);
+
     let log = health_root.path().join("recover.log");
-    let unhealthy = run_linux_upgrade_harness(
+    let recovered = run_linux_upgrade_harness(
         &harness,
         &installer,
         &root,
@@ -3359,34 +3424,356 @@ fn linux_upgrade_recovery_failure_preserves_the_transaction_and_retries() {
         &log,
         &[&old_digest, &new_digest],
     );
-    assert!(!unhealthy.status.success());
-    assert!(fs::read_to_string(&log).unwrap().contains("start refused"));
     assert!(
-        root.join("var/lib/bloom/upgrade-transaction/schema")
-            .is_file()
+        recovered.status.success(),
+        "recovery must not depend on the previous release's health: {}",
+        String::from_utf8_lossy(&recovered.stderr)
     );
+    assert!(!fs::read_to_string(&log).unwrap().contains("start"));
+    assert!(!root.join("var/lib/bloom/upgrade-transaction").exists());
     assert_pre_ipv6_linux_contract(&root, &layout);
-    fs::remove_file(root.join("var/lib/bloom/start-fails")).unwrap();
-    let retry_log = health_root.path().join("retry.log");
-    let retried = run_linux_upgrade_harness(
+
+    let (candidate, _) = make_linux_candidate_payload(
+        health_root.path(),
+        "release-b",
+        b"upgraded broker\n",
+        b"upgraded manifest\n",
+    );
+    let upgraded = run_linux_installer(
+        &root,
+        &["install", "1000", "alice", candidate.to_str().unwrap()],
+    );
+    assert!(
+        upgraded.status.success(),
+        "{}",
+        String::from_utf8_lossy(&upgraded.stderr)
+    );
+    assert_eq!(
+        fs::read_link(root.join("usr/libexec/bloom/current")).unwrap(),
+        format!("releases/{new_digest}")
+    );
+    assert!(!root.join("var/lib/bloom/upgrade-transaction").exists());
+}
+
+/// The AWS KMS Signer drop-in and the credential it loads are Bloom-owned
+/// and deleted or rewritten by an installation. A rollback must return both
+/// with their bytes, modes, and owners — or remove them when the previous
+/// installation had neither — so the previous Signer never starts loading a
+/// credential that is not there.
+#[test]
+fn linux_upgrade_recovery_restores_the_signer_kms_dropin_and_credential() {
+    let directory = tempfile::tempdir().unwrap();
+    let harness = write_linux_upgrade_harness(directory.path());
+    let installer = release_script("install-linux.sh");
+    let dropin = "usr/lib/systemd/system/bloom-signer@1000.service.d/50-aws-kms.conf";
+    let credential = "etc/bloom/1000/signer/aws-credentials";
+    let dropin_bytes = b"[Service]\nIPAddressAllow=192.0.2.0/24\nLoadCredential=aws-credentials:/etc/bloom/%i/signer/aws-credentials\n";
+    let credential_bytes = b"[default]\naws_access_key_id=previous\n";
+
+    // Present before the upgrade; the candidate payload has no KMS overlay
+    // and deletes both.
+    let removed_root = tempfile::tempdir().unwrap();
+    let (root, layout, old_digest, new_digest) = {
+        let (root, layout, old_digest, new_digest, _) =
+            stage_linux_upgrade_root(removed_root.path(), &harness, "interrupt", "all", |root| {
+                for (relative, bytes, mode) in [
+                    (dropin, &dropin_bytes[..], 0o644),
+                    (credential, &credential_bytes[..], 0o600),
+                ] {
+                    let path = root.join(relative);
+                    fs::create_dir_all(path.parent().unwrap()).unwrap();
+                    fs::write(&path, bytes).unwrap();
+                    set_linux_mode(&path, mode);
+                }
+            });
+        (root, layout, old_digest, new_digest)
+    };
+    let manifest =
+        fs::read_to_string(root.join("var/lib/bloom/upgrade-transaction/units/manifest")).unwrap();
+    for relative in [dropin, credential] {
+        assert!(
+            manifest
+                .lines()
+                .any(|line| line.starts_with("present ") && line.ends_with(relative)),
+            "the snapshot must record {relative}: {manifest}"
+        );
+    }
+    let owner = {
+        let metadata = fs::metadata(root.join(credential)).unwrap();
+        (metadata.uid(), metadata.gid())
+    };
+    fs::remove_file(root.join(credential)).unwrap();
+    fs::remove_dir_all(root.join(dropin).parent().unwrap()).unwrap();
+    let recovered = run_linux_upgrade_harness(
         &harness,
         &installer,
         &root,
         "recover",
-        &retry_log,
+        &removed_root.path().join("recover.log"),
         &[&old_digest, &new_digest],
     );
     assert!(
-        retried.status.success(),
+        recovered.status.success(),
         "{}",
-        String::from_utf8_lossy(&retried.stderr)
+        String::from_utf8_lossy(&recovered.stderr)
+    );
+    assert_pre_ipv6_linux_contract(&root, &layout);
+    for (relative, bytes, mode) in [
+        (dropin, &dropin_bytes[..], 0o644),
+        (credential, &credential_bytes[..], 0o600),
+    ] {
+        let path = root.join(relative);
+        assert_eq!(fs::read(&path).unwrap(), bytes, "{relative} bytes");
+        let metadata = fs::metadata(&path).unwrap();
+        assert_eq!(
+            metadata.permissions().mode() & 0o777,
+            mode,
+            "{relative} mode"
+        );
+        assert_eq!((metadata.uid(), metadata.gid()), owner, "{relative} owner");
+    }
+
+    // Absent before the upgrade; the candidate added both. Restoration
+    // removes them and the emptied drop-in directory.
+    let added_root = tempfile::tempdir().unwrap();
+    let (root, _layout, old_digest, new_digest, _) =
+        stage_linux_upgrade_root(added_root.path(), &harness, "interrupt", "all", |root| {
+            fs::remove_file(root.join(credential)).unwrap();
+            fs::remove_dir_all(root.join(dropin).parent().unwrap()).unwrap();
+        });
+    for relative in [dropin, credential] {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, b"candidate").unwrap();
+    }
+    let recovered = run_linux_upgrade_harness(
+        &harness,
+        &installer,
+        &root,
+        "recover",
+        &added_root.path().join("recover.log"),
+        &[&old_digest, &new_digest],
     );
     assert!(
-        fs::read_to_string(&retry_log)
-            .unwrap()
-            .contains("start current=")
+        recovered.status.success(),
+        "{}",
+        String::from_utf8_lossy(&recovered.stderr)
     );
-    assert!(!root.join("var/lib/bloom/upgrade-transaction").exists());
+    assert!(!root.join(credential).exists());
+    assert!(!root.join(dropin).parent().unwrap().exists());
+}
+
+/// Writes a harness that evaluates the real installer functions and treats
+/// the staged root as a live host, with systemctl, runuser, and the
+/// authenticated health check replaced by logging stubs. A marker file
+/// `fail-<words>` under the root makes the matching stub fail.
+fn write_linux_live_harness(directory: &Path, body: &str) -> PathBuf {
+    let script = directory.join("linux-live-harness.sh");
+    fs::write(
+        &script,
+        format!(
+            r##"#!/usr/bin/env bash
+set -euo pipefail
+# The evaluated installer prefix shifts the positional parameters, so every
+# argument is captured before it is loaded.
+installer="$1"; root="$2"; log="$3"
+arg1="${{4:-}}"; arg2="${{5:-}}"; arg3="${{6:-}}"
+eval "$(sed -n '1,/^case "$action" in$/p' "$installer" | sed '$d')"
+cleanup_scratch() {{ status=$?; trap - EXIT; exit "$status"; }}
+linux_root_is_live() {{ return 0; }}
+stub_fails() {{
+  local marker
+  marker="$root/fail-$(printf '%s' "$*" | tr ' /@' '---')"
+  [[ -e "$marker" ]]
+}}
+systemctl() {{
+  echo "systemctl $*" >> "$log"
+  ! stub_fails systemctl "$@"
+}}
+runuser() {{ echo "runuser $*" >> "$log"; }}
+require_linux_triad_health() {{
+  echo "health $2" >> "$log"
+  ! stub_fails health "$2"
+}}
+{body}
+"##
+        ),
+    )
+    .unwrap();
+    set_linux_mode(&script, 0o755);
+    script
+}
+
+fn install_linux_logins(root: &Path, payload: &Path, logins: &[(&str, &str)]) {
+    for (uid, user) in logins {
+        let installed =
+            run_linux_installer(root, &["install", uid, user, payload.to_str().unwrap()]);
+        assert!(
+            installed.status.success(),
+            "{}",
+            String::from_utf8_lossy(&installed.stderr)
+        );
+    }
+}
+
+/// Rollback runs with errexit suspended. Starting and stopping the release
+/// set must still report a failure from any login, not only the last one,
+/// and a rollback whose first login stays unhealthy must keep the
+/// transaction instead of reporting success.
+#[test]
+fn linux_release_set_start_and_stop_fail_when_any_login_fails() {
+    let directory = tempfile::tempdir().unwrap();
+    let root = directory.path().join("root");
+    fs::create_dir(&root).unwrap();
+    let payload = make_installer_payload(&directory.path().join("release-a"));
+    install_linux_logins(&root, &payload, &[("1000", "alice"), ("2000", "bob")]);
+    let harness = write_linux_live_harness(
+        directory.path(),
+        r#"
+case "$arg1" in
+  start)
+    if start_linux_release_set "$root"; then echo "start ok"; else echo "start failed"; fi
+    ;;
+  stop)
+    if stop_linux_release_set "$root"; then echo "stop ok"; else echo "stop failed"; fi
+    ;;
+  rollback)
+    begin_linux_upgrade "$root" "$arg2" "$arg3"
+    if rollback_linux_upgrade; then echo "rollback ok"; else echo "rollback failed"; fi
+    ;;
+esac
+"#,
+    );
+    let installer = release_script("install-linux.sh");
+    let run = |log: &Path, args: &[&str]| {
+        Command::new(&harness)
+            .arg(&installer)
+            .arg(&root)
+            .arg(log)
+            .args(args)
+            .output()
+            .unwrap()
+    };
+
+    // The first login fails its health gate; the second is still started,
+    // and the set reports failure.
+    fs::write(root.join("fail-health-1000"), b"").unwrap();
+    let log = directory.path().join("start.log");
+    let started = run(&log, &["start"]);
+    assert_eq!(
+        String::from_utf8_lossy(&started.stdout).trim(),
+        "start failed"
+    );
+    let log = fs::read_to_string(&log).unwrap();
+    assert!(
+        log.contains("health 1000") && log.contains("health 2000"),
+        "{log}"
+    );
+    fs::remove_file(root.join("fail-health-1000")).unwrap();
+
+    // With every login healthy, the set starts.
+    let log = directory.path().join("start-ok.log");
+    assert_eq!(
+        String::from_utf8_lossy(&run(&log, &["start"]).stdout).trim(),
+        "start ok"
+    );
+
+    // A failed Broker stop for the first login is reported even though the
+    // last stop succeeds.
+    fs::write(
+        root.join("fail-systemctl-stop-bloom-broker-1000.service"),
+        b"",
+    )
+    .unwrap();
+    let log = directory.path().join("stop.log");
+    assert_eq!(
+        String::from_utf8_lossy(&run(&log, &["stop"]).stdout).trim(),
+        "stop failed"
+    );
+    assert!(
+        fs::read_to_string(&log)
+            .unwrap()
+            .contains("bloom-signer@2000.service")
+    );
+    fs::remove_file(root.join("fail-systemctl-stop-bloom-broker-1000.service")).unwrap();
+
+    // A rollback whose first login stays unhealthy keeps the transaction.
+    let old_digest = hex::encode(Sha256::digest(b"test payload\n"));
+    let new_digest = hex::encode(Sha256::digest(b"upgraded manifest\n"));
+    fs::write(root.join("fail-health-1000"), b"").unwrap();
+    let log = directory.path().join("rollback.log");
+    let rolled_back = run(&log, &["rollback", &old_digest, &new_digest]);
+    assert_eq!(
+        String::from_utf8_lossy(&rolled_back.stdout).trim(),
+        "rollback failed",
+        "{}",
+        String::from_utf8_lossy(&rolled_back.stderr)
+    );
+    assert!(
+        root.join("var/lib/bloom/upgrade-transaction/schema")
+            .is_file(),
+        "a rollback with an unhealthy login must keep its transaction"
+    );
+}
+
+#[test]
+fn linux_installer_requires_ipv6_loopback_on_a_live_host() {
+    let directory = tempfile::tempdir().unwrap();
+    let root = directory.path().join("root");
+    fs::create_dir(&root).unwrap();
+    let harness = write_linux_live_harness(
+        directory.path(),
+        r#"
+if require_linux_ipv6_loopback "$arg1"; then echo "available"; else echo "unavailable $?"; fi
+"#,
+    );
+    let installer = release_script("install-linux.sh");
+    let loopback_v6 = "00000000000000000000000000000001 01 80 10 80       lo\n";
+    let other_v6 = "fe800000000000000000000000000001 02 40 20 80     eth0\n";
+    for (name, disable_ipv6, if_inet6, expected) in [
+        ("enabled", Some("0\n"), Some(loopback_v6), "available"),
+        ("kernel-disabled", None, None, "unavailable 69"),
+        (
+            "sysctl-disabled",
+            Some("1\n"),
+            Some(loopback_v6),
+            "unavailable 69",
+        ),
+        (
+            "no-loopback-address",
+            Some("0\n"),
+            Some(other_v6),
+            "unavailable 69",
+        ),
+        ("no-address-table", Some("0\n"), None, "unavailable 69"),
+    ] {
+        let proc_root = directory.path().join(name);
+        if let Some(value) = disable_ipv6 {
+            let sysctl = proc_root.join("sys/net/ipv6/conf/lo/disable_ipv6");
+            fs::create_dir_all(sysctl.parent().unwrap()).unwrap();
+            fs::write(sysctl, value).unwrap();
+        }
+        if let Some(table) = if_inet6 {
+            fs::create_dir_all(proc_root.join("net")).unwrap();
+            fs::write(proc_root.join("net/if_inet6"), table).unwrap();
+        }
+        let output = Command::new(&harness)
+            .arg(&installer)
+            .arg(&root)
+            .arg(directory.path().join(format!("{name}.log")))
+            .arg(&proc_root)
+            .output()
+            .unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            expected,
+            "{name}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        if expected != "available" {
+            assert!(String::from_utf8_lossy(&output.stderr).contains("requires IPv6 loopback"));
+        }
+    }
 }
 
 #[test]

--- a/crates/bloom-it/tests/triad_release.rs
+++ b/crates/bloom-it/tests/triad_release.rs
@@ -415,11 +415,11 @@ fn build(staging: &Path, output: &Path, key: &Path) -> std::process::Output {
         &compatibility,
         compatibility_source
             .replace(
-                "broker_commit = \"cd1e31e9f33c74355bf3e7fa244af12159716064\"",
+                "broker_commit = \"bd85885bb4fc2c05f20af1f4410683ffbebca6a9\"",
                 &format!("broker_commit = \"{}\"", "22".repeat(20)),
             )
             .replace(
-                "signer_commit = \"9abe7917b8380d8b6d31af0b376a79c26e816764\"",
+                "signer_commit = \"941dd376568b52ccd269ecf495bcff7dcd9af504\"",
                 &format!("signer_commit = \"{}\"", "33".repeat(20)),
             ),
     )

--- a/crates/bloom-it/tests/triad_release.rs
+++ b/crates/bloom-it/tests/triad_release.rs
@@ -3401,6 +3401,7 @@ fn linux_upgrade_recovery_failure_preserves_the_transaction_and_retries() {
     let health_root = tempfile::tempdir().unwrap();
     let (root, layout, old_digest, new_digest, rolled_back) =
         stage_linux_upgrade_root(health_root.path(), &harness, "rollback", "all", |root| {
+            fs::create_dir_all(root.join("var/lib/bloom")).unwrap();
             fs::write(root.join("var/lib/bloom/start-fails"), b"1").unwrap();
         });
     assert!(!rolled_back.status.success());

--- a/crates/bloom-it/tests/triad_release.rs
+++ b/crates/bloom-it/tests/triad_release.rs
@@ -2689,12 +2689,17 @@ fn installer_upgrade_transactions_preserve_recovery_state_atomically() {
                 .unwrap(),
         "rollback must restore the installed unit contract before any restart"
     );
-    // Recovery restores without starting: it must not depend on the previous
-    // release passing its health gate.
+    // Recovery clears the transaction before its restart, so it never depends
+    // on the previous release passing its health gate.
     let recovery = &linux[linux.find("recover_interrupted_linux_upgrade() {").unwrap()
         ..linux.find("allocate_linux_nfs_port() {").unwrap()];
     assert!(recovery.contains("restore_linux_previous_release"));
-    assert!(!recovery.contains("start_linux_release_set"));
+    assert!(
+        recovery.find("finish_linux_upgrade").unwrap()
+            < recovery
+                .find("start_linux_release_set \"$install_root\" ||")
+                .unwrap()
+    );
     assert!(!recovery.contains("rollback_linux_upgrade"));
     assert!(!recovery.contains("upgrade_rollback_required=true"));
     assert!(!linux.contains("completing interrupted"));
@@ -3176,11 +3181,13 @@ fn linux_interrupted_upgrade_recovery_restores_before_any_restart() {
             stop < rewrite,
             "the release set must stop before it is restored at {stage}"
         );
-        // Recovery restores the previous release without starting it; the
-        // retried installation is the first thing to start anything.
+        // Recovery restarts the previous release only after restoring it.
+        let start = log
+            .find(&format!("start current=releases/{old_digest} "))
+            .unwrap_or_else(|| panic!("no restart of the restored release at {stage}: {log}"));
         assert!(
-            !log.contains("start"),
-            "recovery must not start a release at {stage}: {log}"
+            rewrite < start && log.contains("v6=absent"),
+            "recovery must restart only the restored release at {stage}: {log}"
         );
         assert_eq!(
             fs::read_link(root.join("usr/libexec/bloom/current")).unwrap(),
@@ -3396,8 +3403,9 @@ fn linux_upgrade_recovery_failure_preserves_the_transaction_and_retries() {
     // A previous release that cannot pass its health gate — the release a
     // host is upgrading away from — must not strand the host. The in-process
     // rollback restores it coherently, fails its health gate, and keeps the
-    // transaction. Recovery then restores without starting it, and the
-    // retried upgrade to the candidate completes.
+    // transaction. Recovery then restores it, clears the transaction, and
+    // attempts a restart without gating on it, and the retried upgrade to the
+    // candidate completes.
     let health_root = tempfile::tempdir().unwrap();
     let (root, layout, old_digest, new_digest, rolled_back) =
         stage_linux_upgrade_root(health_root.path(), &harness, "rollback", "all", |root| {
@@ -3430,7 +3438,8 @@ fn linux_upgrade_recovery_failure_preserves_the_transaction_and_retries() {
         "recovery must not depend on the previous release's health: {}",
         String::from_utf8_lossy(&recovered.stderr)
     );
-    assert!(!fs::read_to_string(&log).unwrap().contains("start"));
+    assert!(fs::read_to_string(&log).unwrap().contains("start refused"));
+    assert!(String::from_utf8_lossy(&recovered.stderr).contains("did not start cleanly"));
     assert!(!root.join("var/lib/bloom/upgrade-transaction").exists());
     assert_pre_ipv6_linux_contract(&root, &layout);
 
@@ -3562,6 +3571,76 @@ fn linux_upgrade_recovery_restores_the_signer_kms_dropin_and_credential() {
     );
     assert!(!root.join(credential).exists());
     assert!(!root.join(dropin).parent().unwrap().exists());
+}
+
+/// The snapshot covers every enrolled login's Signer drop-in and credential,
+/// and restoration checks it against the enrollments present at that time.
+/// Uninstalling a login in between would leave a transaction no later run can
+/// restore, so uninstall refuses until recovery has run.
+#[test]
+fn linux_uninstall_refuses_while_an_interrupted_upgrade_is_pending() {
+    let directory = tempfile::tempdir().unwrap();
+    let root = directory.path().join("root");
+    fs::create_dir(&root).unwrap();
+    let payload = make_installer_payload(&directory.path().join("release-a"));
+    install_linux_logins(&root, &payload, &[("1000", "alice"), ("2000", "bob")]);
+    let harness = write_linux_upgrade_harness(directory.path());
+    let installer = release_script("install-linux.sh");
+    let old_digest = hex::encode(Sha256::digest(b"test payload\n"));
+    let new_digest = hex::encode(Sha256::digest(b"upgraded manifest\n"));
+    let interrupted = run_linux_upgrade_harness(
+        &harness,
+        &installer,
+        &root,
+        "interrupt",
+        &directory.path().join("interrupt.log"),
+        &["all", &old_digest, &new_digest],
+    );
+    assert!(
+        interrupted.status.success(),
+        "{}",
+        String::from_utf8_lossy(&interrupted.stderr)
+    );
+    let transaction = root.join("var/lib/bloom/upgrade-transaction");
+    let uninstall = || {
+        Command::new(&installer)
+            .args(["uninstall", "--retain-custody"])
+            .arg(&root)
+            .arg("2000")
+            .output()
+            .unwrap()
+    };
+
+    let refused = uninstall();
+    assert_eq!(refused.status.code(), Some(65));
+    assert!(
+        String::from_utf8_lossy(&refused.stderr)
+            .contains("an interrupted Linux upgrade must be recovered first")
+    );
+    assert!(root.join("etc/bloom/enrollments/2000.json").is_file());
+    assert!(transaction.join("schema").is_file());
+
+    let recovered = run_linux_upgrade_harness(
+        &harness,
+        &installer,
+        &root,
+        "recover",
+        &directory.path().join("recover.log"),
+        &[&old_digest, &new_digest],
+    );
+    assert!(
+        recovered.status.success(),
+        "{}",
+        String::from_utf8_lossy(&recovered.stderr)
+    );
+    assert!(!transaction.exists());
+    let uninstalled = uninstall();
+    assert!(
+        uninstalled.status.success(),
+        "{}",
+        String::from_utf8_lossy(&uninstalled.stderr)
+    );
+    assert!(root.join("etc/bloom/retained/2000.json").is_file());
 }
 
 /// Writes a harness that evaluates the real installer functions and treats

--- a/crates/bloom-machine-client/src/lib.rs
+++ b/crates/bloom-machine-client/src/lib.rs
@@ -4128,7 +4128,7 @@ mod tests {
             petal_key_scope: None,
             legacy_passkey_migration: None,
             wallet_seed_profile: None,
-            derivation_request: None,
+            derivation_requests: Vec::new(),
             account_terms: None,
         };
         assert_eq!(
@@ -4901,7 +4901,7 @@ mod tests {
             petal_key_scope: None,
             legacy_passkey_migration: None,
             wallet_seed_profile: None,
-            derivation_request: None,
+            derivation_requests: Vec::new(),
             account_terms: None,
         };
         let error = client

--- a/crates/bloom-vfs/src/handlers/wallets.rs
+++ b/crates/bloom-vfs/src/handlers/wallets.rs
@@ -701,7 +701,7 @@ impl WalletsHandler {
                     petal_key_scope: None,
                     legacy_passkey_migration: None,
                     wallet_seed_profile: None,
-                    derivation_request: None,
+                    derivation_requests: Vec::new(),
                     account_terms: None,
                 },
             )

--- a/crates/bloom/src/main.rs
+++ b/crates/bloom/src/main.rs
@@ -708,7 +708,7 @@ async fn launch_custody_ceremony(
                 petal_key_scope: None,
                 legacy_passkey_migration,
                 wallet_seed_profile: input.wallet_seed_profile(),
-                derivation_request: None,
+                derivation_requests: Vec::new(),
                 account_terms: None,
             },
         )
@@ -809,7 +809,7 @@ async fn launch_account_allocation(
             .map_err(|error| machine_error(MachineErrorKind::InvalidParams, error.to_string()))?,
         wallet_id: wallet_id.clone(),
         seed_profile: bloom_broker_api::WalletSeedProfile::Bip39MulticurveV1,
-        derivation: Some(derivation.clone()),
+        derivations: vec![derivation.clone()],
         retire_key_fingerprint: None,
         path_template: derivation_profile.path_template().to_owned(),
         key_spec: derivation_profile.key_spec(),
@@ -835,7 +835,7 @@ async fn launch_account_allocation(
             petal_key_scope: None,
             legacy_passkey_migration: None,
             wallet_seed_profile: None,
-            derivation_request: Some(derivation),
+            derivation_requests: vec![derivation],
             account_terms: Some(terms),
         })
         .await
@@ -907,7 +907,7 @@ async fn launch_account_retirement(
             .map_err(|error| machine_error(MachineErrorKind::InvalidParams, error.to_string()))?,
         wallet_id: wallet_id.clone(),
         seed_profile: accounts.seed_profile,
-        derivation: None,
+        derivations: Vec::new(),
         retire_key_fingerprint: Some(account.public_key_fingerprint.clone()),
         path_template: account.derivation_profile.path_template().to_owned(),
         key_spec: account.derivation_profile.key_spec(),
@@ -933,7 +933,7 @@ async fn launch_account_retirement(
             petal_key_scope: None,
             legacy_passkey_migration: None,
             wallet_seed_profile: None,
-            derivation_request: None,
+            derivation_requests: Vec::new(),
             account_terms: Some(terms),
         })
         .await

--- a/packaging/triad/linux/README.md
+++ b/packaging/triad/linux/README.md
@@ -26,7 +26,9 @@ on port 18734 — `127.0.0.1` as `broker-ceremony-ipv4` and `[::1]` as
 about half the time. Broker takes each by name and never binds one itself; each family is
 published by its own socket unit, and the host must have IPv6 loopback
 enabled (`::1` bindable) because the Broker exits when either listener is
-missing — `net.ipv6.conf.lo.disable_ipv6=1` is unsupported. The
+missing — `net.ipv6.conf.lo.disable_ipv6=1` is unsupported. The installer
+checks this before installing anything: it requires `disable_ipv6=0` for `lo`
+and `::1` assigned to `lo`, and otherwise exits with status 69. The
 authenticated login-session sentinel owns its Unix socket while the user's
 systemd session is active. A path unit starts Broker and Signer only after that
 session socket exists. A canonical-listener conflict therefore fails that family's socket unit

--- a/packaging/triad/release/README.md
+++ b/packaging/triad/release/README.md
@@ -157,13 +157,22 @@ Before any unit is mutated, the transaction (`schema
 bloom.linux-upgrade-transaction.2`) snapshots the installed Bloom-owned unit
 templates — both ceremony sockets, the Broker and Signer service templates, the
 session path, the two user service units, and the retired RPC/control socket
-templates — recording explicit absence alongside bytes and modes. A rollback
-stops the release set, restores that unit contract, reselects the previous
-release, and rewrites release metadata before any restart; a failure at any of
-those steps preserves the transaction instead of starting a Broker over
-mismatched units. Recovery after an interruption always restores the coherent
-previous installation first and then lets the verified installer retry the
-requested release; it never completes the interrupted candidate in place. A
+templates — and, for each enrolled login, the AWS KMS Signer drop-in and the
+credential it loads. It records explicit absence alongside bytes, modes, and
+owners. A rollback stops the release set, restores that contract, reselects the
+previous release, and rewrites release metadata before any restart; a failure
+at any of those steps preserves the transaction instead of starting a Broker
+over mismatched units. The rollback clears the transaction only when every
+enrolled login passes the authenticated health gate.
+
+Recovery after an interruption restores the coherent previous installation and
+then lets the verified installer retry the requested release; it never
+completes the interrupted candidate in place. Recovery does not start the
+previous release or require it to pass the health gate: the retry stops it
+again immediately, and a host whose previous release cannot start must still be
+able to install the release that fixes it. If the installer exits after
+recovery but before its retry starts anything, the restored release is left
+stopped, as the interruption left it, until the next installer run or reboot. A
 transaction recorded by an earlier installer (`schema
 bloom.linux-upgrade-transaction.1`) carries no unit snapshot; it is recovered
 by rolling the binary selection and release metadata back on their own, as the

--- a/packaging/triad/release/README.md
+++ b/packaging/triad/release/README.md
@@ -157,13 +157,16 @@ Before any unit is mutated, the transaction (`schema
 bloom.linux-upgrade-transaction.2`) snapshots the installed Bloom-owned unit
 templates — both ceremony sockets, the Broker and Signer service templates, the
 session path, the two user service units, and the retired RPC/control socket
-templates — and, for each enrolled login, the AWS KMS Signer drop-in and the
-credential it loads. It records explicit absence alongside bytes, modes, and
-owners. A rollback stops the release set, restores that contract, reselects the
-previous release, and rewrites release metadata before any restart; a failure
-at any of those steps preserves the transaction instead of starting a Broker
-over mismatched units. The rollback clears the transaction only when every
-enrolled login passes the authenticated health gate.
+templates — recording explicit absence alongside bytes and modes. A rollback
+stops the release set, restores that unit contract, reselects the previous
+release, and rewrites release metadata before any restart; a failure at any of
+those steps preserves the transaction instead of starting a Broker over
+mismatched units. The rollback clears the transaction only when every enrolled
+login passes the authenticated health gate. The per-login AWS KMS Signer
+drop-in and its credential are not part of the snapshot: they follow the
+payload of the last installation, so a KMS host that rolls back after an
+upgrade with a payload lacking the KMS overlay is repaired by rerunning the
+installer with that overlay.
 
 Recovery after an interruption restores the coherent previous installation and
 then lets the verified installer retry the requested release; it never

--- a/packaging/triad/release/README.md
+++ b/packaging/triad/release/README.md
@@ -167,12 +167,13 @@ enrolled login passes the authenticated health gate.
 
 Recovery after an interruption restores the coherent previous installation and
 then lets the verified installer retry the requested release; it never
-completes the interrupted candidate in place. Recovery does not start the
-previous release or require it to pass the health gate: the retry stops it
-again immediately, and a host whose previous release cannot start must still be
-able to install the release that fixes it. If the installer exits after
-recovery but before its retry starts anything, the restored release is left
-stopped, as the interruption left it, until the next installer run or reboot. A
+completes the interrupted candidate in place. Recovery clears the transaction
+as soon as the previous installation is restored and only then restarts it,
+without gating on the health check: a host whose previous release cannot start
+must still be able to install the release that fixes it, and a run that stops
+after recovery, or reinstalls the previous release, must not leave the other
+enrolled logins stopped until a reboot. Uninstalling a login is refused while
+an interrupted upgrade is pending. A
 transaction recorded by an earlier installer (`schema
 bloom.linux-upgrade-transaction.1`) carries no unit snapshot; it is recovered
 by rolling the binary selection and release metadata back on their own, as the

--- a/packaging/triad/release/compatibility-v1.toml
+++ b/packaging/triad/release/compatibility-v1.toml
@@ -1,8 +1,8 @@
 schema = "bloom.triad-compatibility/1"
 
 [revisions]
-broker_commit = "cd1e31e9f33c74355bf3e7fa244af12159716064"
-signer_commit = "9abe7917b8380d8b6d31af0b376a79c26e816764"
+broker_commit = "bd85885bb4fc2c05f20af1f4410683ffbebca6a9"
+signer_commit = "941dd376568b52ccd269ecf495bcff7dcd9af504"
 service_runtime_commit = "bc88cc6760b00bbff0c6a6e5f56d42bb03004436"
 petal_contract_commit = "9ad7a5c635f092bbcdf8f00a06b23676806ff70c"
 

--- a/packaging/triad/release/install-linux.sh
+++ b/packaging/triad/release/install-linux.sh
@@ -188,14 +188,6 @@ numeric_file_mode() {
   fi
 }
 
-numeric_file_owner() {
-  if [[ "$(uname -s)" == Darwin ]]; then
-    stat -f '%u:%g' "$1"
-  else
-    stat -c '%u:%g' "$1"
-  fi
-}
-
 # The Broker requires both loopback ceremony listeners, so a host whose
 # kernel cannot bind [::1] cannot run this release. Check before anything is
 # mutated rather than let the health gate discover it after the unit writes.
@@ -638,17 +630,12 @@ switch_linux_release() {
   mv -fT "$replacement" "$release_base/current"
 }
 
-# Every Bloom-owned file the installer overwrites or removes while installing
-# a release. An upgrade transaction snapshots exactly these paths so a
-# rollback restores the previous binary selection together with the unit
-# contract and Signer instance configuration it ran with. The unit templates
-# are shared by every login. Each enrolled login also has an AWS KMS Signer
-# drop-in and the credential it loads: installing a payload without the KMS
-# overlay deletes both, and restoring one without the other would leave the
-# previous Signer loading a missing credential. Administrator units and
-# drop-ins outside this list are never touched by restoration.
+# Every Bloom-owned unit template the installer overwrites or removes while
+# installing a release. An upgrade transaction snapshots exactly these paths
+# so a rollback restores the previous binary selection together with the unit
+# contract it ran with. Administrator units and drop-ins outside this list are
+# never touched by restoration.
 linux_upgrade_unit_paths() {
-  local install_root="$1" record uid
   printf '%s\n' \
     usr/lib/systemd/system/bloom-broker-ceremony@.socket \
     usr/lib/systemd/system/bloom-broker-ceremony-ipv6@.socket \
@@ -661,41 +648,32 @@ linux_upgrade_unit_paths() {
     usr/lib/systemd/system/bloom-broker-control@.socket \
     usr/lib/systemd/user/bloom-session.service \
     usr/lib/systemd/user/bloom-machine.service
-  for record in "$install_root/etc/bloom/enrollments"/*.json; do
-    [[ -f "$record" && ! -L "$record" ]] || continue
-    uid="$(linux_record_number "$record" login_uid)"
-    [[ "$uid" =~ ^[1-9][0-9]*$ ]] || continue
-    printf '%s\n' \
-      "usr/lib/systemd/system/bloom-signer@$uid.service.d/50-aws-kms.conf" \
-      "etc/bloom/$uid/signer/aws-credentials"
-  done
 }
 
 linux_upgrade_unit_is_tracked() {
-  local install_root="$1" candidate="$2" tracked
+  local candidate="$1" tracked
   while IFS= read -r tracked; do
     [[ "$tracked" == "$candidate" ]] && return 0
-  done < <(linux_upgrade_unit_paths "$install_root")
+  done < <(linux_upgrade_unit_paths)
   return 1
 }
 
-# Records the actually installed contract — explicit absence included — into
-# the upgrade transaction scratch directory, one manifest line per tracked
-# path: "present MODE UID:GID PATH" or "absent - - PATH". Fails without
-# mutating the installation when a tracked file is substituted or unreadable.
+# Records the actually installed unit contract — explicit absence included —
+# into the upgrade transaction scratch directory. Fails without mutating the
+# installation when a tracked unit is missing, substituted, or unreadable.
 # Every write is checked explicitly: when this function runs inside a
 # rollback step, errexit is suspended for the whole call tree, so a skipped
 # operation would otherwise be reported as a successful snapshot.
 snapshot_linux_upgrade_units() {
   local install_root="$1" scratch="$2"
-  local relative path mode owner
+  local relative path mode
 
   mkdir -m 0700 "$scratch/units" "$scratch/units/files" || return 65
   : > "$scratch/units/manifest" || return 65
   while IFS= read -r relative; do
     path="$install_root/$relative"
     if [[ ! -e "$path" && ! -L "$path" ]]; then
-      printf 'absent - - %s\n' "$relative" >> "$scratch/units/manifest" || return 65
+      printf 'absent - %s\n' "$relative" >> "$scratch/units/manifest" || return 65
       continue
     fi
     [[ -f "$path" && ! -L "$path" ]] || {
@@ -707,37 +685,16 @@ snapshot_linux_upgrade_units() {
       echo "installed Linux unit has an unusable mode: /$relative" >&2
       return 65
     }
-    owner="$(numeric_file_owner "$path")"
-    [[ "$owner" =~ ^[0-9]+:[0-9]+$ ]] || {
-      echo "installed Linux unit has an unusable owner: /$relative" >&2
-      return 65
-    }
     mkdir -p "$scratch/units/files/$(dirname "$relative")" || return 65
     cp -- "$path" "$scratch/units/files/$relative" || return 65
-    printf 'present %s %s %s\n' "$mode" "$owner" "$relative" \
-      >> "$scratch/units/manifest" || return 65
-  done < <(linux_upgrade_unit_paths "$install_root")
+    printf 'present %s %s\n' "$mode" "$relative" >> "$scratch/units/manifest" || return 65
+  done < <(linux_upgrade_unit_paths)
 }
 
-# Installs one snapshotted file with its recorded mode and owner. Ownership is
-# applied before the rename so a restored credential is never visible under
-# the wrong owner.
-restore_linux_upgrade_file() {
-  local source="$1" destination="$2" mode="$3" owner="$4" temporary
-  temporary="${destination}.restore.$$"
-  mkdir -p "$(dirname "$destination")" || return
-  install -m "$mode" "$source" "$temporary" || return
-  chown "$owner" "$temporary" || {
-    rm -f -- "$temporary"
-    return 1
-  }
-  mv -f "$temporary" "$destination"
-}
-
-# Restores the snapshotted contract: previously present files return with
-# their recorded bytes, modes, and owners, and files that did not exist
-# before the upgrade — such as a newly introduced ceremony socket template —
-# are removed. Every manifest entry is validated against the tracked set
+# Restores the snapshotted unit contract: previously present files return
+# with their recorded bytes and modes, and files that did not exist before
+# the upgrade — such as a newly introduced ceremony socket template — are
+# removed. Every manifest entry is validated against the fixed tracked set
 # before any file is touched, and restoration never interprets a stored path
 # outside that set. The operation is idempotent, so an interrupted recovery
 # can simply run it again.
@@ -745,8 +702,8 @@ restore_linux_upgrade_units() {
   local install_root="$1" transaction="$2"
   local manifest="$transaction/units/manifest"
   local files_root="$transaction/units/files"
-  local state mode owner relative covered="" tracked index
-  local -a states=() modes=() owners=() relatives=()
+  local state mode relative covered="" tracked index
+  local -a states=() modes=() relatives=()
 
   # A schema-1 transaction was recorded before this installer snapshotted
   # units, so there is no unit contract to restore and the binary selection
@@ -766,12 +723,12 @@ restore_linux_upgrade_units() {
     echo "Linux upgrade unit snapshot is missing or unsafe" >&2
     return 65
   }
-  while read -r state mode owner relative; do
+  while read -r state mode relative; do
     [[ "$state" == present || "$state" == absent ]] || {
       echo "Linux upgrade unit snapshot entry is malformed" >&2
       return 65
     }
-    linux_upgrade_unit_is_tracked "$install_root" "$relative" || {
+    linux_upgrade_unit_is_tracked "$relative" || {
       echo "Linux upgrade unit snapshot names an untracked path" >&2
       return 65
     }
@@ -780,21 +737,15 @@ restore_linux_upgrade_units() {
       return 65
     }
     if [[ "$state" == present ]]; then
-      [[ "$mode" =~ ^[0-7]{3,4}$ && "$owner" =~ ^[0-9]+:[0-9]+$ && \
+      [[ "$mode" =~ ^[0-7]{3,4}$ && \
         -f "$files_root/$relative" && ! -L "$files_root/$relative" ]] || {
         echo "Linux upgrade unit snapshot content is missing or unsafe" >&2
-        return 65
-      }
-    else
-      [[ "$mode" == - && "$owner" == - ]] || {
-        echo "Linux upgrade unit snapshot entry is malformed" >&2
         return 65
       }
     fi
     covered="$covered $relative"
     states+=("$state")
     modes+=("$mode")
-    owners+=("$owner")
     relatives+=("$relative")
   done < "$manifest"
   while IFS= read -r tracked; do
@@ -802,7 +753,7 @@ restore_linux_upgrade_units() {
       echo "Linux upgrade unit snapshot does not cover the tracked unit set" >&2
       return 65
     }
-  done < <(linux_upgrade_unit_paths "$install_root")
+  done < <(linux_upgrade_unit_paths)
 
   # Activation audit: the only persisted enablement this design creates is
   # bloom-session@<uid>.path, which start_linux_release_set re-enables. The
@@ -815,11 +766,14 @@ restore_linux_upgrade_units() {
   for index in "${!relatives[@]}"; do
     relative="${relatives[$index]}"
     if [[ "${states[$index]}" == present ]]; then
-      restore_linux_upgrade_file \
+      mkdir -p "$install_root/$(dirname "$relative")" || {
+        echo "Linux upgrade unit restoration failed: /$relative" >&2
+        return 65
+      }
+      atomic_install \
         "$files_root/$relative" \
         "$install_root/$relative" \
-        "${modes[$index]}" \
-        "${owners[$index]}" || {
+        "${modes[$index]}" || {
         echo "Linux upgrade unit restoration failed: /$relative" >&2
         return 65
       }
@@ -828,11 +782,6 @@ restore_linux_upgrade_units() {
         echo "Linux upgrade unit restoration failed: /$relative" >&2
         return 65
       }
-      # The installer removes an emptied drop-in directory; so does the
-      # restoration of a drop-in that did not exist before the upgrade.
-      if [[ "$relative" == */*.service.d/* ]]; then
-        rmdir -- "$install_root/$(dirname "$relative")" 2>/dev/null || true
-      fi
     fi
   done
 }
@@ -1807,9 +1756,9 @@ case "$action" in
         exit 64
       }
     fi
-    # An upgrade snapshot covers every enrolled login's Signer drop-in and
-    # credential, and restoration checks it against the enrollments present
-    # then. Removing an enrollment first leaves a transaction no run restores.
+    # A pending upgrade transaction means the installed units, binaries, and
+    # release metadata may be mixed. Recover the previous installation before
+    # changing which logins are enrolled.
     [[ ! -e "$root/var/lib/bloom/upgrade-transaction" && \
       ! -L "$root/var/lib/bloom/upgrade-transaction" ]] || {
       echo "an interrupted Linux upgrade must be recovered first; rerun the Bloom installer" >&2

--- a/packaging/triad/release/install-linux.sh
+++ b/packaging/triad/release/install-linux.sh
@@ -53,9 +53,11 @@ atomic_install() {
   source_file="$1"
   destination="$2"
   mode="$3"
-  mkdir -p "$(dirname "$destination")"
+  # Checked explicitly: rollback runs with errexit suspended, and an ignored
+  # failed copy must not be reported as an installed file.
+  mkdir -p "$(dirname "$destination")" || return
   temporary="${destination}.new.$$"
-  install -m "$mode" "$source_file" "$temporary"
+  install -m "$mode" "$source_file" "$temporary" || return
   mv -f "$temporary" "$destination"
 }
 
@@ -186,6 +188,39 @@ numeric_file_mode() {
   fi
 }
 
+numeric_file_owner() {
+  if [[ "$(uname -s)" == Darwin ]]; then
+    stat -f '%u:%g' "$1"
+  else
+    stat -c '%u:%g' "$1"
+  fi
+}
+
+# The Broker requires both loopback ceremony listeners, so a host whose
+# kernel cannot bind [::1] cannot run this release. Check before anything is
+# mutated rather than let the health gate discover it after the unit writes.
+linux_ipv6_loopback_available() {
+  local proc_root="$1"
+  local disable="$proc_root/sys/net/ipv6/conf/lo/disable_ipv6"
+  [[ -r "$disable" && "$(<"$disable")" == 0 ]] || return 1
+  # /proc/net/if_inet6 lists "address ifindex prefix scope flags name";
+  # ::1 must be assigned to the loopback interface.
+  awk '$1 == "00000000000000000000000000000001" && $6 == "lo" { found = 1 }
+    END { exit found ? 0 : 1 }' "$proc_root/net/if_inet6" 2>/dev/null
+}
+
+require_linux_ipv6_loopback() {
+  linux_ipv6_loopback_available "$1" || {
+    echo "Bloom requires IPv6 loopback: the Broker listens on both 127.0.0.1:18734 and [::1]:18734." >&2
+    echo "Enable it (net.ipv6.conf.lo.disable_ipv6=0, and no ipv6.disable=1 kernel parameter) and retry." >&2
+    return 69
+  }
+}
+
+linux_root_is_live() {
+  [[ "$1" == "/" ]]
+}
+
 install_linux_mount_authorization() {
   local install_root="$1"
   local mount_uid="$2"
@@ -280,8 +315,8 @@ write_linux_record() {
   local replacement="${record}.new.$$"
 
   printf '{"schema":"bloom.linux-enrollment.1","state":"%s","login_uid":%s,"login_user":"%s","release_digest":"%s","nfs_port":%s}\n' \
-    "$state" "$uid" "$user" "$digest" "$port" > "$replacement"
-  chmod 0644 "$replacement"
+    "$state" "$uid" "$user" "$digest" "$port" > "$replacement" || return
+  chmod 0644 "$replacement" || return
   mv -f "$replacement" "$record"
 }
 
@@ -482,11 +517,17 @@ replace_linux_json_digest() {
     echo "installed Linux service build digest cannot be updated" >&2
     return 65
   }
-  preserve_file_mode "$config" "$replacement"
+  preserve_file_mode "$config" "$replacement" || {
+    rm -f -- "$replacement"
+    return 65
+  }
   chown --reference="$config" "$replacement" 2>/dev/null || true
   mv -f "$replacement" "$config"
 }
 
+# Every step is checked explicitly: recovery runs this with errexit
+# suspended and then clears the transaction, so an ignored failure would
+# leave release metadata that disagrees with the selected binaries.
 rewrite_linux_release_set() {
   local install_root="$1" digest="$2" active_state="$3"
   local directory record uid state user port principal machine_environment
@@ -501,22 +542,22 @@ rewrite_linux_release_set() {
       for principal in broker signer; do
         replace_linux_json_digest \
           "$install_root/etc/bloom/$uid/$principal/config.json" \
-          "$digest"
+          "$digest" || return 65
       done
       machine_environment="$install_root/etc/bloom/$uid/.machine-env.source.$$"
       printf 'BLOOM_NFS_LISTEN=127.0.0.1:%s\nBLOOM_RELEASE_DIGEST=%s\n' \
-        "$port" "$digest" > "$machine_environment"
+        "$port" "$digest" > "$machine_environment" || return 65
       atomic_install \
         "$machine_environment" \
         "$install_root/etc/bloom/$uid/machine.env" \
-        0644
+        0644 || return 65
       rm -f -- "$machine_environment"
       if [[ "$directory" == enrollments ]]; then
         state="$active_state"
       else
         state=retained
       fi
-      write_linux_record "$record" "$state" "$uid" "$user" "$digest" "$port"
+      write_linux_record "$record" "$state" "$uid" "$user" "$digest" "$port" || return 65
     done
   done
 }
@@ -597,12 +638,17 @@ switch_linux_release() {
   mv -fT "$replacement" "$release_base/current"
 }
 
-# Every Bloom-owned unit template the installer overwrites or removes while
-# installing a release. An upgrade transaction snapshots exactly these paths
-# so a rollback restores the previous binary selection together with the unit
-# contract it ran with. Administrator units and drop-ins outside this list are
-# never touched by restoration.
+# Every Bloom-owned file the installer overwrites or removes while installing
+# a release. An upgrade transaction snapshots exactly these paths so a
+# rollback restores the previous binary selection together with the unit
+# contract and Signer instance configuration it ran with. The unit templates
+# are shared by every login. Each enrolled login also has an AWS KMS Signer
+# drop-in and the credential it loads: installing a payload without the KMS
+# overlay deletes both, and restoring one without the other would leave the
+# previous Signer loading a missing credential. Administrator units and
+# drop-ins outside this list are never touched by restoration.
 linux_upgrade_unit_paths() {
+  local install_root="$1" record uid
   printf '%s\n' \
     usr/lib/systemd/system/bloom-broker-ceremony@.socket \
     usr/lib/systemd/system/bloom-broker-ceremony-ipv6@.socket \
@@ -615,32 +661,41 @@ linux_upgrade_unit_paths() {
     usr/lib/systemd/system/bloom-broker-control@.socket \
     usr/lib/systemd/user/bloom-session.service \
     usr/lib/systemd/user/bloom-machine.service
+  for record in "$install_root/etc/bloom/enrollments"/*.json; do
+    [[ -f "$record" && ! -L "$record" ]] || continue
+    uid="$(linux_record_number "$record" login_uid)"
+    [[ "$uid" =~ ^[1-9][0-9]*$ ]] || continue
+    printf '%s\n' \
+      "usr/lib/systemd/system/bloom-signer@$uid.service.d/50-aws-kms.conf" \
+      "etc/bloom/$uid/signer/aws-credentials"
+  done
 }
 
 linux_upgrade_unit_is_tracked() {
-  local candidate="$1" tracked
+  local install_root="$1" candidate="$2" tracked
   while IFS= read -r tracked; do
     [[ "$tracked" == "$candidate" ]] && return 0
-  done < <(linux_upgrade_unit_paths)
+  done < <(linux_upgrade_unit_paths "$install_root")
   return 1
 }
 
-# Records the actually installed unit contract — explicit absence included —
-# into the upgrade transaction scratch directory. Fails without mutating the
-# installation when a tracked unit is missing, substituted, or unreadable.
+# Records the actually installed contract — explicit absence included — into
+# the upgrade transaction scratch directory, one manifest line per tracked
+# path: "present MODE UID:GID PATH" or "absent - - PATH". Fails without
+# mutating the installation when a tracked file is substituted or unreadable.
 # Every write is checked explicitly: when this function runs inside a
 # rollback step, errexit is suspended for the whole call tree, so a skipped
 # operation would otherwise be reported as a successful snapshot.
 snapshot_linux_upgrade_units() {
   local install_root="$1" scratch="$2"
-  local relative path mode
+  local relative path mode owner
 
   mkdir -m 0700 "$scratch/units" "$scratch/units/files" || return 65
   : > "$scratch/units/manifest" || return 65
   while IFS= read -r relative; do
     path="$install_root/$relative"
     if [[ ! -e "$path" && ! -L "$path" ]]; then
-      printf 'absent - %s\n' "$relative" >> "$scratch/units/manifest" || return 65
+      printf 'absent - - %s\n' "$relative" >> "$scratch/units/manifest" || return 65
       continue
     fi
     [[ -f "$path" && ! -L "$path" ]] || {
@@ -652,16 +707,37 @@ snapshot_linux_upgrade_units() {
       echo "installed Linux unit has an unusable mode: /$relative" >&2
       return 65
     }
+    owner="$(numeric_file_owner "$path")"
+    [[ "$owner" =~ ^[0-9]+:[0-9]+$ ]] || {
+      echo "installed Linux unit has an unusable owner: /$relative" >&2
+      return 65
+    }
     mkdir -p "$scratch/units/files/$(dirname "$relative")" || return 65
     cp -- "$path" "$scratch/units/files/$relative" || return 65
-    printf 'present %s %s\n' "$mode" "$relative" >> "$scratch/units/manifest" || return 65
-  done < <(linux_upgrade_unit_paths)
+    printf 'present %s %s %s\n' "$mode" "$owner" "$relative" \
+      >> "$scratch/units/manifest" || return 65
+  done < <(linux_upgrade_unit_paths "$install_root")
 }
 
-# Restores the snapshotted unit contract: previously present files return
-# with their recorded bytes and modes, and files that did not exist before
-# the upgrade — such as a newly introduced ceremony socket template — are
-# removed. Every manifest entry is validated against the fixed tracked set
+# Installs one snapshotted file with its recorded mode and owner. Ownership is
+# applied before the rename so a restored credential is never visible under
+# the wrong owner.
+restore_linux_upgrade_file() {
+  local source="$1" destination="$2" mode="$3" owner="$4" temporary
+  temporary="${destination}.restore.$$"
+  mkdir -p "$(dirname "$destination")" || return
+  install -m "$mode" "$source" "$temporary" || return
+  chown "$owner" "$temporary" || {
+    rm -f -- "$temporary"
+    return 1
+  }
+  mv -f "$temporary" "$destination"
+}
+
+# Restores the snapshotted contract: previously present files return with
+# their recorded bytes, modes, and owners, and files that did not exist
+# before the upgrade — such as a newly introduced ceremony socket template —
+# are removed. Every manifest entry is validated against the tracked set
 # before any file is touched, and restoration never interprets a stored path
 # outside that set. The operation is idempotent, so an interrupted recovery
 # can simply run it again.
@@ -669,8 +745,8 @@ restore_linux_upgrade_units() {
   local install_root="$1" transaction="$2"
   local manifest="$transaction/units/manifest"
   local files_root="$transaction/units/files"
-  local state mode relative covered="" tracked index
-  local -a states=() modes=() relatives=()
+  local state mode owner relative covered="" tracked index
+  local -a states=() modes=() owners=() relatives=()
 
   # A schema-1 transaction was recorded before this installer snapshotted
   # units, so there is no unit contract to restore and the binary selection
@@ -690,12 +766,12 @@ restore_linux_upgrade_units() {
     echo "Linux upgrade unit snapshot is missing or unsafe" >&2
     return 65
   }
-  while read -r state mode relative; do
+  while read -r state mode owner relative; do
     [[ "$state" == present || "$state" == absent ]] || {
       echo "Linux upgrade unit snapshot entry is malformed" >&2
       return 65
     }
-    linux_upgrade_unit_is_tracked "$relative" || {
+    linux_upgrade_unit_is_tracked "$install_root" "$relative" || {
       echo "Linux upgrade unit snapshot names an untracked path" >&2
       return 65
     }
@@ -704,15 +780,21 @@ restore_linux_upgrade_units() {
       return 65
     }
     if [[ "$state" == present ]]; then
-      [[ "$mode" =~ ^[0-7]{3,4}$ && \
+      [[ "$mode" =~ ^[0-7]{3,4}$ && "$owner" =~ ^[0-9]+:[0-9]+$ && \
         -f "$files_root/$relative" && ! -L "$files_root/$relative" ]] || {
         echo "Linux upgrade unit snapshot content is missing or unsafe" >&2
+        return 65
+      }
+    else
+      [[ "$mode" == - && "$owner" == - ]] || {
+        echo "Linux upgrade unit snapshot entry is malformed" >&2
         return 65
       }
     fi
     covered="$covered $relative"
     states+=("$state")
     modes+=("$mode")
+    owners+=("$owner")
     relatives+=("$relative")
   done < "$manifest"
   while IFS= read -r tracked; do
@@ -720,7 +802,7 @@ restore_linux_upgrade_units() {
       echo "Linux upgrade unit snapshot does not cover the tracked unit set" >&2
       return 65
     }
-  done < <(linux_upgrade_unit_paths)
+  done < <(linux_upgrade_unit_paths "$install_root")
 
   # Activation audit: the only persisted enablement this design creates is
   # bloom-session@<uid>.path, which start_linux_release_set re-enables. The
@@ -733,14 +815,11 @@ restore_linux_upgrade_units() {
   for index in "${!relatives[@]}"; do
     relative="${relatives[$index]}"
     if [[ "${states[$index]}" == present ]]; then
-      mkdir -p "$install_root/$(dirname "$relative")" || {
-        echo "Linux upgrade unit restoration failed: /$relative" >&2
-        return 65
-      }
-      atomic_install \
+      restore_linux_upgrade_file \
         "$files_root/$relative" \
         "$install_root/$relative" \
-        "${modes[$index]}" || {
+        "${modes[$index]}" \
+        "${owners[$index]}" || {
         echo "Linux upgrade unit restoration failed: /$relative" >&2
         return 65
       }
@@ -749,12 +828,21 @@ restore_linux_upgrade_units() {
         echo "Linux upgrade unit restoration failed: /$relative" >&2
         return 65
       }
+      # The installer removes an emptied drop-in directory; so does the
+      # restoration of a drop-in that did not exist before the upgrade.
+      if [[ "$relative" == */*.service.d/* ]]; then
+        rmdir -- "$install_root/$(dirname "$relative")" 2>/dev/null || true
+      fi
     fi
   done
 }
+
+# Checked explicitly and aggregated across logins: rollback runs with
+# errexit suspended, where only the last command's status would otherwise
+# be reported, and restoring units under a still-running service is unsafe.
 stop_linux_release_set() {
-  local install_root="$1" record uid user user_runtime
-  [[ "$install_root" == "/" ]] || return 0
+  local install_root="$1" record uid user user_runtime stop_status=0
+  linux_root_is_live "$install_root" || return 0
 
   for record in "$install_root/etc/bloom/enrollments"/*.json; do
     [[ -f "$record" && ! -L "$record" ]] || continue
@@ -771,14 +859,15 @@ stop_linux_release_set() {
     systemctl stop "bloom-session@$uid.path" 2>/dev/null || true
     systemctl stop "bloom-broker-ceremony@$uid.socket" 2>/dev/null || true
     systemctl stop "bloom-broker-ceremony-ipv6@$uid.socket" 2>/dev/null || true
-    systemctl stop "bloom-broker@$uid.service"
-    systemctl stop "bloom-signer@$uid.service"
+    systemctl stop "bloom-broker@$uid.service" || stop_status=1
+    systemctl stop "bloom-signer@$uid.service" || stop_status=1
   done
+  return "$stop_status"
 }
 
 preflight_linux_release_set() {
   local install_root="$1" record uid user_runtime
-  [[ "$install_root" == "/" ]] || return 0
+  linux_root_is_live "$install_root" || return 0
 
   for record in "$install_root/etc/bloom/enrollments"/*.json; do
     [[ -f "$record" && ! -L "$record" ]] || continue
@@ -845,30 +934,45 @@ require_linux_triad_health() {
       serve triad-health-check "$digest"
 }
 
+# Starts every enrolled login and fails if any of them does not pass the
+# authenticated health gate. Rollback runs this with errexit suspended, where
+# only the last login's status would otherwise be reported, so every step is
+# checked explicitly. Later logins are still started after one fails, but the
+# set is never reported healthy while any enrolled login is down.
 start_linux_release_set() {
-  local install_root="$1" record uid user digest user_runtime
-  [[ "$install_root" == "/" ]] || return 0
+  local install_root="$1" record uid user digest user_runtime start_status=0
+  linux_root_is_live "$install_root" || return 0
 
-  systemctl daemon-reload
+  systemctl daemon-reload || return 1
   for record in "$install_root/etc/bloom/enrollments"/*.json; do
     [[ -f "$record" && ! -L "$record" ]] || continue
     uid="$(linux_record_number "$record" login_uid)"
     user="$(linux_record_string "$record" login_user)"
     digest="$(linux_record_string "$record" release_digest)"
     user_runtime="/run/user/$uid"
-    systemctl enable --now "bloom-session@$uid.path"
-    if [[ -S "$user_runtime/bus" ]]; then
-      runuser -u "$user" -- env \
-        XDG_RUNTIME_DIR="$user_runtime" \
-        DBUS_SESSION_BUS_ADDRESS="unix:path=$user_runtime/bus" \
-        systemctl --user daemon-reload
-      runuser -u "$user" -- env \
-        XDG_RUNTIME_DIR="$user_runtime" \
-        DBUS_SESSION_BUS_ADDRESS="unix:path=$user_runtime/bus" \
-        systemctl --user start bloom-session.service bloom-machine.service
+    if ! systemctl enable --now "bloom-session@$uid.path"; then
+      echo "Bloom Linux release could not start the session path for UID $uid" >&2
+      start_status=1
+      continue
     fi
-    require_linux_triad_health "$install_root" "$uid" "$user" "$digest"
+    if [[ -S "$user_runtime/bus" ]]; then
+      if ! runuser -u "$user" -- env \
+        XDG_RUNTIME_DIR="$user_runtime" \
+        DBUS_SESSION_BUS_ADDRESS="unix:path=$user_runtime/bus" \
+        systemctl --user daemon-reload ||
+        ! runuser -u "$user" -- env \
+          XDG_RUNTIME_DIR="$user_runtime" \
+          DBUS_SESSION_BUS_ADDRESS="unix:path=$user_runtime/bus" \
+          systemctl --user start bloom-session.service bloom-machine.service
+      then
+        echo "Bloom Linux release could not start the user services for UID $uid" >&2
+        start_status=1
+        continue
+      fi
+    fi
+    require_linux_triad_health "$install_root" "$uid" "$user" "$digest" || start_status=1
   done
+  return "$start_status"
 }
 
 upgrade_root=""
@@ -921,17 +1025,23 @@ rollback_step() {
   return "$step_status"
 }
 
+# Restores the previous release's installed state — its unit contract,
+# binary selection, and release metadata — without starting anything. Each
+# step runs only after the one before it succeeded, and every step is
+# idempotent, so a failure leaves the transaction for a later attempt.
+restore_linux_previous_release() {
+  rollback_step "stop the release set" stop_linux_release_set "$upgrade_root" &&
+    rollback_step "restore installed units" restore_linux_upgrade_units "$upgrade_root" "$upgrade_transaction" &&
+    rollback_step "select the previous release" switch_linux_release "$upgrade_root" "$upgrade_old_digest" &&
+    rollback_step "restore release metadata" rewrite_linux_release_set "$upgrade_root" "$upgrade_old_digest" active
+}
+
 rollback_linux_upgrade() {
   local rollback_status=0
   [[ -n "$upgrade_root" && -n "$upgrade_old_digest" ]] || return 0
   # Never start services over a partially restored installation: the restart
-  # below only runs when stop, unit restoration, binary selection, and
-  # release metadata are all restored coherently.
-  if rollback_step "stop the release set" stop_linux_release_set "$upgrade_root" &&
-    rollback_step "restore installed units" restore_linux_upgrade_units "$upgrade_root" "$upgrade_transaction" &&
-    rollback_step "select the previous release" switch_linux_release "$upgrade_root" "$upgrade_old_digest" &&
-    rollback_step "restore release metadata" rewrite_linux_release_set "$upgrade_root" "$upgrade_old_digest" active
-  then
+  # below only runs when the previous release is restored coherently.
+  if restore_linux_previous_release; then
     start_linux_release_set "$upgrade_root" || rollback_status=$?
   else
     rollback_status=$?
@@ -953,12 +1063,17 @@ finish_linux_upgrade() {
   upgrade_old_digest=""
 }
 
-# New-format interrupted transactions always recover through one path:
-# restore the coherent previous installation first, then let the verified
-# installation that triggered recovery retry the requested release through
-# the normal upgrade steps. Starting the interrupted candidate directly is
-# unsafe because the interruption may have happened before or between unit
-# writes, and it must never be restarted over mixed old and new units.
+# Interrupted transactions always recover through one path: restore the
+# coherent previous installation, then let the verified installation that
+# triggered recovery retry the requested release through the normal upgrade
+# steps. Starting the interrupted candidate directly is unsafe because the
+# interruption may have happened before or between unit writes, and it must
+# never be restarted over mixed old and new units.
+#
+# Recovery does not start the previous release either. The retry stops it
+# again straight away, and gating recovery on its health check would strand
+# a host whose previous release cannot start — typically the release it is
+# upgrading away from — with no installer path to the release that fixes it.
 recover_interrupted_linux_upgrade() {
   local install_root="$1"
   local transaction="$install_root/var/lib/bloom/upgrade-transaction"
@@ -992,9 +1107,12 @@ recover_interrupted_linux_upgrade() {
   upgrade_transaction="$transaction"
   upgrade_root="$install_root"
   upgrade_old_digest="$old_digest"
-  upgrade_rollback_required=true
+  # upgrade_rollback_required stays false: a failed restoration preserves the
+  # transaction for the next run rather than attempting a restart from the
+  # EXIT trap.
   echo "restoring the interrupted Bloom Linux release before retrying" >&2
-  if ! rollback_linux_upgrade; then
+  if ! restore_linux_previous_release; then
+    echo "Bloom Linux upgrade recovery failed; transaction preserved for retry" >&2
     return 65
   fi
   finish_linux_upgrade
@@ -1269,6 +1387,9 @@ case "$action" in
       exit 65
     }
     recover_interrupted_linux_upgrade "$root"
+    if linux_root_is_live "$root"; then
+      require_linux_ipv6_loopback /proc
+    fi
     migrate_legacy_linux_records "$root"
     validate_linux_release_set "$root"
     shared_release_digest="$validated_release_digest"

--- a/packaging/triad/release/install-linux.sh
+++ b/packaging/triad/release/install-linux.sh
@@ -1070,10 +1070,14 @@ finish_linux_upgrade() {
 # interruption may have happened before or between unit writes, and it must
 # never be restarted over mixed old and new units.
 #
-# Recovery does not start the previous release either. The retry stops it
-# again straight away, and gating recovery on its health check would strand
-# a host whose previous release cannot start — typically the release it is
-# upgrading away from — with no installer path to the release that fixes it.
+# Recovery then restarts the previous release but never gates on it. The
+# transaction is already cleared, so a previous release that cannot start —
+# typically the release the host is upgrading away from — still leaves the
+# installer free to install the release that fixes it. The restart keeps a
+# run that exits after recovery, or that reinstalls the previous release,
+# from leaving every enrolled login stopped until a reboot. Recovery needs no
+# login sessions, because it neither starts services under a health gate nor
+# touches user state.
 recover_interrupted_linux_upgrade() {
   local install_root="$1"
   local transaction="$install_root/var/lib/bloom/upgrade-transaction"
@@ -1103,7 +1107,6 @@ recover_interrupted_linux_upgrade() {
     echo "invalid interrupted Linux upgrade" >&2
     return 65
   }
-  preflight_linux_release_set "$install_root"
   upgrade_transaction="$transaction"
   upgrade_root="$install_root"
   upgrade_old_digest="$old_digest"
@@ -1116,6 +1119,8 @@ recover_interrupted_linux_upgrade() {
     return 65
   fi
   finish_linux_upgrade
+  start_linux_release_set "$install_root" ||
+    echo "the restored Bloom Linux release did not start cleanly; continuing" >&2
 }
 
 allocate_linux_nfs_port() {
@@ -1802,6 +1807,14 @@ case "$action" in
         exit 64
       }
     fi
+    # An upgrade snapshot covers every enrolled login's Signer drop-in and
+    # credential, and restoration checks it against the enrollments present
+    # then. Removing an enrollment first leaves a transaction no run restores.
+    [[ ! -e "$root/var/lib/bloom/upgrade-transaction" && \
+      ! -L "$root/var/lib/bloom/upgrade-transaction" ]] || {
+      echo "an interrupted Linux upgrade must be recovered first; rerun the Bloom installer" >&2
+      exit 65
+    }
     config_target="$root/etc/bloom/$login_uid"
     state_target="$root/var/lib/bloom/$login_uid"
     run_target="$root/run/bloom/$login_uid"

--- a/tests/conformance/macos-unix-principals/run-disposable.sh
+++ b/tests/conformance/macos-unix-principals/run-disposable.sh
@@ -518,10 +518,12 @@ then
   echo "services did not drain after the login-session sentinel disappeared" >&2
   exit 1
 fi
-if curl --silent --max-time 1 http://127.0.0.1:18734/ >/dev/null 2>&1; then
-  echo "Broker retained the ceremony listener after session logout" >&2
-  exit 1
-fi
+for ceremony_host in 127.0.0.1 '[::1]'; do
+  if curl --silent --globoff --max-time 1 "http://$ceremony_host:18734/" >/dev/null 2>&1; then
+    echo "Broker retained the ceremony listener on $ceremony_host after session logout" >&2
+    exit 1
+  fi
+done
 launchctl print "$broker_label" >/dev/null
 launchctl print "$signer_label" >/dev/null
 launchctl bootstrap "user/$login_uid" "$session_plist"
@@ -542,134 +544,152 @@ sudo -u "$login_user" \
   serve triad-health-check \
   "$release_digest"
 
-ceremony_headers=""
-deadline=$((SECONDS + 20))
-while [[ $SECONDS -lt $deadline ]]; do
-  if ceremony_headers="$(
-    curl --silent --show-error --max-time 2 --dump-header - \
-      --output /dev/null http://127.0.0.1:18734/ 2>/dev/null
-  )" &&
-    grep -Fi \
-      'x-bloom-ceremony-owner: bloom-broker-v1' \
-      <<<"$ceremony_headers" >/dev/null
-  then
-    break
-  fi
-  sleep 1
+# Chromium resolves localhost to ::1 before 127.0.0.1, so the Broker must
+# answer on both loopback families.
+for ceremony_host in 127.0.0.1 '[::1]'; do
+  ceremony_headers=""
+  deadline=$((SECONDS + 20))
+  while [[ $SECONDS -lt $deadline ]]; do
+    if ceremony_headers="$(
+      curl --silent --show-error --globoff --max-time 2 --dump-header - \
+        --output /dev/null "http://$ceremony_host:18734/" 2>/dev/null
+    )" &&
+      grep -Fi \
+        'x-bloom-ceremony-owner: bloom-broker-v1' \
+        <<<"$ceremony_headers" >/dev/null
+    then
+      break
+    fi
+    sleep 1
+  done
+  grep -Fi \
+    'x-bloom-ceremony-owner: bloom-broker-v1' \
+    <<<"$ceremony_headers" >/dev/null || {
+    echo "Broker did not publish the canonical ceremony-owner marker on $ceremony_host" >&2
+    exit 1
+  }
 done
-grep -Fi \
-  'x-bloom-ceremony-owner: bloom-broker-v1' \
-  <<<"$ceremony_headers" >/dev/null || {
-  echo "Broker did not publish the canonical ceremony-owner marker" >&2
-  exit 1
-}
 
 broker_plist="/Library/LaunchDaemons/com.bloom.broker.$login_uid.plist"
 broker_state="/private/var/db/bloom/$login_uid/broker"
 broker_startup_status="/private/var/run/bloom/$login_uid/status/broker-startup.json"
 containment_status="/private/var/run/bloom/$login_uid/containment/status.json"
-launchctl bootout "$broker_label"
-broker_durable_before="$(
-  find "$broker_state" -type f ! -name broker.log -exec shasum -a 256 {} \; |
-    LC_ALL=C sort |
-    shasum -a 256 |
-    awk '{print $1}'
-)"
-/usr/bin/nc -lk 127.0.0.1 18734 >/dev/null 2>&1 &
-foreign_listener_pid=$!
-deadline=$((SECONDS + 10))
-while [[ $SECONDS -lt $deadline ]]; do
-  lsof -nP -a -p "$foreign_listener_pid" -iTCP@127.0.0.1:18734 -sTCP:LISTEN |
-    grep 18734 >/dev/null && break
-  sleep 0.05
-done
-kill -0 "$foreign_listener_pid"
-launchctl bootstrap system "$broker_plist"
-deadline=$((SECONDS + 15))
-while [[ $SECONDS -lt $deadline ]]; do
-  if [[ -f "$broker_startup_status" ]] &&
-    [[ "$(plutil -extract state raw -o - "$broker_startup_status" 2>/dev/null)" == "fatal" ]] &&
-    [[ "$(plutil -extract incident raw -o - "$broker_startup_status" 2>/dev/null)" == \
-      "ceremony_listeners_unavailable" ]]
+
+# A foreign listener on either loopback family must keep the Broker from
+# serving at all. Chromium tries ::1 before 127.0.0.1, so a Broker that
+# served only the family it could bind would hand the approval page request
+# to whatever process squats the other one.
+assert_foreign_ceremony_conflict() {
+  local family="$1" address="$2" lsof_address="$3"
+  local broker_durable_before broker_durable_after foreign_machine_failure
+
+  launchctl bootout "$broker_label"
+  broker_durable_before="$(
+    find "$broker_state" -type f ! -name broker.log -exec shasum -a 256 {} \; |
+      LC_ALL=C sort |
+      shasum -a 256 |
+      awk '{print $1}'
+  )"
+  /usr/bin/nc "-$family" -lk "$address" 18734 >/dev/null 2>&1 &
+  foreign_listener_pid=$!
+  deadline=$((SECONDS + 10))
+  while [[ $SECONDS -lt $deadline ]]; do
+    lsof -nP -a -p "$foreign_listener_pid" "-iTCP@$lsof_address:18734" -sTCP:LISTEN |
+      grep 18734 >/dev/null && break
+    sleep 0.05
+  done
+  kill -0 "$foreign_listener_pid"
+  launchctl bootstrap system "$broker_plist"
+  deadline=$((SECONDS + 15))
+  while [[ $SECONDS -lt $deadline ]]; do
+    if [[ -f "$broker_startup_status" ]] &&
+      [[ "$(plutil -extract state raw -o - "$broker_startup_status" 2>/dev/null)" == "fatal" ]] &&
+      [[ "$(plutil -extract incident raw -o - "$broker_startup_status" 2>/dev/null)" == \
+        "ceremony_listeners_unavailable" ]]
+    then
+      break
+    fi
+    sleep 0.1
+  done
+  assert_metadata \
+    "$broker_startup_status" \
+    "$broker_uid:$machine_broker_gid:640"
+  [[ "$(plutil -extract schema raw -o - "$broker_startup_status")" == \
+    "bloom.broker-startup.1" ]]
+  [[ "$(plutil -extract state raw -o - "$broker_startup_status")" == "fatal" ]]
+  [[ "$(plutil -extract incident raw -o - "$broker_startup_status")" == \
+    "ceremony_listeners_unavailable" ]]
+  [[ "$(plutil -extract address raw -o - "$broker_startup_status")" == \
+    "localhost:18734" ]]
+  [[ "$(plutil -extract message raw -o - "$broker_startup_status")" == \
+    "could not acquire both ceremony loopback listeners; see Broker service logs" ]]
+  if foreign_machine_failure="$(
+    sudo -u "$login_user" \
+      "$machine_binary" \
+      serve triad-health-check "$release_digest" 2>&1
+  )"
   then
-    break
+    echo "Machine reported healthy while a foreign process owned the $address ceremony port" >&2
+    exit 1
   fi
-  sleep 0.1
-done
-assert_metadata \
-  "$broker_startup_status" \
-  "$broker_uid:$machine_broker_gid:640"
-[[ "$(plutil -extract schema raw -o - "$broker_startup_status")" == \
-  "bloom.broker-startup.1" ]]
-[[ "$(plutil -extract state raw -o - "$broker_startup_status")" == "fatal" ]]
-[[ "$(plutil -extract incident raw -o - "$broker_startup_status")" == \
-  "ceremony_listeners_unavailable" ]]
-[[ "$(plutil -extract address raw -o - "$broker_startup_status")" == \
-  "localhost:18734" ]]
-[[ "$(plutil -extract message raw -o - "$broker_startup_status")" == \
-  "could not acquire both ceremony loopback listeners; see Broker service logs" ]]
-if foreign_machine_failure="$(
+  if ! grep -F \
+    'Bloom Broker startup failed: could not acquire both ceremony loopback listeners; see Broker service logs' \
+    <<<"$foreign_machine_failure" >/dev/null
+  then
+    echo "Machine did not report the authenticated foreign-listener diagnostic for $address:" >&2
+    printf '%s\n' "$foreign_machine_failure" >&2
+    stat -f 'startup diagnostic metadata: %u:%g:%Lp links=%l bytes=%z' \
+      "$broker_startup_status" >&2
+    echo "startup diagnostic content:" >&2
+    sudo -u "$login_user" cat "$broker_startup_status" >&2 || true
+    exit 1
+  fi
+  # The Broker must not keep the family it could bind, nor fall back to
+  # another address or port.
+  if lsof -nP -a -u "bloom-broker-$login_uid" -iTCP -sTCP:LISTEN |
+    grep . >/dev/null
+  then
+    echo "Broker opened a fallback TCP listener after the canonical bind conflict on $address" >&2
+    exit 1
+  fi
+  broker_durable_after="$(
+    find "$broker_state" -type f ! -name broker.log -exec shasum -a 256 {} \; |
+      LC_ALL=C sort |
+      shasum -a 256 |
+      awk '{print $1}'
+  )"
+  [[ "$broker_durable_after" == "$broker_durable_before" ]] || {
+    echo "a Broker that lost the canonical $address listener mutated durable authority state" >&2
+    exit 1
+  }
+  kill "$foreign_listener_pid" 2>/dev/null || true
+  wait "$foreign_listener_pid" 2>/dev/null || true
+  foreign_listener_pid=""
+  # Multiple fatal starts while the port is occupied can put launchd into a
+  # failure-backoff interval. Prove failure-only KeepAlive recovery without
+  # imposing a shorter deadline than launchd's scheduler.
+  deadline=$((SECONDS + 60))
+  while [[ $SECONDS -lt $deadline ]]; do
+    if sudo -u "$login_user" \
+      "$machine_binary" \
+      serve triad-health-check \
+      "$release_digest"
+    then
+      break
+    fi
+    sleep 1
+  done
   sudo -u "$login_user" \
-    "$machine_binary" \
-    serve triad-health-check "$release_digest" 2>&1
-)"
-then
-  echo "Machine reported healthy while a foreign process owned the ceremony port" >&2
-  exit 1
-fi
-if ! grep -F \
-  'Bloom Broker startup failed: could not acquire both ceremony loopback listeners; see Broker service logs' \
-  <<<"$foreign_machine_failure" >/dev/null
-then
-  echo "Machine did not report the authenticated foreign-listener diagnostic:" >&2
-  printf '%s\n' "$foreign_machine_failure" >&2
-  stat -f 'startup diagnostic metadata: %u:%g:%Lp links=%l bytes=%z' \
-    "$broker_startup_status" >&2
-  echo "startup diagnostic content:" >&2
-  sudo -u "$login_user" cat "$broker_startup_status" >&2 || true
-  exit 1
-fi
-if lsof -nP -a -u "bloom-broker-$login_uid" -iTCP -sTCP:LISTEN |
-  grep . >/dev/null
-then
-  echo "Broker opened a fallback TCP listener after the canonical bind conflict" >&2
-  exit 1
-fi
-broker_durable_after="$(
-  find "$broker_state" -type f ! -name broker.log -exec shasum -a 256 {} \; |
-    LC_ALL=C sort |
-    shasum -a 256 |
-    awk '{print $1}'
-)"
-[[ "$broker_durable_after" == "$broker_durable_before" ]] || {
-  echo "a Broker that lost the canonical listener mutated durable authority state" >&2
-  exit 1
-}
-kill "$foreign_listener_pid" 2>/dev/null || true
-wait "$foreign_listener_pid" 2>/dev/null || true
-foreign_listener_pid=""
-# Multiple fatal starts while the port is occupied can put launchd into a
-# failure-backoff interval. Prove failure-only KeepAlive recovery without
-# imposing a shorter deadline than launchd's scheduler.
-deadline=$((SECONDS + 60))
-while [[ $SECONDS -lt $deadline ]]; do
-  if sudo -u "$login_user" \
     "$machine_binary" \
     serve triad-health-check \
     "$release_digest"
-  then
-    break
-  fi
-  sleep 1
-done
-sudo -u "$login_user" \
-  "$machine_binary" \
-  serve triad-health-check \
-  "$release_digest"
-[[ ! -e "$broker_startup_status" ]] || {
-  echo "Broker retained a stale startup diagnostic after acquiring the listener" >&2
-  exit 1
+  [[ ! -e "$broker_startup_status" ]] || {
+    echo "Broker retained a stale startup diagnostic after acquiring the listeners" >&2
+    exit 1
+  }
 }
+assert_foreign_ceremony_conflict 4 127.0.0.1 127.0.0.1
+assert_foreign_ceremony_conflict 6 ::1 '[::1]'
 
 # Legacy telemetry must never advertise a network boundary after PF retirement.
 assert_metadata "$containment_status" "0:0:644"


### PR DESCRIPTION
## Summary

Follow-up to #238, targeting its branch. It covers the review findings on #238: the Broker repin #238 needs before it can merge, the recovery P2, and lower-priority installer and conformance items. It also includes #263, which fixed three regressions the review of this PR found.

### 1. Pin Broker master (`bd85885b`) and the Signer it is built against

- **No standalone #54 commit exists.** Broker #54 was merged into #35's branch and reached Broker master inside #35's squash commit (`90bc3ea5`). `bd85885b` is that commit plus a dependency bump. Every Broker commit that contains #54 also contains #58.
- **Broker pinned in all 7 places:**
  - `Cargo.toml` and `Cargo.lock`
  - `packaging/triad/release/compatibility-v1.toml`
  - the `ci.yml` macOS W0 call
  - the defaults in `macos-unix-conformance.yml` and `macos-two-login-conformance.yml`
  - the matrix assertion in `triad_release.rs`
- **Signer advanced to `941dd376`** (Signer master) in the same places and in `crates/bloom-it/Cargo.toml`. That is the revision Broker master is built against.
  - Relative to #238's old pin (`9abe7917`) the bump is required: that Signer predates the `derivation_request` → `derivation_requests` rename, so the release pair would disagree on account-allocation requests.
  - Relative to #248/#250's pin (`104cf218`) the bump is only additive.
- **Machine migrated for Broker #58:**
  - `CustodyPrepareRequest.derivation_request` becomes `derivation_requests: Vec<_>`.
  - `AccountTerms.derivation` becomes `derivations`.
  - The change is mechanical because Machine already sends no pinned account number, which the new contract requires.
  - The Machine–Broker API (`bloom-broker-api`) is identical between #248/#250's `81b30c07` and `bd85885b`. #248 and #250 make the same rename, so whichever lands second resolves trivial textual conflicts.

### 2. P2: recovery no longer strands a host whose previous release cannot start

**Before:** recovery rolled back through `rollback_linux_upgrade`, which clears the transaction only after the *previous* release passes its health gate. A host upgrading away from a release that can't start never got past that gate, so every later run restored the old release, failed its health check, kept the transaction and exited.

**Now:**
- The stop, restore-units, select-binary and restore-metadata steps live in `restore_linux_previous_release`.
- The in-process rollback still restarts and health-checks the restored release, and keeps the transaction if that fails.
- Recovery restores, **clears the transaction**, and only then restarts the previous release without gating on it (#263). A broken previous release no longer blocks the retry, and a run that exits after recovery, or reinstalls the previous payload, doesn't leave logins stopped.
- Recovery no longer requires every login to have an active session, since it doesn't start anything under a health gate (#263).
- `rewrite_linux_release_set`, `write_linux_record`, `replace_linux_json_digest` and `atomic_install` now check their own failures. Rollback runs with errexit off, and with no health gate after recovery nothing else would catch a half-written metadata rewrite.
- Uninstall refuses while an upgrade transaction is pending (#263).

### 3. Lower-priority fixes

- **Rollback no longer reports success while a login is down.** `start_linux_release_set` and `stop_linux_release_set` used to return only the *last* login's status, because rollback runs with errexit off. They now check each step, keep going for later logins, and fail if any login failed.
- **IPv6 check before installing.** A live install stops with status 69 unless `lo` has `disable_ipv6=0` and `::1` assigned. The check runs after recovery, which restarts the restored release first, and before anything new is written.
- **Conformance for the IPv6 family.** The macOS W0 foreign-listener conflict now runs once per family (`127.0.0.1` and `[::1]`). A foreign listener on either address must stop the Broker from serving at all, with no TCP listener of its own and no durable-state change. W0 also requires the ceremony-owner marker on both addresses after activation, and no answer on either after logout.

### Reverted: Signer KMS drop-in snapshot

An earlier commit here added each login's AWS KMS Signer drop-in and credential to the upgrade snapshot. `16017e95` reverts it, returning to #238's fixed unit set and three-field manifest.
- **Low value:** it only helped when a KMS host was upgraded with a payload lacking the KMS overlay and the upgrade then failed. Rerunning with the overlay repairs that, as it does after a successful upgrade with the same payload.
- **Caused a regression:** it made restoration depend on which logins were enrolled at restore time, which is what the uninstall regression came from.
- **Copied secrets:** it copied every login's AWS credential into the transaction directory, although an install only rewrites the installing login's.

The README now says the KMS files aren't snapshotted and how to repair them.

## Verification

- **Linux, run locally:** `cargo test -p bloom-it --test triad_release --test linux_packaging --locked -- --skip macos_` in a Debian container as a non-root user gives 47 + 7 passed, 0 failed. This covers every Linux installer test, including the rollback, recovery, uninstall-guard, start/stop and IPv6 tests.
- `cargo clippy --workspace --all-targets --locked -- -D warnings` and `cargo fmt --all -- --check`: clean. `--test macos_launchagent` (21) passes on macOS.
- **CI:** the "local integration tests" job runs the Linux installer tests on every push.
- **macOS W0 ([run 34639530054](https://github.com/bloom-directory/bloom/actions/runs/34639530054)):** dispatched on `w0/pr261`, which is this branch plus a cherry-pick of #244 because #238's branch lacks it. It failed at install, before the ceremony checks, with the same activation failure every W0 run has hit since Sept 8. The captured Machine log shows the cause: the LaunchAgent's `--mount-home` NFS mount of `127.0.0.1:12049` times out after 10s on GitHub's hosted runners, Machine treats that as fatal, and launchd restarts it 14 times. This is unrelated to this PR.
- **Not run:** an end-to-end upgrade to this Broker/Signer pair on a live host.

## Landing notes

- `schema bloom.linux-upgrade-transaction.2` is unchanged from #238's head.
- #241 should be updated: the #238 repin target is now `bd85885b` (Broker #54 is inside `90bc3ea5`), the Signer moves to `941dd376`, and #248/#250 overlap on the `derivation_requests` rename.

## Checklist

- [x] Tests added or updated for behavior changes
- [x] Architecture docs (`docs/architecture/`) updated if contracts or
      behavior changed — N/A: the Machine–Broker field rename follows the Broker API and no architecture doc names these fields. Operator behavior is documented in `packaging/triad/release/README.md` and `packaging/triad/linux/README.md`.
- [x] Sealed Approval invariants respected (no signing outside a grant or
      bounded capability, no PRF/grant persistence, execution from sealed
      bytes) — see `docs/architecture/Sealed Approvals.md` — N/A, no approval path touched
- [x] Agent Documentation updated (`crates/bloom-vfs/src/docs/agent-guidance.md`
      and affected Petal READMEs) — see
      `docs/architecture/Agent-native Documentation.md` — N/A, no agent-visible surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WU9eDmAqur5eXvU9SEaWZB
