### PR TITLE
Add Solana mainnet to newly generated configuration

### DIFF
--- a/crates/bloom-proto/src/config.rs
+++ b/crates/bloom-proto/src/config.rs
@@ -401,9 +401,10 @@ fn default_chains() -> BTreeMap<String, ChainSpec> {
 }
 
 impl Config {
-    /// An agentic-wallet default: read-ready public EVM networks and Anvil.
+    /// An agentic-wallet default: public EVM networks, Anvil, and Solana mainnet.
     ///
-    /// Per-chain broadcast is enabled by default. Signing, policy,
+    /// EVM broadcast is enabled by default; Solana mainnet starts with
+    /// broadcasting disabled. Signing, policy,
     /// confirmation, and Sealed Approval gates still apply to value-moving
     /// actions.
     pub fn local_default() -> Self {
@@ -415,7 +416,23 @@ impl Config {
             default_chain: default_chain_name(),
             stage_ttl: default_stage_ttl(),
             chains,
-            solana_chains: BTreeMap::new(),
+            solana_chains: BTreeMap::from([(
+                "solana-mainnet".into(),
+                SolanaSpec {
+                    name: "solana-mainnet".into(),
+                    endpoints: vec![crate::chain::EndpointSpec {
+                        url: "https://api.mainnet.solana.com".into(),
+                        weight: 100,
+                        cu_per_sec: None,
+                        max_rps: None,
+                        http_only: true,
+                    }],
+                    expected_genesis_base58: Some(
+                        crate::chain::SOLANA_MAINNET_BETA_GENESIS_HASH.into(),
+                    ),
+                    allow_broadcast: false,
+                },
+            )]),
             etherscan: None,
             enso: None,
             petals: PetalsConfig::default(),
@@ -711,6 +728,18 @@ mod tests {
         assert!(cfg.enso.is_none());
         assert_eq!(cfg.petals.preinstalled, default_preinstalled_petals());
         assert_eq!(cfg.chains.len(), 13);
+        assert_eq!(cfg.solana_chains.len(), 1);
+        let solana = cfg
+            .solana_chains
+            .get("solana-mainnet")
+            .expect("Solana mainnet entry");
+        assert_eq!(solana.name, "solana-mainnet");
+        assert_eq!(
+            solana.expected_genesis_base58.as_deref(),
+            Some(crate::chain::SOLANA_MAINNET_BETA_GENESIS_HASH)
+        );
+        assert!(!solana.allow_broadcast);
+        assert_eq!(solana.endpoints[0].url, "https://api.mainnet.solana.com");
         let ethereum = cfg.chains.get("ethereum").expect("ethereum entry");
         assert_eq!(ethereum.chain_id, 1);
         assert!(ethereum.allow_broadcast);
@@ -1056,6 +1085,7 @@ mod tests {
         assert!(path.exists());
         assert_eq!(cfg.default_chain, "ethereum");
         // Second call should load, not overwrite — round-trip equivalent.
+        assert!(cfg.solana_chains.contains_key("solana-mainnet"));
         let cfg2 = Config::load_or_init(&path).unwrap();
         assert_configs_equivalent(&cfg, &cfg2);
     }
@@ -1077,6 +1107,7 @@ allow_broadcast = false
 
         let cfg = Config::load_or_init(&path).unwrap();
         assert!(!cfg.chains["anvil"].allow_broadcast);
+        assert!(cfg.solana_chains.is_empty());
         assert_eq!(std::fs::read_to_string(&path).unwrap(), existing);
     }
 

--- a/crates/bloom-vfs/src/docs/agent-guidance.md
+++ b/crates/bloom-vfs/src/docs/agent-guidance.md
@@ -87,6 +87,12 @@ enumerates both together. Solana chains route through the exact same
 inspect `outbox/{pending,sent,failed}/<id>/`) — there is no separate
 Solana-specific surface to look for.
 
+Newly generated Bloom configuration includes `solana-mainnet` for reads, with
+broadcasting disabled. Existing configurations keep their configured networks;
+devnet and local validators are opt-in. If an owner enables mainnet broadcasting,
+wallet policy and the approval ceremony still apply. Discover the available
+networks with `ls wallets/<wallet>/chains` rather than assuming a network exists.
+
 ### Reading Solana balances
 
 A Solana chain directory exposes an account-addressed surface:

--- a/docs/architecture/Solana Native Integration.md
+++ b/docs/architecture/Solana Native Integration.md
@@ -106,6 +106,16 @@ config where a chain name is configured in both.
 
 ## Mainnet posture
 
+Newly generated configuration includes `solana-mainnet`, using the public
+`https://api.mainnet.solana.com` RPC endpoint and the pinned mainnet genesis
+hash. Its `allow_broadcast` defaults to `false`. Devnet and local validators
+remain explicitly configured networks. Loading an existing configuration does
+not add Solana networks or overwrite endpoint and broadcast settings.
+
+The public endpoint is rate-limited; operators can replace it with their own
+RPC endpoint under `[solana_chains.solana-mainnet]`. See Solana's
+[public RPC documentation](https://solana.com/docs/references/clusters).
+
 Mainnet uses the ordinary Solana transaction path. Operators must explicitly
 enable `allow_broadcast` and pin `expected_genesis_base58`; Machine verifies every
 configured endpoint against that genesis at staging and again before its


### PR DESCRIPTION
New Bloom configurations currently contain no Solana network. This adds `solana-mainnet` to `Config::local_default()`, so new installations can discover and read mainnet alongside the existing EVM networks.

The entry uses `https://api.mainnet.solana.com`, pins the existing mainnet genesis constant, and leaves `allow_broadcast = false`. Existing configurations are loaded unchanged, and devnet/local validators remain opt-in. Ethereum remains the default chain. Operator and agent documentation describe the new default and endpoint customization.

Targets `feat/solana-native` (#170). Network-scoped recipient permissions remain separate work in #264; this grants no wallet permissions.

Validation: `cargo test -p bloom-proto --locked --offline` (169 passed), formatting check for the changed Rust file, and `git diff --check`. The default-shape test was observed failing before implementation. Existing-config loading and new-config round-trip tests cover the rollout behavior. No live RPC or transfer test was run.
