### PR TITLE
Restart the restored release after Linux upgrade recovery; refuse uninstall mid-upgrade

### DIFF
--- a/crates/bloom-it/tests/triad_release.rs
+++ b/crates/bloom-it/tests/triad_release.rs
@@ -2689,12 +2689,17 @@ fn installer_upgrade_transactions_preserve_recovery_state_atomically() {
                 .unwrap(),
         "rollback must restore the installed unit contract before any restart"
     );
-    // Recovery restores without starting: it must not depend on the previous
-    // release passing its health gate.
+    // Recovery clears the transaction before its restart, so it never depends
+    // on the previous release passing its health gate.
     let recovery = &linux[linux.find("recover_interrupted_linux_upgrade() {").unwrap()
         ..linux.find("allocate_linux_nfs_port() {").unwrap()];
     assert!(recovery.contains("restore_linux_previous_release"));
-    assert!(!recovery.contains("start_linux_release_set"));
+    assert!(
+        recovery.find("finish_linux_upgrade").unwrap()
+            < recovery
+                .find("start_linux_release_set \"$install_root\" ||")
+                .unwrap()
+    );
     assert!(!recovery.contains("rollback_linux_upgrade"));
     assert!(!recovery.contains("upgrade_rollback_required=true"));
     assert!(!linux.contains("completing interrupted"));
@@ -3176,11 +3181,13 @@ fn linux_interrupted_upgrade_recovery_restores_before_any_restart() {
             stop < rewrite,
             "the release set must stop before it is restored at {stage}"
         );
