### PR TITLE
feat(mcp): proxy the VFS command surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2133,6 +2133,7 @@ dependencies = [
  "bloom-daemon",
  "bloom-evm",
  "bloom-machine-client",
+ "bloom-mcp",
  "bloom-mount",
  "bloom-petals",
  "bloom-proto",
@@ -2357,6 +2358,23 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.23",
+]
+
+[[package]]
+name = "bloom-mcp"
+version = "0.2.1"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bloom-daemon",
+ "bloom-proto",
+ "bloom-vfs",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2369,6 +2369,7 @@ dependencies = [
  "bloom-daemon",
  "bloom-proto",
  "bloom-vfs",
+ "percent-encoding",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 flate2 = "1"
 mpp = { version = "0.10.4", default-features = false, features = ["client", "tempo", "reqwest-rustls-tls"] }
 url = "2"
+percent-encoding = "2"
 humantime = "2"
 humantime-serde = "1"
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "crates/bloom-machine",
   "crates/bloom-daemon",
   "crates/bloom-vfs",
+  "crates/bloom-mcp",
   "crates/bloom-paid-mpp",
   "crates/bloom-paid-x402",
   "crates/bloom-paid-http",
@@ -109,6 +110,7 @@ bloom-rpc      = { path = "crates/bloom-rpc" }
 bloom-evm      = { path = "crates/bloom-evm" }
 bloom-tx       = { path = "crates/bloom-tx" }
 bloom-vfs      = { path = "crates/bloom-vfs" }
+bloom-mcp      = { path = "crates/bloom-mcp" }
 bloom-paid-mpp = { path = "crates/bloom-paid-mpp" }
 bloom-paid-x402 = { path = "crates/bloom-paid-x402" }
 bloom-paid-http = { path = "crates/bloom-paid-http" }

--- a/README.md
+++ b/README.md
@@ -112,6 +112,28 @@ For the full wallet walkthrough, read
 [`docs/AGENTIC_WALLET.md`](./docs/AGENTIC_WALLET.md) and
 [`QUICKSTART.md`](./QUICKSTART.md).
 
+## MCP server
+
+Agent clients that speak the Model Context Protocol can reach the same VFS
+commands over stdio, without a mount. It is **off by default**; enabling it is
+an explicit edit to `~/.bloom/config.toml`:
+
+```toml
+[mcp]
+enabled = true
+```
+
+```sh
+cargo run -p bloom -- mcp status   # is it on, and which socket would it use
+cargo run -p bloom -- mcp serve    # stdio; an MCP client spawns this
+```
+
+`mcp serve` adds no permissions of its own: it forwards `list`, `read`,
+`lookup`, `write`, and `write_with_lookup` to the daemon a mount would have
+used, so policy, confirmation, and audit gates apply unchanged. There is no
+network listener. See [`docs/guides/mcp.md`](./docs/guides/mcp.md) for the tool
+catalog, resource URI rules, and error codes.
+
 ## Development commands
 
 For local development, use the package-manager-native checks:

--- a/crates/bloom-daemon/src/ipc.rs
+++ b/crates/bloom-daemon/src/ipc.rs
@@ -1128,7 +1128,18 @@ impl IpcServer {
     async fn do_lookup(&self, params: &Value) -> Result<Value, HandlerError> {
         let path = parse_path(params)?;
         let e = self.vfs.lookup(&path).await?;
-        Ok(entry_to_json(&e))
+        let mut entry = entry_to_json(&e);
+        // The mount layer already consults this before rendering content at
+        // GETATTR. Surfacing it on `lookup` lets non-mount clients make the
+        // same decision instead of discovering a signature or a broadcast by
+        // reading a path speculatively.
+        if let Value::Object(fields) = &mut entry {
+            fields.insert(
+                "read_side_effecting".into(),
+                Value::Bool(self.vfs.is_read_side_effecting(&path)),
+            );
+        }
+        Ok(entry)
     }
 
     async fn do_read(
@@ -2342,6 +2353,62 @@ mod tests {
             *self.0.lock().await = data.to_vec();
             Ok(())
         }
+    }
+
+    /// Models the outbox control files: reading `confirm` signs and
+    /// broadcasts, while the sibling status file is inert.
+    struct SideEffectingReadHandler;
+
+    #[async_trait::async_trait]
+    impl Handler for SideEffectingReadHandler {
+        async fn lookup(&self, path: &VfsPath) -> Result<Entry, HandlerError> {
+            match path.segments().last().map(String::as_str) {
+                Some(name @ ("confirm" | "status.json")) => Ok(Entry::file(name)),
+                _ => Err(HandlerError::NotFound(path.to_string_path())),
+            }
+        }
+
+        fn is_read_side_effecting(&self, path: &VfsPath) -> bool {
+            path.segments().last().map(String::as_str) == Some("confirm")
+        }
+    }
+
+    /// `lookup` is the only pre-read probe a non-mount client has. It must
+    /// report whether reading the path would sign or broadcast, so the client
+    /// can refuse to fetch it speculatively.
+    #[tokio::test]
+    async fn lookup_reports_whether_reading_the_path_is_side_effecting() {
+        let server = IpcServer::new(
+            Vfs::builder()
+                .mount("outbox", Arc::new(SideEffectingReadHandler))
+                .build(),
+            "0",
+            vec![],
+        );
+        let lookup = |path: &'static str| {
+            let server = server.clone();
+            async move {
+                server
+                    .dispatch(Request {
+                        jsonrpc: "2.0".into(),
+                        id: json!(1),
+                        method: "lookup".into(),
+                        params: json!({ "path": path }),
+                    })
+                    .await
+                    .result
+                    .expect("lookup result")
+            }
+        };
+
+        let confirm = lookup("/outbox/confirm").await;
+        assert_eq!(confirm["read_side_effecting"], true, "{confirm}");
+        // The pre-existing entry projection is untouched by the new field.
+        assert_eq!(confirm["name"], "confirm");
+        assert_eq!(confirm["kind"], "file");
+
+        let inert = lookup("/outbox/status.json").await;
+        assert_eq!(inert["read_side_effecting"], false, "{inert}");
     }
 
     struct AtomicProjectionHandler {

--- a/crates/bloom-mcp/Cargo.toml
+++ b/crates/bloom-mcp/Cargo.toml
@@ -13,6 +13,7 @@ bloom-daemon.workspace = true
 bloom-proto.workspace = true
 async-trait.workspace = true
 base64.workspace = true
+percent-encoding.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/bloom-mcp/Cargo.toml
+++ b/crates/bloom-mcp/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "bloom-mcp"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Model Context Protocol proxy over the Bloom VFS command surface"
+
+[lib]
+doctest = false
+
+[dependencies]
+bloom-daemon.workspace = true
+bloom-proto.workspace = true
+async-trait.workspace = true
+base64.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+bloom-vfs.workspace = true
+tempfile.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/bloom-mcp/src/backend.rs
+++ b/crates/bloom-mcp/src/backend.rs
@@ -12,10 +12,24 @@ use bloom_daemon::ipc::{IpcClient, IpcClientError};
 use serde_json::Value;
 use thiserror::Error;
 
-/// JSON-RPC code used when the proxy could not reach the daemon at all.
-/// Daemon-originated failures keep the daemon's own code (`-32004` not found,
-/// `-32007` permission denied, …) so clients see one error vocabulary.
-pub const DAEMON_UNREACHABLE_CODE: i32 = -32002;
+/// JSON-RPC code used when the proxy could not reach the daemon at all, or the
+/// daemon answered with a reply this proxy cannot decode. Both are failures of
+/// this server rather than of the request, which is exactly JSON-RPC's
+/// `-32603 Internal error`.
+///
+/// It deliberately is **not** `-32002`: MCP reserves that code for "Resource
+/// not found" on `resources/read`, so using it for a transport failure would
+/// tell clients a path is absent when the daemon is merely down.
+///
+/// Daemon-originated failures keep the daemon's own code
+/// ([`DAEMON_NOT_FOUND_CODE`], `-32007` permission denied, …) so clients see
+/// one error vocabulary.
+pub const DAEMON_UNREACHABLE_CODE: i32 = -32603;
+
+/// The daemon's "not found" code, as emitted by `HandlerError::NotFound`. The
+/// resource surface translates it into MCP's own not-found code; the tool
+/// surface passes it through untouched.
+pub const DAEMON_NOT_FOUND_CODE: i32 = -32004;
 
 /// The five VFS commands `bloom vfs …` uses, and the only methods this proxy
 /// can name. Modelling them as an enum keeps non-VFS IPC methods
@@ -167,5 +181,14 @@ mod tests {
             .unwrap_err();
         assert_eq!(error.code, DAEMON_UNREACHABLE_CODE);
         assert!(error.message.contains("bloom serve"), "{error}");
+    }
+
+    /// A dead daemon must never be reported with MCP's resource-not-found
+    /// code, which would read as "this VFS path does not exist".
+    #[test]
+    fn the_unreachable_code_does_not_collide_with_mcp_or_daemon_codes() {
+        assert_eq!(DAEMON_UNREACHABLE_CODE, -32603);
+        assert_ne!(DAEMON_UNREACHABLE_CODE, -32002);
+        assert_ne!(DAEMON_UNREACHABLE_CODE, DAEMON_NOT_FOUND_CODE);
     }
 }

--- a/crates/bloom-mcp/src/backend.rs
+++ b/crates/bloom-mcp/src/backend.rs
@@ -1,0 +1,171 @@
+//! The canonical VFS command surface the MCP server is allowed to proxy.
+//!
+//! Every MCP tool and resource lands on [`VfsCommands::call`], which speaks the
+//! daemon's existing JSON-RPC IPC methods. There is no second semantic layer:
+//! path parsing, authorization, audit, caching, and error shaping all happen
+//! where they already happen — inside `bloom_vfs::Vfs` and its handlers.
+
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+use bloom_daemon::ipc::{IpcClient, IpcClientError};
+use serde_json::Value;
+use thiserror::Error;
+
+/// JSON-RPC code used when the proxy could not reach the daemon at all.
+/// Daemon-originated failures keep the daemon's own code (`-32004` not found,
+/// `-32007` permission denied, …) so clients see one error vocabulary.
+pub const DAEMON_UNREACHABLE_CODE: i32 = -32002;
+
+/// The five VFS commands `bloom vfs …` uses, and the only methods this proxy
+/// can name. Modelling them as an enum keeps non-VFS IPC methods
+/// (`machine.execute`, `petals.*`, `confirm_batch`, `shutdown`) unreachable
+/// from MCP by construction rather than by review.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VfsMethod {
+    /// `bloom vfs stat` — metadata for one path.
+    Lookup,
+    /// `bloom vfs cat` — file bytes.
+    Read,
+    /// `bloom vfs write` — bytes into a writable path.
+    Write,
+    /// Write, then look up the identity projection it produced, under the
+    /// daemon's mutation gate.
+    WriteWithLookup,
+    /// `bloom vfs ls` — directory children.
+    List,
+}
+
+impl VfsMethod {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            VfsMethod::Lookup => "lookup",
+            VfsMethod::Read => "read",
+            VfsMethod::Write => "write",
+            VfsMethod::WriteWithLookup => "write_with_lookup",
+            VfsMethod::List => "list",
+        }
+    }
+}
+
+/// A failed VFS command, carrying the daemon's JSON-RPC code verbatim.
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+#[error("{message}")]
+pub struct VfsCommandError {
+    pub code: i32,
+    pub message: String,
+}
+
+impl VfsCommandError {
+    pub fn new(code: i32, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+
+    pub fn unreachable(message: impl Into<String>) -> Self {
+        Self::new(DAEMON_UNREACHABLE_CODE, message)
+    }
+}
+
+/// Transport for the canonical VFS command surface.
+#[async_trait]
+pub trait VfsCommands: Send + Sync {
+    async fn call(&self, method: VfsMethod, params: Value) -> Result<Value, VfsCommandError>;
+
+    /// Human-readable upstream description, surfaced in MCP server
+    /// instructions and transport errors.
+    fn endpoint(&self) -> String;
+}
+
+/// Production transport: the same Unix-socket JSON-RPC endpoint the CLI uses.
+#[derive(Clone, Debug)]
+pub struct IpcVfsCommands {
+    socket: PathBuf,
+}
+
+impl IpcVfsCommands {
+    pub fn new(socket: impl Into<PathBuf>) -> Self {
+        Self {
+            socket: socket.into(),
+        }
+    }
+
+    pub fn socket(&self) -> &Path {
+        &self.socket
+    }
+}
+
+#[async_trait]
+impl VfsCommands for IpcVfsCommands {
+    async fn call(&self, method: VfsMethod, params: Value) -> Result<Value, VfsCommandError> {
+        let client = IpcClient::new(&self.socket);
+        client
+            .call(method.as_str(), params)
+            .await
+            .map_err(|error| self.map_error(error))
+    }
+
+    fn endpoint(&self) -> String {
+        format!("unix:{}", self.socket.display())
+    }
+}
+
+impl IpcVfsCommands {
+    fn map_error(&self, error: IpcClientError) -> VfsCommandError {
+        match error {
+            // A daemon-side failure. Keep its code and message exactly as the
+            // CLI would print them.
+            IpcClientError::Rpc(error) => VfsCommandError::new(error.rpc_code, error.message),
+            IpcClientError::Transport(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                VfsCommandError::unreachable(format!(
+                    "Bloom daemon endpoint {} is not available: {error}; start it with 'bloom serve'",
+                    self.endpoint()
+                ))
+            }
+            IpcClientError::Transport(error) => VfsCommandError::unreachable(format!(
+                "Bloom daemon endpoint {} failed: {error}; start it with 'bloom serve'",
+                self.endpoint()
+            )),
+            IpcClientError::Protocol(message) => VfsCommandError::unreachable(format!(
+                "Bloom daemon endpoint {} returned {message}",
+                self.endpoint()
+            )),
+            IpcClientError::EndpointSecurity(message) => VfsCommandError::unreachable(format!(
+                "Bloom daemon endpoint {} is insecure: {message}",
+                self.endpoint()
+            )),
+            error @ IpcClientError::Incompatible { .. } => VfsCommandError::unreachable(format!(
+                "Bloom daemon endpoint {} rejected: {error}",
+                self.endpoint()
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn method_names_match_the_daemon_ipc_surface() {
+        assert_eq!(VfsMethod::Lookup.as_str(), "lookup");
+        assert_eq!(VfsMethod::Read.as_str(), "read");
+        assert_eq!(VfsMethod::Write.as_str(), "write");
+        assert_eq!(VfsMethod::WriteWithLookup.as_str(), "write_with_lookup");
+        assert_eq!(VfsMethod::List.as_str(), "list");
+    }
+
+    #[tokio::test]
+    async fn a_missing_socket_is_reported_as_an_unreachable_daemon() {
+        let dir = tempfile::tempdir().unwrap();
+        let commands = IpcVfsCommands::new(dir.path().join("absent.sock"));
+        let error = commands
+            .call(VfsMethod::List, serde_json::json!({"path": "/"}))
+            .await
+            .unwrap_err();
+        assert_eq!(error.code, DAEMON_UNREACHABLE_CODE);
+        assert!(error.message.contains("bloom serve"), "{error}");
+    }
+}

--- a/crates/bloom-mcp/src/lib.rs
+++ b/crates/bloom-mcp/src/lib.rs
@@ -1,0 +1,85 @@
+//! Model Context Protocol proxy over the Bloom VFS command surface.
+//!
+//! This crate adds no wallet semantics of its own. Every MCP tool and resource
+//! is a thin adapter over one of the five canonical VFS commands the daemon
+//! already exposes over its Unix-socket JSON-RPC endpoint — the same commands
+//! `bloom vfs cat|ls|stat|write` use:
+//!
+//! | MCP tool              | VFS command         | CLI equivalent    |
+//! | --------------------- | ------------------- | ----------------- |
+//! | `vfs_list`            | `list`              | `bloom vfs ls`    |
+//! | `vfs_read`            | `read`              | `bloom vfs cat`   |
+//! | `vfs_stat`            | `lookup`            | `bloom vfs stat`  |
+//! | `vfs_write`           | `write`             | `bloom vfs write` |
+//! | `vfs_write_then_stat` | `write_with_lookup` | (staging flows)   |
+//!
+//! `resources/read` maps `bloom:///<path>` onto the same `read` command.
+//! Because the proxy delegates, path parsing, authorization, policy gates,
+//! audit journalling, caching, and error codes all keep happening in
+//! `bloom_vfs` and its handlers — new VFS capabilities appear here for free.
+//!
+//! The server is **disabled by default**. [`ensure_enabled`] is the single gate;
+//! `bloom mcp serve` calls it before touching stdin, stdout, or the daemon
+//! socket, so an operator must set `[mcp] enabled = true` in `config.toml`
+//! before anything can start.
+
+#![forbid(unsafe_code)]
+
+mod backend;
+mod server;
+mod tools;
+
+use std::path::Path;
+
+use bloom_proto::McpConfig;
+use thiserror::Error;
+
+pub use backend::{
+    DAEMON_UNREACHABLE_CODE, IpcVfsCommands, VfsCommandError, VfsCommands, VfsMethod,
+};
+pub use server::{McpServer, PROTOCOL_VERSION, SERVER_NAME, SUPPORTED_PROTOCOL_VERSIONS};
+pub use tools::{RESOURCE_SCHEME, TOOLS, ToolSpec};
+
+/// Returned when the MCP server is asked to start without an explicit opt-in.
+#[derive(Debug, Error)]
+#[error(
+    "the Bloom MCP server is disabled; set `enabled = true` under `[mcp]` in {config_path} to allow it to start"
+)]
+pub struct McpDisabled {
+    pub config_path: String,
+}
+
+/// The only way to start an MCP server. Fails closed: a missing `[mcp]` block,
+/// a missing config file, and `enabled = false` all mean disabled.
+pub fn ensure_enabled(config: &McpConfig, config_path: &Path) -> Result<(), McpDisabled> {
+    if config.enabled {
+        return Ok(());
+    }
+    Err(McpDisabled {
+        config_path: config_path.display().to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_default_configuration_refuses_to_start() {
+        let error = ensure_enabled(&McpConfig::default(), Path::new("/home/.bloom/config.toml"))
+            .unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("disabled"), "{message}");
+        assert!(message.contains("[mcp]"), "{message}");
+        assert!(message.contains("/home/.bloom/config.toml"), "{message}");
+    }
+
+    #[test]
+    fn an_explicit_opt_in_starts() {
+        ensure_enabled(
+            &McpConfig { enabled: true },
+            Path::new("/home/.bloom/config.toml"),
+        )
+        .unwrap();
+    }
+}

--- a/crates/bloom-mcp/src/lib.rs
+++ b/crates/bloom-mcp/src/lib.rs
@@ -13,10 +13,23 @@
 //! | `vfs_write`           | `write`             | `bloom vfs write` |
 //! | `vfs_write_then_stat` | `write_with_lookup` | (staging flows)   |
 //!
-//! `resources/read` maps `bloom:///<path>` onto the same `read` command.
+//! `resources/read` maps `bloom:///<path>` onto the same `read` command,
+//! except for the few paths whose read *is* the action — those stay tool-only,
+//! because MCP clients fetch resources without asking.
+//!
 //! Because the proxy delegates, path parsing, authorization, policy gates,
 //! audit journalling, caching, and error codes all keep happening in
-//! `bloom_vfs` and its handlers — new VFS capabilities appear here for free.
+//! `bloom_vfs` and its handlers. New *paths* therefore appear here for free:
+//! every subtree the daemon grows is immediately listable, readable, and
+//! writable through these five tools. New *parameters* do not. Each tool
+//! forwards a fixed argument allowlist (`tools::ToolSpec::accepted_arguments`)
+//! and rejects anything else before the daemon is called, so adding an
+//! argument to a daemon VFS method also means adding it here — which is the
+//! trade for never letting an MCP client name a parameter this proxy has not
+//! reviewed. Two tests keep that list honest against the rest of the surface:
+//! `advertised_schema_matches_the_forwarded_argument_allowlist` (allowlist vs.
+//! `tools/list` schema) and `every_advertised_argument_reaches_the_daemon` in
+//! `tests/vfs_proxy.rs` (allowlist vs. a live daemon).
 //!
 //! The server is **disabled by default**. [`ensure_enabled`] is the single gate;
 //! `bloom mcp serve` calls it before touching stdin, stdout, or the daemon
@@ -35,9 +48,13 @@ use bloom_proto::McpConfig;
 use thiserror::Error;
 
 pub use backend::{
-    DAEMON_UNREACHABLE_CODE, IpcVfsCommands, VfsCommandError, VfsCommands, VfsMethod,
+    DAEMON_NOT_FOUND_CODE, DAEMON_UNREACHABLE_CODE, IpcVfsCommands, VfsCommandError, VfsCommands,
+    VfsMethod,
 };
-pub use server::{McpServer, PROTOCOL_VERSION, SERVER_NAME, SUPPORTED_PROTOCOL_VERSIONS};
+pub use server::{
+    McpServer, PROTOCOL_VERSION, RESOURCE_IS_AN_ACTION_CODE, RESOURCE_NOT_FOUND_CODE, SERVER_NAME,
+    SUPPORTED_PROTOCOL_VERSIONS,
+};
 pub use tools::{RESOURCE_SCHEME, TOOLS, ToolSpec};
 
 /// Returned when the MCP server is asked to start without an explicit opt-in.

--- a/crates/bloom-mcp/src/server.rs
+++ b/crates/bloom-mcp/src/server.rs
@@ -12,7 +12,9 @@ use serde_json::{Value, json};
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 use tracing::{debug, warn};
 
-use crate::backend::{VfsCommandError, VfsCommands, VfsMethod};
+use crate::backend::{
+    DAEMON_NOT_FOUND_CODE, DAEMON_UNREACHABLE_CODE, VfsCommandError, VfsCommands, VfsMethod,
+};
 use crate::tools::{self, ToolError};
 
 /// Server name reported in `initialize`.
@@ -23,7 +25,21 @@ pub const PROTOCOL_VERSION: &str = "2025-06-18";
 
 /// Revisions this server can speak. `initialize` echoes the client's revision
 /// when it is one of these, and otherwise answers with [`PROTOCOL_VERSION`].
+///
+/// `2025-03-26` and `2024-11-05` are only claimed because every feature they
+/// require is implemented, including the JSON-RPC batching `2025-03-26`
+/// permits on stdio and `2025-06-18` removed again — see [`McpServer::serve`].
 pub const SUPPORTED_PROTOCOL_VERSIONS: [&str; 3] = ["2025-06-18", "2025-03-26", "2024-11-05"];
+
+/// MCP's own "Resource not found" code for `resources/read`. The daemon's
+/// not-found code is translated into this one on the resource surface so a
+/// client can tell an absent path from a server that is not working.
+pub const RESOURCE_NOT_FOUND_CODE: i32 = -32002;
+
+/// `resources/read` refused because reading the path would sign, broadcast, or
+/// otherwise act. Deliberately outside the daemon's code space: no VFS command
+/// failed, the proxy declined to issue one.
+pub const RESOURCE_IS_AN_ACTION_CODE: i32 = -32010;
 
 /// Largest accepted inbound frame. MCP requests are small; the cap stops a
 /// misbehaving client from growing the read buffer without bound.
@@ -57,6 +73,11 @@ impl McpServer {
     }
 
     /// Serve MCP over any framed byte pair. Exits cleanly at end of input.
+    ///
+    /// One frame is one JSON-RPC message: either a single request/notification
+    /// object, or the batch array `2025-03-26` allows on stdio. Anything else
+    /// is answered with an `id: null` invalid-request error rather than being
+    /// dropped, so a client never waits forever on a malformed frame.
     pub async fn serve<R, W>(&self, mut reader: R, mut writer: W) -> std::io::Result<()>
     where
         R: AsyncBufRead + Unpin,
@@ -69,7 +90,7 @@ impl McpServer {
                 continue;
             }
             let response = match serde_json::from_str::<Value>(frame) {
-                Ok(request) => self.handle(request).await,
+                Ok(message) => self.handle_message(message).await,
                 Err(error) => {
                     warn!(%error, "mcp.parse_error");
                     Some(error_response(
@@ -88,23 +109,84 @@ impl McpServer {
         Ok(())
     }
 
-    /// Handle one decoded JSON-RPC message. `None` means "notification — say
-    /// nothing", which MCP requires for `notifications/*`.
+    /// Handle one decoded JSON-RPC message of any shape: a single request or
+    /// notification object, or a batch array. `None` means "nothing to send",
+    /// which happens only when every message in hand was a notification.
+    pub async fn handle_message(&self, message: Value) -> Option<Value> {
+        match message {
+            Value::Object(_) => self.handle(message).await,
+            // JSON-RPC batching. `2025-03-26` allows it on stdio; `2025-06-18`
+            // removed it. Accepting it either way costs one loop and keeps the
+            // revisions this server claims honest.
+            Value::Array(messages) => {
+                if messages.is_empty() {
+                    return Some(invalid_request(Value::Null, "batch must not be empty"));
+                }
+                let mut responses = Vec::new();
+                for message in messages {
+                    let response = match message {
+                        Value::Object(_) => self.handle(message).await,
+                        other => Some(invalid_request(
+                            Value::Null,
+                            format!("batch member must be an object, got {}", json_kind(&other)),
+                        )),
+                    };
+                    responses.extend(response);
+                }
+                // An all-notification batch gets no reply at all, per JSON-RPC.
+                (!responses.is_empty()).then_some(Value::Array(responses))
+            }
+            other => Some(invalid_request(
+                Value::Null,
+                format!(
+                    "JSON-RPC message must be an object or a batch array, got {}",
+                    json_kind(&other)
+                ),
+            )),
+        }
+    }
+
+    /// Handle one decoded JSON-RPC request object. `None` means "notification
+    /// — say nothing", which MCP requires for `notifications/*`.
     pub async fn handle(&self, request: Value) -> Option<Value> {
-        let method = request.get("method").and_then(Value::as_str).unwrap_or("");
         let id = request.get("id").cloned();
         let params = request.get("params").cloned().unwrap_or(Value::Null);
+
+        // Structural validity first: a message that is not a well-formed
+        // request *or* notification is an invalid request, and JSON-RPC wants
+        // that answered with `id: null` rather than silently dropped.
+        if let Some(version) = request.get("jsonrpc")
+            && version.as_str() != Some("2.0")
+        {
+            return Some(invalid_request(Value::Null, "jsonrpc must be \"2.0\""));
+        }
+        let id = match id {
+            None | Some(Value::Null) => None,
+            Some(id @ (Value::String(_) | Value::Number(_))) => Some(id),
+            Some(other) => {
+                return Some(invalid_request(
+                    Value::Null,
+                    format!("id must be a string or a number, got {}", json_kind(&other)),
+                ));
+            }
+        };
+        let Some(method) = request.get("method").and_then(Value::as_str) else {
+            // A `result`/`error` object is a JSON-RPC *response*. This server
+            // never sends the client a request, so one can only be stray —
+            // and answering a response with an error would loop.
+            if request.get("result").is_some() || request.get("error").is_some() {
+                debug!("mcp.stray_response");
+                return None;
+            }
+            return Some(invalid_request(
+                id.unwrap_or(Value::Null),
+                "request must carry a string `method`",
+            ));
+        };
         debug!(%method, "mcp.request");
 
         // No id: a notification. Never answer, not even on error.
-        let Some(id) = id.filter(|id| !id.is_null()) else {
-            return None;
-        };
-        if let Some(version) = request.get("jsonrpc").and_then(Value::as_str)
-            && version != "2.0"
-        {
-            return Some(error_response(id, -32600, "jsonrpc must be 2.0"));
-        }
+        let Some(id) = id else { return None };
 
         Some(match method {
             "initialize" => ok_response(id, self.initialize(&params)),
@@ -183,6 +265,14 @@ impl McpServer {
         ok_response(id, json!({ "resources": resources }))
     }
 
+    /// Read a VFS path as an MCP resource.
+    ///
+    /// Clients treat resources as inert context and fetch them without asking,
+    /// so this refuses the handful of VFS paths whose read *is* the action
+    /// (outbox `confirm`/`replace`/`cancel`). The daemon's `lookup` reports
+    /// that per path, which keeps the judgement in the VFS instead of in a
+    /// path list maintained here. Nothing is lost: `vfs_read` still performs
+    /// those reads, under a tool call the client can present for confirmation.
     async fn resources_read(&self, id: Value, params: &Value) -> Value {
         let Some(uri) = params.get("uri").and_then(Value::as_str) else {
             return error_response(id, -32602, "resources/read requires a `uri`");
@@ -191,13 +281,32 @@ impl McpServer {
             Ok(path) => path,
             Err(message) => return error_response(id, -32602, message),
         };
+        match self
+            .commands
+            .call(VfsMethod::Lookup, json!({ "path": path }))
+            .await
+        {
+            Ok(entry) if tools::read_is_side_effecting(&entry) => {
+                return error_response_with_data(
+                    id,
+                    RESOURCE_IS_AN_ACTION_CODE,
+                    format!(
+                        "reading {path} performs an action (it signs or broadcasts), so it is not \
+                         served as a resource; call the `vfs_read` tool if you intend to trigger it"
+                    ),
+                    json!({ "uri": uri, "path": path, "tool": "vfs_read" }),
+                );
+            }
+            Ok(_) => {}
+            Err(error) => return resource_error_response(id, uri, &error),
+        }
         let read = self
             .commands
             .call(VfsMethod::Read, json!({ "path": path }))
             .await;
         let bytes = match read.and_then(|result| tools::read_bytes(&result)) {
             Ok(bytes) => bytes,
-            Err(error) => return vfs_error_response(id, &error),
+            Err(error) => return resource_error_response(id, uri, &error),
         };
         let content = match std::str::from_utf8(&bytes) {
             Ok(text) => json!({
@@ -226,7 +335,7 @@ fn resource_templates() -> Value {
             "uriTemplate": "bloom:///{+path}",
             "name": "bloom-vfs-path",
             "title": "Bloom VFS path",
-            "description": "Any readable Bloom VFS path, for example `bloom:///status/health`. Use `vfs_list` to discover paths.",
+            "description": "Any inert Bloom VFS path, for example `bloom:///status/health`. Use `vfs_list` to discover paths, and percent-encode `%`, spaces, `?`, and `#` inside a path segment. Bloom's few side-effecting reads (a wallet outbox `confirm`, `confirm.override`, `replace`, or `cancel` file, whose read performs the action) are refused here with error -32010 and remain reachable only through the `vfs_read` tool, so fetching a resource never signs or broadcasts.",
         }],
     })
 }
@@ -243,8 +352,57 @@ fn error_response(id: Value, code: i32, message: impl Into<String>) -> Value {
     })
 }
 
-/// Protocol-level surfaces (`resources/*`) propagate the daemon's own JSON-RPC
-/// code and message rather than inventing a proxy-specific vocabulary.
+fn error_response_with_data(
+    id: Value,
+    code: i32,
+    message: impl Into<String>,
+    data: Value,
+) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": { "code": code, "message": message.into(), "data": data },
+    })
+}
+
+fn invalid_request(id: Value, message: impl Into<String>) -> Value {
+    error_response(id, -32600, format!("invalid request: {}", message.into()))
+}
+
+/// `"an array"`, `"a string"`, … for invalid-request diagnostics.
+fn json_kind(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "a boolean",
+        Value::Number(_) => "a number",
+        Value::String(_) => "a string",
+        Value::Array(_) => "an array",
+        Value::Object(_) => "an object",
+    }
+}
+
+/// Protocol-level surfaces (`resources/*`) speak MCP's error vocabulary, not
+/// the daemon's: a client reads `-32002` as "this resource does not exist" and
+/// `-32603` as "this server is broken", and conflating the two hides a dead
+/// daemon behind a missing path. The daemon's own code always survives in
+/// `data.daemonCode` so nothing is lost in translation.
+fn resource_error_response(id: Value, uri: &str, error: &VfsCommandError) -> Value {
+    let code = match error.code {
+        DAEMON_NOT_FOUND_CODE => RESOURCE_NOT_FOUND_CODE,
+        DAEMON_UNREACHABLE_CODE => DAEMON_UNREACHABLE_CODE,
+        // Everything else (`not a file`, `permission denied`, …) is a real
+        // daemon verdict about a real path; pass it through.
+        other => other,
+    };
+    error_response_with_data(
+        id,
+        code,
+        error.message.clone(),
+        json!({ "uri": uri, "daemonCode": error.code }),
+    )
+}
+
+/// `resources/list` has no single URI to blame, so it keeps the plain form.
 fn vfs_error_response(id: Value, error: &VfsCommandError) -> Value {
     error_response(id, error.code, error.message.clone())
 }
@@ -413,9 +571,14 @@ mod tests {
         assert!(response.get("error").is_none(), "{response}");
     }
 
+    /// A missing VFS path must reach the client as MCP's own resource-not-found
+    /// code, with the daemon's code preserved as diagnostic data.
     #[tokio::test]
-    async fn resources_read_propagates_the_daemon_error_as_a_protocol_error() {
-        let (server, _) = server(Err(VfsCommandError::new(-32004, "not found: /nope")));
+    async fn resources_read_reports_a_missing_path_as_mcp_resource_not_found() {
+        let (server, _) = server(Err(VfsCommandError::new(
+            DAEMON_NOT_FOUND_CODE,
+            "not found: /nope",
+        )));
         let response = server
             .handle(json!({
                 "jsonrpc": "2.0", "id": 1, "method": "resources/read",
@@ -423,8 +586,194 @@ mod tests {
             }))
             .await
             .unwrap();
-        assert_eq!(response["error"]["code"], -32004);
+        assert_eq!(response["error"]["code"], RESOURCE_NOT_FOUND_CODE);
         assert_eq!(response["error"]["message"], "not found: /nope");
+        assert_eq!(response["error"]["data"]["uri"], "bloom:///nope");
+        assert_eq!(
+            response["error"]["data"]["daemonCode"],
+            DAEMON_NOT_FOUND_CODE
+        );
+    }
+
+    /// …and a daemon that is simply not running must *not*, or the client
+    /// learns "that path does not exist" when the right answer is "start the
+    /// daemon".
+    #[tokio::test]
+    async fn a_dead_daemon_is_an_internal_error_not_a_missing_resource() {
+        let (server, _) = server(Err(VfsCommandError::unreachable(
+            "Bloom daemon endpoint unix:/x is not available; start it with 'bloom serve'",
+        )));
+        let response = server
+            .handle(json!({
+                "jsonrpc": "2.0", "id": 1, "method": "resources/read",
+                "params": {"uri": "bloom:///status/health"},
+            }))
+            .await
+            .unwrap();
+        assert_eq!(response["error"]["code"], -32603);
+        assert_ne!(response["error"]["code"], RESOURCE_NOT_FOUND_CODE);
+        assert!(
+            response["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("bloom serve"),
+            "{response}"
+        );
+        assert_eq!(
+            response["error"]["data"]["daemonCode"],
+            DAEMON_UNREACHABLE_CODE
+        );
+    }
+
+    /// Other daemon verdicts are real statements about a real path and keep
+    /// their code.
+    #[tokio::test]
+    async fn resources_read_passes_other_daemon_codes_through() {
+        let (server, _) = server(Err(VfsCommandError::new(-32007, "permission denied")));
+        let response = server
+            .handle(json!({
+                "jsonrpc": "2.0", "id": 1, "method": "resources/read",
+                "params": {"uri": "bloom:///secret"},
+            }))
+            .await
+            .unwrap();
+        assert_eq!(response["error"]["code"], -32007);
+        assert_eq!(response["error"]["data"]["daemonCode"], -32007);
+    }
+
+    /// Clients fetch resources without asking. A path whose read signs or
+    /// broadcasts must therefore never be served as one — but must stay
+    /// reachable through the tool.
+    #[tokio::test]
+    async fn a_side_effecting_read_is_refused_as_a_resource_and_never_issued() {
+        let (server, commands) = server(Ok(json!({
+            "name": "confirm", "kind": "file", "read_side_effecting": true,
+        })));
+        let response = server
+            .handle(json!({
+                "jsonrpc": "2.0", "id": 1, "method": "resources/read",
+                "params": {"uri": "bloom:///wallets/w/chains/ethereum/outbox/pending/1/confirm"},
+            }))
+            .await
+            .unwrap();
+        assert_eq!(response["error"]["code"], RESOURCE_IS_AN_ACTION_CODE);
+        assert_eq!(response["error"]["data"]["tool"], "vfs_read");
+
+        // Only the (inert) lookup was issued; the read never happened.
+        let calls = commands.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1, "{calls:?}");
+        assert_eq!(calls[0].0, VfsMethod::Lookup);
+    }
+
+    #[tokio::test]
+    async fn an_inert_path_is_still_served_as_a_resource() {
+        // The lookup reply says inert; the read reply follows it.
+        let (server, commands) = server(Ok(json!({
+            "name": "health", "kind": "file", "read_side_effecting": false,
+            "bytes_b64": "aGk=", "len": 2,
+        })));
+        let response = server
+            .handle(json!({
+                "jsonrpc": "2.0", "id": 1, "method": "resources/read",
+                "params": {"uri": "bloom:///status/health"},
+            }))
+            .await
+            .unwrap();
+        assert_eq!(response["result"]["contents"][0]["text"], "hi");
+        assert_eq!(
+            response["result"]["contents"][0]["uri"],
+            "bloom:///status/health"
+        );
+        let calls = commands.calls.lock().unwrap();
+        assert_eq!(
+            calls.iter().map(|call| call.0).collect::<Vec<_>>(),
+            [VfsMethod::Lookup, VfsMethod::Read]
+        );
+    }
+
+    #[tokio::test]
+    async fn non_object_messages_get_an_invalid_request_instead_of_silence() {
+        let (server, commands) = server(Ok(Value::Null));
+        for message in [json!(42), json!("ping"), json!(true), json!(null)] {
+            let response = server
+                .handle_message(message.clone())
+                .await
+                .unwrap_or_else(|| panic!("{message} must be answered"));
+            assert_eq!(response["error"]["code"], -32600, "{message}");
+            assert_eq!(response["id"], Value::Null, "{message}");
+            assert_eq!(response["jsonrpc"], "2.0", "{message}");
+        }
+        // An empty batch is an invalid request too, per JSON-RPC 2.0.
+        let response = server.handle_message(json!([])).await.unwrap();
+        assert_eq!(response["error"]["code"], -32600);
+        assert!(commands.calls.lock().unwrap().is_empty());
+    }
+
+    /// `2025-03-26` allows a batch on stdio, and this server claims that
+    /// revision, so a batch has to be answered with a batch.
+    #[tokio::test]
+    async fn batches_are_answered_as_batches() {
+        let (server, _) = server(Ok(Value::Null));
+        let response = server
+            .handle_message(json!([
+                {"jsonrpc": "2.0", "id": 1, "method": "ping"},
+                {"jsonrpc": "2.0", "method": "notifications/initialized"},
+                {"jsonrpc": "2.0", "id": 2, "method": "does/not/exist"},
+                7,
+            ]))
+            .await
+            .unwrap();
+        let responses = response.as_array().expect("batch reply");
+        // The notification contributes nothing; the other three do.
+        assert_eq!(responses.len(), 3, "{response}");
+        assert_eq!(responses[0]["id"], 1);
+        assert_eq!(responses[0]["result"], json!({}));
+        assert_eq!(responses[1]["id"], 2);
+        assert_eq!(responses[1]["error"]["code"], -32601);
+        assert_eq!(responses[2]["id"], Value::Null);
+        assert_eq!(responses[2]["error"]["code"], -32600);
+    }
+
+    #[tokio::test]
+    async fn an_all_notification_batch_is_not_answered() {
+        let (server, _) = server(Ok(Value::Null));
+        assert!(
+            server
+                .handle_message(json!([
+                    {"jsonrpc": "2.0", "method": "notifications/initialized"},
+                    {"jsonrpc": "2.0", "method": "notifications/cancelled"},
+                ]))
+                .await
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn structurally_invalid_requests_are_rejected_not_dropped() {
+        let (server, _) = server(Ok(Value::Null));
+        for message in [
+            // No `method` at all: neither a request nor a notification.
+            json!({"jsonrpc": "2.0", "id": 1}),
+            json!({"jsonrpc": "2.0"}),
+            json!({"jsonrpc": "2.0", "id": 1, "method": 7}),
+            json!({"jsonrpc": "1.0", "id": 1, "method": "ping"}),
+            json!({"jsonrpc": "2.0", "id": {"nested": true}, "method": "ping"}),
+        ] {
+            let response = server
+                .handle(message.clone())
+                .await
+                .unwrap_or_else(|| panic!("{message} must be answered"));
+            assert_eq!(response["error"]["code"], -32600, "{message}");
+        }
+
+        // A stray JSON-RPC *response* is not a request; answering it with an
+        // error would bounce messages back and forth forever.
+        assert!(
+            server
+                .handle(json!({"jsonrpc": "2.0", "id": 1, "result": {}}))
+                .await
+                .is_none()
+        );
     }
 
     #[tokio::test]
@@ -504,6 +853,39 @@ mod tests {
             .collect();
         assert_eq!(lines[0]["error"]["code"], -32700);
         assert_eq!(lines[1]["id"], 2);
+    }
+
+    /// Every frame a client writes gets exactly one frame back unless it was
+    /// purely notifications. A dropped frame strands a client that is blocking
+    /// on its response.
+    #[tokio::test]
+    async fn every_non_notification_frame_is_answered_on_the_wire() {
+        let (server, _) = server(Ok(Value::Null));
+        let input = concat!(
+            "[{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"},",
+            "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"ping\"}]\n",
+            "42\n",
+            "[]\n",
+            "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n",
+            "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"ping\"}\n",
+        );
+        let mut output = Vec::new();
+        server
+            .serve(BufReader::new(input.as_bytes()), &mut output)
+            .await
+            .unwrap();
+        let frames: Vec<Value> = std::str::from_utf8(&output)
+            .unwrap()
+            .lines()
+            .filter(|line| !line.is_empty())
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect();
+        assert_eq!(frames.len(), 4, "{frames:?}");
+        // A batch frame answers with one batch frame, on one line.
+        assert_eq!(frames[0].as_array().unwrap().len(), 2);
+        assert_eq!(frames[1]["error"]["code"], -32600, "scalar frame");
+        assert_eq!(frames[2]["error"]["code"], -32600, "empty batch frame");
+        assert_eq!(frames[3]["id"], 3, "the session survives all of it");
     }
 
     #[tokio::test]

--- a/crates/bloom-mcp/src/server.rs
+++ b/crates/bloom-mcp/src/server.rs
@@ -1,0 +1,518 @@
+//! Newline-delimited JSON-RPC 2.0 server speaking the Model Context Protocol.
+//!
+//! Transport is stdio only: an MCP client spawns `bloom mcp serve` as a child
+//! process and owns its lifetime. That keeps the proxy off the network, gives
+//! it the invoking user's identity for the daemon's peer-uid check, and means
+//! nothing is listening when no client is attached. Diagnostics go to stderr;
+//! stdout carries protocol frames exclusively.
+
+use std::sync::Arc;
+
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
+use tracing::{debug, warn};
+
+use crate::backend::{VfsCommandError, VfsCommands, VfsMethod};
+use crate::tools::{self, ToolError};
+
+/// Server name reported in `initialize`.
+pub const SERVER_NAME: &str = "bloom-vfs";
+
+/// MCP revision this server implements.
+pub const PROTOCOL_VERSION: &str = "2025-06-18";
+
+/// Revisions this server can speak. `initialize` echoes the client's revision
+/// when it is one of these, and otherwise answers with [`PROTOCOL_VERSION`].
+pub const SUPPORTED_PROTOCOL_VERSIONS: [&str; 3] = ["2025-06-18", "2025-03-26", "2024-11-05"];
+
+/// Largest accepted inbound frame. MCP requests are small; the cap stops a
+/// misbehaving client from growing the read buffer without bound.
+const MAX_MESSAGE_BYTES: usize = 8 * 1024 * 1024;
+
+const INSTRUCTIONS: &str = "Bloom exposes an agentic Ethereum wallet as a virtual filesystem. \
+Discover paths with `vfs_list` starting at `/`, read files with `vfs_read`, inspect metadata with \
+`vfs_stat`, and stage actions by writing intents with `vfs_write`. Value-moving actions are staged \
+and must be confirmed by a second write after reviewing the generated plan. This server is a proxy \
+for the same VFS commands as `bloom vfs …`; it holds no keys and adds no permissions of its own.";
+
+/// An MCP server bound to one canonical VFS command transport.
+#[derive(Clone)]
+pub struct McpServer {
+    commands: Arc<dyn VfsCommands>,
+    version: String,
+}
+
+impl McpServer {
+    pub fn new(commands: Arc<dyn VfsCommands>, version: impl Into<String>) -> Self {
+        Self {
+            commands,
+            version: version.into(),
+        }
+    }
+
+    /// Serve MCP on this process's stdin/stdout until the client closes stdin.
+    pub async fn serve_stdio(&self) -> std::io::Result<()> {
+        self.serve(BufReader::new(tokio::io::stdin()), tokio::io::stdout())
+            .await
+    }
+
+    /// Serve MCP over any framed byte pair. Exits cleanly at end of input.
+    pub async fn serve<R, W>(&self, mut reader: R, mut writer: W) -> std::io::Result<()>
+    where
+        R: AsyncBufRead + Unpin,
+        W: AsyncWrite + Unpin,
+    {
+        while let Some(frame) = read_bounded_line(&mut reader).await? {
+            let frame = String::from_utf8_lossy(&frame);
+            let frame = frame.trim();
+            if frame.is_empty() {
+                continue;
+            }
+            let response = match serde_json::from_str::<Value>(frame) {
+                Ok(request) => self.handle(request).await,
+                Err(error) => {
+                    warn!(%error, "mcp.parse_error");
+                    Some(error_response(
+                        Value::Null,
+                        -32700,
+                        format!("parse error: {error}"),
+                    ))
+                }
+            };
+            let Some(response) = response else { continue };
+            let mut line = serde_json::to_vec(&response).map_err(std::io::Error::other)?;
+            line.push(b'\n');
+            writer.write_all(&line).await?;
+            writer.flush().await?;
+        }
+        Ok(())
+    }
+
+    /// Handle one decoded JSON-RPC message. `None` means "notification — say
+    /// nothing", which MCP requires for `notifications/*`.
+    pub async fn handle(&self, request: Value) -> Option<Value> {
+        let method = request.get("method").and_then(Value::as_str).unwrap_or("");
+        let id = request.get("id").cloned();
+        let params = request.get("params").cloned().unwrap_or(Value::Null);
+        debug!(%method, "mcp.request");
+
+        // No id: a notification. Never answer, not even on error.
+        let Some(id) = id.filter(|id| !id.is_null()) else {
+            return None;
+        };
+        if let Some(version) = request.get("jsonrpc").and_then(Value::as_str)
+            && version != "2.0"
+        {
+            return Some(error_response(id, -32600, "jsonrpc must be 2.0"));
+        }
+
+        Some(match method {
+            "initialize" => ok_response(id, self.initialize(&params)),
+            "ping" => ok_response(id, json!({})),
+            "tools/list" => ok_response(id, json!({ "tools": tool_descriptors() })),
+            "tools/call" => self.tools_call(id, &params).await,
+            "resources/list" => self.resources_list(id).await,
+            "resources/templates/list" => ok_response(id, resource_templates()),
+            "resources/read" => self.resources_read(id, &params).await,
+            other => error_response(id, -32601, format!("method not found: {other}")),
+        })
+    }
+
+    fn initialize(&self, params: &Value) -> Value {
+        let requested = params.get("protocolVersion").and_then(Value::as_str);
+        let negotiated = requested
+            .filter(|version| SUPPORTED_PROTOCOL_VERSIONS.contains(version))
+            .unwrap_or(PROTOCOL_VERSION);
+        json!({
+            "protocolVersion": negotiated,
+            "capabilities": {
+                "tools": { "listChanged": false },
+                "resources": { "listChanged": false, "subscribe": false },
+            },
+            "serverInfo": {
+                "name": SERVER_NAME,
+                "title": "Bloom VFS",
+                "version": self.version,
+            },
+            "instructions": INSTRUCTIONS,
+        })
+    }
+
+    async fn tools_call(&self, id: Value, params: &Value) -> Value {
+        let Some(name) = params.get("name").and_then(Value::as_str) else {
+            return error_response(id, -32602, "tools/call requires a tool `name`");
+        };
+        let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
+        match tools::call(self.commands.as_ref(), name, &arguments).await {
+            Ok(result) => ok_response(id, result),
+            Err(error @ (ToolError::UnknownTool(_) | ToolError::InvalidArguments(_))) => {
+                error_response(id, -32602, error.message())
+            }
+        }
+    }
+
+    /// Resources are the VFS root's files. Everything deeper is reachable
+    /// through the `bloom:///{path}` template and the `vfs_*` tools, which is
+    /// also what keeps this from eagerly walking (and side-effecting on) the
+    /// whole tree.
+    async fn resources_list(&self, id: Value) -> Value {
+        let listed = self
+            .commands
+            .call(VfsMethod::List, json!({ "path": "/" }))
+            .await;
+        let entries = match listed {
+            Ok(Value::Array(entries)) => entries,
+            Ok(_) => return error_response(id, -32603, "daemon list reply is not an array"),
+            Err(error) => return vfs_error_response(id, &error),
+        };
+        let resources: Vec<Value> = entries
+            .iter()
+            .filter(|entry| entry.get("kind").and_then(Value::as_str) == Some("file"))
+            .filter_map(|entry| {
+                let name = entry.get("name").and_then(Value::as_str)?;
+                let path = format!("/{name}");
+                Some(json!({
+                    "uri": tools::resource_uri(&path),
+                    "name": name,
+                    "title": path,
+                    "mimeType": tools::mime_type_for(&path, true),
+                    "size": entry.get("size").cloned().unwrap_or(Value::Null),
+                }))
+            })
+            .collect();
+        ok_response(id, json!({ "resources": resources }))
+    }
+
+    async fn resources_read(&self, id: Value, params: &Value) -> Value {
+        let Some(uri) = params.get("uri").and_then(Value::as_str) else {
+            return error_response(id, -32602, "resources/read requires a `uri`");
+        };
+        let path = match tools::path_from_uri(uri) {
+            Ok(path) => path,
+            Err(message) => return error_response(id, -32602, message),
+        };
+        let read = self
+            .commands
+            .call(VfsMethod::Read, json!({ "path": path }))
+            .await;
+        let bytes = match read.and_then(|result| tools::read_bytes(&result)) {
+            Ok(bytes) => bytes,
+            Err(error) => return vfs_error_response(id, &error),
+        };
+        let content = match std::str::from_utf8(&bytes) {
+            Ok(text) => json!({
+                "uri": uri,
+                "mimeType": tools::mime_type_for(&path, true),
+                "text": text,
+            }),
+            Err(_) => {
+                let (content, _) = tools::bytes_payload(&path, &bytes);
+                let mut blob = content[0]["resource"].clone();
+                blob["uri"] = Value::String(uri.to_owned());
+                blob
+            }
+        };
+        ok_response(id, json!({ "contents": [content] }))
+    }
+}
+
+fn tool_descriptors() -> Vec<Value> {
+    tools::TOOLS.iter().map(|tool| tool.descriptor()).collect()
+}
+
+fn resource_templates() -> Value {
+    json!({
+        "resourceTemplates": [{
+            "uriTemplate": "bloom:///{+path}",
+            "name": "bloom-vfs-path",
+            "title": "Bloom VFS path",
+            "description": "Any readable Bloom VFS path, for example `bloom:///status/health`. Use `vfs_list` to discover paths.",
+        }],
+    })
+}
+
+fn ok_response(id: Value, result: Value) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "result": result })
+}
+
+fn error_response(id: Value, code: i32, message: impl Into<String>) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": { "code": code, "message": message.into() },
+    })
+}
+
+/// Protocol-level surfaces (`resources/*`) propagate the daemon's own JSON-RPC
+/// code and message rather than inventing a proxy-specific vocabulary.
+fn vfs_error_response(id: Value, error: &VfsCommandError) -> Value {
+    error_response(id, error.code, error.message.clone())
+}
+
+/// Read one newline-terminated frame, refusing to buffer past
+/// [`MAX_MESSAGE_BYTES`]. Mirrors the daemon's bounded IPC framing.
+async fn read_bounded_line<R>(reader: &mut R) -> std::io::Result<Option<Vec<u8>>>
+where
+    R: AsyncBufRead + Unpin,
+{
+    let mut frame = Vec::new();
+    loop {
+        let available = reader.fill_buf().await?;
+        if available.is_empty() {
+            return Ok((!frame.is_empty()).then_some(frame));
+        }
+        let newline = available.iter().position(|byte| *byte == b'\n');
+        let take = newline.map(|index| index + 1).unwrap_or(available.len());
+        if frame.len().saturating_add(take) > MAX_MESSAGE_BYTES {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("MCP message exceeds {MAX_MESSAGE_BYTES} bytes"),
+            ));
+        }
+        frame.extend_from_slice(&available[..take]);
+        reader.consume(take);
+        if newline.is_some() {
+            return Ok(Some(frame));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+
+    /// Records what the proxy asked the canonical command surface for.
+    struct RecordingCommands {
+        calls: std::sync::Mutex<Vec<(VfsMethod, Value)>>,
+        reply: Result<Value, VfsCommandError>,
+    }
+
+    impl RecordingCommands {
+        fn new(reply: Result<Value, VfsCommandError>) -> Arc<Self> {
+            Arc::new(Self {
+                calls: std::sync::Mutex::new(Vec::new()),
+                reply,
+            })
+        }
+    }
+
+    #[async_trait]
+    impl VfsCommands for RecordingCommands {
+        async fn call(&self, method: VfsMethod, params: Value) -> Result<Value, VfsCommandError> {
+            self.calls.lock().unwrap().push((method, params));
+            self.reply.clone()
+        }
+
+        fn endpoint(&self) -> String {
+            "test".into()
+        }
+    }
+
+    fn server(reply: Result<Value, VfsCommandError>) -> (McpServer, Arc<RecordingCommands>) {
+        let commands = RecordingCommands::new(reply);
+        (McpServer::new(commands.clone(), "0.0.0-test"), commands)
+    }
+
+    #[tokio::test]
+    async fn initialize_echoes_a_supported_client_revision() {
+        let (server, _) = server(Ok(Value::Null));
+        let response = server
+            .handle(json!({
+                "jsonrpc": "2.0", "id": 1, "method": "initialize",
+                "params": {"protocolVersion": "2024-11-05"},
+            }))
+            .await
+            .unwrap();
+        assert_eq!(response["result"]["protocolVersion"], "2024-11-05");
+        assert_eq!(response["result"]["serverInfo"]["name"], SERVER_NAME);
+    }
+
+    #[tokio::test]
+    async fn initialize_falls_back_to_this_servers_revision() {
+        let (server, _) = server(Ok(Value::Null));
+        let response = server
+            .handle(json!({
+                "jsonrpc": "2.0", "id": 1, "method": "initialize",
+                "params": {"protocolVersion": "1999-01-01"},
+            }))
+            .await
+            .unwrap();
+        assert_eq!(response["result"]["protocolVersion"], PROTOCOL_VERSION);
+    }
+
+    #[tokio::test]
+    async fn notifications_get_no_response() {
+        let (server, _) = server(Ok(Value::Null));
+        assert!(
+            server
+                .handle(json!({"jsonrpc": "2.0", "method": "notifications/initialized"}))
+                .await
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_methods_and_tools_are_rejected_without_touching_the_daemon() {
+        let (server, commands) = server(Ok(Value::Null));
+        let response = server
+            .handle(json!({"jsonrpc": "2.0", "id": 1, "method": "resources/subscribe"}))
+            .await
+            .unwrap();
+        assert_eq!(response["error"]["code"], -32601);
+
+        let response = server
+            .handle(json!({
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {"name": "machine_execute", "arguments": {}},
+            }))
+            .await
+            .unwrap();
+        assert_eq!(response["error"]["code"], -32602);
+        assert!(
+            response["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("unknown tool")
+        );
+        assert!(commands.calls.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn tools_call_maps_onto_the_canonical_command() {
+        let (server, commands) = server(Ok(json!({"bytes_b64": "aGk=", "len": 2})));
+        let response = server
+            .handle(json!({
+                "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                "params": {"name": "vfs_read", "arguments": {"path": "/docs/README.md"}},
+            }))
+            .await
+            .unwrap();
+        assert_eq!(response["result"]["isError"], false);
+        assert_eq!(response["result"]["content"][0]["text"], "hi");
+        let calls = commands.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, VfsMethod::Read);
+        assert_eq!(calls[0].1, json!({"path": "/docs/README.md"}));
+    }
+
+    #[tokio::test]
+    async fn daemon_errors_become_tool_errors_with_the_daemon_code() {
+        let (server, _) = server(Err(VfsCommandError::new(-32007, "permission denied")));
+        let response = server
+            .handle(json!({
+                "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                "params": {"name": "vfs_write", "arguments": {"path": "/x", "text": "y"}},
+            }))
+            .await
+            .unwrap();
+        let result = &response["result"];
+        assert_eq!(result["isError"], true);
+        assert_eq!(result["structuredContent"]["error"]["code"], -32007);
+        assert_eq!(result["content"][0]["text"], "permission denied");
+        assert!(response.get("error").is_none(), "{response}");
+    }
+
+    #[tokio::test]
+    async fn resources_read_propagates_the_daemon_error_as_a_protocol_error() {
+        let (server, _) = server(Err(VfsCommandError::new(-32004, "not found: /nope")));
+        let response = server
+            .handle(json!({
+                "jsonrpc": "2.0", "id": 1, "method": "resources/read",
+                "params": {"uri": "bloom:///nope"},
+            }))
+            .await
+            .unwrap();
+        assert_eq!(response["error"]["code"], -32004);
+        assert_eq!(response["error"]["message"], "not found: /nope");
+    }
+
+    #[tokio::test]
+    async fn resources_read_rejects_foreign_uri_schemes() {
+        let (server, commands) = server(Ok(Value::Null));
+        let response = server
+            .handle(json!({
+                "jsonrpc": "2.0", "id": 1, "method": "resources/read",
+                "params": {"uri": "file:///etc/passwd"},
+            }))
+            .await
+            .unwrap();
+        assert_eq!(response["error"]["code"], -32602);
+        assert!(commands.calls.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn tools_list_advertises_every_vfs_capability() {
+        let (server, _) = server(Ok(Value::Null));
+        let response = server
+            .handle(json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}))
+            .await
+            .unwrap();
+        let names: Vec<&str> = response["result"]["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|tool| tool["name"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            names,
+            [
+                "vfs_list",
+                "vfs_read",
+                "vfs_stat",
+                "vfs_write",
+                "vfs_write_then_stat"
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn serve_answers_framed_requests_and_stops_at_end_of_input() {
+        let (server, _) = server(Ok(Value::Null));
+        let input = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"}\n\
+                     {\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n";
+        let mut output = Vec::new();
+        server
+            .serve(BufReader::new(input.as_bytes()), &mut output)
+            .await
+            .unwrap();
+        let lines: Vec<&str> = std::str::from_utf8(&output)
+            .unwrap()
+            .lines()
+            .filter(|line| !line.is_empty())
+            .collect();
+        assert_eq!(lines.len(), 1, "notifications must not be answered");
+        let response: Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(response["id"], 1);
+        assert_eq!(response["result"], json!({}));
+    }
+
+    #[tokio::test]
+    async fn malformed_frames_get_a_parse_error_without_killing_the_session() {
+        let (server, _) = server(Ok(Value::Null));
+        let input = "not json\n{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"ping\"}\n";
+        let mut output = Vec::new();
+        server
+            .serve(BufReader::new(input.as_bytes()), &mut output)
+            .await
+            .unwrap();
+        let lines: Vec<Value> = std::str::from_utf8(&output)
+            .unwrap()
+            .lines()
+            .filter(|line| !line.is_empty())
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect();
+        assert_eq!(lines[0]["error"]["code"], -32700);
+        assert_eq!(lines[1]["id"], 2);
+    }
+
+    #[tokio::test]
+    async fn oversized_frames_are_refused() {
+        let mut input = vec![b'x'; MAX_MESSAGE_BYTES + 1];
+        input.push(b'\n');
+        let error = read_bounded_line(&mut BufReader::new(input.as_slice()))
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+    }
+}

--- a/crates/bloom-mcp/src/tools.rs
+++ b/crates/bloom-mcp/src/tools.rs
@@ -1,0 +1,499 @@
+//! The MCP tool catalog: one tool per canonical VFS command.
+//!
+//! Each tool is a thin adapter — it copies the caller's arguments into the
+//! daemon's JSON-RPC params and shapes the reply into MCP content. Argument
+//! validation beyond "is this JSON the right shape" is deliberately left to the
+//! daemon so MCP callers see exactly the errors `bloom vfs …` sees.
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as B64;
+use serde_json::{Map, Value, json};
+
+use crate::backend::{DAEMON_UNREACHABLE_CODE, VfsCommandError, VfsCommands, VfsMethod};
+
+/// URI scheme for VFS paths exposed as MCP resources: `bloom:///status/health`.
+pub const RESOURCE_SCHEME: &str = "bloom://";
+
+/// A tool the MCP server advertises, bound to the VFS command it proxies.
+#[derive(Clone, Copy, Debug)]
+pub struct ToolSpec {
+    pub name: &'static str,
+    pub title: &'static str,
+    pub description: &'static str,
+    pub method: VfsMethod,
+    /// Mirrors the VFS mutation boundary: `read`/`list`/`lookup` are reads,
+    /// the two write commands are not. Note that a handful of VFS reads are
+    /// deliberately side-effecting (signing, broadcast); the daemon audits
+    /// those regardless of which client asks.
+    pub read_only: bool,
+}
+
+/// Every VFS capability reachable from the public CLI/IPC surface.
+pub const TOOLS: [ToolSpec; 5] = [
+    ToolSpec {
+        name: "vfs_list",
+        title: "List a Bloom VFS directory",
+        description: "List the children of a Bloom VFS directory. Equivalent to `bloom vfs ls <path>`; returns one entry per child with its name, kind (dir/file/symlink), size, POSIX mode, symlink target, and modification time. Start at `/` to discover the available subtrees.",
+        method: VfsMethod::List,
+        read_only: true,
+    },
+    ToolSpec {
+        name: "vfs_read",
+        title: "Read a Bloom VFS file",
+        description: "Read the bytes of a Bloom VFS file. Equivalent to `bloom vfs cat <path>`. UTF-8 content is returned as text; anything else is returned as a base64 blob. Some paths are side-effecting by design (signing, broadcast); check the path's documentation before reading.",
+        method: VfsMethod::Read,
+        read_only: true,
+    },
+    ToolSpec {
+        name: "vfs_stat",
+        title: "Stat a Bloom VFS path",
+        description: "Return Bloom VFS metadata for a path without reading it. Equivalent to `bloom vfs stat <path>`: name, kind, size, POSIX mode, symlink target, and modification time.",
+        method: VfsMethod::Lookup,
+        read_only: false,
+    },
+    ToolSpec {
+        name: "vfs_write",
+        title: "Write a Bloom VFS file",
+        description: "Write bytes to a writable Bloom VFS path. Equivalent to `bloom vfs write <path>`. Supply either `text` (UTF-8) or `bytes_b64` (arbitrary bytes). Writes are audited and only a small set of injection points accept them; everything else fails with `permission denied`.",
+        method: VfsMethod::Write,
+        read_only: false,
+    },
+    ToolSpec {
+        name: "vfs_write_then_stat",
+        title: "Write a Bloom VFS file and stat its projection",
+        description: "Write bytes to a writable Bloom VFS path and, under the daemon's mutation gate, stat the identity projection the write produced (for example writing `/requests/new` and reading back `/requests/latest`). Use this instead of a write followed by a separate stat when the projection identity matters.",
+        method: VfsMethod::WriteWithLookup,
+        read_only: false,
+    },
+];
+
+pub fn find(name: &str) -> Option<&'static ToolSpec> {
+    TOOLS.iter().find(|tool| tool.name == name)
+}
+
+/// A tool call that never reached the daemon: the client asked for something
+/// this server does not expose, or sent arguments of the wrong JSON shape.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ToolError {
+    UnknownTool(String),
+    InvalidArguments(String),
+}
+
+impl ToolError {
+    pub fn message(&self) -> String {
+        match self {
+            ToolError::UnknownTool(name) => format!("unknown tool: {name}"),
+            ToolError::InvalidArguments(detail) => format!("invalid tool arguments: {detail}"),
+        }
+    }
+}
+
+impl ToolSpec {
+    /// The JSON Schema advertised in `tools/list`.
+    pub fn input_schema(&self) -> Value {
+        let path = json!({
+            "type": "string",
+            "description": "Absolute Bloom VFS path, for example `/status/health`.",
+        });
+        let text = json!({
+            "type": "string",
+            "description": "UTF-8 payload to write. Mutually exclusive with `bytes_b64`.",
+        });
+        let bytes_b64 = json!({
+            "type": "string",
+            "description": "Standard base64 payload, for writing arbitrary (non-UTF-8) bytes. Takes precedence over `text`.",
+        });
+        match self.method {
+            VfsMethod::List => json!({
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Absolute Bloom VFS directory path. Defaults to the VFS root.",
+                        "default": "/",
+                    },
+                },
+                "additionalProperties": false,
+            }),
+            VfsMethod::Read | VfsMethod::Lookup => json!({
+                "type": "object",
+                "properties": { "path": path },
+                "required": ["path"],
+                "additionalProperties": false,
+            }),
+            VfsMethod::Write => json!({
+                "type": "object",
+                "properties": { "path": path, "text": text, "bytes_b64": bytes_b64 },
+                "required": ["path"],
+                "additionalProperties": false,
+            }),
+            VfsMethod::WriteWithLookup => json!({
+                "type": "object",
+                "properties": {
+                    "path": path,
+                    "text": text,
+                    "bytes_b64": bytes_b64,
+                    "projection_path": {
+                        "type": "string",
+                        "description": "Absolute Bloom VFS path of the projection to stat after the write, for example `/requests/latest`.",
+                    },
+                },
+                "required": ["path", "projection_path"],
+                "additionalProperties": false,
+            }),
+        }
+    }
+
+    /// The `tools/list` entry for this tool.
+    pub fn descriptor(&self) -> Value {
+        json!({
+            "name": self.name,
+            "title": self.title,
+            "description": self.description,
+            "inputSchema": self.input_schema(),
+            "annotations": {
+                "title": self.title,
+                "readOnlyHint": self.read_only,
+                "destructiveHint": !self.read_only,
+                "idempotentHint": false,
+                "openWorldHint": true,
+            },
+        })
+    }
+}
+
+/// Translate a `tools/call` into its canonical VFS command, run it, and shape
+/// the reply. `Ok` carries a `tools/call` result — including the `isError: true`
+/// form when the daemon rejected the command, which is how MCP reports tool
+/// failures without collapsing them into transport errors.
+pub async fn call(
+    commands: &dyn VfsCommands,
+    name: &str,
+    arguments: &Value,
+) -> Result<Value, ToolError> {
+    let tool = find(name).ok_or_else(|| ToolError::UnknownTool(name.to_owned()))?;
+    let arguments = match arguments {
+        Value::Null => Map::new(),
+        Value::Object(map) => map.clone(),
+        _ => {
+            return Err(ToolError::InvalidArguments(
+                "`arguments` must be an object".into(),
+            ));
+        }
+    };
+    let params = tool.params(&arguments)?;
+    match commands.call(tool.method, params.clone()).await {
+        Ok(result) => Ok(tool.success(&arguments, &params, result)),
+        Err(error) => Ok(error_result(&error)),
+    }
+}
+
+impl ToolSpec {
+    /// The arguments this tool accepts, matching its advertised schema.
+    fn accepted_arguments(&self) -> &'static [&'static str] {
+        match self.method {
+            VfsMethod::List | VfsMethod::Read | VfsMethod::Lookup => &["path"],
+            VfsMethod::Write => &["path", "text", "bytes_b64"],
+            VfsMethod::WriteWithLookup => &["path", "text", "bytes_b64", "projection_path"],
+        }
+    }
+
+    /// Build the daemon params. Accepted keys are forwarded verbatim so the
+    /// daemon — not this proxy — decides what is missing or malformed.
+    fn params(&self, arguments: &Map<String, Value>) -> Result<Value, ToolError> {
+        let accepted = self.accepted_arguments();
+        let mut params = Map::new();
+        for (key, value) in arguments {
+            if !accepted.contains(&key.as_str()) {
+                return Err(ToolError::InvalidArguments(format!(
+                    "unexpected argument `{key}`"
+                )));
+            }
+            let Value::String(value) = value else {
+                return Err(ToolError::InvalidArguments(format!(
+                    "`{key}` must be a string"
+                )));
+            };
+            params.insert(key.clone(), Value::String(value.clone()));
+        }
+        // `vfs_list` mirrors the CLI's `ls` default of the VFS root; the other
+        // tools let the daemon report a missing path in its own words.
+        if self.method == VfsMethod::List && !params.contains_key("path") {
+            params.insert("path".into(), Value::String("/".into()));
+        }
+        Ok(Value::Object(params))
+    }
+
+    fn success(&self, arguments: &Map<String, Value>, params: &Value, result: Value) -> Value {
+        let path = params
+            .get("path")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_owned();
+        match self.method {
+            VfsMethod::List => {
+                let entries = result;
+                ok_result(
+                    vec![json!({
+                        "type": "text",
+                        "text": pretty(&entries),
+                    })],
+                    json!({ "path": path, "entries": entries }),
+                )
+            }
+            VfsMethod::Lookup => ok_result(
+                vec![json!({"type": "text", "text": pretty(&result)})],
+                json!({ "path": path, "entry": result }),
+            ),
+            VfsMethod::Read => match read_bytes(&result) {
+                Ok(bytes) => {
+                    let (content, structured) = bytes_payload(&path, &bytes);
+                    ok_result(content, structured)
+                }
+                Err(error) => error_result(&error),
+            },
+            VfsMethod::Write => {
+                let written = payload_len(arguments);
+                ok_result(
+                    vec![json!({
+                        "type": "text",
+                        "text": format!("wrote {written} byte(s) to {path}"),
+                    })],
+                    json!({ "path": path, "bytes_written": written }),
+                )
+            }
+            VfsMethod::WriteWithLookup => {
+                let written = payload_len(arguments);
+                let projection_path = params
+                    .get("projection_path")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
+                ok_result(
+                    vec![json!({"type": "text", "text": pretty(&result)})],
+                    json!({
+                        "path": path,
+                        "bytes_written": written,
+                        "projection_path": projection_path,
+                        "entry": result,
+                    }),
+                )
+            }
+        }
+    }
+}
+
+/// Decode the daemon's `read` reply. `IpcClient` already reassembles chunked
+/// reads into `bytes_b64`, so both the inline and streamed shapes land here.
+pub fn read_bytes(result: &Value) -> Result<Vec<u8>, VfsCommandError> {
+    let encoded = result
+        .get("bytes_b64")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            VfsCommandError::new(
+                DAEMON_UNREACHABLE_CODE,
+                "Bloom daemon read reply is missing bytes_b64",
+            )
+        })?;
+    B64.decode(encoded).map_err(|error| {
+        VfsCommandError::new(
+            DAEMON_UNREACHABLE_CODE,
+            format!("Bloom daemon read reply is not valid base64: {error}"),
+        )
+    })
+}
+
+/// Render VFS bytes as MCP content. UTF-8 becomes text; everything else stays
+/// a base64 blob so binary artifacts survive the round trip intact.
+pub fn bytes_payload(path: &str, bytes: &[u8]) -> (Vec<Value>, Value) {
+    let uri = resource_uri(path);
+    match std::str::from_utf8(bytes) {
+        Ok(text) => (
+            vec![json!({"type": "text", "text": text})],
+            json!({
+                "path": path,
+                "uri": uri,
+                "len": bytes.len(),
+                "encoding": "utf-8",
+                "mime_type": mime_type_for(path, true),
+                "text": text,
+            }),
+        ),
+        Err(_) => (
+            vec![json!({
+                "type": "resource",
+                "resource": {
+                    "uri": uri,
+                    "mimeType": mime_type_for(path, false),
+                    "blob": B64.encode(bytes),
+                },
+            })],
+            json!({
+                "path": path,
+                "uri": uri,
+                "len": bytes.len(),
+                "encoding": "base64",
+                "mime_type": mime_type_for(path, false),
+                "bytes_b64": B64.encode(bytes),
+            }),
+        ),
+    }
+}
+
+pub fn mime_type_for(path: &str, utf8: bool) -> &'static str {
+    if !utf8 {
+        return "application/octet-stream";
+    }
+    match path.rsplit('.').next() {
+        Some("json") => "application/json",
+        Some("md") => "text/markdown",
+        _ => "text/plain",
+    }
+}
+
+/// `/status/health` → `bloom:///status/health`.
+pub fn resource_uri(path: &str) -> String {
+    if path.starts_with('/') {
+        format!("{RESOURCE_SCHEME}{path}")
+    } else {
+        format!("{RESOURCE_SCHEME}/{path}")
+    }
+}
+
+/// Inverse of [`resource_uri`]. Rejects anything that is not a `bloom://` URI.
+pub fn path_from_uri(uri: &str) -> Result<String, String> {
+    let path = uri
+        .strip_prefix(RESOURCE_SCHEME)
+        .ok_or_else(|| format!("unsupported resource URI {uri:?}; expected a bloom:// URI"))?;
+    if path.starts_with('/') {
+        Ok(path.to_owned())
+    } else {
+        Ok(format!("/{path}"))
+    }
+}
+
+fn payload_len(arguments: &Map<String, Value>) -> usize {
+    if let Some(encoded) = arguments.get("bytes_b64").and_then(Value::as_str) {
+        return B64.decode(encoded).map(|bytes| bytes.len()).unwrap_or(0);
+    }
+    arguments
+        .get("text")
+        .and_then(Value::as_str)
+        .map(|text| text.len())
+        .unwrap_or(0)
+}
+
+fn pretty(value: &Value) -> String {
+    serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
+}
+
+fn ok_result(content: Vec<Value>, structured: Value) -> Value {
+    json!({
+        "content": content,
+        "structuredContent": structured,
+        "isError": false,
+    })
+}
+
+/// A daemon-rejected command. MCP wants tool failures inside the result, and
+/// the daemon's code/message are preserved so clients can branch on them.
+pub fn error_result(error: &VfsCommandError) -> Value {
+    json!({
+        "content": [{"type": "text", "text": error.message.clone()}],
+        "structuredContent": {
+            "error": { "code": error.code, "message": error.message.clone() },
+        },
+        "isError": true,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_canonical_vfs_command_has_exactly_one_tool() {
+        let mut methods: Vec<&str> = TOOLS.iter().map(|tool| tool.method.as_str()).collect();
+        methods.sort_unstable();
+        assert_eq!(
+            methods,
+            ["list", "lookup", "read", "write", "write_with_lookup"]
+        );
+    }
+
+    #[test]
+    fn list_defaults_to_the_vfs_root_like_the_cli() {
+        let spec = find("vfs_list").unwrap();
+        let params = spec.params(&Map::new()).unwrap();
+        assert_eq!(params, json!({"path": "/"}));
+    }
+
+    #[test]
+    fn write_arguments_are_forwarded_verbatim() {
+        let spec = find("vfs_write").unwrap();
+        let arguments = json!({"path": "/x", "bytes_b64": "AAE="});
+        let params = spec
+            .params(arguments.as_object().unwrap())
+            .expect("params build");
+        assert_eq!(params, json!({"path": "/x", "bytes_b64": "AAE="}));
+    }
+
+    #[test]
+    fn unexpected_arguments_are_rejected_before_the_daemon_is_called() {
+        let spec = find("vfs_read").unwrap();
+        let arguments = json!({"path": "/x", "block": 42});
+        let error = spec.params(arguments.as_object().unwrap()).unwrap_err();
+        assert_eq!(
+            error,
+            ToolError::InvalidArguments("unexpected argument `block`".into())
+        );
+
+        // A write-only argument is not silently forwarded on a read tool.
+        let arguments = json!({"path": "/x", "text": "hi"});
+        assert_eq!(
+            spec.params(arguments.as_object().unwrap()).unwrap_err(),
+            ToolError::InvalidArguments("unexpected argument `text`".into())
+        );
+    }
+
+    #[test]
+    fn non_string_path_is_rejected() {
+        let spec = find("vfs_read").unwrap();
+        let arguments = json!({"path": 7});
+        let error = spec.params(arguments.as_object().unwrap()).unwrap_err();
+        assert_eq!(
+            error,
+            ToolError::InvalidArguments("`path` must be a string".into())
+        );
+    }
+
+    #[test]
+    fn resource_uris_round_trip() {
+        assert_eq!(resource_uri("/status/health"), "bloom:///status/health");
+        assert_eq!(resource_uri("status/health"), "bloom:///status/health");
+        assert_eq!(
+            path_from_uri("bloom:///status/health").unwrap(),
+            "/status/health"
+        );
+        assert!(path_from_uri("file:///etc/passwd").is_err());
+    }
+
+    #[test]
+    fn non_utf8_bytes_are_returned_as_a_base64_blob() {
+        let (content, structured) = bytes_payload("/blob.bin", &[0xff, 0x00, 0xfe]);
+        assert_eq!(content[0]["type"], "resource");
+        assert_eq!(
+            content[0]["resource"]["blob"],
+            B64.encode([0xff, 0x00, 0xfe])
+        );
+        assert_eq!(structured["encoding"], "base64");
+        assert_eq!(structured["len"], 3);
+    }
+
+    #[test]
+    fn utf8_bytes_are_returned_as_text() {
+        let (content, structured) = bytes_payload("/notes.md", "hello".as_bytes());
+        assert_eq!(content[0], json!({"type": "text", "text": "hello"}));
+        assert_eq!(structured["encoding"], "utf-8");
+        assert_eq!(structured["mime_type"], "text/markdown");
+    }
+}

--- a/crates/bloom-mcp/src/tools.rs
+++ b/crates/bloom-mcp/src/tools.rs
@@ -7,12 +7,37 @@
 
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as B64;
+use percent_encoding::{AsciiSet, CONTROLS, percent_decode_str, utf8_percent_encode};
 use serde_json::{Map, Value, json};
 
 use crate::backend::{DAEMON_UNREACHABLE_CODE, VfsCommandError, VfsCommands, VfsMethod};
 
 /// URI scheme for VFS paths exposed as MCP resources: `bloom:///status/health`.
 pub const RESOURCE_SCHEME: &str = "bloom://";
+
+/// Characters a VFS path segment may legitimately contain that would change
+/// how an RFC 3986 parser reads the URI: the generic delimiters that end a
+/// path (`?`, `#`), the segment separator itself, the escape character, and
+/// everything a URL parser is entitled to normalise or reject. Encoding this
+/// set — and nothing else — keeps `bloom:///docs/README.md` readable while
+/// making `a/b`, `a#b`, `a?b`, `100%`, and `two words` round-trip exactly.
+const PATH_SEGMENT: &AsciiSet = &CONTROLS
+    .add(b'%')
+    .add(b'/')
+    .add(b'?')
+    .add(b'#')
+    .add(b'[')
+    .add(b']')
+    .add(b' ')
+    .add(b'"')
+    .add(b'<')
+    .add(b'>')
+    .add(b'\\')
+    .add(b'^')
+    .add(b'`')
+    .add(b'{')
+    .add(b'|')
+    .add(b'}');
 
 /// A tool the MCP server advertises, bound to the VFS command it proxies.
 #[derive(Clone, Copy, Debug)]
@@ -21,11 +46,17 @@ pub struct ToolSpec {
     pub title: &'static str,
     pub description: &'static str,
     pub method: VfsMethod,
-    /// Mirrors the VFS mutation boundary: `read`/`list`/`lookup` are reads,
-    /// the two write commands are not. Note that a handful of VFS reads are
-    /// deliberately side-effecting (signing, broadcast); the daemon audits
-    /// those regardless of which client asks.
+    /// `readOnlyHint`: true only when *every* path the tool can reach is inert.
+    /// `list` and `lookup` qualify; `read` does not, because a handful of VFS
+    /// paths (outbox `confirm`/`replace`/`cancel`) sign or broadcast when read.
+    /// The daemon audits those regardless of which client asks, but a client
+    /// that trusts `readOnlyHint` would skip its confirmation prompt.
     pub read_only: bool,
+    /// `destructiveHint`, only meaningful when [`Self::read_only`] is false.
+    /// Writes are staged and confirmable, but they are the surface that moves
+    /// value, so they claim the conservative hint; a side-effecting read
+    /// produces artifacts rather than overwriting them.
+    pub destructive: bool,
 }
 
 /// Every VFS capability reachable from the public CLI/IPC surface.
@@ -36,20 +67,23 @@ pub const TOOLS: [ToolSpec; 5] = [
         description: "List the children of a Bloom VFS directory. Equivalent to `bloom vfs ls <path>`; returns one entry per child with its name, kind (dir/file/symlink), size, POSIX mode, symlink target, and modification time. Start at `/` to discover the available subtrees.",
         method: VfsMethod::List,
         read_only: true,
+        destructive: false,
     },
     ToolSpec {
         name: "vfs_read",
         title: "Read a Bloom VFS file",
-        description: "Read the bytes of a Bloom VFS file. Equivalent to `bloom vfs cat <path>`. UTF-8 content is returned as text; anything else is returned as a base64 blob. Some paths are side-effecting by design (signing, broadcast); check the path's documentation before reading.",
+        description: "Read the bytes of a Bloom VFS file. Equivalent to `bloom vfs cat <path>`. UTF-8 content is returned as text; anything else is returned as a base64 blob. Most paths are inert data, but a few are side-effecting by design: reading a wallet outbox `confirm`, `confirm.override`, `replace`, or `cancel` file performs that action. Call `vfs_stat` first — it reports `read_side_effecting` — and treat a true there as an action needing confirmation, not a fetch.",
         method: VfsMethod::Read,
-        read_only: true,
+        read_only: false,
+        destructive: false,
     },
     ToolSpec {
         name: "vfs_stat",
         title: "Stat a Bloom VFS path",
-        description: "Return Bloom VFS metadata for a path without reading it. Equivalent to `bloom vfs stat <path>`: name, kind, size, POSIX mode, symlink target, and modification time.",
+        description: "Return Bloom VFS metadata for a path without reading it. Equivalent to `bloom vfs stat <path>`: name, kind, size, POSIX mode, symlink target, modification time, and `read_side_effecting` — whether reading the path would sign or broadcast. Always inert; safe to call before any read.",
         method: VfsMethod::Lookup,
-        read_only: false,
+        read_only: true,
+        destructive: false,
     },
     ToolSpec {
         name: "vfs_write",
@@ -57,6 +91,7 @@ pub const TOOLS: [ToolSpec; 5] = [
         description: "Write bytes to a writable Bloom VFS path. Equivalent to `bloom vfs write <path>`. Supply either `text` (UTF-8) or `bytes_b64` (arbitrary bytes). Writes are audited and only a small set of injection points accept them; everything else fails with `permission denied`.",
         method: VfsMethod::Write,
         read_only: false,
+        destructive: true,
     },
     ToolSpec {
         name: "vfs_write_then_stat",
@@ -64,6 +99,7 @@ pub const TOOLS: [ToolSpec; 5] = [
         description: "Write bytes to a writable Bloom VFS path and, under the daemon's mutation gate, stat the identity projection the write produced (for example writing `/requests/new` and reading back `/requests/latest`). Use this instead of a write followed by a separate stat when the projection identity matters.",
         method: VfsMethod::WriteWithLookup,
         read_only: false,
+        destructive: true,
     },
 ];
 
@@ -154,7 +190,7 @@ impl ToolSpec {
             "annotations": {
                 "title": self.title,
                 "readOnlyHint": self.read_only,
-                "destructiveHint": !self.read_only,
+                "destructiveHint": self.destructive,
                 "idempotentHint": false,
                 "openWorldHint": true,
             },
@@ -350,25 +386,63 @@ pub fn mime_type_for(path: &str, utf8: bool) -> &'static str {
     }
 }
 
-/// `/status/health` → `bloom:///status/health`.
+/// `/status/health` → `bloom:///status/health`, percent-encoding each segment
+/// so a path containing `%`, a space, `#`, or `?` survives an RFC 3986 parser.
+/// The authority is always empty, which is what the leading `///` means.
 pub fn resource_uri(path: &str) -> String {
-    if path.starts_with('/') {
-        format!("{RESOURCE_SCHEME}{path}")
-    } else {
-        format!("{RESOURCE_SCHEME}/{path}")
+    let mut uri = format!("{RESOURCE_SCHEME}/");
+    for (index, segment) in path.trim_start_matches('/').split('/').enumerate() {
+        if index > 0 {
+            uri.push('/');
+        }
+        uri.extend(utf8_percent_encode(segment, PATH_SEGMENT));
     }
+    uri
 }
 
-/// Inverse of [`resource_uri`]. Rejects anything that is not a `bloom://` URI.
+/// Inverse of [`resource_uri`]. Rejects anything that is not a `bloom://` URI
+/// with an empty authority, and refuses percent-escapes that would decode into
+/// a different path than the one the URI names.
 pub fn path_from_uri(uri: &str) -> Result<String, String> {
-    let path = uri
+    let rest = uri
         .strip_prefix(RESOURCE_SCHEME)
         .ok_or_else(|| format!("unsupported resource URI {uri:?}; expected a bloom:// URI"))?;
-    if path.starts_with('/') {
-        Ok(path.to_owned())
-    } else {
-        Ok(format!("/{path}"))
+    // `bloom://host/path` names a different authority, not a VFS path.
+    let encoded = rest
+        .strip_prefix('/')
+        .ok_or_else(|| format!("unsupported resource URI {uri:?}; expected bloom:///<path>"))?;
+    if let Some(index) = encoded.find(['?', '#']) {
+        return Err(format!(
+            "unsupported resource URI {uri:?}: a Bloom VFS path has no {:?} component (percent-encode the character to use it in a path)",
+            &encoded[index..index + 1]
+        ));
     }
+    let mut path = String::new();
+    for segment in encoded.split('/') {
+        let decoded = percent_decode_str(segment)
+            .decode_utf8()
+            .map_err(|error| format!("resource URI {uri:?} is not valid UTF-8: {error}"))?;
+        // A `%2F` must not smuggle an extra separator past the split above,
+        // and a NUL cannot appear in a VFS path at all.
+        if decoded.contains('/') || decoded.contains('\0') {
+            return Err(format!(
+                "unsupported resource URI {uri:?}: a percent-escape decodes to a path separator"
+            ));
+        }
+        path.push('/');
+        path.push_str(&decoded);
+    }
+    Ok(path)
+}
+
+/// Whether the daemon's `lookup` reply says reading this path signs,
+/// broadcasts, or otherwise mutates state. A reply from a daemon predating
+/// the field reads as `false`, matching the VFS default for unknown paths.
+pub fn read_is_side_effecting(entry: &Value) -> bool {
+    entry
+        .get("read_side_effecting")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
 }
 
 fn payload_len(arguments: &Map<String, Value>) -> usize {
@@ -418,6 +492,31 @@ mod tests {
             methods,
             ["list", "lookup", "read", "write", "write_with_lookup"]
         );
+    }
+
+    /// The allowlist is what makes a new daemon parameter invisible to MCP
+    /// clients, so it must at least never disagree with the schema clients are
+    /// told to fill in.
+    #[test]
+    fn advertised_schema_matches_the_forwarded_argument_allowlist() {
+        for tool in &TOOLS {
+            let schema = tool.input_schema();
+            let mut advertised: Vec<&str> = schema["properties"]
+                .as_object()
+                .expect("object schema")
+                .keys()
+                .map(String::as_str)
+                .collect();
+            advertised.sort_unstable();
+            let mut accepted = tool.accepted_arguments().to_vec();
+            accepted.sort_unstable();
+            assert_eq!(advertised, accepted, "{}", tool.name);
+            assert_eq!(
+                schema["additionalProperties"], false,
+                "{} must not invite arguments it will reject",
+                tool.name
+            );
+        }
     }
 
     #[test]
@@ -475,6 +574,79 @@ mod tests {
             "/status/health"
         );
         assert!(path_from_uri("file:///etc/passwd").is_err());
+        // An authority is not a path prefix.
+        assert!(path_from_uri("bloom://host/status/health").is_err());
+    }
+
+    /// A VFS segment may hold any byte but `/` and NUL. Every such segment has
+    /// to survive the trip to an RFC 3986 URI and back, or a compliant client
+    /// silently reads a different path.
+    #[test]
+    fn reserved_characters_survive_the_uri_round_trip() {
+        for path in [
+            "/requests/two words/plan.md",
+            "/requests/100%/plan.md",
+            "/requests/a#b",
+            "/requests/a?b=c",
+            "/requests/a%2Fb",
+            "/docs/caf\u{e9}.md",
+            "/requests/a+b",
+            "/",
+        ] {
+            let uri = resource_uri(path);
+            assert!(!uri[RESOURCE_SCHEME.len()..].contains(['?', '#']), "{uri}");
+            assert_eq!(path_from_uri(&uri).unwrap(), path, "via {uri}");
+        }
+
+        // Readable paths stay readable: nothing is over-encoded.
+        assert_eq!(resource_uri("/docs/README.md"), "bloom:///docs/README.md");
+        assert_eq!(resource_uri("/requests/100%"), "bloom:///requests/100%25");
+        assert_eq!(resource_uri("/a b"), "bloom:///a%20b");
+    }
+
+    #[test]
+    fn uris_that_would_name_a_different_path_are_refused() {
+        // A raw `#`/`?` is a fragment/query to an RFC 3986 parser, so it can
+        // never have come from a VFS segment.
+        assert!(path_from_uri("bloom:///requests/a#b").is_err());
+        assert!(path_from_uri("bloom:///requests/a?b").is_err());
+        // `%252F` decodes to `%2F`, a literal segment, not a separator.
+        assert_eq!(
+            path_from_uri("bloom:///requests/a%252Fb").unwrap(),
+            "/requests/a%2Fb"
+        );
+    }
+
+    /// `readOnlyHint` is what a client gates its confirmation prompt on, so it
+    /// has to match the VFS mutation boundary exactly.
+    #[test]
+    fn advertised_annotations_match_the_vfs_mutation_boundary() {
+        let hints = |name: &str| {
+            let annotations = find(name).unwrap().descriptor()["annotations"].clone();
+            (
+                annotations["readOnlyHint"].as_bool().unwrap(),
+                annotations["destructiveHint"].as_bool().unwrap(),
+            )
+        };
+        // `lookup` and `list` touch nothing.
+        assert_eq!(hints("vfs_stat"), (true, false));
+        assert_eq!(hints("vfs_list"), (true, false));
+        // A read can sign or broadcast on outbox control paths, so it cannot
+        // claim to leave the environment alone.
+        assert_eq!(hints("vfs_read"), (false, false));
+        assert_eq!(hints("vfs_write"), (false, true));
+        assert_eq!(hints("vfs_write_then_stat"), (false, true));
+    }
+
+    #[test]
+    fn a_lookup_reply_without_the_flag_reads_as_inert() {
+        assert!(read_is_side_effecting(
+            &json!({"name": "confirm", "read_side_effecting": true})
+        ));
+        assert!(!read_is_side_effecting(
+            &json!({"name": "confirm", "read_side_effecting": false})
+        ));
+        assert!(!read_is_side_effecting(&json!({"name": "greet"})));
     }
 
     #[test]

--- a/crates/bloom-mcp/tests/vfs_proxy.rs
+++ b/crates/bloom-mcp/tests/vfs_proxy.rs
@@ -1,0 +1,509 @@
+//! Category: integration
+//!
+//! End-to-end proof that the MCP server is a proxy: every tool and resource in
+//! these tests travels MCP → daemon JSON-RPC → `bloom_vfs::Vfs` → handler, over
+//! a real Unix socket. Nothing here stubs the command surface, so a behaviour
+//! or error-code change in the VFS shows up as a failure right here.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as B64;
+use bloom_daemon::ipc::IpcServer;
+use bloom_mcp::{IpcVfsCommands, McpServer};
+use bloom_vfs::{Entry, Handler, HandlerError, Vfs, VfsPath};
+use serde_json::{Value, json};
+
+const GREET: &[u8] = b"hi\n";
+const BLOB: &[u8] = &[0xff, 0x00, 0xfe, 0x80];
+/// Larger than the daemon's 1 MiB read chunk, so the reply arrives as streamed
+/// `bloom.output` data rather than a single inline frame.
+const BIG_LEN: usize = 2 * 1024 * 1024 + 7;
+
+/// A handler with one of each thing the VFS can hold: a UTF-8 file, a binary
+/// file, an oversized file, a writable sink, and the projection that sink
+/// produces.
+#[derive(Default)]
+struct ProbeHandler {
+    latest: Mutex<Option<Vec<u8>>>,
+}
+
+impl ProbeHandler {
+    fn big() -> Vec<u8> {
+        (0..BIG_LEN).map(|index| (index % 251) as u8).collect()
+    }
+}
+
+#[async_trait]
+impl Handler for ProbeHandler {
+    async fn lookup(&self, path: &VfsPath) -> Result<Entry, HandlerError> {
+        let latest = self.latest.lock().unwrap().clone();
+        match path
+            .segments()
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>()[..]
+        {
+            [] => Ok(Entry::dir("probe")),
+            ["greet"] => Ok(Entry::read_only_file("greet").with_size(GREET.len() as u64)),
+            ["blob.bin"] => Ok(Entry::read_only_file("blob.bin").with_size(BLOB.len() as u64)),
+            ["big.bin"] => Ok(Entry::read_only_file("big.bin").with_size(BIG_LEN as u64)),
+            ["new"] => Ok(Entry::writable_file("new")),
+            ["latest"] => match latest {
+                Some(bytes) => Ok(Entry::read_only_file("latest").with_size(bytes.len() as u64)),
+                None => Err(HandlerError::not_found(path.to_string_path())),
+            },
+            _ => Err(HandlerError::not_found(path.to_string_path())),
+        }
+    }
+
+    async fn read(&self, path: &VfsPath) -> Result<Vec<u8>, HandlerError> {
+        let latest = self.latest.lock().unwrap().clone();
+        match path
+            .segments()
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>()[..]
+        {
+            [] => Err(HandlerError::NotAFile(path.to_string_path())),
+            ["greet"] => Ok(GREET.to_vec()),
+            ["blob.bin"] => Ok(BLOB.to_vec()),
+            ["big.bin"] => Ok(Self::big()),
+            ["latest"] => latest.ok_or_else(|| HandlerError::not_found(path.to_string_path())),
+            _ => Err(HandlerError::not_found(path.to_string_path())),
+        }
+    }
+
+    async fn write(&self, path: &VfsPath, data: &[u8]) -> Result<(), HandlerError> {
+        match path
+            .segments()
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>()[..]
+        {
+            ["new"] => {
+                *self.latest.lock().unwrap() = Some(data.to_vec());
+                Ok(())
+            }
+            // Read-only entries fail exactly the way the real tree does.
+            ["greet"] | ["blob.bin"] | ["big.bin"] | ["latest"] => {
+                Err(HandlerError::PermissionDenied)
+            }
+            _ => Err(HandlerError::not_found(path.to_string_path())),
+        }
+    }
+
+    async fn list(&self, path: &VfsPath) -> Result<Vec<Entry>, HandlerError> {
+        match path
+            .segments()
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>()[..]
+        {
+            [] => Ok(vec![
+                Entry::read_only_file("blob.bin"),
+                Entry::read_only_file("greet"),
+                Entry::writable_file("new"),
+            ]),
+            ["greet"] => Err(HandlerError::NotADir(path.to_string_path())),
+            _ => Err(HandlerError::not_found(path.to_string_path())),
+        }
+    }
+}
+
+/// A live daemon endpoint plus an MCP server pointed at it.
+struct Harness {
+    server: McpServer,
+    ipc: IpcServer,
+    handle: tokio::task::JoinHandle<()>,
+    _dir: tempfile::TempDir,
+}
+
+impl Harness {
+    async fn start() -> Self {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let socket = dir.path().join("private-run/bloom.sock");
+        let vfs = Vfs::builder()
+            .mount("probe", Arc::new(ProbeHandler::default()))
+            .build();
+        let ipc = IpcServer::new(vfs, "0.0.0-test", vec!["ethereum".into()]);
+        let serving = ipc.clone();
+        let serving_socket = socket.clone();
+        let handle =
+            tokio::spawn(async move { serving.serve(&serving_socket).await.expect("ipc serve") });
+        for _ in 0..200 {
+            if socket.exists() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(socket.exists(), "daemon socket never appeared");
+        Self {
+            server: McpServer::new(Arc::new(IpcVfsCommands::new(socket)), "0.0.0-test"),
+            ipc,
+            handle,
+            _dir: dir,
+        }
+    }
+
+    async fn request(&self, method: &str, params: Value) -> Value {
+        self.server
+            .handle(json!({"jsonrpc": "2.0", "id": 1, "method": method, "params": params}))
+            .await
+            .expect("request gets a response")
+    }
+
+    /// Call a tool and return the `tools/call` result, asserting the call was
+    /// not rejected at the protocol level.
+    async fn tool(&self, name: &str, arguments: Value) -> Value {
+        let response = self
+            .request("tools/call", json!({"name": name, "arguments": arguments}))
+            .await;
+        assert!(
+            response.get("error").is_none(),
+            "unexpected protocol error: {response}"
+        );
+        response["result"].clone()
+    }
+
+    async fn ok_tool(&self, name: &str, arguments: Value) -> Value {
+        let result = self.tool(name, arguments).await;
+        assert_eq!(result["isError"], false, "tool failed: {result}");
+        result
+    }
+
+    async fn tool_error(&self, name: &str, arguments: Value) -> (i64, String) {
+        let result = self.tool(name, arguments).await;
+        assert_eq!(result["isError"], true, "expected failure: {result}");
+        (
+            result["structuredContent"]["error"]["code"]
+                .as_i64()
+                .expect("error code"),
+            result["structuredContent"]["error"]["message"]
+                .as_str()
+                .expect("error message")
+                .to_owned(),
+        )
+    }
+
+    async fn stop(self) {
+        self.ipc.trigger_shutdown();
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), self.handle).await;
+    }
+}
+
+#[tokio::test]
+async fn initialize_then_discover_and_read_through_the_canonical_surface() {
+    let harness = Harness::start().await;
+
+    let initialize = harness
+        .request(
+            "initialize",
+            json!({"protocolVersion": "2025-06-18", "clientInfo": {"name": "test", "version": "1"}}),
+        )
+        .await;
+    assert_eq!(initialize["result"]["protocolVersion"], "2025-06-18");
+    assert_eq!(
+        initialize["result"]["capabilities"]["tools"].is_object(),
+        true
+    );
+
+    // Root discovery goes through the router, so the router's own entries
+    // (agent guidance files) and the mounted subtree both show up.
+    let root = harness.ok_tool("vfs_list", json!({})).await;
+    let names: Vec<&str> = root["structuredContent"]["entries"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["name"].as_str().unwrap())
+        .collect();
+    assert!(names.contains(&"probe"), "{names:?}");
+    assert!(names.contains(&"AGENTS.md"), "{names:?}");
+
+    let listed = harness.ok_tool("vfs_list", json!({"path": "/probe"})).await;
+    let entries = listed["structuredContent"]["entries"].as_array().unwrap();
+    let names: Vec<&str> = entries
+        .iter()
+        .map(|entry| entry["name"].as_str().unwrap())
+        .collect();
+    assert_eq!(names, ["blob.bin", "greet", "new"]);
+    // Entry metadata is the daemon's projection, not a proxy invention.
+    let new_entry = entries.iter().find(|e| e["name"] == "new").unwrap();
+    assert_eq!(new_entry["kind"], "file");
+    assert_eq!(new_entry["mode"], 0o644);
+
+    let read = harness
+        .ok_tool("vfs_read", json!({"path": "/probe/greet"}))
+        .await;
+    assert_eq!(read["content"][0]["type"], "text");
+    assert_eq!(read["content"][0]["text"], "hi\n");
+    assert_eq!(read["structuredContent"]["encoding"], "utf-8");
+    assert_eq!(read["structuredContent"]["len"], GREET.len());
+
+    let stat = harness
+        .ok_tool("vfs_stat", json!({"path": "/probe/greet"}))
+        .await;
+    let entry = &stat["structuredContent"]["entry"];
+    assert_eq!(entry["name"], "greet");
+    assert_eq!(entry["kind"], "file");
+    assert_eq!(entry["mode"], 0o444);
+    assert_eq!(entry["size"], GREET.len());
+
+    harness.stop().await;
+}
+
+#[tokio::test]
+async fn non_utf8_reads_stay_bytes_through_the_proxy() {
+    let harness = Harness::start().await;
+
+    let read = harness
+        .ok_tool("vfs_read", json!({"path": "/probe/blob.bin"}))
+        .await;
+    assert_eq!(read["content"][0]["type"], "resource");
+    assert_eq!(
+        read["content"][0]["resource"]["mimeType"],
+        "application/octet-stream"
+    );
+    assert_eq!(read["structuredContent"]["encoding"], "base64");
+    let decoded = B64
+        .decode(read["structuredContent"]["bytes_b64"].as_str().unwrap())
+        .unwrap();
+    assert_eq!(decoded, BLOB, "binary content must survive byte-for-byte");
+
+    // Reads above the daemon's chunk threshold arrive streamed; the proxy must
+    // reassemble them without truncation.
+    let big = harness
+        .ok_tool("vfs_read", json!({"path": "/probe/big.bin"}))
+        .await;
+    let decoded = B64
+        .decode(big["structuredContent"]["bytes_b64"].as_str().unwrap())
+        .unwrap();
+    assert_eq!(decoded.len(), BIG_LEN);
+    assert_eq!(decoded, ProbeHandler::big());
+
+    harness.stop().await;
+}
+
+#[tokio::test]
+async fn writes_accept_text_and_arbitrary_bytes() {
+    let harness = Harness::start().await;
+
+    let written = harness
+        .ok_tool(
+            "vfs_write",
+            json!({"path": "/probe/new", "text": "confirm"}),
+        )
+        .await;
+    assert_eq!(written["structuredContent"]["bytes_written"], 7);
+    let echoed = harness
+        .ok_tool("vfs_read", json!({"path": "/probe/latest"}))
+        .await;
+    assert_eq!(echoed["structuredContent"]["text"], "confirm");
+
+    // A non-UTF-8 payload must reach the handler unchanged.
+    let payload: Vec<u8> = vec![0x00, 0xff, 0x10, 0x80, 0xfe];
+    let written = harness
+        .ok_tool(
+            "vfs_write",
+            json!({"path": "/probe/new", "bytes_b64": B64.encode(&payload)}),
+        )
+        .await;
+    assert_eq!(written["structuredContent"]["bytes_written"], payload.len());
+    let echoed = harness
+        .ok_tool("vfs_read", json!({"path": "/probe/latest"}))
+        .await;
+    let decoded = B64
+        .decode(echoed["structuredContent"]["bytes_b64"].as_str().unwrap())
+        .unwrap();
+    assert_eq!(decoded, payload);
+
+    harness.stop().await;
+}
+
+#[tokio::test]
+async fn write_then_stat_returns_the_projection_the_write_produced() {
+    let harness = Harness::start().await;
+
+    let result = harness
+        .ok_tool(
+            "vfs_write_then_stat",
+            json!({
+                "path": "/probe/new",
+                "text": "staged intent",
+                "projection_path": "/probe/latest",
+            }),
+        )
+        .await;
+    let entry = &result["structuredContent"]["entry"];
+    assert_eq!(entry["name"], "latest");
+    assert_eq!(entry["size"], "staged intent".len());
+    assert_eq!(
+        result["structuredContent"]["projection_path"],
+        "/probe/latest"
+    );
+
+    // A missing projection_path is the daemon's error to report, not ours.
+    let (code, message) = harness
+        .tool_error("vfs_write", json!({"path": "/probe/new"}))
+        .await;
+    assert_eq!(code, -32602);
+    assert!(message.contains("bytes_b64 or text"), "{message}");
+
+    harness.stop().await;
+}
+
+#[tokio::test]
+async fn vfs_errors_reach_the_client_with_the_daemons_own_codes() {
+    let harness = Harness::start().await;
+
+    let (code, message) = harness
+        .tool_error("vfs_read", json!({"path": "/probe/missing"}))
+        .await;
+    assert_eq!(code, -32004, "{message}");
+    assert!(message.starts_with("not found"), "{message}");
+
+    let (code, _) = harness
+        .tool_error("vfs_read", json!({"path": "/probe"}))
+        .await;
+    assert_eq!(code, -32006, "reading a directory is `not a file`");
+
+    let (code, _) = harness
+        .tool_error("vfs_list", json!({"path": "/probe/greet"}))
+        .await;
+    assert_eq!(code, -32005, "listing a file is `not a dir`");
+
+    let (code, message) = harness
+        .tool_error("vfs_write", json!({"path": "/probe/greet", "text": "nope"}))
+        .await;
+    assert_eq!(code, -32007, "{message}");
+    assert_eq!(message, "permission denied");
+
+    let (code, message) = harness
+        .tool_error("vfs_stat", json!({"path": "/absent-subtree/x"}))
+        .await;
+    assert_eq!(code, -32004, "{message}");
+
+    harness.stop().await;
+}
+
+#[tokio::test]
+async fn resources_expose_the_same_paths_as_the_read_command() {
+    let harness = Harness::start().await;
+
+    let listed = harness.request("resources/list", json!({})).await;
+    let resources = listed["result"]["resources"].as_array().unwrap();
+    let uris: Vec<&str> = resources
+        .iter()
+        .map(|resource| resource["uri"].as_str().unwrap())
+        .collect();
+    assert!(uris.contains(&"bloom:///AGENTS.md"), "{uris:?}");
+    // Directories are not resources; `vfs_list` walks the tree instead.
+    assert!(!uris.iter().any(|uri| *uri == "bloom:///probe"), "{uris:?}");
+
+    let templates = harness.request("resources/templates/list", json!({})).await;
+    assert_eq!(
+        templates["result"]["resourceTemplates"][0]["uriTemplate"],
+        "bloom:///{+path}"
+    );
+
+    let read = harness
+        .request("resources/read", json!({"uri": "bloom:///probe/greet"}))
+        .await;
+    assert_eq!(read["result"]["contents"][0]["uri"], "bloom:///probe/greet");
+    assert_eq!(read["result"]["contents"][0]["text"], "hi\n");
+
+    let read = harness
+        .request("resources/read", json!({"uri": "bloom:///probe/blob.bin"}))
+        .await;
+    let content = &read["result"]["contents"][0];
+    assert_eq!(content["mimeType"], "application/octet-stream");
+    assert_eq!(
+        B64.decode(content["blob"].as_str().unwrap()).unwrap(),
+        BLOB,
+        "binary resources stay bytes"
+    );
+
+    let missing = harness
+        .request("resources/read", json!({"uri": "bloom:///probe/missing"}))
+        .await;
+    assert_eq!(missing["error"]["code"], -32004);
+
+    harness.stop().await;
+}
+
+#[tokio::test]
+async fn the_proxy_cannot_reach_non_vfs_daemon_methods() {
+    let harness = Harness::start().await;
+
+    // The daemon does expose `version`, `chains`, `shutdown`, `petals.*`, and
+    // `machine.execute` — none of them are tools here, and there is no generic
+    // pass-through, so an MCP client cannot name them.
+    let tools = harness.request("tools/list", json!({})).await;
+    let names: Vec<&str> = tools["result"]["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|tool| tool["name"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        names,
+        [
+            "vfs_list",
+            "vfs_read",
+            "vfs_stat",
+            "vfs_write",
+            "vfs_write_then_stat"
+        ]
+    );
+
+    for forbidden in ["shutdown", "machine.execute", "petals.install", "version"] {
+        let response = harness
+            .request("tools/call", json!({"name": forbidden, "arguments": {}}))
+            .await;
+        assert_eq!(response["error"]["code"], -32602, "{response}");
+    }
+
+    // The daemon is still alive: the shutdown attempt above went nowhere.
+    harness
+        .ok_tool("vfs_read", json!({"path": "/probe/greet"}))
+        .await;
+
+    harness.stop().await;
+}
+
+#[tokio::test]
+async fn a_stdio_session_answers_framed_requests_in_order() {
+    let harness = Harness::start().await;
+
+    let input = [
+        json!({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-06-18"}}),
+        json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+        json!({"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {"name": "vfs_read", "arguments": {"path": "/probe/greet"}}}),
+    ]
+    .iter()
+    .map(|message| message.to_string())
+    .collect::<Vec<_>>()
+    .join("\n")
+        + "\n";
+
+    let mut output = Vec::new();
+    harness
+        .server
+        .serve(tokio::io::BufReader::new(input.as_bytes()), &mut output)
+        .await
+        .expect("stdio session");
+
+    let responses: Vec<Value> = String::from_utf8(output)
+        .unwrap()
+        .lines()
+        .filter(|line| !line.is_empty())
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    assert_eq!(responses.len(), 2, "the notification is not answered");
+    assert_eq!(responses[0]["id"], 1);
+    assert_eq!(responses[1]["id"], 2);
+    assert_eq!(responses[1]["result"]["content"][0]["text"], "hi\n");
+
+    harness.stop().await;
+}

--- a/crates/bloom-mcp/tests/vfs_proxy.rs
+++ b/crates/bloom-mcp/tests/vfs_proxy.rs
@@ -17,16 +17,22 @@ use serde_json::{Value, json};
 
 const GREET: &[u8] = b"hi\n";
 const BLOB: &[u8] = &[0xff, 0x00, 0xfe, 0x80];
+/// Every character a VFS segment may hold that an RFC 3986 parser treats
+/// specially. `\` and NUL are the only bytes `VfsPath::parse` rejects.
+const RESERVED_NAME: &str = "odd name#1?q=100%.md";
 /// Larger than the daemon's 1 MiB read chunk, so the reply arrives as streamed
 /// `bloom.output` data rather than a single inline frame.
 const BIG_LEN: usize = 2 * 1024 * 1024 + 7;
 
 /// A handler with one of each thing the VFS can hold: a UTF-8 file, a binary
-/// file, an oversized file, a writable sink, and the projection that sink
-/// produces.
+/// file, an oversized file, a file whose name is full of URI metacharacters, a
+/// writable sink, the projection that sink produces, and — modelling the
+/// wallet outbox control files — a file whose *read* performs an action.
 #[derive(Default)]
 struct ProbeHandler {
     latest: Mutex<Option<Vec<u8>>>,
+    /// Incremented by reading `confirm`, so a test can prove nothing read it.
+    confirmed: std::sync::atomic::AtomicUsize,
 }
 
 impl ProbeHandler {
@@ -50,6 +56,10 @@ impl Handler for ProbeHandler {
             ["blob.bin"] => Ok(Entry::read_only_file("blob.bin").with_size(BLOB.len() as u64)),
             ["big.bin"] => Ok(Entry::read_only_file("big.bin").with_size(BIG_LEN as u64)),
             ["new"] => Ok(Entry::writable_file("new")),
+            ["confirm"] => Ok(Entry::read_only_file("confirm")),
+            [name] if name == RESERVED_NAME => {
+                Ok(Entry::read_only_file(RESERVED_NAME).with_size(GREET.len() as u64))
+            }
             ["latest"] => match latest {
                 Some(bytes) => Ok(Entry::read_only_file("latest").with_size(bytes.len() as u64)),
                 None => Err(HandlerError::not_found(path.to_string_path())),
@@ -70,9 +80,20 @@ impl Handler for ProbeHandler {
             ["greet"] => Ok(GREET.to_vec()),
             ["blob.bin"] => Ok(BLOB.to_vec()),
             ["big.bin"] => Ok(Self::big()),
+            ["confirm"] => {
+                self.confirmed
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(b"broadcast\n".to_vec())
+            }
+            [name] if name == RESERVED_NAME => Ok(GREET.to_vec()),
             ["latest"] => latest.ok_or_else(|| HandlerError::not_found(path.to_string_path())),
             _ => Err(HandlerError::not_found(path.to_string_path())),
         }
+    }
+
+    /// The whole point of the flag: reading `confirm` *is* the broadcast.
+    fn is_read_side_effecting(&self, path: &VfsPath) -> bool {
+        path.segments().last().map(String::as_str) == Some("confirm")
     }
 
     async fn write(&self, path: &VfsPath, data: &[u8]) -> Result<(), HandlerError> {
@@ -116,6 +137,7 @@ impl Handler for ProbeHandler {
 struct Harness {
     server: McpServer,
     ipc: IpcServer,
+    probe: Arc<ProbeHandler>,
     handle: tokio::task::JoinHandle<()>,
     _dir: tempfile::TempDir,
 }
@@ -124,9 +146,8 @@ impl Harness {
     async fn start() -> Self {
         let dir = tempfile::tempdir().expect("temp dir");
         let socket = dir.path().join("private-run/bloom.sock");
-        let vfs = Vfs::builder()
-            .mount("probe", Arc::new(ProbeHandler::default()))
-            .build();
+        let probe = Arc::new(ProbeHandler::default());
+        let vfs = Vfs::builder().mount("probe", probe.clone()).build();
         let ipc = IpcServer::new(vfs, "0.0.0-test", vec!["ethereum".into()]);
         let serving = ipc.clone();
         let serving_socket = socket.clone();
@@ -142,9 +163,16 @@ impl Harness {
         Self {
             server: McpServer::new(Arc::new(IpcVfsCommands::new(socket)), "0.0.0-test"),
             ipc,
+            probe,
             handle,
             _dir: dir,
         }
+    }
+
+    fn confirms(&self) -> usize {
+        self.probe
+            .confirmed
+            .load(std::sync::atomic::Ordering::SeqCst)
     }
 
     async fn request(&self, method: &str, params: Value) -> Value {
@@ -424,10 +452,142 @@ async fn resources_expose_the_same_paths_as_the_read_command() {
         "binary resources stay bytes"
     );
 
+    // A missing path is MCP's own resource-not-found; the daemon's code is
+    // kept as diagnostic data rather than shipped as the protocol code.
     let missing = harness
         .request("resources/read", json!({"uri": "bloom:///probe/missing"}))
         .await;
-    assert_eq!(missing["error"]["code"], -32004);
+    assert_eq!(missing["error"]["code"], -32002);
+    assert_eq!(missing["error"]["data"]["daemonCode"], -32004);
+    assert_eq!(missing["error"]["data"]["uri"], "bloom:///probe/missing");
+
+    harness.stop().await;
+}
+
+/// A resource URI is an RFC 3986 URI: a client that percent-encodes reserved
+/// characters (as it must) has to land on the same VFS path the server
+/// advertised.
+#[tokio::test]
+async fn resource_uris_round_trip_paths_containing_reserved_characters() {
+    let harness = Harness::start().await;
+    let path = format!("/probe/{RESERVED_NAME}");
+
+    // The URI the server itself hands out for this path, via a tool read.
+    let read = harness.ok_tool("vfs_read", json!({"path": path})).await;
+    let uri = read["structuredContent"]["uri"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    assert_eq!(
+        uri, "bloom:///probe/odd%20name%231%3Fq=100%25.md",
+        "reserved characters must be percent-encoded"
+    );
+
+    // Feeding it straight back reaches the same file rather than a truncated
+    // or nonexistent one.
+    let resource = harness.request("resources/read", json!({"uri": uri})).await;
+    assert!(resource.get("error").is_none(), "{resource}");
+    assert_eq!(resource["result"]["contents"][0]["text"], "hi\n");
+    assert_eq!(resource["result"]["contents"][0]["uri"], uri);
+
+    // The unencoded form is a different URI — everything from `#` on is a
+    // fragment — and must be refused rather than silently read as `/probe/odd
+    // name`.
+    let raw = harness
+        .request(
+            "resources/read",
+            json!({"uri": format!("bloom:///probe/{RESERVED_NAME}")}),
+        )
+        .await;
+    assert_eq!(raw["error"]["code"], -32602, "{raw}");
+
+    harness.stop().await;
+}
+
+/// Clients fetch resources without asking a human. The few VFS paths whose
+/// read signs or broadcasts must therefore be unreachable that way — and must
+/// still be reachable through the tool, which a client can gate.
+#[tokio::test]
+async fn a_side_effecting_read_is_not_an_inert_resource_but_is_still_a_tool() {
+    let harness = Harness::start().await;
+    let uri = "bloom:///probe/confirm";
+
+    // `vfs_stat` is how a client finds out, and stat'ing must not trigger it.
+    let stat = harness
+        .ok_tool("vfs_stat", json!({"path": "/probe/confirm"}))
+        .await;
+    assert_eq!(
+        stat["structuredContent"]["entry"]["read_side_effecting"],
+        true
+    );
+    assert_eq!(harness.confirms(), 0, "stat must not broadcast");
+
+    let refused = harness.request("resources/read", json!({"uri": uri})).await;
+    assert_eq!(refused["error"]["code"], -32010, "{refused}");
+    assert_eq!(refused["error"]["data"]["tool"], "vfs_read");
+    assert_eq!(
+        harness.confirms(),
+        0,
+        "resources/read must not have performed the action"
+    );
+
+    // The inert sibling is unaffected: this is a per-path gate, not a subtree
+    // ban, and it is the daemon's judgement rather than a list kept here.
+    let inert = harness
+        .request("resources/read", json!({"uri": "bloom:///probe/greet"}))
+        .await;
+    assert_eq!(inert["result"]["contents"][0]["text"], "hi\n");
+
+    // No VFS functionality is lost: the tool still performs the read.
+    let performed = harness
+        .ok_tool("vfs_read", json!({"path": "/probe/confirm"}))
+        .await;
+    assert_eq!(performed["content"][0]["text"], "broadcast\n");
+    assert_eq!(harness.confirms(), 1, "the tool must still do the work");
+
+    harness.stop().await;
+}
+
+/// The argument allowlist is the reason a new daemon parameter cannot leak
+/// through this proxy; it is only safe while every argument it *does* allow
+/// still means something to the daemon.
+#[tokio::test]
+async fn every_advertised_argument_reaches_the_daemon() {
+    let harness = Harness::start().await;
+
+    let listed = harness.request("tools/list", json!({})).await;
+    for tool in listed["result"]["tools"].as_array().unwrap() {
+        let name = tool["name"].as_str().unwrap();
+        // A path each tool can legitimately act on, so a failure means the
+        // argument did not reach the daemon rather than that the path was
+        // wrong for the command.
+        let path = match name {
+            "vfs_list" => "/probe",
+            "vfs_read" | "vfs_stat" => "/probe/greet",
+            _ => "/probe/new",
+        };
+        let arguments: Value = tool["inputSchema"]["properties"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(|key| {
+                let value = match key.as_str() {
+                    "path" => path,
+                    "projection_path" => "/probe/latest",
+                    "bytes_b64" => "aGk=",
+                    "text" => "hi",
+                    other => panic!("{name} advertises an unhandled argument `{other}`"),
+                };
+                (key.clone(), Value::String(value.into()))
+            })
+            .collect::<serde_json::Map<_, _>>()
+            .into();
+
+        // Every advertised argument is forwarded (no `unexpected argument`
+        // rejection) and the daemon accepts the whole set.
+        let result = harness.tool(name, arguments.clone()).await;
+        assert_eq!(result["isError"], false, "{name}: {result} for {arguments}");
+    }
 
     harness.stop().await;
 }

--- a/crates/bloom-proto/src/config.rs
+++ b/crates/bloom-proto/src/config.rs
@@ -60,6 +60,25 @@ pub struct Config {
     /// reads.
     #[serde(default)]
     pub backends: BackendsConfig,
+    /// Local Model Context Protocol proxy over the VFS command surface.
+    /// Disabled by default; nothing starts an MCP server without an
+    /// explicit `[mcp] enabled = true`.
+    #[serde(default)]
+    pub mcp: McpConfig,
+}
+
+/// Gate for the `bloom mcp serve` stdio proxy.
+///
+/// The proxy exposes the same `lookup`/`read`/`write`/`write_with_lookup`/
+/// `list` command surface the CLI uses, so it is off unless an operator turns
+/// it on. Absent `[mcp]` block, absent `enabled` key, and a fresh
+/// [`Config::local_default`] all mean disabled.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct McpConfig {
+    /// Whether an MCP server may start at all. Disabled by default.
+    #[serde(default)]
+    pub enabled: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -417,6 +436,7 @@ impl Config {
             mempool: BTreeMap::new(),
             private_rpc: BTreeMap::new(),
             backends: BackendsConfig::default(),
+            mcp: McpConfig::default(),
         }
     }
 
@@ -785,6 +805,69 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.to_string().contains("unknown field `apps`"), "{err}");
+    }
+
+    #[test]
+    fn mcp_is_disabled_by_default_and_on_configs_predating_the_block() {
+        assert!(!McpConfig::default().enabled);
+        assert!(!Config::local_default().mcp.enabled);
+
+        let td = tempdir().unwrap();
+        let path = td.path().join("config.toml");
+        // A config written before `[mcp]` existed must keep loading, disabled.
+        std::fs::write(
+            &path,
+            r#"
+default_chain = "ethereum"
+
+[chains.ethereum]
+name = "ethereum"
+chain_id = 1
+rpc_urls = ["https://ethereum-rpc.publicnode.com"]
+"#,
+        )
+        .unwrap();
+        assert!(!Config::load(&path).unwrap().mcp.enabled);
+
+        // An empty `[mcp]` block is still "off"; enabling has to be explicit.
+        std::fs::write(
+            &path,
+            r#"
+default_chain = "ethereum"
+
+[mcp]
+
+[chains.ethereum]
+name = "ethereum"
+chain_id = 1
+rpc_urls = ["https://ethereum-rpc.publicnode.com"]
+"#,
+        )
+        .unwrap();
+        assert!(!Config::load(&path).unwrap().mcp.enabled);
+    }
+
+    #[test]
+    fn mcp_enablement_is_explicit_and_survives_save_load() {
+        let td = tempdir().unwrap();
+        let path = td.path().join("config.toml");
+        let mut cfg = Config::local_default();
+        cfg.mcp.enabled = true;
+        cfg.save(&path).unwrap();
+        assert!(
+            std::fs::read_to_string(&path).unwrap().contains("enabled"),
+            "saved config must spell out the mcp flag"
+        );
+        assert!(Config::load(&path).unwrap().mcp.enabled);
+    }
+
+    #[test]
+    fn unknown_mcp_key_is_rejected() {
+        let err = toml::from_str::<McpConfig>("enabled = true\ntransport = \"tcp\"\n").unwrap_err();
+        assert!(
+            err.to_string().contains("unknown field `transport`"),
+            "{err}"
+        );
     }
 
     #[test]

--- a/crates/bloom-proto/src/lib.rs
+++ b/crates/bloom-proto/src/lib.rs
@@ -34,8 +34,8 @@ pub use capability::{CapabilityStatus, CapabilityViewEntry, SigningModel, Venue}
 pub use ceremony::{CeremonyIntent, CeremonyIntentKind};
 pub use chain::{ChainId, ChainRef, ChainSpec, EndpointSpec, default_endpoint_weight};
 pub use config::{
-    Backend, BackendsConfig, Config, ConfigError, EnsoConfig, EtherscanConfig, MempoolChainConfig,
-    PrivateRpcChainConfig,
+    Backend, BackendsConfig, Config, ConfigError, EnsoConfig, EtherscanConfig, McpConfig,
+    MempoolChainConfig, PrivateRpcChainConfig,
 };
 pub use defi_policy::{DefiPolicy, DefiRouteCtx, ReceiverClass, evaluate_defi_route};
 pub use home::{HomeDir, HomeError, HomeWritePermit};

--- a/crates/bloom/Cargo.toml
+++ b/crates/bloom/Cargo.toml
@@ -39,6 +39,7 @@ bloom-evm.workspace = true
 bloom-tx.workspace = true
 url.workspace = true
 bloom-vfs.workspace = true
+bloom-mcp.workspace = true
 bloom-update.workspace = true
 bloom-petals.workspace = true
 ed25519-dalek.workspace = true

--- a/crates/bloom/src/main.rs
+++ b/crates/bloom/src/main.rs
@@ -2143,6 +2143,10 @@ enum Cmd {
     /// VFS path operations (no NFS mount required).
     #[command(subcommand)]
     Vfs(VfsCmd),
+    /// Model Context Protocol proxy over the VFS command surface
+    /// (disabled by default).
+    #[command(subcommand)]
+    Mcp(McpCmd),
     /// Wallet management.
     #[command(subcommand)]
     Wallet(WalletCmd),
@@ -2272,6 +2276,19 @@ enum VfsCmd {
         #[arg(long)]
         data: Option<String>,
     },
+}
+
+#[derive(Subcommand, Debug)]
+enum McpCmd {
+    /// Serve MCP over stdio for one client, proxying `lookup`/`read`/`write`/
+    /// `write_with_lookup`/`list` to the daemon.
+    ///
+    /// Refuses to start unless `[mcp] enabled = true` in the Bloom config.
+    /// There is no network listener: an MCP client spawns this as a child
+    /// process and owns its lifetime.
+    Serve,
+    /// Report whether the MCP proxy is enabled, and how to enable it.
+    Status,
 }
 
 #[derive(Subcommand, Debug)]
@@ -2850,6 +2867,56 @@ async fn call_machine_command(endpoint: &ResolvedEndpoint, command: MachineComma
     Ok(())
 }
 
+/// Read the MCP gate without initialising or migrating anything. A home that
+/// has never been initialised reads as the disabled default, so `bloom mcp
+/// serve` cannot start by creating its own permission.
+fn mcp_config(home: &HomeDir) -> Result<(bloom_proto::McpConfig, PathBuf)> {
+    let path = home.config_path();
+    if !path.exists() {
+        return Ok((bloom_proto::McpConfig::default(), path));
+    }
+    let config = bloom_proto::Config::load(&path)
+        .with_context(|| format!("load Bloom config from {}", path.display()))?;
+    Ok((config.mcp, path))
+}
+
+async fn run_mcp(home: &HomeDir, endpoint: &ResolvedEndpoint, command: McpCmd) -> Result<()> {
+    let (config, config_path) = mcp_config(home)?;
+    let tools = bloom_mcp::TOOLS
+        .iter()
+        .map(|tool| tool.name)
+        .collect::<Vec<_>>()
+        .join(", ");
+    match command {
+        McpCmd::Status => {
+            println!("enabled: {}", config.enabled);
+            println!("config: {}", config_path.display());
+            println!("transport: stdio");
+            println!("endpoint: {}", endpoint.display);
+            println!("protocol: {}", bloom_mcp::PROTOCOL_VERSION);
+            println!("tools: {tools}");
+            if !config.enabled {
+                println!(
+                    "enable: set `enabled = true` under `[mcp]` in {}",
+                    config_path.display()
+                );
+            }
+            Ok(())
+        }
+        McpCmd::Serve => {
+            // The gate runs before any client bytes are read and before the
+            // daemon socket is touched.
+            bloom_mcp::ensure_enabled(&config, &config_path)?;
+            debug!(endpoint = %endpoint.display, "cli.mcp.serve.stdio");
+            let commands = Arc::new(bloom_mcp::IpcVfsCommands::new(endpoint.socket.clone()));
+            bloom_mcp::McpServer::new(commands, env!("CARGO_PKG_VERSION"))
+                .serve_stdio()
+                .await
+                .context("serve MCP over stdio")
+        }
+    }
+}
+
 async fn run(cli: Cli) -> Result<()> {
     anyhow::ensure!(
         !cli.version || cli.cmd.is_none(),
@@ -3108,6 +3175,7 @@ async fn run(cli: Cli) -> Result<()> {
             debug!(endpoint = %client_endpoint.display, "cli.vfs.write.via_ipc");
             Ok(())
         }
+        Cmd::Mcp(command) => run_mcp(&home, &client_endpoint, command).await,
         Cmd::Request(RequestCmd::New {
             request,
             wallet,

--- a/crates/bloom/tests/cli.rs
+++ b/crates/bloom/tests/cli.rs
@@ -2254,6 +2254,143 @@ fn vfs_routes_via_ipc_when_socket_exists() {
     server_thread.join().expect("ipc server thread panicked");
 }
 
+/// The MCP proxy must be inert until an operator turns it on: a fresh home has
+/// no config at all, and `mcp serve` has to refuse before it reads a single
+/// client byte or touches the daemon socket.
+#[test]
+fn mcp_is_disabled_until_the_config_flag_is_set() {
+    let home = fresh_home();
+    assert!(
+        !bloom_proto::HomeDir::at(home.path()).config_path().exists(),
+        "this test starts from a home with no config at all"
+    );
+
+    bloom_cmd(home.path())
+        .args(["mcp", "status"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("enabled: false"))
+        .stdout(predicate::str::contains("transport: stdio"))
+        .stdout(predicate::str::contains("vfs_read"))
+        .stdout(predicate::str::contains(
+            "set `enabled = true` under `[mcp]`",
+        ));
+
+    // Even handed a complete, valid MCP session on stdin, a disabled server
+    // must answer nothing and exit non-zero.
+    let assertion = bloom_cmd(home.path())
+        .args(["mcp", "serve"])
+        .write_stdin(
+            "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}\n\
+             {\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\"}\n",
+        )
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("disabled"));
+    assert_eq!(
+        assertion.get_output().stdout,
+        b"",
+        "a disabled MCP server must not emit protocol frames"
+    );
+
+    // An explicit `enabled = false` is still disabled.
+    let home_dir = bloom_proto::HomeDir::at(home.path());
+    let mut config = bloom_proto::Config::local_default();
+    config.mcp.enabled = false;
+    config.save(&home_dir.config_path()).unwrap();
+    bloom_cmd(home.path())
+        .args(["mcp", "status"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("enabled: false"));
+}
+
+/// With the flag set, `bloom mcp serve` speaks MCP on stdio and every tool call
+/// lands on the same daemon IPC surface `bloom vfs` uses. The in-process server
+/// mounts a subtree the production daemon never has, so a correct answer proves
+/// the request really travelled the canonical path.
+#[test]
+fn mcp_serve_proxies_vfs_commands_over_stdio_when_enabled() {
+    let home = fresh_home();
+    let home_dir = bloom_proto::HomeDir::at(home.path());
+    let mut config = bloom_proto::Config::local_default();
+    config.mcp.enabled = true;
+    config.save(&home_dir.config_path()).unwrap();
+
+    let handler = RecordingWriteHandler::new();
+    let vfs = bloom_vfs::Vfs::builder()
+        .mount("wallets", handler.clone())
+        .build();
+    let (server, server_thread) = spawn_ipc_server(home.path(), vfs);
+
+    let session = [
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","clientInfo":{"name":"cli-test","version":"1"}}}"#,
+        r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#,
+        r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#,
+        r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"vfs_write","arguments":{"path":"/wallets/alice/chains/base/outbox/pending/0001/confirm","text":"y"}}}"#,
+        r#"{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"vfs_read","arguments":{"path":"/absent-subtree/x"}}}"#,
+    ]
+    .join("\n")
+        + "\n";
+
+    let assertion = bloom_cmd(home.path())
+        .args(["mcp", "serve"])
+        .write_stdin(session)
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assertion.get_output().stdout.clone()).unwrap();
+    let responses: Vec<serde_json::Value> = stdout
+        .lines()
+        .filter(|line| !line.is_empty())
+        .map(|line| serde_json::from_str(line).expect("each frame is one JSON document"))
+        .collect();
+
+    assert_eq!(responses.len(), 4, "the notification is not answered");
+    assert_eq!(responses[0]["result"]["serverInfo"]["name"], "bloom-vfs");
+    assert_eq!(responses[0]["result"]["protocolVersion"], "2025-06-18");
+
+    let tool_names: Vec<&str> = responses[1]["result"]["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|tool| tool["name"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        tool_names,
+        [
+            "vfs_list",
+            "vfs_read",
+            "vfs_stat",
+            "vfs_write",
+            "vfs_write_then_stat"
+        ]
+    );
+
+    assert_eq!(responses[2]["result"]["isError"], false);
+    assert_eq!(
+        responses[2]["result"]["structuredContent"]["bytes_written"],
+        1
+    );
+
+    // A daemon-side failure is reported as an MCP tool error carrying the
+    // daemon's own JSON-RPC code.
+    assert_eq!(responses[3]["result"]["isError"], true);
+    assert_eq!(
+        responses[3]["result"]["structuredContent"]["error"]["code"],
+        -32004
+    );
+
+    stop_ipc_server(server, server_thread);
+
+    let writes = handler.writes();
+    assert_eq!(writes.len(), 1, "expected one VFS write, got {writes:?}");
+    assert_eq!(
+        writes[0].0,
+        "/alice/chains/base/outbox/pending/0001/confirm"
+    );
+    assert_eq!(writes[0].1, b"y");
+}
+
 #[test]
 fn wallet_confirm_uses_plain_ipc_write_when_socket_exists() {
     let home = fresh_home();

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -1,0 +1,135 @@
+# MCP server (`bloom mcp`)
+
+`bloom mcp serve` exposes Bloom's virtual filesystem to Model Context Protocol
+clients over stdio. It is a proxy, not a second API: every tool and resource
+forwards to one of the five VFS commands the daemon already serves on its Unix
+socket — the same commands `bloom vfs ls|cat|stat|write` use. Path parsing,
+authorization, policy gates, confirmation, audit journalling, and error codes
+all stay in `bloom-vfs`.
+
+Use it when your agent client speaks MCP and you would rather not mount the
+filesystem. If you can mount, mounting is still the richer surface: see
+[Interaction Modes](../architecture/Interaction%20Modes.md).
+
+## Enabling it
+
+The server is disabled by default, and a config file that predates the `[mcp]`
+block — or has no config file at all — also reads as disabled. Turning it on is
+an explicit edit to `~/.bloom/config.toml`:
+
+```toml
+[mcp]
+enabled = true
+```
+
+```sh
+bloom mcp status
+# enabled: true
+# config: /home/you/.bloom/config.toml
+# transport: stdio
+# endpoint: unix:/home/you/.bloom/private-run/bloom.sock
+# protocol: 2025-06-18
+# tools: vfs_list, vfs_read, vfs_stat, vfs_write, vfs_write_then_stat
+```
+
+`bloom mcp serve` checks the flag before it reads a byte of stdin or touches
+the daemon socket, so a disabled server fails with an explanation instead of
+starting and then refusing calls.
+
+## Connecting a client
+
+Transport is stdio only: the client spawns `bloom mcp serve` as a child process
+and owns its lifetime. Nothing listens on a network port, and the child runs as
+the invoking user, which is the identity the daemon's peer-uid check sees.
+
+```json
+{
+  "mcpServers": {
+    "bloom": {
+      "command": "bloom",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+Diagnostics go to stderr; stdout carries protocol frames only.
+
+Protocol revisions: `2025-06-18` (default), `2025-03-26`, and `2024-11-05`.
+`initialize` echoes the client's revision when it is one of those and otherwise
+answers with `2025-06-18`. The JSON-RPC batching `2025-03-26` permits on stdio
+is implemented, so the claim holds for every revision listed.
+
+## Tools
+
+| Tool                  | VFS command         | CLI equivalent    | `readOnlyHint` |
+| --------------------- | ------------------- | ----------------- | -------------- |
+| `vfs_list`            | `list`              | `bloom vfs ls`    | true           |
+| `vfs_read`            | `read`              | `bloom vfs cat`   | false          |
+| `vfs_stat`            | `lookup`            | `bloom vfs stat`  | true           |
+| `vfs_write`           | `write`             | `bloom vfs write` | false          |
+| `vfs_write_then_stat` | `write_with_lookup` | (staging flows)   | false          |
+
+`vfs_read` is not marked read-only on purpose. Most of the VFS is inert data,
+but a few paths act when read — a wallet outbox `confirm`, `confirm.override`,
+`replace`, or `cancel` file signs and broadcasts on read. `vfs_stat` reports
+this per path as `read_side_effecting`, and is itself always inert, so a client
+can stat before it reads and prompt when the answer is `true`.
+
+Reads return UTF-8 as text and anything else as a base64 blob, so binary
+artifacts survive byte-for-byte. Writes take either `text` or `bytes_b64`.
+
+Each tool forwards a fixed set of arguments (`path`, plus `text`/`bytes_b64`
+and `projection_path` where they apply) and rejects anything else before the
+daemon is called. A parameter added to a daemon VFS method is therefore *not*
+reachable from MCP until it is added to that allowlist too.
+
+## Resources
+
+VFS paths are also addressable as resources:
+
+- `resources/list` returns the files at the VFS root.
+- `resources/templates/list` advertises `bloom:///{+path}` for everything else.
+- `resources/read` fetches one path.
+
+Resource URIs are RFC 3986 URIs with an empty authority. Path segments are
+percent-encoded, so a VFS name containing `%`, a space, `?`, or `#` round-trips
+exactly:
+
+```
+/docs/README.md          →  bloom:///docs/README.md
+/requests/odd name#1     →  bloom:///requests/odd%20name%231
+```
+
+A URI with a raw `?` or `#`, or with a `%2F` that would decode into an extra
+separator, is rejected rather than read as some other path.
+
+MCP clients treat resources as inert context and commonly fetch them without
+asking a human. Bloom therefore refuses to serve a side-effecting path as a
+resource: `resources/read` stats the path first and answers `-32010` if reading
+it would act, naming `vfs_read` as the way to do it deliberately. No VFS
+functionality is lost — the tool still performs the read.
+
+## Error codes
+
+Tool failures come back inside the result as `isError: true`, with the daemon's
+own code and message in `structuredContent.error` (`-32004` not found, `-32007`
+permission denied, and so on). That vocabulary is unchanged from `bloom vfs`.
+
+The resource surface speaks MCP's vocabulary instead, because clients branch on
+it. The daemon's code is always preserved in `error.data.daemonCode`.
+
+| Condition                     | `resources/read` code | Notes                                  |
+| ----------------------------- | --------------------- | -------------------------------------- |
+| Path does not exist           | `-32002`              | MCP "Resource not found"               |
+| Daemon unreachable            | `-32603`              | Start it with `bloom serve`            |
+| Reading the path would act    | `-32010`              | Use the `vfs_read` tool instead        |
+| Other daemon verdict          | daemon's code         | e.g. `-32007` permission denied        |
+| Unknown URI scheme or shape   | `-32602`              | Not a `bloom:///…` URI                 |
+
+## What it cannot do
+
+The daemon also exposes `machine.execute`, `petals.*`, `confirm_batch`, and
+`shutdown` on the same socket. None of them are tools here and there is no
+generic pass-through, so an MCP client cannot name them — the proxy models the
+five VFS methods as a closed enum rather than forwarding a method string.


### PR DESCRIPTION
## Summary

Adds an opt-in, stdio MCP server that proxies Bloom's canonical daemon VFS command surface.

- Adds `[mcp] enabled = true` as an explicit, disabled-by-default server gate; missing or legacy config remains disabled.
- Adds `bloom mcp status` and `bloom mcp serve`. `serve` refuses before touching stdio or the daemon socket unless the flag is enabled.
- Maps every daemon VFS method one-to-one: `list`, `read`, `lookup`/stat, `write`, and `write_with_lookup`.
- Preserves canonical daemon error codes, VFS path discovery, byte reads/writes (base64 for non-UTF-8), and stdio JSON-RPC/MCP protocol behavior.

## Verification

- `cargo fmt`
- `cargo test -p bloom-mcp` — 32 passed
- `cargo test -p bloom-proto config::tests::mcp` — 2 passed
- `cargo test -p bloom --test cli mcp` — 2 passed
- `git diff --check`

## Checklist

- [x] Tests added or updated for behavior changes
- [x] Architecture docs (`docs/architecture/`) updated if contracts or behavior changed — N/A: this is an opt-in local CLI transport/proxy; VFS and custody contracts are unchanged.
- [x] Sealed Approval invariants respected (no signing outside a grant or bounded capability, no PRF/grant persistence, execution from sealed bytes) — N/A: MCP forwards only existing VFS daemon operations and introduces no signing or approval path.
- [x] Agent Documentation updated (`crates/bloom-vfs/src/docs/agent-guidance.md` and affected Petal READMEs) — N/A: no agent guidance or Petal surface changed; MCP tool descriptions document the new transport.