-        // Recovery restores the previous release without starting it; the
-        // retried installation is the first thing to start anything.
+        // Recovery restarts the previous release only after restoring it.
+        let start = log
+            .find(&format!("start current=releases/{old_digest} "))
+            .unwrap_or_else(|| panic!("no restart of the restored release at {stage}: {log}"));
         assert!(
-            !log.contains("start"),
-            "recovery must not start a release at {stage}: {log}"
+            rewrite < start && log.contains("v6=absent"),
+            "recovery must restart only the restored release at {stage}: {log}"
         );
         assert_eq!(
             fs::read_link(root.join("usr/libexec/bloom/current")).unwrap(),
@@ -3396,8 +3403,9 @@ fn linux_upgrade_recovery_failure_preserves_the_transaction_and_retries() {
     // A previous release that cannot pass its health gate — the release a
     // host is upgrading away from — must not strand the host. The in-process
     // rollback restores it coherently, fails its health gate, and keeps the
-    // transaction. Recovery then restores without starting it, and the
-    // retried upgrade to the candidate completes.
+    // transaction. Recovery then restores it, clears the transaction, and
+    // attempts a restart without gating on it, and the retried upgrade to the
+    // candidate completes.
     let health_root = tempfile::tempdir().unwrap();
     let (root, layout, old_digest, new_digest, rolled_back) =
         stage_linux_upgrade_root(health_root.path(), &harness, "rollback", "all", |root| {
@@ -3430,7 +3438,8 @@ fn linux_upgrade_recovery_failure_preserves_the_transaction_and_retries() {
         "recovery must not depend on the previous release's health: {}",
         String::from_utf8_lossy(&recovered.stderr)
     );
-    assert!(!fs::read_to_string(&log).unwrap().contains("start"));
+    assert!(fs::read_to_string(&log).unwrap().contains("start refused"));
+    assert!(String::from_utf8_lossy(&recovered.stderr).contains("did not start cleanly"));
     assert!(!root.join("var/lib/bloom/upgrade-transaction").exists());
     assert_pre_ipv6_linux_contract(&root, &layout);
 
@@ -3562,6 +3571,76 @@ fn linux_upgrade_recovery_restores_the_signer_kms_dropin_and_credential() {
     );
     assert!(!root.join(credential).exists());
     assert!(!root.join(dropin).parent().unwrap().exists());
+}
+
+/// The snapshot covers every enrolled login's Signer drop-in and credential,
+/// and restoration checks it against the enrollments present at that time.
+/// Uninstalling a login in between would leave a transaction no later run can
+/// restore, so uninstall refuses until recovery has run.
+#[test]
+fn linux_uninstall_refuses_while_an_interrupted_upgrade_is_pending() {
+    let directory = tempfile::tempdir().unwrap();
+    let root = directory.path().join("root");
+    fs::create_dir(&root).unwrap();
+    let payload = make_installer_payload(&directory.path().join("release-a"));
+    install_linux_logins(&root, &payload, &[("1000", "alice"), ("2000", "bob")]);
+    let harness = write_linux_upgrade_harness(directory.path());
+    let installer = release_script("install-linux.sh");
+    let old_digest = hex::encode(Sha256::digest(b"test payload\n"));
+    let new_digest = hex::encode(Sha256::digest(b"upgraded manifest\n"));
+    let interrupted = run_linux_upgrade_harness(
+        &harness,
+        &installer,
+        &root,
+        "interrupt",
+        &directory.path().join("interrupt.log"),
+        &["all", &old_digest, &new_digest],
+    );
+    assert!(
+        interrupted.status.success(),
+        "{}",
+        String::from_utf8_lossy(&interrupted.stderr)
+    );
+    let transaction = root.join("var/lib/bloom/upgrade-transaction");
+    let uninstall = || {
+        Command::new(&installer)
+            .args(["uninstall", "--retain-custody"])
+            .arg(&root)
+            .arg("2000")
+            .output()
+            .unwrap()
+    };
+
+    let refused = uninstall();
+    assert_eq!(refused.status.code(), Some(65));
+    assert!(
+        String::from_utf8_lossy(&refused.stderr)
+            .contains("an interrupted Linux upgrade must be recovered first")
+    );
+    assert!(root.join("etc/bloom/enrollments/2000.json").is_file());
+    assert!(transaction.join("schema").is_file());
+
+    let recovered = run_linux_upgrade_harness(
+        &harness,
+        &installer,
+        &root,
+        "recover",
+        &directory.path().join("recover.log"),
+        &[&old_digest, &new_digest],
+    );
+    assert!(
+        recovered.status.success(),
+        "{}",
+        String::from_utf8_lossy(&recovered.stderr)
+    );
+    assert!(!transaction.exists());
+    let uninstalled = uninstall();
+    assert!(
+        uninstalled.status.success(),
+        "{}",
+        String::from_utf8_lossy(&uninstalled.stderr)
+    );
+    assert!(root.join("etc/bloom/retained/2000.json").is_file());
 }
 
 /// Writes a harness that evaluates the real installer functions and treats

--- a/packaging/triad/release/README.md
+++ b/packaging/triad/release/README.md
@@ -167,12 +167,13 @@ enrolled login passes the authenticated health gate.
 
 Recovery after an interruption restores the coherent previous installation and
 then lets the verified installer retry the requested release; it never
-completes the interrupted candidate in place. Recovery does not start the
-previous release or require it to pass the health gate: the retry stops it
-again immediately, and a host whose previous release cannot start must still be
-able to install the release that fixes it. If the installer exits after
-recovery but before its retry starts anything, the restored release is left
-stopped, as the interruption left it, until the next installer run or reboot. A
+completes the interrupted candidate in place. Recovery clears the transaction
+as soon as the previous installation is restored and only then restarts it,
+without gating on the health check: a host whose previous release cannot start
+must still be able to install the release that fixes it, and a run that stops
+after recovery, or reinstalls the previous release, must not leave the other
+enrolled logins stopped until a reboot. Uninstalling a login is refused while
+an interrupted upgrade is pending. A
 transaction recorded by an earlier installer (`schema
 bloom.linux-upgrade-transaction.1`) carries no unit snapshot; it is recovered
 by rolling the binary selection and release metadata back on their own, as the

--- a/packaging/triad/release/install-linux.sh
+++ b/packaging/triad/release/install-linux.sh
@@ -1070,10 +1070,14 @@ finish_linux_upgrade() {
 # interruption may have happened before or between unit writes, and it must
 # never be restarted over mixed old and new units.
 #
-# Recovery does not start the previous release either. The retry stops it
-# again straight away, and gating recovery on its health check would strand
-# a host whose previous release cannot start — typically the release it is
-# upgrading away from — with no installer path to the release that fixes it.
+# Recovery then restarts the previous release but never gates on it. The
+# transaction is already cleared, so a previous release that cannot start —
+# typically the release the host is upgrading away from — still leaves the
+# installer free to install the release that fixes it. The restart keeps a
+# run that exits after recovery, or that reinstalls the previous release,
+# from leaving every enrolled login stopped until a reboot. Recovery needs no
+# login sessions, because it neither starts services under a health gate nor
+# touches user state.
 recover_interrupted_linux_upgrade() {
   local install_root="$1"
   local transaction="$install_root/var/lib/bloom/upgrade-transaction"
@@ -1103,7 +1107,6 @@ recover_interrupted_linux_upgrade() {
     echo "invalid interrupted Linux upgrade" >&2
     return 65
   }
-  preflight_linux_release_set "$install_root"
   upgrade_transaction="$transaction"
   upgrade_root="$install_root"
   upgrade_old_digest="$old_digest"
@@ -1116,6 +1119,8 @@ recover_interrupted_linux_upgrade() {
     return 65
   fi
   finish_linux_upgrade
+  start_linux_release_set "$install_root" ||
+    echo "the restored Bloom Linux release did not start cleanly; continuing" >&2
 }
 
 allocate_linux_nfs_port() {
@@ -1802,6 +1807,14 @@ case "$action" in
         exit 64
       }
     fi
+    # An upgrade snapshot covers every enrolled login's Signer drop-in and
+    # credential, and restoration checks it against the enrollments present
+    # then. Removing an enrollment first leaves a transaction no run restores.
+    [[ ! -e "$root/var/lib/bloom/upgrade-transaction" && \
+      ! -L "$root/var/lib/bloom/upgrade-transaction" ]] || {
+      echo "an interrupted Linux upgrade must be recovered first; rerun the Bloom installer" >&2
+      exit 65
+    }
     config_target="$root/etc/bloom/$login_uid"
     state_target="$root/var/lib/bloom/$login_uid"
     run_target="$root/run/bloom/$login_uid"


### PR DESCRIPTION
Follow-up to #261, targeting its branch. It fixes the three regressions from the [#261 review](https://github.com/bloom-directory/bloom/pull/261#pullrequestreview-5182978879).

### Recovery restarts the restored release
- **Problem:** #261 made recovery restore the previous release and clear the transaction without starting anything, leaving the next upgrade to start the logins. Any run that recovered and then didn't upgrade left every enrolled login stopped until a reboot:
  - reinstalling the previous payload (`release_upgrade=false` enables only the installing login's path unit);
  - the new IPv6 loopback check (exit 69);
  - any validation exit before `begin_linux_upgrade`.
- **Fix:** recovery now calls `start_linux_release_set` after `finish_linux_upgrade` and doesn't gate on the result. Because the transaction is already cleared, a previous release that can't start still doesn't strand the host, which is the problem #261 set out to fix.
- **Recovery no longer calls `preflight_linux_release_set`:** that check existed to support a restart under the health gate, which recovery no longer does.

### Uninstall refuses while an upgrade transaction is pending
- **Problem:** the snapshot records every enrolled login's KMS drop-in and credential, and `restore_linux_upgrade_units` re-derives the tracked set from whichever enrollments exist at restore time. Uninstalling a login between an interruption and its recovery made every later recovery and install fail with `names an untracked path` (exit 65). I reproduced this against #261's head.
- **Fix:** uninstall exits 65 until the installer has recovered.

### Tests
- **New:** `linux_uninstall_refuses_while_an_interrupted_upgrade_is_pending` covers two logins, an interrupted upgrade, a refused uninstall, recovery, and then a successful uninstall.
- **Updated:** the recovery tests now require the restart to come after the metadata restore, and to run on the restored (pre-IPv6) units. When the old release fails to start, recovery still succeeds and clears the transaction.

### Verification
- **Linux (run locally, which #261 couldn't do):** `cargo test -p bloom-it --test triad_release -- linux` gives 17 passed and 4 failed.
  - The same 4 fail on #261's head unmodified: `upgrade_rotation`, `allocates_distinct_ports`, `legacy_interrupted`, `upgrade_failure_restores`.
  - They fail because this host already has a `bloom` process listening on `127.0.0.1:20000`, so the installer allocates 20001 and the tests' hard-coded port assertions don't match. CI doesn't have this conflict.
- **Also passes:** `bash -n` and `cargo fmt --check`.
